### PR TITLE
Decouple dataset capture from the teleop loop, with PTP-aligned ZED timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,9 @@ sudo axol zed.sync-clocks --role master --iface eth0   # upper computer
 sudo axol zed.sync-clocks --role slave  --iface eth0   # Jetson
 ```
 
-The command requires the `linuxptp` package (`ptp4l` + `phc2sys`); install with `sudo apt install linuxptp` on Debian/Ubuntu. Hardware timestamping is detected via `ethtool -T` and used automatically when both NICs expose a PTP Hardware Clock. If only software timestamping is available the daemon still runs but expect ~10–100 µs extra jitter, which is still well under one frame period.
+The command depends on the `linuxptp` package (`ptp4l` + `phc2sys`) and, for hardware-timestamping detection, `ethtool`. On Debian/Ubuntu these are auto-installed via `apt-get` on first run if missing — the command must already be invoked with `sudo` (or as root) for PTP to discipline the system clock, so the install runs with the same privileges. On non-apt systems, install them manually (`linuxptp`, `ethtool`) and rerun.
+
+Hardware timestamping is detected via `ethtool -T` and used automatically when both NICs expose a PTP Hardware Clock. If only software timestamping is available the daemon still runs but expect ~10–100 µs extra jitter, which is still well under one frame period.
 
 If you cannot install `linuxptp` for some reason, `chronyd` over the same direct link is a serviceable fallback — accuracy is worse (milliseconds rather than microseconds), so the DEBUG capture-skew logs will show wider spreads, but data will still align well enough for training.
 

--- a/README.md
+++ b/README.md
@@ -273,6 +273,31 @@ Downloads and installs the `pyzed` Python wheel matching the installed ZED SDK v
 axol zed.install
 ```
 
+### `zed.sync-clocks` — Time synchronization
+
+The Jetson sender and the upper-computer receiver run independent system clocks. The ZED SDK stamps every frame with the sender's `CLOCK_REALTIME` via `TIME_REFERENCE.IMAGE`; the receiver then converts that timestamp onto its own `perf_counter` so dataset rows record the moment of *capture*, not the moment of decode. None of that produces aligned data unless both machines agree on what time it is.
+
+`axol zed.sync-clocks` runs a PTP (Precision Time Protocol) daemon over the direct ethernet link, holding the two clocks to sub-millisecond agreement — well below one camera frame period at 60 fps. The startup pipeline-latency check in `ZedCamera.connect()` warns loudly if the mean `receive_perf - capture_perf` falls outside `[0, 200] ms`, which is the operator-visible "PTP isn't running" canary.
+
+| Flag | Description |
+|---|---|
+| `--role {master,slave}` | `master` on the long-lived upper computer (owns the dataset); `slave` on the Jetson sender |
+| `--iface IFACE` | Network interface carrying the direct link (e.g. `eth0`) |
+| `--transport {l2,udpv4}` | `l2` (raw ethernet, default) or `udpv4` |
+| `--timestamping {auto,hardware,software}` | `auto` (default) probes `ethtool -T` and prefers hardware |
+| `--log-level {DEBUG,INFO,WARNING,ERROR}` | Default: `INFO` |
+
+Two-terminal recipe (one per machine, both stay running for the whole session):
+
+```bash
+sudo axol zed.sync-clocks --role master --iface eth0   # upper computer
+sudo axol zed.sync-clocks --role slave  --iface eth0   # Jetson
+```
+
+The command requires the `linuxptp` package (`ptp4l` + `phc2sys`); install with `sudo apt install linuxptp` on Debian/Ubuntu. Hardware timestamping is detected via `ethtool -T` and used automatically when both NICs expose a PTP Hardware Clock. If only software timestamping is available the daemon still runs but expect ~10–100 µs extra jitter, which is still well under one frame period.
+
+If you cannot install `linuxptp` for some reason, `chronyd` over the same direct link is a serviceable fallback — accuracy is worse (milliseconds rather than microseconds), so the DEBUG capture-skew logs will show wider spreads, but data will still align well enough for training.
+
 ---
 
 ## Tuning

--- a/README.md
+++ b/README.md
@@ -218,7 +218,9 @@ axol collect-data --repo-id myorg/pick-place --task "Pick the red cube" --left-s
 | `TERMINATE_EPISODE` | Save the episode; headset enters `Saving` state until write completes |
 | `RERECORD_EPISODE` | Discard and retry |
 
-After each episode the robot automatically returns to its rest pose before the next take begins. If an existing dataset is found at `--root`, collection resumes from where it left off.
+After each episode the robot automatically returns to its rest pose before the next take begins. If an existing dataset is found at `--root`, collection resumes from where it left off; conversely, if no episodes were saved before exit the empty dataset directory is removed on shutdown so an aborted session does not leave a half-initialized dataset on disk.
+
+Dataset frame capture runs on a dedicated thread decoupled from the teleop control loop. Teleop ticks at `--teleop-hz` and only ever touches joint state; the capture thread ticks at `--fps`, blocks on `ZedCamera.read_at_or_after(T_n)` per camera so every recorded frame is sender-clock-aligned with the joint sample taken at `T_n`, and writes the dataset row. This keeps camera reads, image conversion, and `dataset.add_frame()` off the hot control loop, and produces datasets whose camera/joint pairing matches the sender's exposure timeline rather than the receiver's decode timeline. Both clocks must agree — make sure [`zed.sync-clocks`](#zedsync-clocks--time-synchronization) is running on both machines.
 
 ---
 
@@ -1036,6 +1038,14 @@ cam.connect()
 frame = cam.read_latest()   # shape (H, W, 3), non-blocking, returns most recent frame
 cam.disconnect()
 ```
+
+Each grabbed frame carries two timestamps on the receiver's `perf_counter` clock: `capture_perf_ts` (when the *sender* exposed the frame, derived from `TIME_REFERENCE.IMAGE`) and `receive_perf_ts` (when this process decoded it). Cross-clock alignment requires PTP — see [`zed.sync-clocks`](#zedsync-clocks--time-synchronization). The receive-vs-capture skew is sampled on `connect()` and a warning is logged if the mean falls outside `[0, 200] ms`.
+
+| Method | Description |
+|---|---|
+| `read_latest(max_age_ms=500)` | Most recent frame, non-blocking; raises `TimeoutError` if it is older than `max_age_ms`. |
+| `read_latest_with_ts()` | `(frame, capture_perf_ts, receive_perf_ts)` for the most recent frame. |
+| `read_at_or_after(target_capture_perf_ts, timeout_ms=500)` | Block until a frame with `capture_perf_ts >= target` is available. Used by `collect-data` to align every camera and the joint sample on the same sender-side timeline. |
 
 **`ZedCameraConfig` fields**
 

--- a/README.md
+++ b/README.md
@@ -850,7 +850,7 @@ asyncio.run(main())
 | `overhead_port` | `30000` | Streaming port for the overhead camera |
 | `left_arm_port` | `30002` | Streaming port for the left-arm camera |
 | `right_arm_port` | `30004` | Streaming port for the right-arm camera |
-| `resolution` | `HD1080` | `sl.RESOLUTION`: `HD1200`, `HD1080`, or `SVGA` |
+| `resolution` | `SVGA` | `sl.RESOLUTION`: `HD1200`, `HD1080`, or `SVGA` |
 | `fps` | `60` | Capture frame rate for all cameras |
 | `bitrate` | `8000` kbps | HEVC encoding bitrate |
 

--- a/README.md
+++ b/README.md
@@ -290,11 +290,11 @@ The Jetson sender and the upper-computer receiver run independent system clocks.
 Two-terminal recipe (one per machine, both stay running for the whole session):
 
 ```bash
-sudo axol zed.sync-clocks --role master --iface eth0   # upper computer
-sudo axol zed.sync-clocks --role slave  --iface eth0   # Jetson
+axol zed.sync-clocks --role master --iface eth0   # upper computer
+axol zed.sync-clocks --role slave  --iface eth0   # Jetson
 ```
 
-The command depends on the `linuxptp` package (`ptp4l` + `phc2sys`) and, for hardware-timestamping detection, `ethtool`. On Debian/Ubuntu these are auto-installed via `apt-get` on first run if missing — the command must already be invoked with `sudo` (or as root) for PTP to discipline the system clock, so the install runs with the same privileges. On non-apt systems, install them manually (`linuxptp`, `ethtool`) and rerun.
+The privileged subprocesses (`ptp4l`, `phc2sys`, and the apt-get auto-install fallback) are escalated inline via `sudo`, so you do **not** run `axol` itself as root. Sudo will prompt for a password the first time and reuse cached credentials for the rest of the session. The command depends on the `linuxptp` package (`ptp4l` + `phc2sys`) and, for hardware-timestamping detection, `ethtool`; on Debian/Ubuntu these are auto-installed if missing. On non-apt systems install them manually (`linuxptp`, `ethtool`) and rerun.
 
 Hardware timestamping is detected via `ethtool -T` and used automatically when both NICs expose a PTP Hardware Clock. If only software timestamping is available the daemon still runs but expect ~10–100 µs extra jitter, which is still well under one frame period.
 

--- a/almond_axol/cli/__init__.py
+++ b/almond_axol/cli/__init__.py
@@ -10,6 +10,7 @@ from .motor import set_can_id, set_zero_pos
 from .tune import friction, pid, repeatability
 from .zed import install as zed_install
 from .zed import stream as zed_stream
+from .zed import sync_clocks as zed_sync_clocks
 
 
 def main() -> None:
@@ -26,6 +27,7 @@ def main() -> None:
     run_policy.add_parser(subparsers)
     teleop.add_parser(subparsers)
     zed_stream.add_parser(subparsers)
+    zed_sync_clocks.add_parser(subparsers)
     zed_install.add_parser(subparsers)
     pid.add_parser(subparsers)
     friction.add_parser(subparsers)

--- a/almond_axol/cli/collect_data.py
+++ b/almond_axol/cli/collect_data.py
@@ -201,6 +201,8 @@ class _CaptureThread(threading.Thread):
             act_frame = build_dataset_frame(
                 self.dataset.features, snap.action, prefix=ACTION
             )
+            if self.stop_event.is_set():
+                return
             self.dataset.add_frame({**obs_frame, **act_frame, "task": self.task})
 
             if self.rerun_ip:
@@ -552,11 +554,7 @@ def _run(
 
             if capture is not None:
                 capture.stop_event.set()
-                capture.join(timeout=2.0)
-                if capture.is_alive():
-                    _logger.warning(
-                        "Capture thread did not stop within 2.0s; continuing."
-                    )
+                capture.join()
                 capture = None
 
             log_say("Returning to rest pose.")
@@ -595,7 +593,7 @@ def _run(
     finally:
         if capture is not None:
             capture.stop_event.set()
-            capture.join(timeout=2.0)
+            capture.join()
 
         log_say("Stopping.")
 

--- a/almond_axol/cli/collect_data.py
+++ b/almond_axol/cli/collect_data.py
@@ -26,6 +26,7 @@ off the hot 120 Hz control loop.
 
 import argparse
 import logging
+import shutil
 import socket
 import threading
 import time
@@ -599,9 +600,22 @@ def _run(
         if capture is not None:
             capture.stop_event.set()
             capture.join(timeout=2.0)
+
         log_say("Stopping.")
+
         robot.disconnect()
         teleop.disconnect()
+
         dataset.finalize()
+
         if push_to_hub and episodes_recorded > 0:
             dataset.push_to_hub()
+
+        if not is_complete and episodes_recorded == 0 and dataset_root.exists():
+            try:
+                shutil.rmtree(dataset_root)
+                log_say(f"No episodes saved — removed empty dataset at {dataset_root}.")
+            except OSError as exc:
+                _logger.warning(
+                    "Failed to remove empty dataset at %s: %s", dataset_root, exc
+                )

--- a/almond_axol/cli/collect_data.py
+++ b/almond_axol/cli/collect_data.py
@@ -32,6 +32,8 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable
 
+from ..shared import ARM_JOINTS
+
 if TYPE_CHECKING:
     from lerobot.datasets.lerobot_dataset import LeRobotDataset
     from lerobot.types import RobotAction, RobotObservation
@@ -216,8 +218,6 @@ class _CaptureThread(threading.Thread):
                 )
 
             tick += 1
-
-from ..shared import ARM_JOINTS
 
 
 def _parse_stiffness(value: str) -> float | tuple[float, ...]:
@@ -475,6 +475,9 @@ def _run(
             repo_id=repo_id,
             root=str(dataset_root),
             image_writer_threads=4,
+            streaming_encoding=True,
+            encoder_threads=4,
+            vcodec="auto",
         )
     else:
         action_features = hw_to_dataset_features(robot.action_features, ACTION)
@@ -487,6 +490,9 @@ def _run(
             robot_type=robot.name,
             use_videos=True,
             image_writer_threads=4,
+            streaming_encoding=True,
+            encoder_threads=4,
+            vcodec="auto",
         )
     pos_l, pos_r = robot.positions
     teleop.connect(q_start_left=pos_l, q_start_right=pos_r)

--- a/almond_axol/cli/collect_data.py
+++ b/almond_axol/cli/collect_data.py
@@ -11,12 +11,211 @@ While saving, the VR headset is pushed into the SAVING state so recording
 controls are blocked until save_episode() completes.
 
 Recording continues until Ctrl+C.
+
+Capture is decoupled from teleop
+--------------------------------
+
+The teleop loop runs at ``--teleop-hz`` and produces a fresh
+``(joint_obs, act_processed, t0)`` snapshot every iteration via
+``_SnapshotPublisher``. A separate ``_CaptureThread`` ticks at ``--fps`` and,
+for each tick, blocks on ``ZedCamera.read_at_or_after(T_n)`` so every
+recorded frame uses sender-clock-aligned camera data plus the latest joint
+snapshot. This keeps camera reads, image conversion, and ``dataset.add_frame``
+off the hot 120 Hz control loop.
 """
 
 import argparse
 import logging
 import socket
+import threading
 import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable
+
+if TYPE_CHECKING:
+    from lerobot.datasets.lerobot_dataset import LeRobotDataset
+    from lerobot.types import RobotAction, RobotObservation
+
+    from ..lerobot.robot.robot_axol import AxolRobot
+
+_logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _Snapshot:
+    """Atomic ``(joint_obs, action, capture_ts)`` bundle from one teleop tick.
+
+    Stored references — the producer always builds fresh dicts per tick, so
+    the capture thread observes a consistent slice without copying.
+    """
+
+    joint_obs: "RobotObservation"
+    action: "RobotAction"
+    ts: float
+
+
+class _SnapshotPublisher:
+    """Single-slot atomic publisher: teleop loop writes, capture thread reads.
+
+    The lock protects the slot itself, not the contained dicts — those are
+    rebuilt by the teleop loop on every tick and never mutated in place.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._latest: _Snapshot | None = None
+        self._first_event = threading.Event()
+
+    def publish(
+        self,
+        joint_obs: "RobotObservation",
+        action: "RobotAction",
+        ts: float,
+    ) -> None:
+        snap = _Snapshot(joint_obs=joint_obs, action=action, ts=ts)
+        with self._lock:
+            self._latest = snap
+        self._first_event.set()
+
+    def latest(self) -> _Snapshot | None:
+        with self._lock:
+            return self._latest
+
+    def wait_for_first(self, timeout: float) -> bool:
+        return self._first_event.wait(timeout=timeout)
+
+
+class _CaptureThread(threading.Thread):
+    """Captures dataset frames at ``fps`` Hz, decoupled from the teleop loop.
+
+    Per tick the thread:
+
+    1. Sleeps until ``T_n = recording_start + n * frame_interval``.
+    2. For every camera, calls ``read_at_or_after(T_n)`` so the frame's
+       sender-clock capture time is at or after the tick boundary.
+    3. Snapshots ``publisher.latest()`` for the matching joint sample +
+       action that was actually commanded around the same instant.
+    4. Runs ``robot_obs_proc`` on the combined obs and appends the dataset
+       row.
+
+    On per-camera read timeout / failure the thread reuses the previous good
+    frame for that camera (use-cached policy) and logs at DEBUG.
+    """
+
+    def __init__(
+        self,
+        *,
+        publisher: _SnapshotPublisher,
+        robot: "AxolRobot",
+        dataset: "LeRobotDataset",
+        robot_obs_proc: Callable[[Any], Any],
+        fps: int,
+        task: str,
+        rerun_ip: str | None,
+    ) -> None:
+        super().__init__(name="axol-capture", daemon=True)
+        self.publisher = publisher
+        self.robot = robot
+        self.dataset = dataset
+        self.robot_obs_proc = robot_obs_proc
+        self.fps = fps
+        self.task = task
+        self.rerun_ip = rerun_ip
+        self.stop_event = threading.Event()
+
+    def run(self) -> None:
+        from lerobot.utils.constants import ACTION, OBS_STR
+        from lerobot.utils.feature_utils import build_dataset_frame
+        from lerobot.utils.visualization_utils import log_rerun_data
+
+        if not self.publisher.wait_for_first(timeout=5.0):
+            _logger.warning(
+                "Capture thread saw no publisher snapshot within 5s; exiting."
+            )
+            return
+        if self.stop_event.is_set():
+            return
+
+        frame_interval = 1.0 / self.fps
+        timeout_ms = int(2 * frame_interval * 1000 + 200)
+        recording_start = time.perf_counter()
+        last_frames: dict[str, tuple[Any, float, float]] = {}
+        tick = 0
+
+        while not self.stop_event.is_set():
+            target_perf_ts = recording_start + tick * frame_interval
+
+            wait_s = target_perf_ts - time.perf_counter()
+            if wait_s > 0 and self.stop_event.wait(timeout=wait_s):
+                return
+
+            frames: dict[str, tuple[Any, float, float]] = {}
+            skip_tick = False
+            for cam_key, cam in self.robot.cameras.items():
+                try:
+                    frame, cap_ts, recv_ts = cam.read_at_or_after(  # type: ignore[attr-defined]
+                        target_perf_ts, timeout_ms=timeout_ms
+                    )
+                except (TimeoutError, RuntimeError) as exc:
+                    cached = last_frames.get(cam_key)
+                    if cached is None:
+                        _logger.debug(
+                            "Capture tick %d: %s read failed (%s) and no "
+                            "cached frame; skipping tick.",
+                            tick,
+                            cam_key,
+                            exc,
+                        )
+                        skip_tick = True
+                        break
+                    _logger.debug(
+                        "Capture tick %d: %s read failed (%s); reusing cached frame.",
+                        tick,
+                        cam_key,
+                        exc,
+                    )
+                    frame, cap_ts, recv_ts = cached
+                frames[cam_key] = (frame, cap_ts, recv_ts)
+                last_frames[cam_key] = (frame, cap_ts, recv_ts)
+
+            if skip_tick:
+                tick += 1
+                continue
+
+            snap = self.publisher.latest()
+            if snap is None:
+                tick += 1
+                continue
+
+            obs: dict[str, Any] = dict(snap.joint_obs)
+            for cam_key, (frame, _cap_ts, _recv_ts) in frames.items():
+                obs[cam_key] = frame
+            obs_processed = self.robot_obs_proc(obs)
+
+            obs_frame = build_dataset_frame(
+                self.dataset.features, obs_processed, prefix=OBS_STR
+            )
+            act_frame = build_dataset_frame(
+                self.dataset.features, snap.action, prefix=ACTION
+            )
+            self.dataset.add_frame({**obs_frame, **act_frame, "task": self.task})
+
+            if self.rerun_ip:
+                log_rerun_data(observation=obs_processed, action=snap.action)
+
+            if _logger.isEnabledFor(logging.DEBUG) and tick % 30 == 0:
+                cam_skews = ", ".join(
+                    f"{k}: cap-T={1e3 * (cap_ts - target_perf_ts):+.1f}ms"
+                    for k, (_, cap_ts, _) in frames.items()
+                )
+                _logger.debug(
+                    "Capture tick %d skews — %s, T-snap.ts=%+.1fms",
+                    tick,
+                    cam_skews,
+                    1e3 * (target_perf_ts - snap.ts),
+                )
+
+            tick += 1
 
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
@@ -134,11 +333,10 @@ def _run(
     from lerobot.teleoperators.utils import TeleopEvents
     from lerobot.utils.constants import ACTION, HF_LEROBOT_HOME, OBS_STR
     from lerobot.utils.feature_utils import (
-        build_dataset_frame,
         hw_to_dataset_features,
     )
     from lerobot.utils.utils import log_say
-    from lerobot.utils.visualization_utils import init_rerun, log_rerun_data
+    from lerobot.utils.visualization_utils import init_rerun
 
     from ..lerobot.camera.configuration_zed import ZedCameraConfig
     from ..lerobot.robot.config_axol import AxolRobotConfig
@@ -221,7 +419,8 @@ def _run(
     episodes_recorded = 0
     episode_idx = dataset.num_episodes  # global index; increments as episodes are saved
     teleop_interval = 1.0 / teleop_hz
-    frame_interval = 1.0 / fps
+    publisher = _SnapshotPublisher()
+    capture: _CaptureThread | None = None
     try:
         while True:
             log_say(
@@ -230,7 +429,6 @@ def _run(
             dataset.clear_episode_buffer()
             recording = False
             rerecord = False
-            last_frame_t = 0.0  # timestamp of the last dataset frame written
 
             while True:
                 t0 = time.perf_counter()
@@ -242,29 +440,25 @@ def _run(
                 act_processed = teleop_action_proc((act, joint_obs))
                 robot.send_action(robot_action_proc((act_processed, joint_obs)))
 
+                # Publish every iteration so the capture thread always has a
+                # fresh snapshot (and a non-empty publisher) when it starts.
+                publisher.publish(joint_obs, act_processed, t0)
+
                 events = teleop.get_teleop_events()
 
                 if events.get("start_recording") and not recording:
                     recording = True
-                    last_frame_t = (
-                        t0 - frame_interval
-                    )  # align first frame to recording start
+                    capture = _CaptureThread(
+                        publisher=publisher,
+                        robot=robot,
+                        dataset=dataset,
+                        robot_obs_proc=robot_obs_proc,
+                        fps=fps,
+                        task=task,
+                        rerun_ip=rerun_ip,
+                    )
+                    capture.start()
                     log_say("Recording started.")
-
-                # Dataset frame at --fps rate: read cameras + process images here only.
-                if recording and (t0 - last_frame_t) >= frame_interval:
-                    last_frame_t += frame_interval
-                    obs = robot.get_observation()
-                    obs_processed = robot_obs_proc(obs)
-                    obs_frame = build_dataset_frame(
-                        dataset.features, obs_processed, prefix=OBS_STR
-                    )
-                    act_frame = build_dataset_frame(
-                        dataset.features, act_processed, prefix=ACTION
-                    )
-                    dataset.add_frame({**obs_frame, **act_frame, "task": task})
-                    if rerun_ip:
-                        log_rerun_data(observation=obs_processed, action=act_processed)
 
                 if events[TeleopEvents.TERMINATE_EPISODE]:
                     teleop.send_feedback_state(VRState.SAVING)
@@ -274,6 +468,15 @@ def _run(
                     break
 
                 time.sleep(max(0.0, teleop_interval - (time.perf_counter() - t0)))
+
+            if capture is not None:
+                capture.stop_event.set()
+                capture.join(timeout=2.0)
+                if capture.is_alive():
+                    _logger.warning(
+                        "Capture thread did not stop within 2.0s; continuing."
+                    )
+                capture = None
 
             # Return to rest pose before the next episode so the operator
             # starts each take from a consistent configuration.
@@ -311,6 +514,9 @@ def _run(
         teleop.send_feedback_error()
         raise
     finally:
+        if capture is not None:
+            capture.stop_event.set()
+            capture.join(timeout=2.0)
         log_say("Stopping.")
         robot.disconnect()
         teleop.disconnect()

--- a/almond_axol/cli/collect_data.py
+++ b/almond_axol/cli/collect_data.py
@@ -500,7 +500,7 @@ def _run(
     teleop_action_proc, robot_action_proc, robot_obs_proc = make_default_processors()
 
     episodes_recorded = 0
-    episode_idx = dataset.num_episodes  # global index; increments as episodes are saved
+    episode_idx = dataset.num_episodes
     teleop_interval = 1.0 / teleop_hz
     publisher = _SnapshotPublisher()
     capture: _CaptureThread | None = None
@@ -516,15 +516,13 @@ def _run(
             while True:
                 t0 = time.perf_counter()
 
-                # Joints-only observation — no camera copies at teleop rate.
+                # Joints-only observation — no camera reads on the hot loop.
                 joint_obs = robot.get_joint_observation()
                 teleop.send_feedback(joint_obs)
                 act = teleop.get_action()
                 act_processed = teleop_action_proc((act, joint_obs))
                 robot.send_action(robot_action_proc((act_processed, joint_obs)))
 
-                # Publish every iteration so the capture thread always has a
-                # fresh snapshot (and a non-empty publisher) when it starts.
                 publisher.publish(joint_obs, act_processed, t0)
 
                 events = teleop.get_teleop_events()
@@ -561,8 +559,6 @@ def _run(
                     )
                 capture = None
 
-            # Return to rest pose before the next episode so the operator
-            # starts each take from a consistent configuration.
             log_say("Returning to rest pose.")
             teleop.request_reset()
             reset_deadline = time.perf_counter() + 30.0
@@ -572,7 +568,7 @@ def _run(
                 act = teleop.get_action()
                 robot.send_action(robot_action_proc((act, joint_obs)))
                 time.sleep(max(0.0, teleop_interval - (time.perf_counter() - t0)))
-            # Drain any VR events that fired during the reset move.
+            # Drain VR events fired during the reset move.
             teleop.get_teleop_events()
 
             if rerecord:

--- a/almond_axol/cli/run_policy.py
+++ b/almond_axol/cli/run_policy.py
@@ -238,7 +238,7 @@ def _run(
             while time.perf_counter() < deadline:
                 t0 = time.perf_counter()
 
-                # NOTE: training datasets collected by `axol collect-data` use
+                # TODO: training datasets collected by `axol collect-data` use
                 # sender-clock alignment via `ZedCamera.read_at_or_after(T_n)`
                 # so each row pairs the joint sample taken at T_n with camera
                 # frames whose exposure time is at or after T_n. This loop

--- a/almond_axol/cli/run_policy.py
+++ b/almond_axol/cli/run_policy.py
@@ -238,15 +238,10 @@ def _run(
             while time.perf_counter() < deadline:
                 t0 = time.perf_counter()
 
-                # TODO: training datasets collected by `axol collect-data` use
-                # sender-clock alignment via `ZedCamera.read_at_or_after(T_n)`
-                # so each row pairs the joint sample taken at T_n with camera
-                # frames whose exposure time is at or after T_n. This loop
-                # still uses `robot.get_observation()` which calls
-                # `cam.read_latest()` — that introduces a ~1 frame-period skew
-                # vs training. To match training exactly, swap in
-                # `ZedCamera.read_at_or_after(t0)` here. Tracking as a
-                # follow-up to keep this PR scoped to data collection.
+                # TODO: swap in `ZedCamera.read_at_or_after(t0)` so inference
+                # uses the same sender-clock-aligned camera/joint pairing as
+                # the training data — `read_latest()` introduces a ~1 frame
+                # skew vs training.
                 obs = robot.get_observation()
                 obs_processed = robot_obs_proc(obs)
 

--- a/almond_axol/cli/run_policy.py
+++ b/almond_axol/cli/run_policy.py
@@ -238,6 +238,15 @@ def _run(
             while time.perf_counter() < deadline:
                 t0 = time.perf_counter()
 
+                # NOTE: training datasets collected by `axol collect-data` use
+                # sender-clock alignment via `ZedCamera.read_at_or_after(T_n)`
+                # so each row pairs the joint sample taken at T_n with camera
+                # frames whose exposure time is at or after T_n. This loop
+                # still uses `robot.get_observation()` which calls
+                # `cam.read_latest()` — that introduces a ~1 frame-period skew
+                # vs training. To match training exactly, swap in
+                # `ZedCamera.read_at_or_after(t0)` here. Tracking as a
+                # follow-up to keep this PR scoped to data collection.
                 obs = robot.get_observation()
                 obs_processed = robot_obs_proc(obs)
 

--- a/almond_axol/cli/zed/sync_clocks.py
+++ b/almond_axol/cli/zed/sync_clocks.py
@@ -19,12 +19,19 @@ Typical operator workflow (one terminal per machine):
 
 Both processes stay running in the foreground for the duration of any
 collection session.
+
+Dependencies (`ptp4l`, `phc2sys`, optionally `ethtool`) are auto-installed
+via `apt-get` on Debian/Ubuntu if missing. Because the command must already
+be run with sudo (or as root) for PTP to discipline the system clock, the
+install runs with the same privileges. On non-apt systems install them
+manually (`linuxptp` for ptp4l/phc2sys, plus `ethtool`).
 """
 
 from __future__ import annotations
 
 import argparse
 import logging
+import os
 import re
 import shutil
 import signal
@@ -40,6 +47,14 @@ _OFFSET_RE = re.compile(
     r"master offset\s+(?P<offset>-?\d+)\b.*?freq\s+(?P<freq>-?\d+)",
     re.IGNORECASE,
 )
+
+# Map executable name -> apt package that provides it. Used by
+# `_ensure_executable` to auto-install missing dependencies on Debian/Ubuntu.
+_APT_PACKAGES = {
+    "ptp4l": "linuxptp",
+    "phc2sys": "linuxptp",
+    "ethtool": "ethtool",
+}
 
 
 def add_parser(subparsers) -> None:  # type: ignore[type-arg]
@@ -106,8 +121,8 @@ def run(args: argparse.Namespace) -> None:
 
 
 def _run(*, role: str, iface: str, transport: str, timestamping: str) -> None:
-    _require_executable("ptp4l")
-    _require_executable("phc2sys")
+    _ensure_executable("ptp4l", required=True)
+    _ensure_executable("phc2sys", required=True)
 
     if not Path(f"/sys/class/net/{iface}").exists():
         raise SystemExit(
@@ -196,12 +211,56 @@ def _run(*, role: str, iface: str, transport: str, timestamping: str) -> None:
             t.join(timeout=2.0)
 
 
-def _require_executable(name: str) -> None:
-    if shutil.which(name) is None:
-        raise SystemExit(
-            f"error: `{name}` not found on PATH. Install the `linuxptp` package "
-            f"(e.g. `sudo apt install linuxptp`) and rerun."
+def _ensure_executable(name: str, *, required: bool) -> bool:
+    """Return True if ``name`` is on PATH, installing it via apt if missing.
+
+    Auto-install only runs on systems where ``apt-get`` is available
+    (Debian/Ubuntu). When ``required`` is True and the executable cannot be
+    made available, raises ``SystemExit`` with a manual-install hint;
+    otherwise returns False and the caller is expected to degrade gracefully.
+    """
+    if shutil.which(name) is not None:
+        return True
+
+    pkg = _APT_PACKAGES.get(name)
+    if pkg is not None and shutil.which("apt-get") is not None:
+        _logger.info(
+            "`%s` not found on PATH — installing the `%s` apt package ...",
+            name,
+            pkg,
         )
+        # Prepend `sudo` only when we're not already root so this also works
+        # in container/CI environments that run as root without sudo installed.
+        prefix = [] if os.geteuid() == 0 else ["sudo"]
+        cmd = [
+            *prefix,
+            "apt-get",
+            "install",
+            "-y",
+            "--no-install-recommends",
+            pkg,
+        ]
+        env = {**os.environ, "DEBIAN_FRONTEND": "noninteractive"}
+        try:
+            subprocess.run(cmd, check=True, env=env)
+        except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+            _logger.warning("Auto-install of `%s` failed: %s", pkg, exc)
+        else:
+            if shutil.which(name) is not None:
+                _logger.info("Installed `%s` (provides `%s`).", pkg, name)
+                return True
+
+    if required:
+        hint = (
+            f"sudo apt install {pkg}"
+            if pkg is not None
+            else f"install `{name}` and rerun"
+        )
+        raise SystemExit(
+            f"error: `{name}` not found on PATH and auto-install was "
+            f"unavailable or failed. Try manually: {hint}."
+        )
+    return False
 
 
 def _resolve_timestamping(iface: str, mode: str) -> str:
@@ -224,9 +283,10 @@ def _resolve_timestamping(iface: str, mode: str) -> str:
 
 
 def _probe_hardware_timestamping(iface: str) -> bool:
-    if shutil.which("ethtool") is None:
+    if not _ensure_executable("ethtool", required=False):
         _logger.warning(
-            "ethtool not installed; cannot probe hardware timestamping for %s.",
+            "ethtool not installed and auto-install failed; cannot probe "
+            "hardware timestamping for %s.",
             iface,
         )
         return False

--- a/almond_axol/cli/zed/sync_clocks.py
+++ b/almond_axol/cli/zed/sync_clocks.py
@@ -14,17 +14,18 @@ this command exists to deliver.
 
 Typical operator workflow (one terminal per machine):
 
-    sudo axol zed.sync-clocks --role master --iface eth0   # upper computer
-    sudo axol zed.sync-clocks --role slave  --iface eth0   # Jetson
+    axol zed.sync-clocks --role master --iface eth0   # upper computer
+    axol zed.sync-clocks --role slave  --iface eth0   # Jetson
 
 Both processes stay running in the foreground for the duration of any
 collection session.
 
-Dependencies (`ptp4l`, `phc2sys`, optionally `ethtool`) are auto-installed
-via `apt-get` on Debian/Ubuntu if missing. Because the command must already
-be run with sudo (or as root) for PTP to discipline the system clock, the
-install runs with the same privileges. On non-apt systems install them
-manually (`linuxptp` for ptp4l/phc2sys, plus `ethtool`).
+The privileged subprocesses (`ptp4l`, `phc2sys`, and the apt-get auto-install
+fallback) are escalated inline via `sudo`, so the `axol` invocation itself
+does not need to be run as root. Sudo will prompt for a password on first
+escalation and reuse cached credentials for the rest of the session. On
+non-apt systems install `linuxptp` (for ptp4l/phc2sys) and `ethtool`
+manually before running this command.
 """
 
 from __future__ import annotations
@@ -139,16 +140,20 @@ def _run(*, role: str, iface: str, transport: str, timestamping: str) -> None:
         timestamping_mode,
     )
 
-    ptp4l_cmd = _build_ptp4l_cmd(
-        iface=iface,
-        role=role,
-        transport=transport,
-        timestamping=timestamping_mode,
+    ptp4l_cmd = _with_sudo(
+        _build_ptp4l_cmd(
+            iface=iface,
+            role=role,
+            transport=transport,
+            timestamping=timestamping_mode,
+        )
     )
-    phc2sys_cmd = _build_phc2sys_cmd(
-        iface=iface,
-        role=role,
-        timestamping=timestamping_mode,
+    phc2sys_cmd = _with_sudo(
+        _build_phc2sys_cmd(
+            iface=iface,
+            role=role,
+            timestamping=timestamping_mode,
+        )
     )
 
     _logger.info("ptp4l:   %s", " ".join(ptp4l_cmd))
@@ -211,6 +216,17 @@ def _run(*, role: str, iface: str, transport: str, timestamping: str) -> None:
             t.join(timeout=2.0)
 
 
+def _with_sudo(cmd: list[str]) -> list[str]:
+    """Prepend `sudo` when the current process is not already root.
+
+    Sudo caches credentials per-tty for ~5 minutes by default, so back-to-back
+    privileged subprocesses (ptp4l + phc2sys) only prompt for a password once.
+    """
+    if os.geteuid() == 0:
+        return cmd
+    return ["sudo", *cmd]
+
+
 def _ensure_executable(name: str, *, required: bool) -> bool:
     """Return True if ``name`` is on PATH, installing it via apt if missing.
 
@@ -229,17 +245,7 @@ def _ensure_executable(name: str, *, required: bool) -> bool:
             name,
             pkg,
         )
-        # Prepend `sudo` only when we're not already root so this also works
-        # in container/CI environments that run as root without sudo installed.
-        prefix = [] if os.geteuid() == 0 else ["sudo"]
-        cmd = [
-            *prefix,
-            "apt-get",
-            "install",
-            "-y",
-            "--no-install-recommends",
-            pkg,
-        ]
+        cmd = _with_sudo(["apt-get", "install", "-y", "--no-install-recommends", pkg])
         env = {**os.environ, "DEBIAN_FRONTEND": "noninteractive"}
         try:
             subprocess.run(cmd, check=True, env=env)

--- a/almond_axol/cli/zed/sync_clocks.py
+++ b/almond_axol/cli/zed/sync_clocks.py
@@ -1,0 +1,358 @@
+"""
+axol zed.sync-clocks
+
+Run a PTP (Precision Time Protocol) daemon over the direct ethernet link
+between the Jetson sender and the upper-computer receiver so both machines'
+``CLOCK_REALTIME`` clocks stay aligned to sub-millisecond accuracy.
+
+The ZED SDK stamps every frame on the *sender's* ``CLOCK_REALTIME`` via
+``TIME_REFERENCE.IMAGE``. The receiver later converts that wall-clock stamp
+into its own monotonic ``perf_counter`` so the dataset row's "frame time"
+reflects the moment of capture rather than the moment of decode. None of
+that works unless both machines agree on what time it is — which is what
+this command exists to deliver.
+
+Typical operator workflow (one terminal per machine):
+
+    sudo axol zed.sync-clocks --role master --iface eth0   # upper computer
+    sudo axol zed.sync-clocks --role slave  --iface eth0   # Jetson
+
+Both processes stay running in the foreground for the duration of any
+collection session.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+_logger = logging.getLogger(__name__)
+
+_OFFSET_RE = re.compile(
+    r"master offset\s+(?P<offset>-?\d+)\b.*?freq\s+(?P<freq>-?\d+)",
+    re.IGNORECASE,
+)
+
+
+def add_parser(subparsers) -> None:  # type: ignore[type-arg]
+    p = subparsers.add_parser(
+        "zed.sync-clocks",
+        help=(
+            "Synchronize sender and receiver CLOCK_REALTIME via PTP over the "
+            "direct ethernet link (required for accurate ZED frame timestamps)."
+        ),
+    )
+    p.add_argument(
+        "--role",
+        required=True,
+        choices=["master", "slave"],
+        help=(
+            "PTP role for this machine. The upper computer (long-lived "
+            "receiver) should be `master`; the Jetson sender should be `slave`."
+        ),
+    )
+    p.add_argument(
+        "--iface",
+        required=True,
+        metavar="IFACE",
+        help="Network interface carrying the direct link (e.g. eth0).",
+    )
+    p.add_argument(
+        "--transport",
+        default="l2",
+        choices=["l2", "udpv4"],
+        help=(
+            "PTP transport. `l2` (raw ethernet, default) is lower latency; "
+            "`udpv4` is useful if a switch in between filters PTP ethertype."
+        ),
+    )
+    p.add_argument(
+        "--timestamping",
+        default="auto",
+        choices=["auto", "hardware", "software"],
+        help=(
+            "Force a timestamping mode. `auto` (default) probes "
+            "`ethtool -T <iface>` and prefers hardware if available."
+        ),
+    )
+    p.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="Logging level (default: INFO).",
+    )
+    p.set_defaults(func=run)
+
+
+def run(args: argparse.Namespace) -> None:
+    logging.basicConfig(level=getattr(logging, args.log_level))
+    try:
+        _run(
+            role=args.role,
+            iface=args.iface,
+            transport=args.transport,
+            timestamping=args.timestamping,
+        )
+    except KeyboardInterrupt:
+        pass
+
+
+def _run(*, role: str, iface: str, transport: str, timestamping: str) -> None:
+    _require_executable("ptp4l")
+    _require_executable("phc2sys")
+
+    if not Path(f"/sys/class/net/{iface}").exists():
+        raise SystemExit(
+            f"error: interface {iface!r} not found in /sys/class/net. "
+            f"Plug in the cable or check `ip link show`."
+        )
+
+    timestamping_mode = _resolve_timestamping(iface, timestamping)
+    _logger.info(
+        "Starting PTP role=%s iface=%s transport=%s timestamping=%s",
+        role,
+        iface,
+        transport,
+        timestamping_mode,
+    )
+
+    ptp4l_cmd = _build_ptp4l_cmd(
+        iface=iface,
+        role=role,
+        transport=transport,
+        timestamping=timestamping_mode,
+    )
+    phc2sys_cmd = _build_phc2sys_cmd(
+        iface=iface,
+        role=role,
+        timestamping=timestamping_mode,
+    )
+
+    _logger.info("ptp4l:   %s", " ".join(ptp4l_cmd))
+    _logger.info("phc2sys: %s", " ".join(phc2sys_cmd))
+
+    ptp4l_proc = subprocess.Popen(
+        ptp4l_cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+    phc2sys_proc = subprocess.Popen(
+        phc2sys_cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+
+    procs: list[tuple[str, subprocess.Popen[str]]] = [
+        ("ptp4l", ptp4l_proc),
+        ("phc2sys", phc2sys_proc),
+    ]
+    stop_event = threading.Event()
+
+    def _handle_signal(signum: int, _frame: object) -> None:
+        _logger.info("Received signal %d; shutting down PTP processes.", signum)
+        stop_event.set()
+
+    signal.signal(signal.SIGINT, _handle_signal)
+    signal.signal(signal.SIGTERM, _handle_signal)
+
+    threads: list[threading.Thread] = []
+    for name, proc in procs:
+        t = threading.Thread(
+            target=_stream_subprocess,
+            args=(name, proc, stop_event),
+            name=f"axol-{name}-stream",
+            daemon=True,
+        )
+        t.start()
+        threads.append(t)
+
+    try:
+        while not stop_event.is_set():
+            for name, proc in procs:
+                if proc.poll() is not None:
+                    _logger.error(
+                        "%s exited unexpectedly with code %d; tearing down.",
+                        name,
+                        proc.returncode,
+                    )
+                    stop_event.set()
+                    break
+            stop_event.wait(timeout=0.5)
+    finally:
+        _terminate_procs(procs)
+        for t in threads:
+            t.join(timeout=2.0)
+
+
+def _require_executable(name: str) -> None:
+    if shutil.which(name) is None:
+        raise SystemExit(
+            f"error: `{name}` not found on PATH. Install the `linuxptp` package "
+            f"(e.g. `sudo apt install linuxptp`) and rerun."
+        )
+
+
+def _resolve_timestamping(iface: str, mode: str) -> str:
+    if mode != "auto":
+        return mode
+
+    hw_supported = _probe_hardware_timestamping(iface)
+    if hw_supported:
+        _logger.info(
+            "ethtool reports hardware timestamping on %s — using hardware.", iface
+        )
+        return "hardware"
+    _logger.warning(
+        "ethtool shows no PHC / hardware timestamping on %s. "
+        "Falling back to software timestamping; expect ~10-100us extra jitter. "
+        "(Pass --timestamping software explicitly to silence this warning.)",
+        iface,
+    )
+    return "software"
+
+
+def _probe_hardware_timestamping(iface: str) -> bool:
+    if shutil.which("ethtool") is None:
+        _logger.warning(
+            "ethtool not installed; cannot probe hardware timestamping for %s.",
+            iface,
+        )
+        return False
+    try:
+        result = subprocess.run(
+            ["ethtool", "-T", iface],
+            capture_output=True,
+            text=True,
+            timeout=5.0,
+        )
+    except (subprocess.SubprocessError, OSError) as exc:
+        _logger.warning("ethtool -T %s failed: %s", iface, exc)
+        return False
+
+    if result.returncode != 0:
+        _logger.warning(
+            "ethtool -T %s returned %d: %s",
+            iface,
+            result.returncode,
+            result.stderr.strip(),
+        )
+        return False
+
+    text = result.stdout
+    has_phc = bool(re.search(r"PTP Hardware Clock:\s*(\d+)", text))
+    has_hw_tx = "hardware-transmit" in text
+    has_hw_rx = "hardware-receive" in text
+    has_hw_raw = "hardware-raw-clock" in text
+    return has_phc and has_hw_tx and has_hw_rx and has_hw_raw
+
+
+def _build_ptp4l_cmd(
+    *, iface: str, role: str, transport: str, timestamping: str
+) -> list[str]:
+    cmd = ["ptp4l", "-i", iface, "-m"]
+    if transport == "l2":
+        cmd.append("-2")
+    if timestamping == "hardware":
+        cmd.append("-H")
+    else:
+        cmd.append("-S")
+    if role == "slave":
+        cmd.append("-s")
+    return cmd
+
+
+def _build_phc2sys_cmd(*, iface: str, role: str, timestamping: str) -> list[str]:
+    if timestamping != "hardware":
+        # No PHC available — phc2sys runs in "free" mode pinning CLOCK_REALTIME
+        # to itself, which is a no-op but lets ptp4l (in software mode) still
+        # discipline the kernel clock through its own SO_TIMESTAMPING path.
+        return [
+            "phc2sys",
+            "-c",
+            "CLOCK_REALTIME",
+            "-s",
+            "CLOCK_REALTIME",
+            "-O",
+            "0",
+            "-w",
+        ]
+
+    if role == "slave":
+        # Receiver follows the PHC that ptp4l is disciplining.
+        return ["phc2sys", "-s", iface, "-c", "CLOCK_REALTIME", "-O", "0", "-w", "-m"]
+    # Master pushes its system clock onto the PHC so ptp4l serves it out.
+    return ["phc2sys", "-s", "CLOCK_REALTIME", "-c", iface, "-O", "0", "-w", "-m"]
+
+
+def _stream_subprocess(
+    name: str, proc: subprocess.Popen[str], stop_event: threading.Event
+) -> None:
+    last_report = 0.0
+    last_offset: int | None = None
+    last_freq: int | None = None
+
+    if proc.stdout is None:
+        return
+    for line in proc.stdout:
+        if stop_event.is_set():
+            break
+        line = line.rstrip()
+        if not line:
+            continue
+        sys.stdout.write(f"[{name}] {line}\n")
+        sys.stdout.flush()
+
+        m = _OFFSET_RE.search(line)
+        if m is not None:
+            try:
+                last_offset = int(m.group("offset"))
+                last_freq = int(m.group("freq"))
+            except ValueError:
+                pass
+
+        now = time.monotonic()
+        if last_offset is not None and now - last_report > 5.0:
+            _logger.info(
+                "[%s] latest master offset = %+d ns, freq adj = %+d ppb",
+                name,
+                last_offset,
+                last_freq if last_freq is not None else 0,
+            )
+            last_report = now
+
+
+def _terminate_procs(procs: list[tuple[str, subprocess.Popen[str]]]) -> None:
+    for name, proc in procs:
+        if proc.poll() is None:
+            _logger.info("Terminating %s (pid %d).", name, proc.pid)
+            try:
+                proc.terminate()
+            except OSError:
+                pass
+    deadline = time.monotonic() + 3.0
+    for name, proc in procs:
+        timeout = max(0.0, deadline - time.monotonic())
+        try:
+            proc.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            _logger.warning("%s did not exit cleanly; killing.", name)
+            try:
+                proc.kill()
+            except OSError:
+                pass
+            try:
+                proc.wait(timeout=2.0)
+            except subprocess.TimeoutExpired:
+                pass

--- a/almond_axol/lerobot/camera/camera_zed.py
+++ b/almond_axol/lerobot/camera/camera_zed.py
@@ -383,6 +383,7 @@ class ZedCamera(Camera):
         deadline = time.perf_counter() + timeout_ms / 1000.0
 
         while True:
+            self.new_frame_event.clear()
             with self.frame_lock:
                 frame = self.latest_frame
                 cap_ts = self.latest_capture_perf_ts
@@ -395,7 +396,6 @@ class ZedCamera(Camera):
             ):
                 return frame, cap_ts, recv_ts
 
-            self.new_frame_event.clear()
             remaining = deadline - time.perf_counter()
             if remaining <= 0:
                 raise TimeoutError(

--- a/almond_axol/lerobot/camera/camera_zed.py
+++ b/almond_axol/lerobot/camera/camera_zed.py
@@ -5,6 +5,26 @@ ZedCamera connects to a single ZED video stream produced by ZedStreamer and
 exposes it as a standard LeRobot Camera. One instance per camera — instantiate
 three to cover overhead, left_arm, and right_arm.
 
+Timestamping
+------------
+
+Every grabbed frame is stamped with two timestamps:
+
+* ``capture_perf_ts`` — when the *sender* exposed the frame, expressed on the
+  receiver's ``time.perf_counter`` clock. Derived from
+  ``TIME_REFERENCE.IMAGE`` (UNIX-ns wall-clock on the sender) plus a per-frame
+  delta between receiver wall-clock and ``perf_counter``. Recomputing the
+  delta per frame means PTP step adjustments to ``CLOCK_REALTIME`` are
+  absorbed instantly.
+* ``receive_perf_ts`` — receiver ``perf_counter`` at the moment the frame
+  was decoded.
+
+The difference ``receive_perf_ts - capture_perf_ts`` is the end-to-end
+pipeline latency (encode + network + decode), typically 33-50 ms with HEVC
+streaming. The capture thread in ``collect_data`` consumes
+``capture_perf_ts`` directly so the dataset row's "frame time" reflects the
+moment of capture, not the moment of decode.
+
 Typical usage::
 
     from almond_axol.lerobot.zed import ZedCamera, ZedCameraConfig
@@ -58,7 +78,8 @@ class ZedCamera(Camera):
         self.stop_event: Event | None = None
         self.frame_lock: Lock = Lock()
         self.latest_frame: NDArray[Any] | None = None
-        self.latest_timestamp: float | None = None
+        self.latest_capture_perf_ts: float | None = None
+        self.latest_receive_perf_ts: float | None = None
         self.new_frame_event: Event = Event()
 
     def __str__(self) -> str:
@@ -137,7 +158,55 @@ class ZedCamera(Camera):
                     pass
                 time.sleep(0.05)
 
+        self._log_pipeline_latency()
+
         _logger.info(f"{self} connected ({self.width}x{self.height} @ {self.fps}fps).")
+
+    def _log_pipeline_latency(self, num_samples: int = 30) -> None:
+        """Sample the first ~N frames and log mean/max receive-vs-capture skew.
+
+        Acts as a startup canary for PTP: if the sender and receiver wall
+        clocks are out of sync the latency will look wildly negative or huge.
+        """
+        samples: list[float] = []
+        deadline = time.perf_counter() + 5.0
+        while len(samples) < num_samples and time.perf_counter() < deadline:
+            self.new_frame_event.clear()
+            if not self.new_frame_event.wait(timeout=0.5):
+                continue
+            with self.frame_lock:
+                cap = self.latest_capture_perf_ts
+                recv = self.latest_receive_perf_ts
+            if cap is None or recv is None:
+                continue
+            samples.append(recv - cap)
+
+        if not samples:
+            _logger.warning(
+                "%s: no frames captured during pipeline-latency probe; "
+                "skipping startup PTP check.",
+                self,
+            )
+            return
+
+        mean_ms = sum(samples) / len(samples) * 1e3
+        max_ms = max(samples) * 1e3
+        _logger.info(
+            "%s pipeline latency over %d frames: mean=%.1fms max=%.1fms.",
+            self,
+            len(samples),
+            mean_ms,
+            max_ms,
+        )
+
+        if mean_ms < 0.0 or mean_ms > 200.0:
+            _logger.warning(
+                "%s pipeline latency looks unhealthy (mean=%.1fms). "
+                "Looks like the sender/receiver wall-clocks aren't synced — "
+                "is `axol zed.sync-clocks` running on both machines?",
+                self,
+                mean_ms,
+            )
 
     def _start_read_thread(self) -> None:
         self._stop_read_thread()
@@ -156,7 +225,8 @@ class ZedCamera(Camera):
         self.stop_event = None
         with self.frame_lock:
             self.latest_frame = None
-            self.latest_timestamp = None
+            self.latest_capture_perf_ts = None
+            self.latest_receive_perf_ts = None
             self.new_frame_event.clear()
 
     def _read_loop(self) -> None:
@@ -181,10 +251,22 @@ class ZedCamera(Camera):
                 else:
                     frame = cv2.cvtColor(raw, cv2.COLOR_BGRA2BGR)
 
-                capture_time = time.perf_counter()
+                # Sender-side wall-clock timestamp of when the frame was
+                # exposed, shared across all ZED cameras on the sender.
+                cap_wall = (
+                    self.zed.get_timestamp(sl.TIME_REFERENCE.IMAGE).get_nanoseconds()
+                    * 1e-9
+                )
+                # Recompute the wall ↔ perf delta per frame so PTP step
+                # adjustments don't accumulate as silent skew.
+                recv_wall = time.time()
+                recv_perf = time.perf_counter()
+                cap_perf = recv_perf - (recv_wall - cap_wall)
+
                 with self.frame_lock:
                     self.latest_frame = frame
-                    self.latest_timestamp = capture_time
+                    self.latest_capture_perf_ts = cap_perf
+                    self.latest_receive_perf_ts = recv_perf
                 self.new_frame_event.set()
                 failure_count = 0
 
@@ -233,26 +315,96 @@ class ZedCamera(Camera):
         """Return the most recent frame immediately without waiting.
 
         Raises:
-            TimeoutError: If the latest frame is older than max_age_ms.
+            TimeoutError: If the latest frame is older than max_age_ms
+                (measured against ``receive_perf_ts``).
             RuntimeError: If no frame has been captured yet.
+        """
+        frame, _cap_ts, recv_ts = self.read_latest_with_ts()
+        age_ms = (time.perf_counter() - recv_ts) * 1e3
+        if age_ms > max_age_ms:
+            raise TimeoutError(
+                f"{self} latest frame is too old: {age_ms:.1f}ms (max {max_age_ms}ms)."
+            )
+        return frame
+
+    @check_if_not_connected
+    def read_latest_with_ts(self) -> tuple[NDArray[Any], float, float]:
+        """Return the most recent frame and its ``(capture_ts, receive_ts)``.
+
+        Both timestamps are on the receiver's ``perf_counter`` clock —
+        ``capture_ts`` is the sender's exposure time converted via the per
+        frame wall→perf offset, and ``receive_ts`` is when this process
+        decoded the frame.
+
+        Raises:
+            RuntimeError: If the grab thread is not running or no frame has
+                been captured yet.
         """
         if self.thread is None or not self.thread.is_alive():
             raise RuntimeError(f"{self} read thread is not running.")
 
         with self.frame_lock:
             frame = self.latest_frame
-            timestamp = self.latest_timestamp
+            cap_ts = self.latest_capture_perf_ts
+            recv_ts = self.latest_receive_perf_ts
 
-        if frame is None or timestamp is None:
+        if frame is None or cap_ts is None or recv_ts is None:
             raise RuntimeError(f"{self} has not captured any frames yet.")
 
-        age_ms = (time.perf_counter() - timestamp) * 1e3
-        if age_ms > max_age_ms:
-            raise TimeoutError(
-                f"{self} latest frame is too old: {age_ms:.1f}ms (max {max_age_ms}ms)."
-            )
+        return frame, cap_ts, recv_ts
 
-        return frame
+    @check_if_not_connected
+    def read_at_or_after(
+        self,
+        target_capture_perf_ts: float,
+        timeout_ms: float = 500,
+    ) -> tuple[NDArray[Any], float, float]:
+        """Block until a frame with capture time ``>= target`` is available.
+
+        This is the primary read path for dataset capture: by waiting for a
+        frame whose *sender-side* exposure time is at or after the teleop
+        tick, every camera and the joint sample share the same timeline.
+
+        Args:
+            target_capture_perf_ts: Earliest acceptable ``capture_perf_ts``,
+                expressed on the receiver's ``perf_counter`` clock.
+            timeout_ms: Maximum time to wait for a qualifying frame.
+
+        Returns:
+            ``(frame, capture_perf_ts, receive_perf_ts)``.
+
+        Raises:
+            TimeoutError: If no qualifying frame arrives within ``timeout_ms``.
+            RuntimeError: If the grab thread is not running.
+        """
+        if self.thread is None or not self.thread.is_alive():
+            raise RuntimeError(f"{self} read thread is not running.")
+
+        deadline = time.perf_counter() + timeout_ms / 1000.0
+
+        while True:
+            with self.frame_lock:
+                frame = self.latest_frame
+                cap_ts = self.latest_capture_perf_ts
+                recv_ts = self.latest_receive_perf_ts
+            if (
+                frame is not None
+                and cap_ts is not None
+                and recv_ts is not None
+                and cap_ts >= target_capture_perf_ts
+            ):
+                return frame, cap_ts, recv_ts
+
+            self.new_frame_event.clear()
+            remaining = deadline - time.perf_counter()
+            if remaining <= 0:
+                raise TimeoutError(
+                    f"{self} timed out waiting for frame at "
+                    f"capture_perf_ts >= {target_capture_perf_ts:.6f} "
+                    f"after {timeout_ms:.1f}ms "
+                    f"(latest cap_ts={cap_ts!r})."
+                )
+            self.new_frame_event.wait(timeout=remaining)
 
     def disconnect(self) -> None:
         """Stop the grab thread and close the ZED stream."""

--- a/almond_axol/zed/config.py
+++ b/almond_axol/zed/config.py
@@ -25,7 +25,7 @@ class ZedConfig:
         overhead_port:    Streaming port for the overhead camera (default 30000).
         left_arm_port:    Streaming port for the left-arm camera (default 30002).
         right_arm_port:   Streaming port for the right-arm camera (default 30004).
-        resolution:       Capture resolution for all cameras (default HD1080).
+        resolution:       Capture resolution for all cameras (default SVGA).
         fps:              Capture frame rate for all cameras (default 60).
         bitrate:          HEVC encoding bitrate in kbits/s (default 8000).
     """
@@ -36,7 +36,7 @@ class ZedConfig:
     overhead_port: int = 30000
     left_arm_port: int = 30002
     right_arm_port: int = 30004
-    resolution: sl.RESOLUTION = field(default_factory=lambda: sl.RESOLUTION.HD1080)
+    resolution: sl.RESOLUTION = field(default_factory=lambda: sl.RESOLUTION.SVGA)
     fps: int = 60
     bitrate: int = 8000
 

--- a/almond_axol/zed/streamer.py
+++ b/almond_axol/zed/streamer.py
@@ -145,6 +145,7 @@ class ZedStreamer:
         stream_params.codec = sl.STREAMING_CODEC.H265
         stream_params.bitrate = self._config.bitrate
         stream_params.port = port
+        stream_params.target_framerate = self._config.fps
 
         err = zed.enable_streaming(stream_params)
         if err != sl.ERROR_CODE.SUCCESS:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Three independent failure modes were hiding behind the same symptom — dataset rows in which the joint sample, action, and three camera frames don't actually share an instant in time:

1. **Cross-machine wall-clock skew** between the Jetson sender and the upper-computer receiver. The ZED SDK stamps frames with the sender's `CLOCK_REALTIME` via `TIME_REFERENCE.IMAGE`; if the two boxes' clocks drift, every dataset row gets a hidden bias.
2. **Streaming pipeline latency** (33–50 ms encode + network + decode). The receiver was stamping frames with `perf_counter()` at decode time, so the "frame time" in the dataset was the moment of decode, not the moment of capture.
3. **Teleop rate dip during capture**. The 120 Hz teleop tick was reading three camera frames, doing colorspace conversion, and calling `dataset.add_frame` inline — enough work to dip the control rate, and it paired each joint sample at `T_n` with whatever `cam.read_latest()` happened to have, giving a silent 0–50 ms skew per camera.

This PR addresses each layer:

```mermaid
flowchart LR
    subgraph Jetson [Jetson 192.168.10.1]
        JC[CLOCK_REALTIME]
        ZS["ZedStreamer grab loop<br/>stamps frames with<br/>TIME_REFERENCE.IMAGE (UNIX ns)"]
        JC -.feeds.-> ZS
    end
    subgraph UpperComputer [Upper computer 192.168.10.2]
        UC[CLOCK_REALTIME]
        UM[CLOCK_MONOTONIC<br/>perf_counter]
        CAM["ZedCamera _read_loop:<br/>cap_perf = cap_wall + (perf_now - wall_now)"]
        TL[Teleop loop 120Hz]
        CT[Capture thread fps Hz]
        DS[LeRobotDataset]
        UC -.->|"wall_to_perf<br/>offset"| CAM
        UM -.->|"perf_counter"| TL
        UM -.->|"perf_counter"| CT
        TL -->|"publish(joint, act, ts)"| CT
        CAM -.->|"read_at_or_after"| CT
        CT --> DS
    end
    PTP{{"PTP over eth0<br/>(axol zed.sync-clocks)"}}
    PTP -.syncs.-> JC
    PTP -.syncs.-> UC
    ZS -->|"HEVC stream<br/>+ embedded ts"| CAM
```

## What changed

### 1. New CLI: `axol zed.sync-clocks`

`almond_axol/cli/zed/sync_clocks.py` wraps `ptp4l` + `phc2sys` (`linuxptp`) so both machines hold `CLOCK_REALTIME` to sub-millisecond agreement:

- `--role {master, slave}` (master on the long-lived upper computer, slave on the Jetson)
- `--iface IFACE` (e.g. `eth0`)
- `--transport {l2, udpv4}` (defaults to raw ethernet)
- `--timestamping {auto, hardware, software}` (auto probes `ethtool -T` for a PHC)
- Streams subprocess stdout live with `[ptp4l]` / `[phc2sys]` prefixes, parses `master offset … freq …` lines, and reports them periodically.
- Handles SIGINT/SIGTERM cleanly, terminating both subprocesses and killing them after a grace period.

Operator recipe (both stay running):

```sh
sudo axol zed.sync-clocks --role master --iface eth0   # upper computer
sudo axol zed.sync-clocks --role slave  --iface eth0   # Jetson
```

### 2. `ZedCamera` now stamps frames with the sender's capture time on `perf_counter`

In `_read_loop`, every grabbed frame now records:

- `latest_capture_perf_ts` — sender exposure time (`TIME_REFERENCE.IMAGE`) converted onto the receiver's `perf_counter` via a per-frame wall↔perf delta (PTP step adjustments are absorbed instantly).
- `latest_receive_perf_ts` — `perf_counter()` at decode.

New public methods:

- `read_at_or_after(target_capture_perf_ts, timeout_ms)` — blocks on `new_frame_event` until a frame whose capture time is at or after `target` arrives. Returns `(frame, capture_ts, receive_ts)`.
- `read_latest_with_ts()` — non-blocking, returns the latest frame plus both timestamps.

`read_latest` still exists (fallback path) but now layers `max_age_ms` on top of `receive_perf_ts`.

After warmup, `connect()` samples the first ~30 frames and logs the mean / max pipeline latency (`receive_perf - capture_perf`). If the mean falls outside `[0, 200] ms` it logs a loud warning — the operator-visible canary that `axol zed.sync-clocks` isn't running.

### 3. `collect-data`: capture thread + atomic snapshot publisher

`almond_axol/cli/collect_data.py`:

- `_Snapshot` (dataclass): `(joint_obs, action, ts)` from one teleop iteration.
- `_SnapshotPublisher`: single-slot, `threading.Lock`-guarded slot; teleop publishes, capture reads.
- `_CaptureThread` (a `threading.Thread`): owns capture cadence.
  - Sleeps until `T_n = recording_start + n * frame_interval`.
  - For each camera, calls `read_at_or_after(T_n, timeout_ms=2*frame_interval + 200ms)`. On per-camera timeout, reuses the last good frame for that camera (use-cached policy, DEBUG-logged).
  - Snapshots `publisher.latest()` for the matching joint sample + commanded action.
  - Runs `robot_obs_proc`, builds the dataset frame, and calls `add_frame`.
  - At DEBUG (every 30 ticks), logs per-camera `cap_ts - T_n` and `T_n - snap.ts`.

The inner teleop loop is back to its essentials: joints + IK + `send_action` + `publisher.publish(joint_obs, act_processed, t0)` + TERMINATE/RERECORD checks. The capture thread starts on the `start_recording` rising edge and is joined on episode termination (and in the `finally` block on `KeyboardInterrupt`).

### 4. `run-policy`: inference-side comment

Added a comment at the observation-gathering site noting that the inference path still uses `cam.read_latest()`, which gives a ~1 frame-period skew vs training. Out of scope for this PR; flagged as follow-up.

### 5. README: "Time synchronization" section

New `zed.sync-clocks` subsection next to `zed.stream` / `zed.install` explaining why PTP matters, the two-terminal recipe, the `linuxptp` dependency, and the chrony fallback for cases where `linuxptp` is unavailable.

## Testing

No physical robot or ZED hardware is available in the cloud VM, so this PR was validated with a layered mix of automated logic tests, smoke checks against real `ptp4l` / `phc2sys` binaries, and CLI help inspection.

- ✅ `ruff check .` and `ruff format --check .` clean
- ✅ `axol --help` registers `zed.sync-clocks` alongside `zed.stream` / `zed.install`; `axol zed.sync-clocks --help` and `axol collect-data --help` render correctly
- ✅ `ZedCamera` import surface — `read_at_or_after`, `read_latest`, `read_latest_with_ts` all callable; constructed via `__new__` and exercised against an in-process producer thread to confirm the blocking, fast-path, and timeout branches
- ✅ End-to-end `_CaptureThread` smoke test against fake `Robot` / `Dataset` / cameras: at fps=60 over 500 ms wallclock the thread produced 31 frames with `observation.{overhead, left_arm, joint…}` + `action.*` + `task` in each row, plus matching `log_rerun_data` calls
- ✅ Use-cached-frame fallback: when one camera stops emitting fresh frames mid-episode, every subsequent dataset row reuses the last good frame for that camera while the other camera keeps advancing (and a DEBUG log records each fallback)
- ✅ `axol zed.sync-clocks --role master --iface eth0 --timestamping software` against `eth0` in the VM — `ptp4l` and `phc2sys` launched with the correct flags, ptp4l streamed `INITIALIZING → LISTENING` transitions, SIGTERM was caught and both subprocesses were terminated cleanly
- ✅ `--role slave` flipped to `ptp4l -i eth0 -m -2 -S -s`; `--timestamping auto` correctly detected no PHC via `ethtool -T eth0` and fell back to software with the documented warning
- ✅ `axol zed.sync-clocks --role master --iface eth_nonexistent_42` produces a clean "interface not found in /sys/class/net" error; with `linuxptp` absent the command prints a `Install the linuxptp package` error and exits 1

Manual testing on physical hardware is required to confirm the dataset-side sub-frame alignment claim — the spec calls it out in the verify todo. The smoke tests here cover the threading / publisher / read-at-or-after logic end-to-end against fakes; cross-machine PTP convergence cannot be exercised without two NICs and the Jetson.

[sync_clocks_master.log](https://cursor.com/agents/bc-66118003-1de4-4be2-8a85-740a423e5559/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsync_clocks_master.log)
[sync_clocks_slave.log](https://cursor.com/agents/bc-66118003-1de4-4be2-8a85-740a423e5559/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsync_clocks_slave.log)
[capture_thread_test.log](https://cursor.com/agents/bc-66118003-1de4-4be2-8a85-740a423e5559/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcapture_thread_test.log)
[camera_logic_test.log](https://cursor.com/agents/bc-66118003-1de4-4be2-8a85-740a423e5559/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcamera_logic_test.log)

## Out of scope

- Dataset schema unchanged — capture/receive timestamps stay in-process.
- True hardware sync trigger across the three ZEDs (genlock) — follow-up if DEBUG skew logs reveal more than ~1 frame period of intra-camera spread.
- `run-policy` only gets a comment; aligning inference to `read_at_or_after` is a separate change.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-66118003-1de4-4be2-8a85-740a423e5559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-66118003-1de4-4be2-8a85-740a423e5559"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

