### PR TITLE
update gravity comp

### DIFF
--- a/almond_axol/cli/teleop.py
+++ b/almond_axol/cli/teleop.py
@@ -29,10 +29,16 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[
         help="Disable the right arm.",
     )
     p.add_argument(
-        "--gripper-torque-limit",
+        "--left-gripper-torque-limit",
         type=float,
         default=1.0,
-        help="Max output torque (Nm) for the gripper in POSITION_FORCE mode (default: 1.0).",
+        help="Max output torque (Nm) for the left gripper in POSITION_FORCE mode (default: 1.0).",
+    )
+    p.add_argument(
+        "--right-gripper-torque-limit",
+        type=float,
+        default=1.0,
+        help="Max output torque (Nm) for the right gripper in POSITION_FORCE mode (default: 1.0).",
     )
     p.add_argument(
         "--stiffness",
@@ -73,7 +79,8 @@ def run(args: argparse.Namespace) -> None:
             args.robot,
             no_left=args.no_left,
             no_right=args.no_right,
-            gripper_torque_limit=args.gripper_torque_limit,
+            left_gripper_torque_limit=args.left_gripper_torque_limit,
+            right_gripper_torque_limit=args.right_gripper_torque_limit,
             stiffness=args.stiffness,
         )
     )
@@ -84,7 +91,8 @@ async def _run(
     *,
     no_left: bool = False,
     no_right: bool = False,
-    gripper_torque_limit: float = 1.0,
+    left_gripper_torque_limit: float = 1.0,
+    right_gripper_torque_limit: float = 1.0,
     stiffness: float = 0.0,
 ) -> None:
     from ..robot import Axol, Sim
@@ -100,8 +108,8 @@ async def _run(
         if no_right:
             kwargs["right_channel"] = None
         axol_config = AxolConfig(stiffness=stiffness)
-        axol_config.left.gripper.torque_limit = gripper_torque_limit
-        axol_config.right.gripper.torque_limit = gripper_torque_limit
+        axol_config.left.gripper.torque_limit = left_gripper_torque_limit
+        axol_config.right.gripper.torque_limit = right_gripper_torque_limit
         robot = Axol(config=axol_config, **kwargs)
     async with VRTeleop(robot) as teleop:
         await teleop.run()

--- a/almond_axol/robot/config.py
+++ b/almond_axol/robot/config.py
@@ -144,7 +144,7 @@ class ArmConfig:
             kp=50.0,
             kd=5.0,
             friction=_ZERO_FRICTION,
-            mass=1.50,
+            mass=1.0,
             com=(0.0, 0.0115864, -0.0302711),
             # Identified from step response (ζ ≈ 0.36 at kp=50, kd=5 → J ≈ 0.91).
             j_eff=0.91,
@@ -156,7 +156,7 @@ class ArmConfig:
             kp=45.0,
             kd=1.0,
             friction=_ZERO_FRICTION,
-            mass=2.75,
+            mass=3.50,
             com=(0.0, 0.00286547, -0.164964),
         )
     )
@@ -165,7 +165,7 @@ class ArmConfig:
             kp=40.0,
             kd=3.0,
             friction=_ZERO_FRICTION,
-            mass=0.80,
+            mass=0.9,
             com=(-0.0256064, 0.0, -0.072044),
         )
     )
@@ -174,7 +174,7 @@ class ArmConfig:
             kp=30.0,
             kd=1.0,
             friction=_ZERO_FRICTION,
-            mass=0.50,
+            mass=0.1,
             com=(0.0, 0.0, -0.0614121),
         )
     )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes robot inertial parameters used for gravity compensation and alters the `teleop` CLI interface, which can affect hardware behavior and user scripts.
> 
> **Overview**
> Updates the `axol teleop` CLI to accept separate `--left-gripper-torque-limit` and `--right-gripper-torque-limit` options (replacing the single shared flag) and wires them through to per-arm gripper configs.
> 
> Retunes default link masses in `ArmConfig` (shoulder_2, shoulder_3, elbow, wrist_1) to adjust gravity compensation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 375d83879aa7cf16fc586e4a3725aa05c483eb89. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->