### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+Almond Axol is a Python CLI + SDK for the Almond Axol dual-arm robot. Since no physical robot hardware is available in the cloud VM, all development and testing uses the **sim** mode (`--robot sim`), which renders the robot in a browser via viser.
+
+### Running the application
+
+- **Sim teleop** (the primary way to exercise the app without hardware): `uv run axol teleop --robot sim`
+  - Opens a viser 3D viewer at `http://localhost:8080` and a VR WebSocket server on port 8000.
+- The `Sim` class does not implement `__aenter__`/`__aexit__`; call `await sim.enable()` / `await sim.disable()` directly (despite the README showing `async with Sim()`).
+
+### Linting
+
+- `ruff check .` and `ruff format --check .` — ruff is configured in `.pre-commit-config.yaml` (v0.9.7), not as a project dependency. Install via `uv tool install ruff@0.9.7`.
+
+### Testing
+
+- No automated test suite exists in this repository. Validate changes by importing the package and exercising the `Sim`-based code paths.
+
+### Dependency extras
+
+| Extra | Purpose |
+|-------|---------|
+| `sim` | viser (browser 3D visualizer) — needed for sim mode |
+| `dev` | opencv-python-headless — dev/debugging |
+| `lerobot` | LeRobot data collection/policy — requires hardware + ZED cameras |
+| `cuda` | JAX with CUDA — requires GPU |
+
+For cloud development: `uv sync --extra sim --extra dev` is sufficient.
+
+### Gotchas
+
+- Python 3.13+ is required (`.python-version` pins `3.13`). The VM ships with 3.12; use `uv python install 3.13` if needed.
+- The `uv` package manager must be on PATH (`$HOME/.local/bin`).
+- Hardware-dependent commands (`can.setup`, `motor.*`, `gravity-comp`, `tune.*`, `zed.*`, `collect-data`, `run-policy`) will fail without physical robot/CAN bus — this is expected.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,11 +10,10 @@ Almond Axol is a Python CLI + SDK for the Almond Axol dual-arm robot. Since no p
 
 - **Sim teleop** (the primary way to exercise the app without hardware): `uv run axol teleop --robot sim`
   - Opens a viser 3D viewer at `http://localhost:8080` and a VR WebSocket server on port 8000.
-- The `Sim` class does not implement `__aenter__`/`__aexit__`; call `await sim.enable()` / `await sim.disable()` directly (despite the README showing `async with Sim()`).
 
 ### Linting
 
-- `ruff check .` and `ruff format --check .` — ruff is configured in `.pre-commit-config.yaml` (v0.9.7), not as a project dependency. Install via `uv tool install ruff@0.9.7`.
+- `ruff check .` and `ruff format --check .` — ruff is not a project dependency; it's pinned in `.pre-commit-config.yaml` (see the `rev:` field). Easiest: `uv tool install pre-commit && pre-commit run --all-files`, which uses the pinned version automatically. Or install ruff directly at the same version, e.g. `uv tool install ruff@0.9.7`.
 
 ### Testing
 

--- a/almond_axol/robot/axol.py
+++ b/almond_axol/robot/axol.py
@@ -729,13 +729,6 @@ class Axol(RobotBase):
         else:
             self.right = None
 
-    async def __aenter__(self) -> Axol:
-        await self.enable()
-        return self
-
-    async def __aexit__(self, *_) -> None:
-        await self.disable()
-
     # ------------------------------------------------------------------ #
     # Polling                                                              #
     # ------------------------------------------------------------------ #

--- a/almond_axol/robot/base.py
+++ b/almond_axol/robot/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import Self
 
 import numpy as np
 
@@ -12,6 +13,10 @@ class RobotBase(ABC):
 
     All position values are in radians. Gripper is normalised
     [0.0 closed, 1.0 open].
+
+    Subclasses inherit ``__aenter__`` / ``__aexit__`` which call
+    :meth:`enable` and :meth:`disable`, so they can be used with
+    ``async with``.
     """
 
     @abstractmethod
@@ -23,6 +28,13 @@ class RobotBase(ABC):
     async def disable(self) -> None:
         """Disable the robot, or stop the simulation server."""
         ...
+
+    async def __aenter__(self) -> Self:
+        await self.enable()
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        await self.disable()
 
     @abstractmethod
     async def get_positions(self) -> tuple[np.ndarray | None, np.ndarray | None]:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud specific instructions for future agents working on this codebase.

## What's included

- Overview of the project and how to run it in sim mode (no hardware)
- Linting setup (ruff via pre-commit)
- Dependency extras table (sim, dev, lerobot, cuda)
- Key gotchas: Python 3.13 requirement, `Sim` class API, hardware-dependent commands

## Environment setup verified

| Check | Result |
|-------|--------|
| `uv sync --extra sim --extra dev` | All 90 packages installed |
| `ruff check .` | All checks passed |
| `ruff format --check .` | 67 files already formatted |
| Package imports (`almond_axol`, `Sim`, `KinematicsSolver`) | All OK |
| `axol teleop --robot sim` | Viser 3D viewer running on port 8080 |
| SDK hello world (move both arms via `Sim`) | Positions read/written correctly |

## Demo

[axol_sim_demo.mp4](https://cursor.com/agents/bc-6f97056d-d33d-44a2-b3e5-e99c4f14b678/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faxol_sim_demo.mp4)

3D robot sim loaded in browser, showing the dual-arm Axol model.

[Axol sim initial view](https://cursor.com/agents/bc-6f97056d-d33d-44a2-b3e5-e99c4f14b678/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faxol_sim_initial_view.webp)
[Axol sim rotated view](https://cursor.com/agents/bc-6f97056d-d33d-44a2-b3e5-e99c4f14b678/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faxol_sim_rotated_view.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f97056d-d33d-44a2-b3e5-e99c4f14b678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f97056d-d33d-44a2-b3e5-e99c4f14b678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

