### PR TITLE
use end stops for zero pos

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,9 +128,20 @@ axol motor.set-can-id --l --current-id 0x01 --new-id 0x03 --type myactuator
 
 Sets the motor's zero-position reference to its current mechanical position (persisted to flash). Damiao motors require a power cycle afterward.
 
+| Flag | Description |
+|---|---|
+| `--id ID` | CAN ID of the motor to zero (single-motor mode) |
+| `--type {myactuator,damiao}` | Motor type (inferred from `--id` if omitted) |
+| `--guided` | Walk through every arm joint, zeroing each at its closer end stop |
+
+In `--guided` mode the CLI iterates through all 7 arm joints (the gripper is auto-calibrated at runtime). For each joint you place it somewhere inside its operating range, press Enter, then move it to the prompted end stop and press Enter again. If the motion direction doesn't match the expected sign the CLI loops back automatically and asks you to retry. Once the direction checks out, press Enter once more to commit the zero, or Ctrl-C to skip that joint.
+
 ```bash
-axol motor.set-zero-pos --l --id 0x01
+axol motor.set-zero-pos --l --id 0x01      # single motor
+axol motor.set-zero-pos --l --guided       # all left-arm joints
 ```
+
+> After `--guided` calibration each motor's encoder zero coincides with its calibration end stop. `AxolArm` carries a per-joint offset internally so the public API (`positions`, `motion_control`, etc.) stays in joint frame (`0` = rest position). Damiao motors (`WRIST_2`, `WRIST_3`) need a power cycle for the new zero to take effect.
 
 ---
 

--- a/almond_axol/cli/motor/set_zero_pos.py
+++ b/almond_axol/cli/motor/set_zero_pos.py
@@ -1,23 +1,25 @@
 """
 axol motor.set-zero-pos
 
-Set the zero position of a single motor to its current position.
-The motor type is inferred automatically from the CAN ID.
-
-The motor must be powered and on the CAN bus. The command sets the current
-mechanical position as the new zero reference (persisted to flash).
+Set the zero position of a single motor, or walk every arm joint with
+``--guided`` and zero each one against its closer end stop. The current
+mechanical position becomes the new zero reference (persisted to flash).
 
 Examples:
     axol motor.set-zero-pos --l --id 0x01
     axol motor.set-zero-pos --r --id 0x06
+    axol motor.set-zero-pos --l --guided
 """
 
 import argparse
 import asyncio
+import math
 
 from ...motor.bus import CanBus
 from ...motor.damiao import DamiaoMotor
-from ...motor.motor import make_driver
+from ...motor.motor import Motor, make_driver
+from ...robot.axol import closer_end_stop
+from ...shared import ARM_JOINTS, CAN_LEFT, CAN_RIGHT, Joint
 
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
@@ -32,16 +34,21 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[
     side.add_argument("--r", action="store_true", help="Right arm (can_alm_axol_r)")
     p.add_argument(
         "--id",
-        required=True,
         type=lambda x: int(x, 0),
+        default=None,
         metavar="ID",
-        help="CAN ID of the motor (hex or decimal, e.g. 0x01 or 1)",
+        help="CAN ID (hex or decimal).  Required unless --guided.",
     )
     p.add_argument(
         "--type",
         choices=["myactuator", "damiao"],
         default=None,
         help="Motor driver type (inferred from ID if omitted)",
+    )
+    p.add_argument(
+        "--guided",
+        action="store_true",
+        help="Walk every arm joint, zeroing each at its closer end stop.",
     )
     p.set_defaults(func=run)
 
@@ -51,24 +58,134 @@ def run(args: argparse.Namespace) -> None:
 
 
 async def _run(args: argparse.Namespace) -> None:
-    channel = "can_alm_axol_l" if args.l else "can_alm_axol_r"
+    if args.guided:
+        if args.id is not None:
+            print("note: --id is ignored in --guided mode.")
+        await _run_guided(args)
+        return
+
+    if args.id is None:
+        raise SystemExit("error: --id is required (or use --guided).")
+    await _run_single(args)
+
+
+async def _run_single(args: argparse.Namespace) -> None:
+    channel = CAN_LEFT if args.l else CAN_RIGHT
     print(f"\nset-zero-pos — {channel}  id={args.id:#04x}")
 
     async with CanBus(channel) as bus:
         motor = make_driver(bus, args.id, kt=1.0, motor_type=args.type)
 
-        position_before = await motor.get_position()
-        print(f"  position before: {position_before:.4f} rad")
+        before = await motor.get_position()
+        print(f"  before: {before:+.4f} rad")
 
-        print("  setting zero position ...")
         await motor.set_zero_position()
 
-        position_after = await motor.get_position()
-        print(f"  position after:  {position_after:.4f} rad")
+        after = await motor.get_position()
+        print(f"  after:  {after:+.4f} rad")
         print("  done")
 
         if isinstance(motor, DamiaoMotor):
+            print("\n  ⚠  Damiao motor — power-cycle required to apply.")
+
+
+# ---------------------------------------------------------------------------
+# Guided mode
+# ---------------------------------------------------------------------------
+
+# Motion tolerances used to validate each end-stop press (rad).
+_MIN_MOTION_RAD = math.radians(3.0)
+_MAGNITUDE_WARN_RAD = math.radians(20.0)
+
+
+def _prompt(msg: str) -> bool:
+    """Block on Enter; return ``False`` on Ctrl-C / EOF."""
+    try:
+        input(msg)
+        return True
+    except (EOFError, KeyboardInterrupt):
+        print("\n    skipped.")
+        return False
+
+
+def _fmt(rad: float) -> str:
+    """Format an angle as ``+1.5708 rad (+90.0°)``."""
+    return f"{rad:+.4f} rad ({math.degrees(rad):+.1f}°)"
+
+
+async def _calibrate_joint(
+    motor: Motor, joint: Joint, target_rad: float, expected_sign: int
+) -> bool:
+    """Zero one joint at its closer end stop. Returns ``True`` on success."""
+    target_deg = math.degrees(target_rad)
+    direction = "−" if expected_sign < 0 else "+"
+    print(f"\n— {joint.name}  →  end stop {target_deg:+.1f}° ({direction} motion) —")
+
+    while True:
+        if not _prompt("  1) hold the joint inside its range, then Enter: "):
+            return False
+        p_start = await motor.get_position()
+        print(f"     start: {_fmt(p_start)}")
+
+        if not _prompt(
+            f"  2) move to the END STOP at {target_deg:+.1f}°, then Enter: "
+        ):
+            return False
+        p_end = await motor.get_position()
+        print(f"     end:   {_fmt(p_end)}")
+
+        delta = p_end - p_start
+        print(f"     moved: {_fmt(delta)}")
+
+        if abs(delta) < _MIN_MOTION_RAD:
+            print("    ✗ no motion — retry.")
+            continue
+
+        if (1 if delta > 0 else -1) != expected_sign:
+            print(f"    ✗ wrong direction (expected {direction}) — retry.")
+            continue
+
+        mag_diff = abs(abs(delta) - abs(target_rad))
+        if mag_diff > _MAGNITUDE_WARN_RAD:
             print(
-                "\n  ⚠  WARNING: Damiao motors require a power cycle to apply the new"
-                " zero position. Please restart the motor now."
+                f"    ⚠  moved {math.degrees(abs(delta)):.1f}°, expected"
+                f" ~{abs(target_deg):.1f}° — make sure you're against the stop."
+            )
+
+        if not _prompt(f"    set zero at {_fmt(p_end)}? Enter to confirm: "):
+            return False
+
+        await motor.set_zero_position()
+        print("    ✓ zeroed.")
+        return True
+
+
+async def _run_guided(args: argparse.Namespace) -> None:
+    is_left = args.l
+    channel = CAN_LEFT if is_left else CAN_RIGHT
+    side = "LEFT" if is_left else "RIGHT"
+    print(f"\nset-zero-pos --guided — {side} arm  ({channel})")
+
+    async with CanBus(channel) as bus:
+        results: list[tuple[Joint, bool]] = []
+        any_damiao = False
+        for joint in ARM_JOINTS:
+            target, sign = closer_end_stop(joint, is_left)
+            motor = Motor(bus, joint)
+            try:
+                ok = await _calibrate_joint(motor, joint, target, sign)
+            except KeyboardInterrupt:
+                print("\naborted.")
+                break
+            results.append((joint, ok))
+            if ok and isinstance(motor._driver, DamiaoMotor):
+                any_damiao = True
+
+        print("\n— summary —")
+        for joint, ok in results:
+            print(f"  {joint.name:<12} {'zeroed' if ok else 'skipped'}")
+
+        if any_damiao:
+            print(
+                "\n⚠  Damiao motors zeroed (WRIST_2 / WRIST_3) — power-cycle required."
             )

--- a/almond_axol/kinematics/urdf/axol.urdf
+++ b/almond_axol/kinematics/urdf/axol.urdf
@@ -414,14 +414,14 @@
         <axis xyz="-1 0 2.98117e-16" />
         <parent link="left_e1" />
         <child link="left_e2" />
-        <limit lower="0.0" upper="2.6389" velocity="30.0" effort="87.0" />
+        <limit lower="0.0" upper="2.6180" velocity="30.0" effort="87.0" />
     </joint>
     <joint name="left_e2_0" type="revolute">
         <origin xyz="-0.04229 -1.48698e-17 -0.12429" rpy="-8.32667e-17 -6.33174e-17 7.22079e-17" />
         <axis xyz="0 0 1" />
         <parent link="left_e2" />
         <child link="left_w0" />
-        <limit lower="-1.5708" upper="1.5708" velocity="30.0" effort="87.0" />
+        <limit lower="-2.3562" upper="2.3562" velocity="30.0" effort="87.0" />
     </joint>
     <joint name="left_gripper_0" type="fixed">
         <origin xyz="-0.0285 -7.09742e-18 -0.032251" rpy="9.71445e-17 -2.22045e-16 2.77556e-17" />
@@ -434,21 +434,21 @@
         <axis xyz="-1 0 0" />
         <parent link="s1" />
         <child link="left_s2" />
-        <limit lower="-1.5708" upper="1.5708" velocity="30.0" effort="87.0" />
+        <limit lower="-1.5708" upper="3.1416" velocity="30.0" effort="87.0" />
     </joint>
     <joint name="left_s2_0" type="revolute">
         <origin xyz="0.06958 -0.04475 4.44089e-16" rpy="2.498e-16 3.92274e-16 -2.48934e-16" />
         <axis xyz="0 1 0" />
         <parent link="left_s2" />
         <child link="left_s3" />
-        <limit lower="-1.5708" upper="0.1885" velocity="30.0" effort="87.0" />
+        <limit lower="-0.3491" upper="3.1416" velocity="30.0" effort="87.0" />
     </joint>
     <joint name="left_s3_0" type="revolute">
         <origin xyz="-1.91513e-15 0.04475 -0.07335" rpy="3.33067e-16 -1.05818e-16 -2.03288e-16" />
         <axis xyz="0 0 1" />
         <parent link="left_s3" />
         <child link="left_e1" />
-        <limit lower="-1.5708" upper="1.5708" velocity="30.0" effort="87.0" />
+        <limit lower="-2.3562" upper="2.3562" velocity="30.0" effort="87.0" />
     </joint>
     <joint name="left_w1_0" type="revolute">
         <origin xyz="-5.55112e-17 -0.0285 -0.13567" rpy="-4.71845e-16 3.45904e-15 -1.18829e-15" />
@@ -469,14 +469,14 @@
         <axis xyz="1 0 2.98117e-16" />
         <parent link="right_e1" />
         <child link="right_e2" />
-        <limit lower="-2.6389" upper="0.0" velocity="30.0" effort="87.0" />
+        <limit lower="-2.6180" upper="0.0" velocity="30.0" effort="87.0" />
     </joint>
     <joint name="right_e2_0" type="revolute">
         <origin xyz="0.04229 -5.37817e-17 -0.12429" rpy="7.66335e-47 -2.46519e-32 3.14159" />
         <axis xyz="0 0 1" />
         <parent link="right_e2" />
         <child link="right_w0" />
-        <limit lower="-1.5708" upper="1.5708" velocity="30.0" effort="87.0" />
+        <limit lower="-2.3562" upper="2.3562" velocity="30.0" effort="87.0" />
     </joint>
     <joint name="right_gripper_0" type="fixed">
         <origin xyz="0.0285 -7.09742e-18 -0.032251" rpy="0 -0 0" />
@@ -489,21 +489,21 @@
         <axis xyz="1 0 0" />
         <parent link="s1" />
         <child link="right_s2" />
-        <limit lower="-1.5708" upper="1.5708" velocity="30.0" effort="87.0" />
+        <limit lower="-1.5708" upper="3.1416" velocity="30.0" effort="87.0" />
     </joint>
     <joint name="right_s2_0" type="revolute">
         <origin xyz="-0.06958 -0.04475 4.44089e-16" rpy="-1.28654e-32 -9.17877e-18 -7.824e-17" />
         <axis xyz="0 1 0" />
         <parent link="right_s2" />
         <child link="right_s3" />
-        <limit lower="-0.1885" upper="1.5708" velocity="30.0" effort="87.0" />
+        <limit lower="-3.1416" upper="0.3491" velocity="30.0" effort="87.0" />
     </joint>
     <joint name="right_s3_0" type="revolute">
         <origin xyz="3.88578e-16 0.04475 -0.07335" rpy="-1.08655e-45 -1.28919e-43 -6.16298e-33" />
         <axis xyz="0 0 1" />
         <parent link="right_s3" />
         <child link="right_e1" />
-        <limit lower="-1.5708" upper="1.5708" velocity="30.0" effort="87.0" />
+        <limit lower="-2.3562" upper="2.3562" velocity="30.0" effort="87.0" />
     </joint>
     <joint name="right_w1_0" type="revolute">
         <origin xyz="1.11022e-16 0.0285 -0.13567" rpy="1.09476e-47 2.55312e-94 -4.66423e-47" />

--- a/almond_axol/kinematics/urdf/axol.urdf
+++ b/almond_axol/kinematics/urdf/axol.urdf
@@ -441,7 +441,7 @@
         <axis xyz="0 1 0" />
         <parent link="left_s2" />
         <child link="left_s3" />
-        <limit lower="-0.3491" upper="3.1416" velocity="30.0" effort="87.0" />
+        <limit lower="-3.1416" upper="0.3491" velocity="30.0" effort="87.0" />
     </joint>
     <joint name="left_s3_0" type="revolute">
         <origin xyz="-1.91513e-15 0.04475 -0.07335" rpy="3.33067e-16 -1.05818e-16 -2.03288e-16" />
@@ -489,14 +489,14 @@
         <axis xyz="1 0 0" />
         <parent link="s1" />
         <child link="right_s2" />
-        <limit lower="-1.5708" upper="3.1416" velocity="30.0" effort="87.0" />
+        <limit lower="-3.1416" upper="1.5708" velocity="30.0" effort="87.0" />
     </joint>
     <joint name="right_s2_0" type="revolute">
         <origin xyz="-0.06958 -0.04475 4.44089e-16" rpy="-1.28654e-32 -9.17877e-18 -7.824e-17" />
         <axis xyz="0 1 0" />
         <parent link="right_s2" />
         <child link="right_s3" />
-        <limit lower="-3.1416" upper="0.3491" velocity="30.0" effort="87.0" />
+        <limit lower="-0.3491" upper="3.1416" velocity="30.0" effort="87.0" />
     </joint>
     <joint name="right_s3_0" type="revolute">
         <origin xyz="3.88578e-16 0.04475 -0.07335" rpy="-1.08655e-45 -1.28919e-43 -6.16298e-33" />

--- a/almond_axol/robot/__init__.py
+++ b/almond_axol/robot/__init__.py
@@ -1,6 +1,6 @@
 """Public re-exports for almond_axol.robot."""
 
-from .axol import Axol, AxolArm, arm_limits
+from .axol import Axol, AxolArm, arm_limits, closer_end_stop
 from .base import RobotBase
 from .config import (
     ArmConfig,
@@ -16,6 +16,7 @@ __all__ = [
     "Axol",
     "AxolArm",
     "arm_limits",
+    "closer_end_stop",
     "ArmConfig",
     "AxolConfig",
     "FrictionParams",

--- a/almond_axol/robot/axol.py
+++ b/almond_axol/robot/axol.py
@@ -29,14 +29,15 @@ from .gravity import GravityCompensator
 
 _logger = logging.getLogger(__name__)
 
-# Per-joint position limits (rad).  shoulder_2 and elbow are mirrored across arms.
-SHOULDER_2_LEFT_LIMITS = (math.radians(-20), math.radians(180))
-SHOULDER_2_RIGHT_LIMITS = (math.radians(-180), math.radians(20))
+# Per-joint position limits (rad).  shoulder_1, shoulder_2, and elbow are mirrored across arms.
+SHOULDER_1_LEFT_LIMITS = (math.radians(-90), math.radians(180))
+SHOULDER_1_RIGHT_LIMITS = (math.radians(-180), math.radians(90))
+SHOULDER_2_LEFT_LIMITS = (math.radians(-180), math.radians(20))
+SHOULDER_2_RIGHT_LIMITS = (math.radians(-20), math.radians(180))
 ELBOW_LEFT_LIMITS = (math.radians(0), math.radians(150))
 ELBOW_RIGHT_LIMITS = (math.radians(-150), math.radians(0))
 
 LIMITS: dict[Joint, tuple[float, float]] = {
-    Joint.SHOULDER_1: (math.radians(-90), math.radians(180)),
     Joint.SHOULDER_3: (math.radians(-135), math.radians(135)),
     Joint.WRIST_1: (math.radians(-135), math.radians(135)),
     Joint.WRIST_2: (math.radians(-90), math.radians(90)),
@@ -66,6 +67,8 @@ def arm_limits(joint: Joint, is_left: bool) -> tuple[float, float]:
     1 = open] — the raw motor limits vary per unit and are calibrated at
     runtime by AxolArm._calibrate_gripper().
     """
+    if joint == Joint.SHOULDER_1:
+        return SHOULDER_1_LEFT_LIMITS if is_left else SHOULDER_1_RIGHT_LIMITS
     if joint == Joint.SHOULDER_2:
         return SHOULDER_2_LEFT_LIMITS if is_left else SHOULDER_2_RIGHT_LIMITS
     if joint == Joint.ELBOW:
@@ -73,6 +76,52 @@ def arm_limits(joint: Joint, is_left: bool) -> tuple[float, float]:
     if joint == Joint.GRIPPER:
         return (0.0, 1.0)
     return LIMITS.get(joint, (-math.inf, math.inf))
+
+
+# Joints whose joint frame is kinematically mirrored across arms but whose
+# limits are symmetric (equidistant from 0).  For these the calibration end
+# stop on the right arm is the upper bound rather than the lower (the
+# physical end stop closer to rest is at +X on the right arm and -X on the
+# left).  Joints with already-asymmetric per-arm limits (s1, s2, elbow) are
+# disambiguated by their range and don't need to be listed here.
+_MIRRORED_SYMMETRIC_JOINTS: frozenset[Joint] = frozenset({Joint.WRIST_2, Joint.WRIST_3})
+
+
+def closer_end_stop(joint: Joint, is_left: bool) -> tuple[float, int]:
+    """Return ``(target_rad, expected_motion_sign)`` for the joint's calibration end stop.
+
+    Picks the limit with the smallest absolute value, except when that limit
+    is exactly 0 (it coincides with the rest position, so direction detection
+    is unreliable) — in that case the *other* limit is used instead.  When
+    both limits are equidistant the lower bound wins, except for joints in
+    :data:`_MIRRORED_SYMMETRIC_JOINTS` on the right arm, which default to
+    the upper bound to follow the kinematic mirror.
+
+    ``expected_motion_sign`` is the sign of motion when the user starts inside
+    the joint range and moves toward the chosen end stop:
+
+    - target == lower bound  → range extends positively → motion is negative
+    - target == upper bound  → range extends negatively → motion is positive
+
+    Used by the guided ``set-zero-pos`` flow and by :class:`AxolArm` to derive
+    the per-joint offset between motor frame (zero at end stop) and joint
+    frame (zero at rest).  Not defined for ``Joint.GRIPPER``.
+    """
+    if joint == Joint.GRIPPER:
+        raise ValueError("closer_end_stop is undefined for the gripper")
+    lo, hi = arm_limits(joint, is_left)
+    if lo == 0.0:
+        return hi, +1
+    if hi == 0.0:
+        return lo, -1
+    if abs(hi) < abs(lo):
+        return hi, +1
+    if abs(lo) < abs(hi):
+        return lo, -1
+    # Equidistant: default to lo, except mirrored joints on the right arm.
+    if not is_left and joint in _MIRRORED_SYMMETRIC_JOINTS:
+        return hi, +1
+    return lo, -1
 
 
 class AxolArm:
@@ -112,10 +161,13 @@ class AxolArm:
         self._gc_hold_q: np.ndarray | None = None
         self._gc_hold_free: frozenset[Joint] | None = None
 
-        # Clipping arrays in raw motor radians.  arm_limits() returns normalised [0, 1]
-        # for the gripper, so the gripper entries are seeded with raw defaults here;
-        # _calibrate_gripper() overwrites them on enable.
-        # Pre-calibration defaults assume zero is closed — do not rely on for actual motion.
+        # Clipping arrays.  Arm joints are in joint frame (0 = rest position,
+        # matching the URDF and ``arm_limits``); gripper entries are in raw
+        # motor radians (``arm_limits`` returns normalised [0, 1] for the
+        # gripper, so the gripper bounds are seeded with raw defaults here
+        # and ``_calibrate_gripper()`` overwrites them on enable).
+        # Pre-calibration gripper defaults assume zero is closed — do not rely
+        # on for actual motion.
         joints = list(Joint)
         self._gripper_i: int = joints.index(Joint.GRIPPER)
         self._limits_lo = np.array(
@@ -127,6 +179,20 @@ class AxolArm:
         )
         self._limits_hi = np.array(
             [0.0 if j == Joint.GRIPPER else arm_limits(j, is_left)[1] for j in joints],
+            dtype=float,
+        )
+
+        # Per-joint offset between motor frame and joint frame:
+        #   joint_angle (rad) = motor_angle (rad) + offset
+        # After end-stop calibration the motor's encoder zero coincides with
+        # the closer end stop, so motor 0 → joint angle ``target_rad``.  The
+        # gripper offset is 0 because the gripper uses its own [0, 1]
+        # normalisation and is calibrated against torque, not an end stop.
+        self._joint_offsets = np.array(
+            [
+                0.0 if j == Joint.GRIPPER else closer_end_stop(j, is_left)[0]
+                for j in joints
+            ],
             dtype=float,
         )
 
@@ -153,9 +219,10 @@ class AxolArm:
     def positions(self) -> np.ndarray:
         """Latest cached joint positions. Requires start_telemetry().
 
-        Returns shape (8,) array in Joint enum order. Arm joints are in radians;
-        the gripper is normalized to [0, 1] (0.0 = closed, 1.0 = fully open),
-        consistent with set_position_velocity and motion_control.
+        Returns shape (8,) array in Joint enum order. Arm joints are in
+        radians in the joint frame (0 = rest position); the gripper is
+        normalized to [0, 1] (0.0 = closed, 1.0 = fully open), consistent
+        with set_position_velocity and motion_control.
         """
         joints = list(Joint)
         values = [self.motors[j].position for j in joints]
@@ -163,7 +230,8 @@ class AxolArm:
         values[gripper_i] = (values[gripper_i] - self._limits_hi[gripper_i]) / (
             self._limits_lo[gripper_i] - self._limits_hi[gripper_i]
         )
-        return np.array(values, dtype=np.float32)
+        arr = np.array(values, dtype=np.float32)
+        return arr + self._joint_offsets.astype(np.float32)
 
     @property
     def torques(self) -> np.ndarray:
@@ -241,9 +309,10 @@ class AxolArm:
     async def get_positions(self) -> np.ndarray:
         """Return joint positions for every joint, fetched concurrently.
 
-        Returns shape (8,) array in Joint enum order. Arm joints are in radians;
-        the gripper is normalized to [0, 1] (0.0 = closed, 1.0 = fully open),
-        consistent with set_position_velocity and motion_control.
+        Returns shape (8,) array in Joint enum order. Arm joints are in
+        radians in the joint frame (0 = rest position); the gripper is
+        normalized to [0, 1] (0.0 = closed, 1.0 = fully open), consistent
+        with set_position_velocity and motion_control.
         """
         joints = list(Joint)
         values = list(
@@ -253,7 +322,8 @@ class AxolArm:
         values[gripper_i] = (values[gripper_i] - self._limits_hi[gripper_i]) / (
             self._limits_lo[gripper_i] - self._limits_hi[gripper_i]
         )
-        return np.array(values, dtype=np.float32)
+        arr = np.array(values, dtype=np.float32)
+        return arr + self._joint_offsets.astype(np.float32)
 
     async def get_velocities(self) -> np.ndarray:
         """Return shaft velocity (rad/s) for every joint, fetched concurrently.
@@ -347,7 +417,8 @@ class AxolArm:
         """Move joints to absolute positions using each motor's built-in controller.
 
         Positions are clipped to the arm's joint limits before being sent.
-        The gripper value is normalized: 0.0 = closed, 1.0 = fully open.
+        Arm joints are in joint frame (0 = rest position); the gripper value
+        is normalized: 0.0 = closed, 1.0 = fully open.
 
         Args:
             positions: Shape (8,) array of target positions (rad) in Joint enum order,
@@ -360,9 +431,12 @@ class AxolArm:
             self._limits_lo[gripper_i] - self._limits_hi[gripper_i]
         )
         clipped = np.clip(positions, self._limits_lo, self._limits_hi)
+        # Convert arm joints from joint frame to motor frame before sending.
+        # Gripper offset is 0, so its raw motor value is unchanged.
+        motor_targets = clipped - self._joint_offsets
         await asyncio.gather(
             *[
-                self.motors[j].set_position_velocity(float(clipped[i]), max_speed)
+                self.motors[j].set_position_velocity(float(motor_targets[i]), max_speed)
                 for i, j in enumerate(Joint)
             ]
         )
@@ -395,12 +469,13 @@ class AxolArm:
 
         Args:
             q: Shape (8,) array of desired positions in Joint enum order.
-               Arm joints are in radians; gripper is normalized to [0, 1]
-               (0.0 = closed, 1.0 = fully open).
+               Arm joints are in radians in the joint frame (0 = rest);
+               gripper is normalized to [0, 1] (0.0 = closed, 1.0 = fully open).
         """
         q = q.copy()
 
         # Safety: reject commands with arm-joint deltas that exceed max_step_rad.
+        # Deltas are frame-invariant (constant offset), so compute in joint frame.
         max_step = self._config.max_step_rad
         if self._last_q_commanded is not None and max_step < float("inf"):
             gripper_i = self._gripper_i
@@ -433,6 +508,8 @@ class AxolArm:
 
         # Velocity feedforward via differentiation of commanded positions (rad/s),
         # and acceleration feedforward via a second pass for inertia FF (rad/s²).
+        # Velocities/accelerations are frame-invariant under a constant offset,
+        # so we differentiate the joint-frame ``clipped`` array directly.
         velocities = self._vel_diff.differentiate(list(clipped))
         accelerations = self._accel_diff.differentiate(velocities)
         # v_meas drives software velocity damping. The position cache is
@@ -443,15 +520,19 @@ class AxolArm:
         except MotorError:
             v_meas = list(velocities)
 
-        gripper_i = self._gripper_i
-        gripper_pos = float(clipped[gripper_i])
         gripper_max_speed = self._arm_config.gripper.max_speed
         gripper_torque_limit = self._arm_config.gripper.torque_limit
 
         # Gravity feedforward (Nm) for the seven arm joints, computed from the
         # full URDF chain so child links contribute to each parent joint's load.
+        # ``arm_q`` is in joint frame, which matches the URDF convention.
         arm_q = clipped[: len(ARM_JOINTS)].astype(np.float32)
         gravity = self._gravity_comp.gravity_arm(arm_q, is_left=self._is_left)
+
+        # Convert arm joints to motor frame for the impedance command.  Gripper
+        # offset is 0, so its raw motor value is unchanged.
+        motor_targets = clipped - self._joint_offsets
+        gripper_pos = float(motor_targets[gripper_i])
 
         def _mit_cmd(i: int, j: Joint):
             gains = getattr(self._arm_config, j.value)
@@ -463,7 +544,7 @@ class AxolArm:
                 + gains.kd_soft * (velocities[i] - v_meas[i])
             )
             return self.motors[j].set_impedance(
-                float(clipped[i]),
+                float(motor_targets[i]),
                 velocities[i],
                 gains.kp,
                 gains.kd,
@@ -536,14 +617,18 @@ class AxolArm:
             self._limits_lo[gripper_i] - self._limits_hi[gripper_i]
         )
 
+        # ``arm_q`` and ``_gc_hold_q`` are in joint frame; convert to motor
+        # frame before sending to the impedance controller.
+        arm_offsets = self._joint_offsets[: len(ARM_JOINTS)]
+
         tasks = []
         for i, j in enumerate(ARM_JOINTS):
             if j in free_set:
-                p_des = float(arm_q[i])
+                p_des = float(arm_q[i] - arm_offsets[i])
                 kp_cmd = 0.0
                 kd_cmd = kd
             else:
-                p_des = float(self._gc_hold_q[i])
+                p_des = float(self._gc_hold_q[i] - arm_offsets[i])
                 gains = getattr(self._arm_config, j.value)
                 kp_cmd = gains.kp
                 kd_cmd = gains.kd

--- a/almond_axol/robot/axol.py
+++ b/almond_axol/robot/axol.py
@@ -29,25 +29,23 @@ from .gravity import GravityCompensator
 
 _logger = logging.getLogger(__name__)
 
-_TAU = 2 * math.pi
-
-# Per-joint position limits (rad).  shoulder_2 is asymmetric across arms.
-SHOULDER_2_LEFT_LIMITS = (-0.25 * _TAU, 0.03 * _TAU)
-SHOULDER_2_RIGHT_LIMITS = (-0.03 * _TAU, 0.25 * _TAU)
-ELBOW_LEFT_LIMITS = (0.0, 0.42 * _TAU)
-ELBOW_RIGHT_LIMITS = (-0.42 * _TAU, 0.0)
+# Per-joint position limits (rad).  shoulder_2 and elbow are mirrored across arms.
+SHOULDER_2_LEFT_LIMITS = (math.radians(-20), math.radians(180))
+SHOULDER_2_RIGHT_LIMITS = (math.radians(-180), math.radians(20))
+ELBOW_LEFT_LIMITS = (math.radians(0), math.radians(150))
+ELBOW_RIGHT_LIMITS = (math.radians(-150), math.radians(0))
 
 LIMITS: dict[Joint, tuple[float, float]] = {
-    Joint.SHOULDER_1: (-0.25 * _TAU, 0.25 * _TAU),
-    Joint.SHOULDER_3: (-0.25 * _TAU, 0.25 * _TAU),
-    Joint.WRIST_1: (-0.25 * _TAU, 0.25 * _TAU),
-    Joint.WRIST_2: (-0.25 * _TAU, 0.25 * _TAU),
-    Joint.WRIST_3: (-0.25 * _TAU, 0.25 * _TAU),
+    Joint.SHOULDER_1: (math.radians(-90), math.radians(180)),
+    Joint.SHOULDER_3: (math.radians(-135), math.radians(135)),
+    Joint.WRIST_1: (math.radians(-135), math.radians(135)),
+    Joint.WRIST_2: (math.radians(-90), math.radians(90)),
+    Joint.WRIST_3: (math.radians(-90), math.radians(90)),
     # Gripper absent: open position varies per unit, found at runtime by _calibrate_gripper().
 }
 
 # Fixed open-to-close travel of the gripper (rad).
-GRIPPER_TRAVEL = 0.8037 * _TAU
+GRIPPER_TRAVEL = math.radians(290)
 
 # Gripper open-position calibration parameters.
 _GRIPPER_TORQUE_THRESHOLD = 0.5  # Nm


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes calibration and core arm control/telemetry math by introducing per-joint frame offsets and updating joint limits, which can affect commanded/observed positions and safety clipping if mis-specified.
> 
> **Overview**
> Adds a new `axol motor.set-zero-pos --guided` flow that walks all 7 arm joints, validates motion direction/magnitude to the expected end stop, and then commits each motor’s encoder zero (with improved Damiao power-cycle messaging). 
> 
> Updates `AxolArm` to treat public arm joint angles as *joint-frame* (`0` = rest) by introducing per-joint offsets derived from a new `closer_end_stop()` helper; positions reads add the offset, while motor commands (`set_position_velocity`, `motion_control`, `gravity_compensate`) subtract it before sending to hardware.
> 
> Adjusts joint limit definitions (including mirrored/asymmetric shoulder/elbow limits) and updates the bundled URDF joint limits accordingly, and documents the new calibration behavior in `README.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe47133ab97c4f0e6b1ecedc955cb2b6a5257f0e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->