### PR TITLE
teleop: only actuate gripper when deadman is cleared (ALM-887)

### DIFF
--- a/almond_axol/lerobot/teleop/teleop_vr.py
+++ b/almond_axol/lerobot/teleop/teleop_vr.py
@@ -534,8 +534,6 @@ class AxolVRTeleop(Teleoperator):
                 continue
 
             last_frame = frame
-            self._l_grip = frame.l_grip
-            self._r_grip = frame.r_grip
 
             # Deadman toggle — mirrors native VRTeleop._ik_loop logic:
             #   rising edge of BOTH grips pressed together → enable tracking
@@ -558,6 +556,12 @@ class AxolVRTeleop(Teleoperator):
                     _logger.info("Teleop disabled")
             self._prev_both = both
             self._prev_either = either
+
+            # Only track gripper position when arm movement is also enabled so
+            # that the gripper cannot be actuated independently of the deadman.
+            if self._teleop_enabled:
+                self._l_grip = frame.l_grip
+                self._r_grip = frame.r_grip
 
             # Restore full velocity after engage window expires
             if self._engage_time is not None:

--- a/almond_axol/teleop/teleop.py
+++ b/almond_axol/teleop/teleop.py
@@ -444,8 +444,6 @@ class VRTeleop:
                 time.sleep(0.001)
                 continue
             last_frame = frame
-            self._l_grip = frame.l_grip
-            self._r_grip = frame.r_grip
 
             both = frame.l_lock and frame.r_lock
             either = frame.l_lock or frame.r_lock
@@ -469,6 +467,12 @@ class VRTeleop:
 
             self._prev_both = both
             self._prev_either = either
+
+            # Only track gripper position when arm movement is also enabled so
+            # that the gripper cannot be actuated independently of the deadman.
+            if self._teleop_enabled:
+                self._l_grip = frame.l_grip
+                self._r_grip = frame.r_grip
 
             if self._reset_latched:
                 if self._reset_interp.is_active() or self._q is None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes ALM-887: gripper actuation was possible even when arm tracking was toggled off (deadman not cleared). The same bug existed in both the native `VRTeleop` and the new LeRobot `AxolVRTeleop`.

## Root Cause

In both `VRTeleop._ik_loop` and `AxolVRTeleop._ik_loop`, `self._l_grip` / `self._r_grip` were updated unconditionally from every incoming VR frame — before the deadman toggle logic ran. This meant the gripper tracked the VR trigger regardless of the `_teleop_enabled` state.

## Fix

In both files, move the grip value capture to after the toggle logic and guard it with `if self._teleop_enabled`. When the deadman is not active, grip targets are frozen at their last commanded value. When the deadman is re-enabled the gripper immediately tracks the VR trigger again.

## Changed Files

- `almond_axol/teleop/teleop.py` — native `VRTeleop._ik_loop`
- `almond_axol/lerobot/teleop/teleop_vr.py` — LeRobot `AxolVRTeleop._ik_loop`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [ALM-887](https://linear.app/almondbot/issue/ALM-887/only-actuate-gripper-when-past-deadman)

<div><a href="https://cursor.com/agents/bc-cd6f3661-214c-48e5-9038-c6574928b620"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cd6f3661-214c-48e5-9038-c6574928b620"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

