### PR TITLE
update gravity comp

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,8 +332,8 @@ Holds both arms in gravity-compensation mode so you can move them by hand. Each 
 |---|---|
 | `--no-left` / `--no-right` | Disable an arm |
 | `--joints J1,J2,...` | Comma-separated joints to gravity-compensate (e.g. `WRIST_3` or `SHOULDER_1,ELBOW`). Other arm joints are held in place. Default: all 7 joints free. |
-| `--kd FLOAT` | Velocity damping coefficient on *free* joints (Nm·s/rad). Higher = less floppy. Default 0.5 |
-| `--rate FLOAT` | Control loop rate in Hz (default: 100) |
+| `--kd FLOAT` | Velocity damping coefficient on *free* joints (Nm·s/rad). Higher = less floppy. Default 0.25 |
+| `--rate FLOAT` | Control loop rate in Hz (default: 250) |
 | `--telemetry-rate FLOAT` | Joint telemetry poll rate in Hz (default: 500) |
 
 ```bash

--- a/almond_axol/cli/gravity_comp.py
+++ b/almond_axol/cli/gravity_comp.py
@@ -88,14 +88,14 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[
     p.add_argument(
         "--kd",
         type=float,
-        default=0.5,
-        help="Velocity damping coefficient on *free* joints (Nm·s/rad). Higher = less floppy. Default 0.5.",
+        default=0.25,
+        help="Velocity damping coefficient on *free* joints (Nm·s/rad). Higher = less floppy. Default 0.25.",
     )
     p.add_argument(
         "--rate",
         type=float,
-        default=100.0,
-        help="Control loop rate in Hz (default: 100).",
+        default=250.0,
+        help="Control loop rate in Hz (default: 250).",
     )
     p.add_argument(
         "--telemetry-rate",

--- a/almond_axol/robot/config.py
+++ b/almond_axol/robot/config.py
@@ -153,7 +153,7 @@ class ArmConfig:
             kp=45.0,
             kd=1.0,
             friction=_ZERO_FRICTION,
-            mass=3.50,
+            mass=3,
             com=(0.0, 0.00286547, -0.164964),
         )
     )

--- a/almond_axol/robot/config.py
+++ b/almond_axol/robot/config.py
@@ -131,11 +131,9 @@ class ArmConfig:
             kp=40.0,
             kd=5.0,
             friction=_ZERO_FRICTION,
-            mass=2.00,
+            mass=1.8,
             com=(0.0652231, 0.0, 0.0),
-            # Identified from step response (ζ ≈ 0.35 at kp=40, kd=5 → J ≈ 1.27).
             j_eff=1.27,
-            # Doubles effective kd past the firmware's 5 cap (ζ ≈ 0.35 → 0.70).
             kd_soft=5.0,
         )
     )
@@ -146,7 +144,6 @@ class ArmConfig:
             friction=_ZERO_FRICTION,
             mass=1.0,
             com=(0.0, 0.0115864, -0.0302711),
-            # Identified from step response (ζ ≈ 0.36 at kp=50, kd=5 → J ≈ 0.91).
             j_eff=0.91,
             kd_soft=5.0,
         )
@@ -165,7 +162,7 @@ class ArmConfig:
             kp=40.0,
             kd=3.0,
             friction=_ZERO_FRICTION,
-            mass=0.9,
+            mass=0.75,
             com=(-0.0256064, 0.0, -0.072044),
         )
     )
@@ -174,7 +171,7 @@ class ArmConfig:
             kp=30.0,
             kd=1.0,
             friction=_ZERO_FRICTION,
-            mass=0.1,
+            mass=0.25,
             com=(0.0, 0.0, -0.0614121),
         )
     )
@@ -183,8 +180,7 @@ class ArmConfig:
             kp=25.0,
             kd=1.0,
             friction=_ZERO_FRICTION,
-            mass=0.60,
-            # left_w1 CoM (right side has y sign-flipped — done by mirror_to_right).
+            mass=0.65,
             com=(0.0, 0.0285, -0.0285),
         )
     )
@@ -193,10 +189,7 @@ class ArmConfig:
             kp=25.0,
             kd=0.5,
             friction=_ZERO_FRICTION,
-            mass=0.65,
-            # left_w2 lumps wrist-3 segment with the gripper assembly (fixed
-            # joint): merged CAD inertial is 1.267 kg @ (-0.0285, 0, -0.08945);
-            # the mass is tuned in place.
+            mass=0.75,
             com=(-0.0285, 0.0, -0.089453),
         )
     )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Updates runtime defaults and inertial parameters that directly affect gravity-compensation torques and control-loop behavior, which could change how the arms feel/hold position on real hardware. Main risk is degraded compensation or unexpected motion if the new tuning is off.
> 
> **Overview**
> **Updates gravity-comp tuning defaults** by lowering the default damping `--kd` (0.5→0.25) and raising the default control loop `--rate` (100→250), with matching documentation updates.
> 
> **Retunes gravity-comp inertial parameters** by adjusting several `ArmConfig` per-joint `mass` defaults (shoulder/wrist/elbow), altering the gravity feedforward used during compensation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dddfa9811b61c6d3cb07e295b23d64da399b4f16. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->