### PR TITLE
Standardize new comments/docstrings; document capture decoupling in R…

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,9 @@ axol collect-data --repo-id myorg/pick-place --task "Pick the red cube" --left-s
 | `TERMINATE_EPISODE` | Save the episode; headset enters `Saving` state until write completes |
 | `RERECORD_EPISODE` | Discard and retry |
 
-After each episode the robot automatically returns to its rest pose before the next take begins. If an existing dataset is found at `--root`, collection resumes from where it left off.
+After each episode the robot automatically returns to its rest pose before the next take begins. If an existing dataset is found at `--root`, collection resumes from where it left off; conversely, if no episodes were saved before exit the empty dataset directory is removed on shutdown so an aborted session does not leave a half-initialized dataset on disk.
+
+Dataset frame capture runs on a dedicated thread decoupled from the teleop control loop. Teleop ticks at `--teleop-hz` and only ever touches joint state; the capture thread ticks at `--fps`, blocks on `ZedCamera.read_at_or_after(T_n)` per camera so every recorded frame is sender-clock-aligned with the joint sample taken at `T_n`, and writes the dataset row. This keeps camera reads, image conversion, and `dataset.add_frame()` off the hot control loop, and produces datasets whose camera/joint pairing matches the sender's exposure timeline rather than the receiver's decode timeline. Both clocks must agree — make sure [`zed.sync-clocks`](#zedsync-clocks--time-synchronization) is running on both machines.
 
 ---
 
@@ -1036,6 +1038,14 @@ cam.connect()
 frame = cam.read_latest()   # shape (H, W, 3), non-blocking, returns most recent frame
 cam.disconnect()
 ```
+
+Each grabbed frame carries two timestamps on the receiver's `perf_counter` clock: `capture_perf_ts` (when the *sender* exposed the frame, derived from `TIME_REFERENCE.IMAGE`) and `receive_perf_ts` (when this process decoded it). Cross-clock alignment requires PTP — see [`zed.sync-clocks`](#zedsync-clocks--time-synchronization). The receive-vs-capture skew is sampled on `connect()` and a warning is logged if the mean falls outside `[0, 200] ms`.
+
+| Method | Description |
+|---|---|
+| `read_latest(max_age_ms=500)` | Most recent frame, non-blocking; raises `TimeoutError` if it is older than `max_age_ms`. |
+| `read_latest_with_ts()` | `(frame, capture_perf_ts, receive_perf_ts)` for the most recent frame. |
+| `read_at_or_after(target_capture_perf_ts, timeout_ms=500)` | Block until a frame with `capture_perf_ts >= target` is available. Used by `collect-data` to align every camera and the joint sample on the same sender-side timeline. |
 
 **`ZedCameraConfig` fields**
 

--- a/almond_axol/cli/collect_data.py
+++ b/almond_axol/cli/collect_data.py
@@ -500,7 +500,7 @@ def _run(
     teleop_action_proc, robot_action_proc, robot_obs_proc = make_default_processors()
 
     episodes_recorded = 0
-    episode_idx = dataset.num_episodes  # global index; increments as episodes are saved
+    episode_idx = dataset.num_episodes
     teleop_interval = 1.0 / teleop_hz
     publisher = _SnapshotPublisher()
     capture: _CaptureThread | None = None
@@ -516,15 +516,13 @@ def _run(
             while True:
                 t0 = time.perf_counter()
 
-                # Joints-only observation — no camera copies at teleop rate.
+                # Joints-only observation — no camera reads on the hot loop.
                 joint_obs = robot.get_joint_observation()
                 teleop.send_feedback(joint_obs)
                 act = teleop.get_action()
                 act_processed = teleop_action_proc((act, joint_obs))
                 robot.send_action(robot_action_proc((act_processed, joint_obs)))
 
-                # Publish every iteration so the capture thread always has a
-                # fresh snapshot (and a non-empty publisher) when it starts.
                 publisher.publish(joint_obs, act_processed, t0)
 
                 events = teleop.get_teleop_events()
@@ -561,8 +559,6 @@ def _run(
                     )
                 capture = None
 
-            # Return to rest pose before the next episode so the operator
-            # starts each take from a consistent configuration.
             log_say("Returning to rest pose.")
             teleop.request_reset()
             reset_deadline = time.perf_counter() + 30.0
@@ -572,7 +568,7 @@ def _run(
                 act = teleop.get_action()
                 robot.send_action(robot_action_proc((act, joint_obs)))
                 time.sleep(max(0.0, teleop_interval - (time.perf_counter() - t0)))
-            # Drain any VR events that fired during the reset move.
+            # Drain VR events fired during the reset move.
             teleop.get_teleop_events()
 
             if rerecord:

--- a/almond_axol/cli/run_policy.py
+++ b/almond_axol/cli/run_policy.py
@@ -238,15 +238,10 @@ def _run(
             while time.perf_counter() < deadline:
                 t0 = time.perf_counter()
 
-                # TODO: training datasets collected by `axol collect-data` use
-                # sender-clock alignment via `ZedCamera.read_at_or_after(T_n)`
-                # so each row pairs the joint sample taken at T_n with camera
-                # frames whose exposure time is at or after T_n. This loop
-                # still uses `robot.get_observation()` which calls
-                # `cam.read_latest()` — that introduces a ~1 frame-period skew
-                # vs training. To match training exactly, swap in
-                # `ZedCamera.read_at_or_after(t0)` here. Tracking as a
-                # follow-up to keep this PR scoped to data collection.
+                # TODO: swap in `ZedCamera.read_at_or_after(t0)` so inference
+                # uses the same sender-clock-aligned camera/joint pairing as
+                # the training data — `read_latest()` introduces a ~1 frame
+                # skew vs training.
                 obs = robot.get_observation()
                 obs_processed = robot_obs_proc(obs)
 


### PR DESCRIPTION
…EADME

- run_policy: condense the 9-line read_at_or_after TODO into a 4-line note matching the codebase preference for brief, intent-only inline comments
- collect_data: drop narrative inline comments that simply re-state nearby code (episode_idx index annotation, publisher.publish placement note, rest-pose return) and tighten the surviving teleop/loop comments
- README: document the capture-thread decoupling (sender-clock alignment via read_at_or_after, dependence on zed.sync-clocks, automatic cleanup of empty datasets) under Data Collection, and surface the new ZedCamera read methods with their timestamp semantics under the SDK section

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation and inline comment cleanup, with no behavioral or API changes in the CLI control/data-collection logic.
> 
> **Overview**
> **Documents the data-capture threading/alignment model more explicitly.** The `README` now calls out that `collect-data` captures frames on a dedicated thread, aligns camera frames to the sender’s exposure timeline via `ZedCamera.read_at_or_after(T_n)`, and requires `zed.sync-clocks` on both machines.
> 
> **Expands the `ZedCamera` SDK docs with timestamp semantics and new read methods**, and notes the startup skew warning on `connect()`.
> 
> **Standardizes/condenses inline comments** in `collect_data.py` and `run_policy.py` (including a shorter TODO about matching inference-time camera/joint alignment).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a89cf8278aeed16ae74cc3ddb7cb863232c3536. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->