### PR TITLE
data collection improvements

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -101,7 +101,10 @@ The terminal will print the hostname and IP address. Open the VR app at [axol.al
 |---|---|
 | `--no-left` | Disable the left arm |
 | `--no-right` | Disable the right arm |
-| `--gripper-torque-limit FLOAT` | Max gripper torque in Nm (default: `1.0`) |
+| `--left-gripper-torque-limit FLOAT` | Max torque (Nm) for the left gripper (default: `1.0`) |
+| `--right-gripper-torque-limit FLOAT` | Max torque (Nm) for the right gripper (default: `1.0`) |
+| `--left-stiffness S\|S,S,...` | Compliance↔stiffness blend for the left arm in `[0, 1]`; scalar or 7 comma-separated values. `0` (default) = fully compliant. |
+| `--right-stiffness S\|S,S,...` | Same, for the right arm. |
 | `--log-level {DEBUG,INFO,WARNING,ERROR}` | Default: `INFO` |
 
 ### Test without hardware

--- a/README.md
+++ b/README.md
@@ -218,7 +218,9 @@ axol collect-data --repo-id myorg/pick-place --task "Pick the red cube" --left-s
 | `TERMINATE_EPISODE` | Save the episode; headset enters `Saving` state until write completes |
 | `RERECORD_EPISODE` | Discard and retry |
 
-After each episode the robot automatically returns to its rest pose before the next take begins. If an existing dataset is found at `--root`, collection resumes from where it left off.
+After each episode the robot automatically returns to its rest pose before the next take begins. If an existing dataset is found at `--root`, collection resumes from where it left off; conversely, if no episodes were saved before exit the empty dataset directory is removed on shutdown so an aborted session does not leave a half-initialized dataset on disk.
+
+Dataset frame capture runs on a dedicated thread decoupled from the teleop control loop. Teleop ticks at `--teleop-hz` and only ever touches joint state; the capture thread ticks at `--fps`, blocks on `ZedCamera.read_at_or_after(T_n)` per camera so every recorded frame is sender-clock-aligned with the joint sample taken at `T_n`, and writes the dataset row. This keeps camera reads, image conversion, and `dataset.add_frame()` off the hot control loop, and produces datasets whose camera/joint pairing matches the sender's exposure timeline rather than the receiver's decode timeline. Both clocks must agree — make sure [`zed.sync-clocks`](#zedsync-clocks--time-synchronization) is running on both machines.
 
 ---
 
@@ -281,6 +283,33 @@ Downloads and installs the `pyzed` Python wheel matching the installed ZED SDK v
 ```bash
 axol zed.install
 ```
+
+### `zed.sync-clocks` — Time synchronization
+
+The Jetson sender and the upper-computer receiver run independent system clocks. The ZED SDK stamps every frame with the sender's `CLOCK_REALTIME` via `TIME_REFERENCE.IMAGE`; the receiver then converts that timestamp onto its own `perf_counter` so dataset rows record the moment of *capture*, not the moment of decode. None of that produces aligned data unless both machines agree on what time it is.
+
+`axol zed.sync-clocks` runs a PTP (Precision Time Protocol) daemon over the direct ethernet link, holding the two clocks to sub-millisecond agreement — well below one camera frame period at 60 fps. The startup pipeline-latency check in `ZedCamera.connect()` warns loudly if the mean `receive_perf - capture_perf` falls outside `[0, 200] ms`, which is the operator-visible "PTP isn't running" canary.
+
+| Flag | Description |
+|---|---|
+| `--role {master,slave}` | `master` on the long-lived upper computer (owns the dataset); `slave` on the Jetson sender |
+| `--iface IFACE` | Network interface carrying the direct link (e.g. `eth0`) |
+| `--transport {l2,udpv4}` | `l2` (raw ethernet, default) or `udpv4` |
+| `--timestamping {auto,hardware,software}` | `auto` (default) probes `ethtool -T` and prefers hardware |
+| `--log-level {DEBUG,INFO,WARNING,ERROR}` | Default: `INFO` |
+
+Two-terminal recipe (one per machine, both stay running for the whole session):
+
+```bash
+axol zed.sync-clocks --role master --iface eth0   # upper computer
+axol zed.sync-clocks --role slave  --iface eth0   # Jetson
+```
+
+The privileged subprocesses (`ptp4l`, `phc2sys`, and the apt-get auto-install fallback) are escalated inline via `sudo`, so you do **not** run `axol` itself as root. Sudo will prompt for a password the first time and reuse cached credentials for the rest of the session. The command depends on the `linuxptp` package (`ptp4l` + `phc2sys`) and, for hardware-timestamping detection, `ethtool`; on Debian/Ubuntu these are auto-installed if missing. On non-apt systems install them manually (`linuxptp`, `ethtool`) and rerun.
+
+Hardware timestamping is detected via `ethtool -T` and used automatically when both NICs expose a PTP Hardware Clock. If only software timestamping is available the daemon still runs but expect ~10–100 µs extra jitter, which is still well under one frame period.
+
+If you cannot install `linuxptp` for some reason, `chronyd` over the same direct link is a serviceable fallback — accuracy is worse (milliseconds rather than microseconds), so the DEBUG capture-skew logs will show wider spreads, but data will still align well enough for training.
 
 ---
 
@@ -823,7 +852,7 @@ asyncio.run(main())
 | `overhead_port` | `30000` | Streaming port for the overhead camera |
 | `left_arm_port` | `30002` | Streaming port for the left-arm camera |
 | `right_arm_port` | `30004` | Streaming port for the right-arm camera |
-| `resolution` | `HD1080` | `sl.RESOLUTION`: `HD1200`, `HD1080`, or `SVGA` |
+| `resolution` | `SVGA` | `sl.RESOLUTION`: `HD1200`, `HD1080`, or `SVGA` |
 | `fps` | `60` | Capture frame rate for all cameras |
 | `bitrate` | `8000` kbps | HEVC encoding bitrate |
 
@@ -1009,6 +1038,14 @@ cam.connect()
 frame = cam.read_latest()   # shape (H, W, 3), non-blocking, returns most recent frame
 cam.disconnect()
 ```
+
+Each grabbed frame carries two timestamps on the receiver's `perf_counter` clock: `capture_perf_ts` (when the *sender* exposed the frame, derived from `TIME_REFERENCE.IMAGE`) and `receive_perf_ts` (when this process decoded it). Cross-clock alignment requires PTP — see [`zed.sync-clocks`](#zedsync-clocks--time-synchronization). The receive-vs-capture skew is sampled on `connect()` and a warning is logged if the mean falls outside `[0, 200] ms`.
+
+| Method | Description |
+|---|---|
+| `read_latest(max_age_ms=500)` | Most recent frame, non-blocking; raises `TimeoutError` if it is older than `max_age_ms`. |
+| `read_latest_with_ts()` | `(frame, capture_perf_ts, receive_perf_ts)` for the most recent frame. |
+| `read_at_or_after(target_capture_perf_ts, timeout_ms=500)` | Block until a frame with `capture_perf_ts >= target` is available. Used by `collect-data` to align every camera and the joint sample on the same sender-side timeline. |
 
 **`ZedCameraConfig` fields**
 

--- a/README.md
+++ b/README.md
@@ -560,11 +560,15 @@ Gravity feedforward is computed centrally from the URDF — see [Gravity compens
 | Field | Default | Description |
 |---|---|---|
 | `max_step_rad` | `0.5` | Maximum allowed change in any arm joint (rad) between consecutive `motion_control` calls. Commands that exceed this are dropped and a warning is logged. Set to `float("inf")` to disable. At 30 Hz, 0.5 rad/step ≈ 15 rad/s — roughly 2.5× the teleop velocity ceiling. |
-| `stiffness` | `0.0` | Compliance ↔ stiffness blend in `[0, 1]`. `0` keeps the per-joint compliant gains; `1` restores the pre-tuning industrial gains in `_STIFF_GAINS` (e.g. `shoulder_1` → `kp=500`). `kp` / `kd` interpolate geometrically (log-space — matches perceived stiffness); `j_eff` / `kd_soft` scale linearly to 0 at `s=1`. |
+| `left_stiffness` | `0.0` | Compliance ↔ stiffness blend for the **left** arm. Either a scalar in `[0, 1]` (applied to every joint) or a 7-tuple of per-joint factors (order: `shoulder_1`, `shoulder_2`, `shoulder_3`, `elbow`, `wrist_1`, `wrist_2`, `wrist_3` — gripper excluded). `0` keeps the per-joint compliant gains; `1` restores the pre-tuning industrial gains in `_STIFF_GAINS` (e.g. `shoulder_1` → `kp=500`). `kp` / `kd` interpolate geometrically (log-space — matches perceived stiffness); `j_eff` / `kd_soft` scale linearly to 0 at `s=1`. |
+| `right_stiffness` | `0.0` | Same, for the **right** arm. |
 
 ```python
-config = AxolConfig(stiffness=1.0)   # stiff industrial feel
-config = AxolConfig(stiffness=0.5)   # geometric mean: shoulder_1 kp ≈ 141
+config = AxolConfig(left_stiffness=1.0, right_stiffness=1.0)   # both arms, stiff industrial feel
+config = AxolConfig(left_stiffness=0.5, right_stiffness=0.5)   # geometric mean: shoulder_1 kp ≈ 141
+config = AxolConfig(                                           # per-joint, left only
+    left_stiffness=(0.8, 0.8, 0.5, 0.5, 0.2, 0.2, 0.0),
+)
 ```
 
 Both arms share the same `ArmConfig` defaults for gains and masses; the right arm gets CoMs mirrored across X via `ArmConfig.mirror_to_right()`. Per-motor friction values are identified separately for each arm (left/right motors measurably differ) — see `_LEFT_FRICTION` / `_RIGHT_FRICTION` in `almond_axol/robot/config.py`. Pass an explicit `left=` / `right=` to override either side.

--- a/README.md
+++ b/README.md
@@ -165,12 +165,17 @@ Launches a VR teleoperation session. When started, the hostname (`.local`) and l
 | `--robot {axol,sim}` | `axol` uses real hardware; `sim` uses the software visualizer (required) |
 | `--no-left` | Disable the left arm |
 | `--no-right` | Disable the right arm |
-| `--gripper-torque-limit FLOAT` | Max gripper torque in POSITION_FORCE mode in Nm (default: 1.0) |
+| `--left-gripper-torque-limit FLOAT` | Max torque (Nm) for the left gripper in POSITION_FORCE mode (default: 1.0) |
+| `--right-gripper-torque-limit FLOAT` | Max torque (Nm) for the right gripper in POSITION_FORCE mode (default: 1.0) |
+| `--left-stiffness S\|S,S,...` | Compliance↔stiffness blend for the left arm in `[0, 1]`. Scalar or 7 comma-separated values (one per arm joint, in `Joint` enum order). `0` (default) = fully compliant; `1` = pre-tuning industrial gains. See [`AxolConfig.left_stiffness`](#almond_axolrobot). |
+| `--right-stiffness S\|S,S,...` | Same, for the right arm. |
 | `--log-level {DEBUG,INFO,WARNING,ERROR}` | Default: `INFO` |
 
 ```bash
 axol teleop --robot axol
 axol teleop --robot sim --no-right
+axol teleop --robot axol --left-stiffness 0.5 --right-stiffness 0.5
+axol teleop --robot axol --left-stiffness 0.8,0.8,0.5,0.5,0.2,0.2,0.0
 ```
 
 ---
@@ -191,7 +196,10 @@ Records teleoperation episodes using VR controller inputs and three ZED cameras.
 | `--push-to-hub` | Push to HuggingFace Hub when done |
 | `--zed-host IP` | IP address of the ZED camera streamer (default: `192.168.10.1`) |
 | `--zed-iface IFACE` | Network interface to configure for the ZED link (e.g. `eth0`); assigns `192.168.10.2/24`, requires `sudo` |
-| `--gripper-torque-limit FLOAT` | Max gripper torque in POSITION_FORCE mode in Nm (default: 1.0) |
+| `--left-gripper-torque-limit FLOAT` | Max torque (Nm) for the left gripper in POSITION_FORCE mode (default: 1.0) |
+| `--right-gripper-torque-limit FLOAT` | Max torque (Nm) for the right gripper in POSITION_FORCE mode (default: 1.0) |
+| `--left-stiffness S\|S,S,...` | Compliance↔stiffness blend for the left arm in `[0, 1]`. Scalar or 7 comma-separated values (one per arm joint, in `Joint` enum order). `0` (default) = fully compliant; `1` = pre-tuning industrial gains. See [`AxolConfig.left_stiffness`](#almond_axolrobot). |
+| `--right-stiffness S\|S,S,...` | Same, for the right arm. |
 | `--rerun-ip IP` | IP of a Rerun viewer on your local machine for live visualization |
 | `--rerun-port INT` | Rerun viewer port (default: 9876); only used when `--rerun-ip` is set |
 | `--log-level {DEBUG,INFO,WARNING,ERROR}` | Default: `INFO` |
@@ -199,6 +207,7 @@ Records teleoperation episodes using VR controller inputs and three ZED cameras.
 ```bash
 axol collect-data --repo-id myorg/pick-place --task "Pick the red cube and place it in the bin"
 axol collect-data --repo-id myorg/pick-place --task "Pick the red cube" --fps 30 --zed-iface eth0
+axol collect-data --repo-id myorg/pick-place --task "Pick the red cube" --left-stiffness 0.5 --right-stiffness 0.5
 ```
 
 **VR controller events:**
@@ -230,7 +239,7 @@ Runs a trained policy autonomously on the robot using three ZED cameras. Between
 | `--push-to-hub` | Push rollout dataset to HuggingFace Hub when done |
 | `--zed-host IP` | IP address of the ZED camera streamer (default: `192.168.10.1`) |
 | `--zed-iface IFACE` | Network interface to configure for the ZED link (e.g. `eth0`); assigns `192.168.10.2/24`, requires `sudo` |
-| `--gripper-torque-limit FLOAT` | Max gripper torque in POSITION_FORCE mode in Nm (default: 1.0) |
+| `--gripper-torque-limit FLOAT` | Max gripper torque (Nm) in POSITION_FORCE mode, applied to both grippers (default: 1.0) |
 | `--rerun-ip IP` | IP of a Rerun viewer on your local machine for live visualization |
 | `--rerun-port INT` | Rerun viewer port (default: 9876); only used when `--rerun-ip` is set |
 | `--device STR` | PyTorch device for inference (default: `cuda`) |
@@ -254,7 +263,7 @@ Streams ZED-X One cameras over the local network using HEVC encoding. At least o
 | `--overhead SERIAL` | Serial number of the overhead camera |
 | `--left-arm SERIAL` | Serial number of the left-arm camera |
 | `--right-arm SERIAL` | Serial number of the right-arm camera |
-| `--resolution {HD1080,HD1200,SVGA}` | Default: `HD1080` |
+| `--resolution {HD1080,HD1200,SVGA}` | Default: `SVGA` |
 | `--fps FPS` | Default: 60 |
 | `--bitrate KBPS` | HEVC bitrate in kbit/s (default: 8000) |
 | `--setup-ip IFACE` | Assign sender IP to a network interface before streaming (e.g. `eth0`); requires `sudo` |
@@ -323,6 +332,26 @@ axol tune.friction --r --joint elbow --kp 20 --kd 0.6
 axol tune.friction --l --joint wrist_1 --velocities 0.2 0.6 1.0
 axol tune.friction --l --joint shoulder_2 --dump-csv
 ```
+
+### `tune.repeatability`
+
+Drives both arms between the rest pose and a hard-coded crossed-arms tips-touching pose, planning each leg with pyroki + the URDF so the arms can't clip the torso during the long arc. The gripper is held closed throughout and the arms run at maximum stiffness (the pre-tuning industrial gains) — repeatability is meaningless under the compliant teleop gains. Useful for measuring how reliably the grippers return to the same physical contact point after many motions.
+
+| Flag | Description |
+|---|---|
+| `--cycles INT` | Number of touch-and-return cycles; `0` (default) = run until Ctrl-C |
+| `--gripper-torque-limit FLOAT` | Gripper closing torque limit in Nm (default: 0.3); kept low so the tips collide gently |
+| `--dwell FLOAT` | Seconds to hold each end of the cycle (default: 0.5) |
+| `--rate FLOAT` | Control loop rate in Hz (default: 100) |
+| `--no-left` / `--no-right` | Disable an arm (the disabled side stays at rest while the other still moves) |
+| `--log-level {DEBUG,INFO,WARNING,ERROR}` | Default: `INFO` |
+
+```bash
+axol tune.repeatability               # forever
+axol tune.repeatability --cycles 5    # five touch-and-return cycles
+```
+
+The touching pose is hand-posed and lives at the top of `almond_axol/cli/tune/repeatability.py` — edit `_TOUCH_LEFT` / `_TOUCH_RIGHT` in place to re-calibrate the contact point.
 
 ### `gravity-comp`
 

--- a/almond_axol/cli/__init__.py
+++ b/almond_axol/cli/__init__.py
@@ -10,6 +10,7 @@ from .motor import set_can_id, set_zero_pos
 from .tune import friction, pid, repeatability
 from .zed import install as zed_install
 from .zed import stream as zed_stream
+from .zed import sync_clocks as zed_sync_clocks
 
 
 def main() -> None:
@@ -26,6 +27,7 @@ def main() -> None:
     run_policy.add_parser(subparsers)
     teleop.add_parser(subparsers)
     zed_stream.add_parser(subparsers)
+    zed_sync_clocks.add_parser(subparsers)
     zed_install.add_parser(subparsers)
     pid.add_parser(subparsers)
     friction.add_parser(subparsers)

--- a/almond_axol/cli/collect_data.py
+++ b/almond_axol/cli/collect_data.py
@@ -12,16 +12,12 @@ controls are blocked until save_episode() completes.
 
 Recording continues until Ctrl+C.
 
-Capture is decoupled from teleop
---------------------------------
-
-The teleop loop runs at ``--teleop-hz`` and produces a fresh
-``(joint_obs, act_processed, t0)`` snapshot every iteration via
-``_SnapshotPublisher``. A separate ``_CaptureThread`` ticks at ``--fps`` and,
-for each tick, blocks on ``ZedCamera.read_at_or_after(T_n)`` so every
-recorded frame uses sender-clock-aligned camera data plus the latest joint
-snapshot. This keeps camera reads, image conversion, and ``dataset.add_frame``
-off the hot 120 Hz control loop.
+The teleop loop runs at ``--teleop-hz`` and publishes the latest
+``(joint_obs, action)`` to a single-slot ``_SnapshotPublisher``. A separate
+``_CaptureThread`` ticks at ``--fps`` and, for each tick, blocks on
+``ZedCamera.read_at_or_after(T_n)`` per camera so every recorded frame
+shares the sender-clock instant ``T_n`` with the joint sample, then writes
+the dataset row off the hot control loop.
 """
 
 import argparse
@@ -46,11 +42,7 @@ _logger = logging.getLogger(__name__)
 
 @dataclass
 class _Snapshot:
-    """Atomic ``(joint_obs, action, capture_ts)`` bundle from one teleop tick.
-
-    Stored references — the producer always builds fresh dicts per tick, so
-    the capture thread observes a consistent slice without copying.
-    """
+    """``(joint_obs, action, ts)`` bundle from one teleop tick."""
 
     joint_obs: "RobotObservation"
     action: "RobotAction"
@@ -58,10 +50,12 @@ class _Snapshot:
 
 
 class _SnapshotPublisher:
-    """Single-slot atomic publisher: teleop loop writes, capture thread reads.
+    """Single-slot publisher shared between the teleop loop and capture thread.
 
-    The lock protects the slot itself, not the contained dicts — those are
-    rebuilt by the teleop loop on every tick and never mutated in place.
+    The teleop loop rebuilds fresh ``joint_obs`` / ``action`` dicts every
+    tick and calls :meth:`publish`; the capture thread reads the latest
+    slot via :meth:`latest`. The lock protects the slot pointer only — the
+    contained dicts are never mutated in place.
     """
 
     def __init__(self) -> None:
@@ -89,20 +83,14 @@ class _SnapshotPublisher:
 
 
 class _CaptureThread(threading.Thread):
-    """Captures dataset frames at ``fps`` Hz, decoupled from the teleop loop.
+    """Capture dataset frames at ``fps`` Hz, decoupled from the teleop loop.
 
-    Per tick the thread:
-
-    1. Sleeps until ``T_n = recording_start + n * frame_interval``.
-    2. For every camera, calls ``read_at_or_after(T_n)`` so the frame's
-       sender-clock capture time is at or after the tick boundary.
-    3. Snapshots ``publisher.latest()`` for the matching joint sample +
-       action that was actually commanded around the same instant.
-    4. Runs ``robot_obs_proc`` on the combined obs and appends the dataset
-       row.
-
-    On per-camera read timeout / failure the thread reuses the previous good
-    frame for that camera (use-cached policy) and logs at DEBUG.
+    Each tick the thread sleeps until ``T_n = recording_start + n / fps``,
+    waits for a frame with ``capture_perf_ts >= T_n`` from every camera,
+    pulls the latest joint+action snapshot from ``publisher``, and appends
+    one dataset row. If any camera read times out the previous frame for
+    that camera is reused (logged at DEBUG); if no frame has ever arrived
+    for it the tick is skipped.
     """
 
     def __init__(
@@ -224,12 +212,11 @@ class _CaptureThread(threading.Thread):
 
 
 def _parse_stiffness(value: str) -> float | tuple[float, ...]:
-    """Parse a ``--*-stiffness`` value.
+    """Parse a ``--*-stiffness`` value into a scalar or 7-tuple.
 
-    Accepts either a single number in ``[0, 1]`` (applied to all arm
-    joints) or exactly ``len(ARM_JOINTS)`` comma-separated numbers in
-    ``[0, 1]`` — one per joint in :data:`almond_axol.shared.ARM_JOINTS`
-    order (the gripper is not blended).
+    Accepts a single number in ``[0, 1]`` (applied to all arm joints) or
+    ``len(ARM_JOINTS)`` comma-separated numbers in ``[0, 1]`` — one per
+    joint in :data:`almond_axol.shared.ARM_JOINTS` order (gripper excluded).
     """
     parts = [p.strip() for p in value.split(",")]
 
@@ -518,7 +505,8 @@ def _run(
             while True:
                 t0 = time.perf_counter()
 
-                # Joints-only observation — no camera reads on the hot loop.
+                # Camera reads happen on the capture thread; the teleop loop
+                # only ever touches joint state.
                 joint_obs = robot.get_joint_observation()
                 teleop.send_feedback(joint_obs)
                 act = teleop.get_action()

--- a/almond_axol/cli/collect_data.py
+++ b/almond_axol/cli/collect_data.py
@@ -11,14 +11,216 @@ While saving, the VR headset is pushed into the SAVING state so recording
 controls are blocked until save_episode() completes.
 
 Recording continues until Ctrl+C.
+
+Capture is decoupled from teleop
+--------------------------------
+
+The teleop loop runs at ``--teleop-hz`` and produces a fresh
+``(joint_obs, act_processed, t0)`` snapshot every iteration via
+``_SnapshotPublisher``. A separate ``_CaptureThread`` ticks at ``--fps`` and,
+for each tick, blocks on ``ZedCamera.read_at_or_after(T_n)`` so every
+recorded frame uses sender-clock-aligned camera data plus the latest joint
+snapshot. This keeps camera reads, image conversion, and ``dataset.add_frame``
+off the hot 120 Hz control loop.
 """
 
 import argparse
 import logging
+import shutil
 import socket
+import threading
 import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Callable
 
 from ..shared import ARM_JOINTS
+
+if TYPE_CHECKING:
+    from lerobot.datasets.lerobot_dataset import LeRobotDataset
+    from lerobot.types import RobotAction, RobotObservation
+
+    from ..lerobot.robot.robot_axol import AxolRobot
+
+_logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _Snapshot:
+    """Atomic ``(joint_obs, action, capture_ts)`` bundle from one teleop tick.
+
+    Stored references — the producer always builds fresh dicts per tick, so
+    the capture thread observes a consistent slice without copying.
+    """
+
+    joint_obs: "RobotObservation"
+    action: "RobotAction"
+    ts: float
+
+
+class _SnapshotPublisher:
+    """Single-slot atomic publisher: teleop loop writes, capture thread reads.
+
+    The lock protects the slot itself, not the contained dicts — those are
+    rebuilt by the teleop loop on every tick and never mutated in place.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._latest: _Snapshot | None = None
+        self._first_event = threading.Event()
+
+    def publish(
+        self,
+        joint_obs: "RobotObservation",
+        action: "RobotAction",
+        ts: float,
+    ) -> None:
+        snap = _Snapshot(joint_obs=joint_obs, action=action, ts=ts)
+        with self._lock:
+            self._latest = snap
+        self._first_event.set()
+
+    def latest(self) -> _Snapshot | None:
+        with self._lock:
+            return self._latest
+
+    def wait_for_first(self, timeout: float) -> bool:
+        return self._first_event.wait(timeout=timeout)
+
+
+class _CaptureThread(threading.Thread):
+    """Captures dataset frames at ``fps`` Hz, decoupled from the teleop loop.
+
+    Per tick the thread:
+
+    1. Sleeps until ``T_n = recording_start + n * frame_interval``.
+    2. For every camera, calls ``read_at_or_after(T_n)`` so the frame's
+       sender-clock capture time is at or after the tick boundary.
+    3. Snapshots ``publisher.latest()`` for the matching joint sample +
+       action that was actually commanded around the same instant.
+    4. Runs ``robot_obs_proc`` on the combined obs and appends the dataset
+       row.
+
+    On per-camera read timeout / failure the thread reuses the previous good
+    frame for that camera (use-cached policy) and logs at DEBUG.
+    """
+
+    def __init__(
+        self,
+        *,
+        publisher: _SnapshotPublisher,
+        robot: "AxolRobot",
+        dataset: "LeRobotDataset",
+        robot_obs_proc: Callable[[Any], Any],
+        fps: int,
+        task: str,
+        rerun_ip: str | None,
+    ) -> None:
+        super().__init__(name="axol-capture", daemon=True)
+        self.publisher = publisher
+        self.robot = robot
+        self.dataset = dataset
+        self.robot_obs_proc = robot_obs_proc
+        self.fps = fps
+        self.task = task
+        self.rerun_ip = rerun_ip
+        self.stop_event = threading.Event()
+
+    def run(self) -> None:
+        from lerobot.utils.constants import ACTION, OBS_STR
+        from lerobot.utils.feature_utils import build_dataset_frame
+        from lerobot.utils.visualization_utils import log_rerun_data
+
+        if not self.publisher.wait_for_first(timeout=5.0):
+            _logger.warning(
+                "Capture thread saw no publisher snapshot within 5s; exiting."
+            )
+            return
+        if self.stop_event.is_set():
+            return
+
+        frame_interval = 1.0 / self.fps
+        timeout_ms = int(2 * frame_interval * 1000 + 200)
+        recording_start = time.perf_counter()
+        last_frames: dict[str, tuple[Any, float, float]] = {}
+        tick = 0
+
+        while not self.stop_event.is_set():
+            target_perf_ts = recording_start + tick * frame_interval
+
+            wait_s = target_perf_ts - time.perf_counter()
+            if wait_s > 0 and self.stop_event.wait(timeout=wait_s):
+                return
+
+            frames: dict[str, tuple[Any, float, float]] = {}
+            skip_tick = False
+            for cam_key, cam in self.robot.cameras.items():
+                try:
+                    frame, cap_ts, recv_ts = cam.read_at_or_after(  # type: ignore[attr-defined]
+                        target_perf_ts, timeout_ms=timeout_ms
+                    )
+                except (TimeoutError, RuntimeError) as exc:
+                    cached = last_frames.get(cam_key)
+                    if cached is None:
+                        _logger.debug(
+                            "Capture tick %d: %s read failed (%s) and no "
+                            "cached frame; skipping tick.",
+                            tick,
+                            cam_key,
+                            exc,
+                        )
+                        skip_tick = True
+                        break
+                    _logger.debug(
+                        "Capture tick %d: %s read failed (%s); reusing cached frame.",
+                        tick,
+                        cam_key,
+                        exc,
+                    )
+                    frame, cap_ts, recv_ts = cached
+                frames[cam_key] = (frame, cap_ts, recv_ts)
+                last_frames[cam_key] = (frame, cap_ts, recv_ts)
+
+            if skip_tick:
+                tick += 1
+                continue
+
+            snap = self.publisher.latest()
+            if snap is None:
+                tick += 1
+                continue
+
+            obs: dict[str, Any] = dict(snap.joint_obs)
+            for cam_key, (frame, _cap_ts, _recv_ts) in frames.items():
+                obs[cam_key] = frame
+            obs_processed = self.robot_obs_proc(obs)
+
+            obs_frame = build_dataset_frame(
+                self.dataset.features, obs_processed, prefix=OBS_STR
+            )
+            act_frame = build_dataset_frame(
+                self.dataset.features, snap.action, prefix=ACTION
+            )
+            if self.stop_event.is_set():
+                return
+            self.dataset.add_frame({**obs_frame, **act_frame, "task": self.task})
+
+            if self.rerun_ip:
+                log_rerun_data(observation=obs_processed, action=snap.action)
+
+            if _logger.isEnabledFor(logging.DEBUG) and tick % 30 == 0:
+                cam_skews = ", ".join(
+                    f"{k}: cap-T={1e3 * (cap_ts - target_perf_ts):+.1f}ms"
+                    for k, (_, cap_ts, _) in frames.items()
+                )
+                _logger.debug(
+                    "Capture tick %d skews — %s, T-snap.ts=%+.1fms",
+                    tick,
+                    cam_skews,
+                    1e3 * (target_perf_ts - snap.ts),
+                )
+
+            tick += 1
 
 
 def _parse_stiffness(value: str) -> float | tuple[float, ...]:
@@ -207,11 +409,10 @@ def _run(
     from lerobot.teleoperators.utils import TeleopEvents
     from lerobot.utils.constants import ACTION, HF_LEROBOT_HOME, OBS_STR
     from lerobot.utils.feature_utils import (
-        build_dataset_frame,
         hw_to_dataset_features,
     )
     from lerobot.utils.utils import log_say
-    from lerobot.utils.visualization_utils import init_rerun, log_rerun_data
+    from lerobot.utils.visualization_utils import init_rerun
 
     from ..lerobot.camera.configuration_zed import ZedCameraConfig
     from ..lerobot.robot.config_axol import AxolRobotConfig
@@ -277,6 +478,9 @@ def _run(
             repo_id=repo_id,
             root=str(dataset_root),
             image_writer_threads=4,
+            streaming_encoding=True,
+            encoder_threads=4,
+            vcodec="auto",
         )
     else:
         action_features = hw_to_dataset_features(robot.action_features, ACTION)
@@ -289,15 +493,19 @@ def _run(
             robot_type=robot.name,
             use_videos=True,
             image_writer_threads=4,
+            streaming_encoding=True,
+            encoder_threads=4,
+            vcodec="auto",
         )
     pos_l, pos_r = robot.positions
     teleop.connect(q_start_left=pos_l, q_start_right=pos_r)
     teleop_action_proc, robot_action_proc, robot_obs_proc = make_default_processors()
 
     episodes_recorded = 0
-    episode_idx = dataset.num_episodes  # global index; increments as episodes are saved
+    episode_idx = dataset.num_episodes
     teleop_interval = 1.0 / teleop_hz
-    frame_interval = 1.0 / fps
+    publisher = _SnapshotPublisher()
+    capture: _CaptureThread | None = None
     try:
         while True:
             log_say(
@@ -306,41 +514,34 @@ def _run(
             dataset.clear_episode_buffer()
             recording = False
             rerecord = False
-            last_frame_t = 0.0  # timestamp of the last dataset frame written
 
             while True:
                 t0 = time.perf_counter()
 
-                # Joints-only observation — no camera copies at teleop rate.
+                # Joints-only observation — no camera reads on the hot loop.
                 joint_obs = robot.get_joint_observation()
                 teleop.send_feedback(joint_obs)
                 act = teleop.get_action()
                 act_processed = teleop_action_proc((act, joint_obs))
                 robot.send_action(robot_action_proc((act_processed, joint_obs)))
 
+                publisher.publish(joint_obs, act_processed, t0)
+
                 events = teleop.get_teleop_events()
 
                 if events.get("start_recording") and not recording:
                     recording = True
-                    last_frame_t = (
-                        t0 - frame_interval
-                    )  # align first frame to recording start
+                    capture = _CaptureThread(
+                        publisher=publisher,
+                        robot=robot,
+                        dataset=dataset,
+                        robot_obs_proc=robot_obs_proc,
+                        fps=fps,
+                        task=task,
+                        rerun_ip=rerun_ip,
+                    )
+                    capture.start()
                     log_say("Recording started.")
-
-                # Dataset frame at --fps rate: read cameras + process images here only.
-                if recording and (t0 - last_frame_t) >= frame_interval:
-                    last_frame_t += frame_interval
-                    obs = robot.get_observation()
-                    obs_processed = robot_obs_proc(obs)
-                    obs_frame = build_dataset_frame(
-                        dataset.features, obs_processed, prefix=OBS_STR
-                    )
-                    act_frame = build_dataset_frame(
-                        dataset.features, act_processed, prefix=ACTION
-                    )
-                    dataset.add_frame({**obs_frame, **act_frame, "task": task})
-                    if rerun_ip:
-                        log_rerun_data(observation=obs_processed, action=act_processed)
 
                 if events[TeleopEvents.TERMINATE_EPISODE]:
                     teleop.send_feedback_state(VRState.SAVING)
@@ -351,8 +552,11 @@ def _run(
 
                 time.sleep(max(0.0, teleop_interval - (time.perf_counter() - t0)))
 
-            # Return to rest pose before the next episode so the operator
-            # starts each take from a consistent configuration.
+            if capture is not None:
+                capture.stop_event.set()
+                capture.join()
+                capture = None
+
             log_say("Returning to rest pose.")
             teleop.request_reset()
             reset_deadline = time.perf_counter() + 30.0
@@ -362,7 +566,7 @@ def _run(
                 act = teleop.get_action()
                 robot.send_action(robot_action_proc((act, joint_obs)))
                 time.sleep(max(0.0, teleop_interval - (time.perf_counter() - t0)))
-            # Drain any VR events that fired during the reset move.
+            # Drain VR events fired during the reset move.
             teleop.get_teleop_events()
 
             if rerecord:
@@ -387,9 +591,25 @@ def _run(
         teleop.send_feedback_error()
         raise
     finally:
+        if capture is not None:
+            capture.stop_event.set()
+            capture.join()
+
         log_say("Stopping.")
+
         robot.disconnect()
         teleop.disconnect()
+
         dataset.finalize()
+
         if push_to_hub and episodes_recorded > 0:
             dataset.push_to_hub()
+
+        if not is_complete and episodes_recorded == 0 and dataset_root.exists():
+            try:
+                shutil.rmtree(dataset_root)
+                log_say(f"No episodes saved — removed empty dataset at {dataset_root}.")
+            except OSError as exc:
+                _logger.warning(
+                    "Failed to remove empty dataset at %s: %s", dataset_root, exc
+                )

--- a/almond_axol/cli/collect_data.py
+++ b/almond_axol/cli/collect_data.py
@@ -18,6 +18,44 @@ import logging
 import socket
 import time
 
+from ..shared import ARM_JOINTS
+
+
+def _parse_stiffness(value: str) -> float | tuple[float, ...]:
+    """Parse a ``--*-stiffness`` value.
+
+    Accepts either a single number in ``[0, 1]`` (applied to all arm
+    joints) or exactly ``len(ARM_JOINTS)`` comma-separated numbers in
+    ``[0, 1]`` — one per joint in :data:`almond_axol.shared.ARM_JOINTS`
+    order (the gripper is not blended).
+    """
+    parts = [p.strip() for p in value.split(",")]
+
+    def _parse_one(raw: str, label: str) -> float:
+        try:
+            x = float(raw)
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError(
+                f"stiffness{label} is not a number: {raw!r}"
+            ) from exc
+        if not 0.0 <= x <= 1.0:
+            raise argparse.ArgumentTypeError(
+                f"stiffness{label} must be in [0, 1], got {x}"
+            )
+        return x
+
+    if len(parts) == 1:
+        return _parse_one(parts[0], "")
+    if len(parts) != len(ARM_JOINTS):
+        raise argparse.ArgumentTypeError(
+            f"stiffness must be a single value or {len(ARM_JOINTS)} "
+            f"comma-separated values (one per joint: "
+            f"{', '.join(j.value for j in ARM_JOINTS)}), got {len(parts)}"
+        )
+    return tuple(
+        _parse_one(p, f"[{i}={ARM_JOINTS[i].value}]") for i, p in enumerate(parts)
+    )
+
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
     p = subparsers.add_parser("collect-data", help="Record teleoperation episodes.")
@@ -68,10 +106,39 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[
         ),
     )
     p.add_argument(
-        "--gripper-torque-limit",
+        "--left-gripper-torque-limit",
         type=float,
         default=1.0,
-        help="Max output torque (Nm) for the gripper in POSITION_FORCE mode (default: 1.0).",
+        help="Max output torque (Nm) for the left gripper in POSITION_FORCE mode (default: 1.0).",
+    )
+    p.add_argument(
+        "--right-gripper-torque-limit",
+        type=float,
+        default=1.0,
+        help="Max output torque (Nm) for the right gripper in POSITION_FORCE mode (default: 1.0).",
+    )
+    stiffness_help = (
+        "Compliance ↔ stiffness blend in [0, 1] for the {side} arm. "
+        f"Either a single value applied to all {len(ARM_JOINTS)} joints, "
+        f"or {len(ARM_JOINTS)} comma-separated values (one per joint, in "
+        f"order: {', '.join(j.value for j in ARM_JOINTS)}; gripper "
+        "excluded). 0 (default) is fully compliant; 1 restores the "
+        "pre-tuning industrial gains. See AxolConfig.{attr}."
+    )
+    stiffness_metavar = "S|" + ",".join("S" for _ in ARM_JOINTS)
+    p.add_argument(
+        "--left-stiffness",
+        type=_parse_stiffness,
+        default=0.0,
+        metavar=stiffness_metavar,
+        help=stiffness_help.format(side="left", attr="left_stiffness"),
+    )
+    p.add_argument(
+        "--right-stiffness",
+        type=_parse_stiffness,
+        default=0.0,
+        metavar=stiffness_metavar,
+        help=stiffness_help.format(side="right", attr="right_stiffness"),
     )
     p.add_argument(
         "--rerun-ip",
@@ -108,7 +175,10 @@ def run(args: argparse.Namespace) -> None:
         push_to_hub=args.push_to_hub,
         zed_host=args.zed_host,
         zed_iface=args.zed_iface,
-        gripper_torque_limit=args.gripper_torque_limit,
+        left_gripper_torque_limit=args.left_gripper_torque_limit,
+        right_gripper_torque_limit=args.right_gripper_torque_limit,
+        left_stiffness=args.left_stiffness,
+        right_stiffness=args.right_stiffness,
         rerun_ip=args.rerun_ip,
         rerun_port=args.rerun_port,
     )
@@ -123,7 +193,10 @@ def _run(
     push_to_hub: bool = False,
     zed_host: str = "192.168.10.1",
     zed_iface: str | None = None,
-    gripper_torque_limit: float = 1.0,
+    left_gripper_torque_limit: float = 1.0,
+    right_gripper_torque_limit: float = 1.0,
+    left_stiffness: float | tuple[float, ...] = 0.0,
+    right_stiffness: float | tuple[float, ...] = 0.0,
     rerun_ip: str | None = None,
     rerun_port: int = 9876,
 ) -> None:
@@ -152,9 +225,12 @@ def _run(
     if zed_iface:
         setup_link_ip(zed_iface, "192.168.10.2/24")
 
-    axol_config = AxolConfig()
-    axol_config.left.gripper.torque_limit = gripper_torque_limit
-    axol_config.right.gripper.torque_limit = gripper_torque_limit
+    axol_config = AxolConfig(
+        left_stiffness=left_stiffness,
+        right_stiffness=right_stiffness,
+    )
+    axol_config.left.gripper.torque_limit = left_gripper_torque_limit
+    axol_config.right.gripper.torque_limit = right_gripper_torque_limit
     robot_config = AxolRobotConfig(
         cameras={
             "overhead": ZedCameraConfig(host=zed_host, port=30000),

--- a/almond_axol/cli/run_policy.py
+++ b/almond_axol/cli/run_policy.py
@@ -238,6 +238,10 @@ def _run(
             while time.perf_counter() < deadline:
                 t0 = time.perf_counter()
 
+                # TODO: swap in `ZedCamera.read_at_or_after(t0)` so inference
+                # uses the same sender-clock-aligned camera/joint pairing as
+                # the training data — `read_latest()` introduces a ~1 frame
+                # skew vs training.
                 obs = robot.get_observation()
                 obs_processed = robot_obs_proc(obs)
 

--- a/almond_axol/cli/teleop.py
+++ b/almond_axol/cli/teleop.py
@@ -9,6 +9,44 @@ import asyncio
 import logging
 import socket
 
+from ..shared import ARM_JOINTS
+
+
+def _parse_stiffness(value: str) -> float | tuple[float, ...]:
+    """Parse a ``--*-stiffness`` value.
+
+    Accepts either a single number in ``[0, 1]`` (applied to all arm
+    joints) or exactly ``len(ARM_JOINTS)`` comma-separated numbers in
+    ``[0, 1]`` — one per joint in :data:`almond_axol.shared.ARM_JOINTS`
+    order (the gripper is not blended).
+    """
+    parts = [p.strip() for p in value.split(",")]
+
+    def _parse_one(raw: str, label: str) -> float:
+        try:
+            x = float(raw)
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError(
+                f"stiffness{label} is not a number: {raw!r}"
+            ) from exc
+        if not 0.0 <= x <= 1.0:
+            raise argparse.ArgumentTypeError(
+                f"stiffness{label} must be in [0, 1], got {x}"
+            )
+        return x
+
+    if len(parts) == 1:
+        return _parse_one(parts[0], "")
+    if len(parts) != len(ARM_JOINTS):
+        raise argparse.ArgumentTypeError(
+            f"stiffness must be a single value or {len(ARM_JOINTS)} "
+            f"comma-separated values (one per joint: "
+            f"{', '.join(j.value for j in ARM_JOINTS)}), got {len(parts)}"
+        )
+    return tuple(
+        _parse_one(p, f"[{i}={ARM_JOINTS[i].value}]") for i, p in enumerate(parts)
+    )
+
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
     p = subparsers.add_parser("teleop", help="Run a VR teleoperation session.")
@@ -40,15 +78,28 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[
         default=1.0,
         help="Max output torque (Nm) for the right gripper in POSITION_FORCE mode (default: 1.0).",
     )
+    stiffness_help = (
+        "Compliance ↔ stiffness blend in [0, 1] for the {side} arm. "
+        f"Either a single value applied to all {len(ARM_JOINTS)} joints, "
+        f"or {len(ARM_JOINTS)} comma-separated values (one per joint, in "
+        f"order: {', '.join(j.value for j in ARM_JOINTS)}; gripper "
+        "excluded). 0 (default) is fully compliant; 1 restores the "
+        "pre-tuning industrial gains. See AxolConfig.{attr}."
+    )
+    stiffness_metavar = "S|" + ",".join("S" for _ in ARM_JOINTS)
     p.add_argument(
-        "--stiffness",
-        type=float,
+        "--left-stiffness",
+        type=_parse_stiffness,
         default=0.0,
-        help=(
-            "Compliance ↔ stiffness blend in [0, 1]. 0 (default) is fully "
-            "compliant; 1 restores the pre-tuning industrial gains. See "
-            "AxolConfig.stiffness."
-        ),
+        metavar=stiffness_metavar,
+        help=stiffness_help.format(side="left", attr="left_stiffness"),
+    )
+    p.add_argument(
+        "--right-stiffness",
+        type=_parse_stiffness,
+        default=0.0,
+        metavar=stiffness_metavar,
+        help=stiffness_help.format(side="right", attr="right_stiffness"),
     )
     p.add_argument(
         "--log-level",
@@ -81,7 +132,8 @@ def run(args: argparse.Namespace) -> None:
             no_right=args.no_right,
             left_gripper_torque_limit=args.left_gripper_torque_limit,
             right_gripper_torque_limit=args.right_gripper_torque_limit,
-            stiffness=args.stiffness,
+            left_stiffness=args.left_stiffness,
+            right_stiffness=args.right_stiffness,
         )
     )
 
@@ -93,7 +145,8 @@ async def _run(
     no_right: bool = False,
     left_gripper_torque_limit: float = 1.0,
     right_gripper_torque_limit: float = 1.0,
-    stiffness: float = 0.0,
+    left_stiffness: float | tuple[float, ...] = 0.0,
+    right_stiffness: float | tuple[float, ...] = 0.0,
 ) -> None:
     from ..robot import Axol, Sim
     from ..robot.config import AxolConfig
@@ -107,7 +160,10 @@ async def _run(
             kwargs["left_channel"] = None
         if no_right:
             kwargs["right_channel"] = None
-        axol_config = AxolConfig(stiffness=stiffness)
+        axol_config = AxolConfig(
+            left_stiffness=left_stiffness,
+            right_stiffness=right_stiffness,
+        )
         axol_config.left.gripper.torque_limit = left_gripper_torque_limit
         axol_config.right.gripper.torque_limit = right_gripper_torque_limit
         robot = Axol(config=axol_config, **kwargs)

--- a/almond_axol/cli/tune/repeatability.py
+++ b/almond_axol/cli/tune/repeatability.py
@@ -14,10 +14,13 @@ touch.
 Useful for measuring how reliably the grippers return to the same
 physical contact point after a long sequence of motions.
 
+The arms always run at maximum stiffness (the pre-tuning industrial gains
+in :data:`_STIFF_GAINS`) — repeatability is meaningless under the compliant
+gains used for teleop.
+
 Examples:
-    axol tune.repeatability                    # forever, max compliance
-    axol tune.repeatability --stiffness 0.5    # blend partway to stiff gains
-    axol tune.repeatability --cycles 5         # five touch-and-return cycles
+    axol tune.repeatability               # forever
+    axol tune.repeatability --cycles 5    # five touch-and-return cycles
 """
 
 from __future__ import annotations
@@ -256,16 +259,6 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[
         description=__doc__,
     )
     p.add_argument(
-        "--stiffness",
-        type=float,
-        default=0.0,
-        help=(
-            "Compliance ↔ stiffness blend in [0, 1]. 0 (default) is fully "
-            "compliant; 1 restores the pre-tuning industrial gains. See "
-            "AxolConfig.stiffness."
-        ),
-    )
-    p.add_argument(
         "--cycles",
         type=int,
         default=0,
@@ -325,8 +318,6 @@ def run(args: argparse.Namespace) -> None:
 async def _run(args: argparse.Namespace) -> None:
     if args.no_left and args.no_right:
         raise SystemExit("Both arms disabled — nothing to test.")
-    if not 0.0 <= args.stiffness <= 1.0:
-        raise SystemExit(f"--stiffness must be in [0, 1], got {args.stiffness}")
 
     rest_cfg = VRTeleopConfig()
 
@@ -373,12 +364,12 @@ async def _run(args: argparse.Namespace) -> None:
         axol_kwargs["left_channel"] = None
     if args.no_right:
         axol_kwargs["right_channel"] = None
-    axol_config = AxolConfig(stiffness=args.stiffness)
+    axol_config = AxolConfig(left_stiffness=1.0, right_stiffness=1.0)
     axol_config.left.gripper.torque_limit = args.gripper_torque_limit
     axol_config.right.gripper.torque_limit = args.gripper_torque_limit
 
     print(
-        f"Repeatability run: stiffness={args.stiffness:.2f}, "
+        f"Repeatability run: "
         f"{'∞' if args.cycles == 0 else args.cycles} cycle(s), "
         f"rate={args.rate:.0f} Hz. Press Ctrl-C to stop."
     )

--- a/almond_axol/cli/zed/sync_clocks.py
+++ b/almond_axol/cli/zed/sync_clocks.py
@@ -1,0 +1,424 @@
+"""
+axol zed.sync-clocks
+
+Run a PTP (Precision Time Protocol) daemon over the direct ethernet link
+between the Jetson sender and the upper-computer receiver so both machines'
+``CLOCK_REALTIME`` clocks stay aligned to sub-millisecond accuracy.
+
+The ZED SDK stamps every frame on the *sender's* ``CLOCK_REALTIME`` via
+``TIME_REFERENCE.IMAGE``. The receiver later converts that wall-clock stamp
+into its own monotonic ``perf_counter`` so the dataset row's "frame time"
+reflects the moment of capture rather than the moment of decode. None of
+that works unless both machines agree on what time it is — which is what
+this command exists to deliver.
+
+Typical operator workflow (one terminal per machine):
+
+    axol zed.sync-clocks --role master --iface eth0   # upper computer
+    axol zed.sync-clocks --role slave  --iface eth0   # Jetson
+
+Both processes stay running in the foreground for the duration of any
+collection session.
+
+The privileged subprocesses (`ptp4l`, `phc2sys`, and the apt-get auto-install
+fallback) are escalated inline via `sudo`, so the `axol` invocation itself
+does not need to be run as root. Sudo will prompt for a password on first
+escalation and reuse cached credentials for the rest of the session. On
+non-apt systems install `linuxptp` (for ptp4l/phc2sys) and `ethtool`
+manually before running this command.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+_logger = logging.getLogger(__name__)
+
+_OFFSET_RE = re.compile(
+    r"master offset\s+(?P<offset>-?\d+)\b.*?freq\s+(?P<freq>-?\d+)",
+    re.IGNORECASE,
+)
+
+# Map executable name -> apt package that provides it. Used by
+# `_ensure_executable` to auto-install missing dependencies on Debian/Ubuntu.
+_APT_PACKAGES = {
+    "ptp4l": "linuxptp",
+    "phc2sys": "linuxptp",
+    "ethtool": "ethtool",
+}
+
+
+def add_parser(subparsers) -> None:  # type: ignore[type-arg]
+    p = subparsers.add_parser(
+        "zed.sync-clocks",
+        help=(
+            "Synchronize sender and receiver CLOCK_REALTIME via PTP over the "
+            "direct ethernet link (required for accurate ZED frame timestamps)."
+        ),
+    )
+    p.add_argument(
+        "--role",
+        required=True,
+        choices=["master", "slave"],
+        help=(
+            "PTP role for this machine. The upper computer (long-lived "
+            "receiver) should be `master`; the Jetson sender should be `slave`."
+        ),
+    )
+    p.add_argument(
+        "--iface",
+        required=True,
+        metavar="IFACE",
+        help="Network interface carrying the direct link (e.g. eth0).",
+    )
+    p.add_argument(
+        "--transport",
+        default="l2",
+        choices=["l2", "udpv4"],
+        help=(
+            "PTP transport. `l2` (raw ethernet, default) is lower latency; "
+            "`udpv4` is useful if a switch in between filters PTP ethertype."
+        ),
+    )
+    p.add_argument(
+        "--timestamping",
+        default="auto",
+        choices=["auto", "hardware", "software"],
+        help=(
+            "Force a timestamping mode. `auto` (default) probes "
+            "`ethtool -T <iface>` and prefers hardware if available."
+        ),
+    )
+    p.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="Logging level (default: INFO).",
+    )
+    p.set_defaults(func=run)
+
+
+def run(args: argparse.Namespace) -> None:
+    logging.basicConfig(level=getattr(logging, args.log_level))
+    try:
+        _run(
+            role=args.role,
+            iface=args.iface,
+            transport=args.transport,
+            timestamping=args.timestamping,
+        )
+    except KeyboardInterrupt:
+        pass
+
+
+def _run(*, role: str, iface: str, transport: str, timestamping: str) -> None:
+    _ensure_executable("ptp4l", required=True)
+    _ensure_executable("phc2sys", required=True)
+
+    if not Path(f"/sys/class/net/{iface}").exists():
+        raise SystemExit(
+            f"error: interface {iface!r} not found in /sys/class/net. "
+            f"Plug in the cable or check `ip link show`."
+        )
+
+    timestamping_mode = _resolve_timestamping(iface, timestamping)
+    _logger.info(
+        "Starting PTP role=%s iface=%s transport=%s timestamping=%s",
+        role,
+        iface,
+        transport,
+        timestamping_mode,
+    )
+
+    ptp4l_cmd = _with_sudo(
+        _build_ptp4l_cmd(
+            iface=iface,
+            role=role,
+            transport=transport,
+            timestamping=timestamping_mode,
+        )
+    )
+    phc2sys_cmd = _with_sudo(
+        _build_phc2sys_cmd(
+            iface=iface,
+            role=role,
+            timestamping=timestamping_mode,
+        )
+    )
+
+    _logger.info("ptp4l:   %s", " ".join(ptp4l_cmd))
+    _logger.info("phc2sys: %s", " ".join(phc2sys_cmd))
+
+    ptp4l_proc = subprocess.Popen(
+        ptp4l_cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+    phc2sys_proc = subprocess.Popen(
+        phc2sys_cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+
+    procs: list[tuple[str, subprocess.Popen[str]]] = [
+        ("ptp4l", ptp4l_proc),
+        ("phc2sys", phc2sys_proc),
+    ]
+    stop_event = threading.Event()
+
+    def _handle_signal(signum: int, _frame: object) -> None:
+        _logger.info("Received signal %d; shutting down PTP processes.", signum)
+        stop_event.set()
+
+    signal.signal(signal.SIGINT, _handle_signal)
+    signal.signal(signal.SIGTERM, _handle_signal)
+
+    threads: list[threading.Thread] = []
+    for name, proc in procs:
+        t = threading.Thread(
+            target=_stream_subprocess,
+            args=(name, proc, stop_event),
+            name=f"axol-{name}-stream",
+            daemon=True,
+        )
+        t.start()
+        threads.append(t)
+
+    try:
+        while not stop_event.is_set():
+            for name, proc in procs:
+                if proc.poll() is not None:
+                    _logger.error(
+                        "%s exited unexpectedly with code %d; tearing down.",
+                        name,
+                        proc.returncode,
+                    )
+                    stop_event.set()
+                    break
+            stop_event.wait(timeout=0.5)
+    finally:
+        _terminate_procs(procs)
+        for t in threads:
+            t.join(timeout=2.0)
+
+
+def _with_sudo(cmd: list[str]) -> list[str]:
+    """Prepend `sudo` when the current process is not already root.
+
+    Sudo caches credentials per-tty for ~5 minutes by default, so back-to-back
+    privileged subprocesses (ptp4l + phc2sys) only prompt for a password once.
+    """
+    if os.geteuid() == 0:
+        return cmd
+    return ["sudo", *cmd]
+
+
+def _ensure_executable(name: str, *, required: bool) -> bool:
+    """Return True if ``name`` is on PATH, installing it via apt if missing.
+
+    Auto-install only runs on systems where ``apt-get`` is available
+    (Debian/Ubuntu). When ``required`` is True and the executable cannot be
+    made available, raises ``SystemExit`` with a manual-install hint;
+    otherwise returns False and the caller is expected to degrade gracefully.
+    """
+    if shutil.which(name) is not None:
+        return True
+
+    pkg = _APT_PACKAGES.get(name)
+    if pkg is not None and shutil.which("apt-get") is not None:
+        _logger.info(
+            "`%s` not found on PATH — installing the `%s` apt package ...",
+            name,
+            pkg,
+        )
+        cmd = _with_sudo(["apt-get", "install", "-y", "--no-install-recommends", pkg])
+        env = {**os.environ, "DEBIAN_FRONTEND": "noninteractive"}
+        try:
+            subprocess.run(cmd, check=True, env=env)
+        except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+            _logger.warning("Auto-install of `%s` failed: %s", pkg, exc)
+        else:
+            if shutil.which(name) is not None:
+                _logger.info("Installed `%s` (provides `%s`).", pkg, name)
+                return True
+
+    if required:
+        hint = (
+            f"sudo apt install {pkg}"
+            if pkg is not None
+            else f"install `{name}` and rerun"
+        )
+        raise SystemExit(
+            f"error: `{name}` not found on PATH and auto-install was "
+            f"unavailable or failed. Try manually: {hint}."
+        )
+    return False
+
+
+def _resolve_timestamping(iface: str, mode: str) -> str:
+    if mode != "auto":
+        return mode
+
+    hw_supported = _probe_hardware_timestamping(iface)
+    if hw_supported:
+        _logger.info(
+            "ethtool reports hardware timestamping on %s — using hardware.", iface
+        )
+        return "hardware"
+    _logger.warning(
+        "ethtool shows no PHC / hardware timestamping on %s. "
+        "Falling back to software timestamping; expect ~10-100us extra jitter. "
+        "(Pass --timestamping software explicitly to silence this warning.)",
+        iface,
+    )
+    return "software"
+
+
+def _probe_hardware_timestamping(iface: str) -> bool:
+    if not _ensure_executable("ethtool", required=False):
+        _logger.warning(
+            "ethtool not installed and auto-install failed; cannot probe "
+            "hardware timestamping for %s.",
+            iface,
+        )
+        return False
+    try:
+        result = subprocess.run(
+            ["ethtool", "-T", iface],
+            capture_output=True,
+            text=True,
+            timeout=5.0,
+        )
+    except (subprocess.SubprocessError, OSError) as exc:
+        _logger.warning("ethtool -T %s failed: %s", iface, exc)
+        return False
+
+    if result.returncode != 0:
+        _logger.warning(
+            "ethtool -T %s returned %d: %s",
+            iface,
+            result.returncode,
+            result.stderr.strip(),
+        )
+        return False
+
+    text = result.stdout
+    has_phc = bool(re.search(r"PTP Hardware Clock:\s*(\d+)", text))
+    has_hw_tx = "hardware-transmit" in text
+    has_hw_rx = "hardware-receive" in text
+    has_hw_raw = "hardware-raw-clock" in text
+    return has_phc and has_hw_tx and has_hw_rx and has_hw_raw
+
+
+def _build_ptp4l_cmd(
+    *, iface: str, role: str, transport: str, timestamping: str
+) -> list[str]:
+    cmd = ["ptp4l", "-i", iface, "-m"]
+    if transport == "l2":
+        cmd.append("-2")
+    if timestamping == "hardware":
+        cmd.append("-H")
+    else:
+        cmd.append("-S")
+    if role == "slave":
+        cmd.append("-s")
+    return cmd
+
+
+def _build_phc2sys_cmd(*, iface: str, role: str, timestamping: str) -> list[str]:
+    if timestamping != "hardware":
+        # No PHC available — phc2sys runs in "free" mode pinning CLOCK_REALTIME
+        # to itself, which is a no-op but lets ptp4l (in software mode) still
+        # discipline the kernel clock through its own SO_TIMESTAMPING path.
+        return [
+            "phc2sys",
+            "-c",
+            "CLOCK_REALTIME",
+            "-s",
+            "CLOCK_REALTIME",
+            "-O",
+            "0",
+            "-w",
+        ]
+
+    if role == "slave":
+        # Receiver follows the PHC that ptp4l is disciplining.
+        return ["phc2sys", "-s", iface, "-c", "CLOCK_REALTIME", "-O", "0", "-w", "-m"]
+    # Master pushes its system clock onto the PHC so ptp4l serves it out.
+    return ["phc2sys", "-s", "CLOCK_REALTIME", "-c", iface, "-O", "0", "-w", "-m"]
+
+
+def _stream_subprocess(
+    name: str, proc: subprocess.Popen[str], stop_event: threading.Event
+) -> None:
+    last_report = 0.0
+    last_offset: int | None = None
+    last_freq: int | None = None
+
+    if proc.stdout is None:
+        return
+    for line in proc.stdout:
+        if stop_event.is_set():
+            break
+        line = line.rstrip()
+        if not line:
+            continue
+        sys.stdout.write(f"[{name}] {line}\n")
+        sys.stdout.flush()
+
+        m = _OFFSET_RE.search(line)
+        if m is not None:
+            try:
+                last_offset = int(m.group("offset"))
+                last_freq = int(m.group("freq"))
+            except ValueError:
+                pass
+
+        now = time.monotonic()
+        if last_offset is not None and now - last_report > 5.0:
+            _logger.info(
+                "[%s] latest master offset = %+d ns, freq adj = %+d ppb",
+                name,
+                last_offset,
+                last_freq if last_freq is not None else 0,
+            )
+            last_report = now
+
+
+def _terminate_procs(procs: list[tuple[str, subprocess.Popen[str]]]) -> None:
+    for name, proc in procs:
+        if proc.poll() is None:
+            _logger.info("Terminating %s (pid %d).", name, proc.pid)
+            try:
+                proc.terminate()
+            except OSError:
+                pass
+    deadline = time.monotonic() + 3.0
+    for name, proc in procs:
+        timeout = max(0.0, deadline - time.monotonic())
+        try:
+            proc.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            _logger.warning("%s did not exit cleanly; killing.", name)
+            try:
+                proc.kill()
+            except OSError:
+                pass
+            try:
+                proc.wait(timeout=2.0)
+            except subprocess.TimeoutExpired:
+                pass

--- a/almond_axol/cli/zed/sync_clocks.py
+++ b/almond_axol/cli/zed/sync_clocks.py
@@ -2,30 +2,19 @@
 axol zed.sync-clocks
 
 Run a PTP (Precision Time Protocol) daemon over the direct ethernet link
-between the Jetson sender and the upper-computer receiver so both machines'
-``CLOCK_REALTIME`` clocks stay aligned to sub-millisecond accuracy.
+between the Jetson sender and the upper-computer receiver, holding both
+machines' ``CLOCK_REALTIME`` to sub-millisecond agreement. Required for the
+ZED-frame ``TIME_REFERENCE.IMAGE`` timestamps consumed by ``collect-data``.
 
-The ZED SDK stamps every frame on the *sender's* ``CLOCK_REALTIME`` via
-``TIME_REFERENCE.IMAGE``. The receiver later converts that wall-clock stamp
-into its own monotonic ``perf_counter`` so the dataset row's "frame time"
-reflects the moment of capture rather than the moment of decode. None of
-that works unless both machines agree on what time it is — which is what
-this command exists to deliver.
-
-Typical operator workflow (one terminal per machine):
+Both processes run in the foreground for the duration of a collection
+session, one per machine:
 
     axol zed.sync-clocks --role master --iface eth0   # upper computer
     axol zed.sync-clocks --role slave  --iface eth0   # Jetson
 
-Both processes stay running in the foreground for the duration of any
-collection session.
-
-The privileged subprocesses (`ptp4l`, `phc2sys`, and the apt-get auto-install
-fallback) are escalated inline via `sudo`, so the `axol` invocation itself
-does not need to be run as root. Sudo will prompt for a password on first
-escalation and reuse cached credentials for the rest of the session. On
-non-apt systems install `linuxptp` (for ptp4l/phc2sys) and `ethtool`
-manually before running this command.
+``ptp4l``, ``phc2sys`` and the apt-get auto-install fallback are escalated
+via ``sudo`` so the ``axol`` invocation itself does not need to be root.
+On non-apt systems install ``linuxptp`` and ``ethtool`` manually first.
 """
 
 from __future__ import annotations
@@ -49,8 +38,8 @@ _OFFSET_RE = re.compile(
     re.IGNORECASE,
 )
 
-# Map executable name -> apt package that provides it. Used by
-# `_ensure_executable` to auto-install missing dependencies on Debian/Ubuntu.
+# Executable -> apt package, used by ``_ensure_executable`` to auto-install
+# missing dependencies on Debian/Ubuntu.
 _APT_PACKAGES = {
     "ptp4l": "linuxptp",
     "phc2sys": "linuxptp",
@@ -217,23 +206,19 @@ def _run(*, role: str, iface: str, transport: str, timestamping: str) -> None:
 
 
 def _with_sudo(cmd: list[str]) -> list[str]:
-    """Prepend `sudo` when the current process is not already root.
-
-    Sudo caches credentials per-tty for ~5 minutes by default, so back-to-back
-    privileged subprocesses (ptp4l + phc2sys) only prompt for a password once.
-    """
+    """Prepend ``sudo`` unless the current process is already root."""
     if os.geteuid() == 0:
         return cmd
     return ["sudo", *cmd]
 
 
 def _ensure_executable(name: str, *, required: bool) -> bool:
-    """Return True if ``name`` is on PATH, installing it via apt if missing.
+    """Return True if ``name`` is on PATH, installing via apt if missing.
 
-    Auto-install only runs on systems where ``apt-get`` is available
-    (Debian/Ubuntu). When ``required`` is True and the executable cannot be
-    made available, raises ``SystemExit`` with a manual-install hint;
-    otherwise returns False and the caller is expected to degrade gracefully.
+    Auto-install runs only on Debian/Ubuntu (where ``apt-get`` exists). If
+    ``required`` is True and the executable still isn't available, raises
+    ``SystemExit`` with a manual-install hint; otherwise returns False so
+    the caller can degrade gracefully.
     """
     if shutil.which(name) is not None:
         return True
@@ -341,9 +326,8 @@ def _build_ptp4l_cmd(
 
 def _build_phc2sys_cmd(*, iface: str, role: str, timestamping: str) -> list[str]:
     if timestamping != "hardware":
-        # No PHC available — phc2sys runs in "free" mode pinning CLOCK_REALTIME
-        # to itself, which is a no-op but lets ptp4l (in software mode) still
-        # discipline the kernel clock through its own SO_TIMESTAMPING path.
+        # No PHC available — pin CLOCK_REALTIME to itself so ptp4l's own
+        # SO_TIMESTAMPING path is the only thing disciplining the kernel clock.
         return [
             "phc2sys",
             "-c",
@@ -356,9 +340,7 @@ def _build_phc2sys_cmd(*, iface: str, role: str, timestamping: str) -> list[str]
         ]
 
     if role == "slave":
-        # Receiver follows the PHC that ptp4l is disciplining.
         return ["phc2sys", "-s", iface, "-c", "CLOCK_REALTIME", "-O", "0", "-w", "-m"]
-    # Master pushes its system clock onto the PHC so ptp4l serves it out.
     return ["phc2sys", "-s", "CLOCK_REALTIME", "-c", iface, "-O", "0", "-w", "-m"]
 
 

--- a/almond_axol/lerobot/camera/camera_zed.py
+++ b/almond_axol/lerobot/camera/camera_zed.py
@@ -5,25 +5,15 @@ ZedCamera connects to a single ZED video stream produced by ZedStreamer and
 exposes it as a standard LeRobot Camera. One instance per camera — instantiate
 three to cover overhead, left_arm, and right_arm.
 
-Timestamping
-------------
+Each grabbed frame carries two timestamps, both on the receiver's
+``time.perf_counter`` clock:
 
-Every grabbed frame is stamped with two timestamps:
-
-* ``capture_perf_ts`` — when the *sender* exposed the frame, expressed on the
-  receiver's ``time.perf_counter`` clock. Derived from
-  ``TIME_REFERENCE.IMAGE`` (UNIX-ns wall-clock on the sender) plus a per-frame
-  delta between receiver wall-clock and ``perf_counter``. Recomputing the
-  delta per frame means PTP step adjustments to ``CLOCK_REALTIME`` are
-  absorbed instantly.
-* ``receive_perf_ts`` — receiver ``perf_counter`` at the moment the frame
-  was decoded.
-
-The difference ``receive_perf_ts - capture_perf_ts`` is the end-to-end
-pipeline latency (encode + network + decode), typically 33-50 ms with HEVC
-streaming. The capture thread in ``collect_data`` consumes
-``capture_perf_ts`` directly so the dataset row's "frame time" reflects the
-moment of capture, not the moment of decode.
+* ``capture_perf_ts`` — when the sender exposed the frame, derived from
+  the SDK's ``TIME_REFERENCE.IMAGE`` (sender wall clock) plus a per-frame
+  wall→perf offset. Used by ``collect_data`` so dataset rows record the
+  moment of capture, not the moment of decode. Requires the two machines'
+  ``CLOCK_REALTIME`` to be aligned — see ``axol zed.sync-clocks``.
+* ``receive_perf_ts`` — when this process decoded the frame.
 
 Typical usage::
 
@@ -163,10 +153,10 @@ class ZedCamera(Camera):
         _logger.info(f"{self} connected ({self.width}x{self.height} @ {self.fps}fps).")
 
     def _log_pipeline_latency(self, num_samples: int = 30) -> None:
-        """Sample the first ~N frames and log mean/max receive-vs-capture skew.
+        """Log mean/max ``receive_perf_ts - capture_perf_ts`` over ~N frames.
 
         Acts as a startup canary for PTP: if the sender and receiver wall
-        clocks are out of sync the latency will look wildly negative or huge.
+        clocks are out of sync the latency looks wildly negative or huge.
         """
         samples: list[float] = []
         deadline = time.perf_counter() + 5.0
@@ -251,13 +241,11 @@ class ZedCamera(Camera):
                 else:
                     frame = cv2.cvtColor(raw, cv2.COLOR_BGRA2BGR)
 
-                # Sender-side wall-clock timestamp of when the frame was
-                # exposed, shared across all ZED cameras on the sender.
                 cap_wall = (
                     self.zed.get_timestamp(sl.TIME_REFERENCE.IMAGE).get_nanoseconds()
                     * 1e-9
                 )
-                # Recompute the wall ↔ perf delta per frame so PTP step
+                # Recompute the wall→perf offset per frame so PTP step
                 # adjustments don't accumulate as silent skew.
                 recv_wall = time.time()
                 recv_perf = time.perf_counter()
@@ -329,12 +317,10 @@ class ZedCamera(Camera):
 
     @check_if_not_connected
     def read_latest_with_ts(self) -> tuple[NDArray[Any], float, float]:
-        """Return the most recent frame and its ``(capture_ts, receive_ts)``.
+        """Return ``(frame, capture_perf_ts, receive_perf_ts)`` for the latest frame.
 
-        Both timestamps are on the receiver's ``perf_counter`` clock —
-        ``capture_ts`` is the sender's exposure time converted via the per
-        frame wall→perf offset, and ``receive_ts`` is when this process
-        decoded the frame.
+        Both timestamps are on the receiver's ``perf_counter`` clock (see the
+        module docstring).
 
         Raises:
             RuntimeError: If the grab thread is not running or no frame has
@@ -359,16 +345,14 @@ class ZedCamera(Camera):
         target_capture_perf_ts: float,
         timeout_ms: float = 500,
     ) -> tuple[NDArray[Any], float, float]:
-        """Block until a frame with capture time ``>= target`` is available.
+        """Block until a frame with ``capture_perf_ts >= target`` is available.
 
-        This is the primary read path for dataset capture: by waiting for a
-        frame whose *sender-side* exposure time is at or after the teleop
-        tick, every camera and the joint sample share the same timeline.
+        Used by ``collect-data`` so every camera and the joint sample share
+        the same sender-side timeline.
 
         Args:
-            target_capture_perf_ts: Earliest acceptable ``capture_perf_ts``,
-                expressed on the receiver's ``perf_counter`` clock.
-            timeout_ms: Maximum time to wait for a qualifying frame.
+            target_capture_perf_ts: Earliest acceptable ``capture_perf_ts``.
+            timeout_ms:             Maximum time to wait for a qualifying frame.
 
         Returns:
             ``(frame, capture_perf_ts, receive_perf_ts)``.

--- a/almond_axol/lerobot/camera/camera_zed.py
+++ b/almond_axol/lerobot/camera/camera_zed.py
@@ -5,6 +5,26 @@ ZedCamera connects to a single ZED video stream produced by ZedStreamer and
 exposes it as a standard LeRobot Camera. One instance per camera — instantiate
 three to cover overhead, left_arm, and right_arm.
 
+Timestamping
+------------
+
+Every grabbed frame is stamped with two timestamps:
+
+* ``capture_perf_ts`` — when the *sender* exposed the frame, expressed on the
+  receiver's ``time.perf_counter`` clock. Derived from
+  ``TIME_REFERENCE.IMAGE`` (UNIX-ns wall-clock on the sender) plus a per-frame
+  delta between receiver wall-clock and ``perf_counter``. Recomputing the
+  delta per frame means PTP step adjustments to ``CLOCK_REALTIME`` are
+  absorbed instantly.
+* ``receive_perf_ts`` — receiver ``perf_counter`` at the moment the frame
+  was decoded.
+
+The difference ``receive_perf_ts - capture_perf_ts`` is the end-to-end
+pipeline latency (encode + network + decode), typically 33-50 ms with HEVC
+streaming. The capture thread in ``collect_data`` consumes
+``capture_perf_ts`` directly so the dataset row's "frame time" reflects the
+moment of capture, not the moment of decode.
+
 Typical usage::
 
     from almond_axol.lerobot.zed import ZedCamera, ZedCameraConfig
@@ -58,7 +78,8 @@ class ZedCamera(Camera):
         self.stop_event: Event | None = None
         self.frame_lock: Lock = Lock()
         self.latest_frame: NDArray[Any] | None = None
-        self.latest_timestamp: float | None = None
+        self.latest_capture_perf_ts: float | None = None
+        self.latest_receive_perf_ts: float | None = None
         self.new_frame_event: Event = Event()
 
     def __str__(self) -> str:
@@ -137,7 +158,55 @@ class ZedCamera(Camera):
                     pass
                 time.sleep(0.05)
 
+        self._log_pipeline_latency()
+
         _logger.info(f"{self} connected ({self.width}x{self.height} @ {self.fps}fps).")
+
+    def _log_pipeline_latency(self, num_samples: int = 30) -> None:
+        """Sample the first ~N frames and log mean/max receive-vs-capture skew.
+
+        Acts as a startup canary for PTP: if the sender and receiver wall
+        clocks are out of sync the latency will look wildly negative or huge.
+        """
+        samples: list[float] = []
+        deadline = time.perf_counter() + 5.0
+        while len(samples) < num_samples and time.perf_counter() < deadline:
+            self.new_frame_event.clear()
+            if not self.new_frame_event.wait(timeout=0.5):
+                continue
+            with self.frame_lock:
+                cap = self.latest_capture_perf_ts
+                recv = self.latest_receive_perf_ts
+            if cap is None or recv is None:
+                continue
+            samples.append(recv - cap)
+
+        if not samples:
+            _logger.warning(
+                "%s: no frames captured during pipeline-latency probe; "
+                "skipping startup PTP check.",
+                self,
+            )
+            return
+
+        mean_ms = sum(samples) / len(samples) * 1e3
+        max_ms = max(samples) * 1e3
+        _logger.info(
+            "%s pipeline latency over %d frames: mean=%.1fms max=%.1fms.",
+            self,
+            len(samples),
+            mean_ms,
+            max_ms,
+        )
+
+        if mean_ms < 0.0 or mean_ms > 200.0:
+            _logger.warning(
+                "%s pipeline latency looks unhealthy (mean=%.1fms). "
+                "Looks like the sender/receiver wall-clocks aren't synced — "
+                "is `axol zed.sync-clocks` running on both machines?",
+                self,
+                mean_ms,
+            )
 
     def _start_read_thread(self) -> None:
         self._stop_read_thread()
@@ -156,7 +225,8 @@ class ZedCamera(Camera):
         self.stop_event = None
         with self.frame_lock:
             self.latest_frame = None
-            self.latest_timestamp = None
+            self.latest_capture_perf_ts = None
+            self.latest_receive_perf_ts = None
             self.new_frame_event.clear()
 
     def _read_loop(self) -> None:
@@ -181,10 +251,22 @@ class ZedCamera(Camera):
                 else:
                     frame = cv2.cvtColor(raw, cv2.COLOR_BGRA2BGR)
 
-                capture_time = time.perf_counter()
+                # Sender-side wall-clock timestamp of when the frame was
+                # exposed, shared across all ZED cameras on the sender.
+                cap_wall = (
+                    self.zed.get_timestamp(sl.TIME_REFERENCE.IMAGE).get_nanoseconds()
+                    * 1e-9
+                )
+                # Recompute the wall ↔ perf delta per frame so PTP step
+                # adjustments don't accumulate as silent skew.
+                recv_wall = time.time()
+                recv_perf = time.perf_counter()
+                cap_perf = recv_perf - (recv_wall - cap_wall)
+
                 with self.frame_lock:
                     self.latest_frame = frame
-                    self.latest_timestamp = capture_time
+                    self.latest_capture_perf_ts = cap_perf
+                    self.latest_receive_perf_ts = recv_perf
                 self.new_frame_event.set()
                 failure_count = 0
 
@@ -233,26 +315,96 @@ class ZedCamera(Camera):
         """Return the most recent frame immediately without waiting.
 
         Raises:
-            TimeoutError: If the latest frame is older than max_age_ms.
+            TimeoutError: If the latest frame is older than max_age_ms
+                (measured against ``receive_perf_ts``).
             RuntimeError: If no frame has been captured yet.
+        """
+        frame, _cap_ts, recv_ts = self.read_latest_with_ts()
+        age_ms = (time.perf_counter() - recv_ts) * 1e3
+        if age_ms > max_age_ms:
+            raise TimeoutError(
+                f"{self} latest frame is too old: {age_ms:.1f}ms (max {max_age_ms}ms)."
+            )
+        return frame
+
+    @check_if_not_connected
+    def read_latest_with_ts(self) -> tuple[NDArray[Any], float, float]:
+        """Return the most recent frame and its ``(capture_ts, receive_ts)``.
+
+        Both timestamps are on the receiver's ``perf_counter`` clock —
+        ``capture_ts`` is the sender's exposure time converted via the per
+        frame wall→perf offset, and ``receive_ts`` is when this process
+        decoded the frame.
+
+        Raises:
+            RuntimeError: If the grab thread is not running or no frame has
+                been captured yet.
         """
         if self.thread is None or not self.thread.is_alive():
             raise RuntimeError(f"{self} read thread is not running.")
 
         with self.frame_lock:
             frame = self.latest_frame
-            timestamp = self.latest_timestamp
+            cap_ts = self.latest_capture_perf_ts
+            recv_ts = self.latest_receive_perf_ts
 
-        if frame is None or timestamp is None:
+        if frame is None or cap_ts is None or recv_ts is None:
             raise RuntimeError(f"{self} has not captured any frames yet.")
 
-        age_ms = (time.perf_counter() - timestamp) * 1e3
-        if age_ms > max_age_ms:
-            raise TimeoutError(
-                f"{self} latest frame is too old: {age_ms:.1f}ms (max {max_age_ms}ms)."
-            )
+        return frame, cap_ts, recv_ts
 
-        return frame
+    @check_if_not_connected
+    def read_at_or_after(
+        self,
+        target_capture_perf_ts: float,
+        timeout_ms: float = 500,
+    ) -> tuple[NDArray[Any], float, float]:
+        """Block until a frame with capture time ``>= target`` is available.
+
+        This is the primary read path for dataset capture: by waiting for a
+        frame whose *sender-side* exposure time is at or after the teleop
+        tick, every camera and the joint sample share the same timeline.
+
+        Args:
+            target_capture_perf_ts: Earliest acceptable ``capture_perf_ts``,
+                expressed on the receiver's ``perf_counter`` clock.
+            timeout_ms: Maximum time to wait for a qualifying frame.
+
+        Returns:
+            ``(frame, capture_perf_ts, receive_perf_ts)``.
+
+        Raises:
+            TimeoutError: If no qualifying frame arrives within ``timeout_ms``.
+            RuntimeError: If the grab thread is not running.
+        """
+        if self.thread is None or not self.thread.is_alive():
+            raise RuntimeError(f"{self} read thread is not running.")
+
+        deadline = time.perf_counter() + timeout_ms / 1000.0
+
+        while True:
+            self.new_frame_event.clear()
+            with self.frame_lock:
+                frame = self.latest_frame
+                cap_ts = self.latest_capture_perf_ts
+                recv_ts = self.latest_receive_perf_ts
+            if (
+                frame is not None
+                and cap_ts is not None
+                and recv_ts is not None
+                and cap_ts >= target_capture_perf_ts
+            ):
+                return frame, cap_ts, recv_ts
+
+            remaining = deadline - time.perf_counter()
+            if remaining <= 0:
+                raise TimeoutError(
+                    f"{self} timed out waiting for frame at "
+                    f"capture_perf_ts >= {target_capture_perf_ts:.6f} "
+                    f"after {timeout_ms:.1f}ms "
+                    f"(latest cap_ts={cap_ts!r})."
+                )
+            self.new_frame_event.wait(timeout=remaining)
 
     def disconnect(self) -> None:
         """Stop the grab thread and close the ZED stream."""

--- a/almond_axol/robot/config.py
+++ b/almond_axol/robot/config.py
@@ -309,7 +309,7 @@ class _ArmGains:
 
 
 # Pre-compliance-tuning gains — the high-``kp`` "industrial robot" defaults
-# used as the ``s=1.0`` endpoint of :attr:`AxolConfig.left_stiffness` /
+# used as the ``s=1.0`` endpoint of :attr:`AxolConfig.left_stiffness` and
 # :attr:`AxolConfig.right_stiffness`.
 _STIFF_GAINS = _ArmGains(
     shoulder_1=(500.0, 5.0),
@@ -341,12 +341,10 @@ def _blend_joint(
 
 
 def _normalize_stiffness(s: float | Sequence[float]) -> tuple[float, ...]:
-    """Coerce ``s`` to a 7-tuple of per-joint blend factors and validate.
+    """Coerce ``s`` to a 7-tuple of per-joint blend factors in ``[0, 1]``.
 
-    Accepts either a scalar (broadcast to all 7 joints) or a sequence of
-    length ``len(ARM_JOINTS)`` (one value per joint, in
-    :data:`almond_axol.shared.ARM_JOINTS` order). Every value must lie in
-    ``[0, 1]``.
+    Accepts a scalar (broadcast to all 7 joints) or a sequence of length
+    ``len(ARM_JOINTS)`` in :data:`almond_axol.shared.ARM_JOINTS` order.
     """
     if isinstance(s, (int, float)):
         if not 0.0 <= float(s) <= 1.0:
@@ -367,12 +365,11 @@ def _normalize_stiffness(s: float | Sequence[float]) -> tuple[float, ...]:
 
 
 def _apply_stiffness(arm: ArmConfig, s: float | Sequence[float]) -> ArmConfig:
-    """Return ``arm`` with each of the 7 joints blended toward
-    :data:`_STIFF_GAINS` by factors ``s`` ∈ ``[0, 1]``.
+    """Blend each of ``arm``'s 7 joints toward :data:`_STIFF_GAINS` by ``s``.
 
-    ``s`` may be a scalar (applied to every joint) or a 7-tuple of per-joint
-    factors in :data:`almond_axol.shared.ARM_JOINTS` order. An all-zero
-    blend returns ``arm`` unchanged.
+    ``s`` is either a scalar or a 7-tuple in
+    :data:`almond_axol.shared.ARM_JOINTS` order (see
+    :func:`_normalize_stiffness`). An all-zero blend returns ``arm`` unchanged.
     """
     factors = _normalize_stiffness(s)
     if all(f == 0.0 for f in factors):
@@ -408,21 +405,19 @@ class AxolConfig:
                          Commands that exceed this are dropped and a warning
                          is logged. Set to ``float('inf')`` to disable.
         left_stiffness:  Compliance ↔ stiffness blend for the **left** arm
-                         in ``[0, 1]``. A scalar applies the same blend to
-                         every joint; a 7-tuple sets each joint
-                         individually, in
+                         in ``[0, 1]``. Either a scalar (applied to every
+                         joint) or 7 values in
                          :data:`almond_axol.shared.ARM_JOINTS` order
-                         (shoulder_1, shoulder_2, shoulder_3, elbow,
-                         wrist_1, wrist_2, wrist_3 — the gripper is not
-                         blended). ``0`` (default) keeps the per-joint
-                         compliant gains; ``1`` restores the pre-tuning
-                         industrial gains in :data:`_STIFF_GAINS`. ``kp``
-                         / ``kd`` interpolate geometrically (log-space);
-                         ``j_eff`` / ``kd_soft`` scale linearly to 0 at
-                         ``s=1``. The blend is baked into ``left`` at
-                         construction time — mutating
-                         ``left_stiffness`` after the fact has no effect,
-                         and ``replace()`` would re-apply it (don't).
+                         (gripper excluded). ``0`` (default) keeps the
+                         per-joint compliant gains; ``1`` restores the
+                         pre-tuning industrial gains in
+                         :data:`_STIFF_GAINS`. ``kp`` / ``kd`` interpolate
+                         geometrically (log-space); ``j_eff`` /
+                         ``kd_soft`` scale linearly to 0 at ``s=1``. The
+                         blend is baked into ``left`` at construction —
+                         mutating ``left_stiffness`` afterwards has no
+                         effect, and ``replace()`` would re-apply it
+                         (don't).
         right_stiffness: Same, for the **right** arm.
     """
 

--- a/almond_axol/robot/config.py
+++ b/almond_axol/robot/config.py
@@ -25,7 +25,10 @@ via :func:`dataclasses.replace`::
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass, field, replace
+
+from ..shared import ARM_JOINTS
 
 
 @dataclass
@@ -313,7 +316,8 @@ class _ArmGains:
 
 
 # Pre-compliance-tuning gains — the high-``kp`` "industrial robot" defaults
-# used as the ``stiffness=1.0`` endpoint of :attr:`AxolConfig.stiffness`.
+# used as the ``s=1.0`` endpoint of :attr:`AxolConfig.left_stiffness` /
+# :attr:`AxolConfig.right_stiffness`.
 _STIFF_GAINS = _ArmGains(
     shoulder_1=(500.0, 5.0),
     shoulder_2=(500.0, 5.0),
@@ -343,21 +347,52 @@ def _blend_joint(
     )
 
 
-def _apply_stiffness(arm: ArmConfig, s: float) -> ArmConfig:
-    """Return ``arm`` with all 7 joints blended toward :data:`_STIFF_GAINS`
-    by factor ``s`` ∈ ``[0, 1]``. ``s=0`` returns ``arm`` unchanged.
+def _normalize_stiffness(s: float | Sequence[float]) -> tuple[float, ...]:
+    """Coerce ``s`` to a 7-tuple of per-joint blend factors and validate.
+
+    Accepts either a scalar (broadcast to all 7 joints) or a sequence of
+    length ``len(ARM_JOINTS)`` (one value per joint, in
+    :data:`almond_axol.shared.ARM_JOINTS` order). Every value must lie in
+    ``[0, 1]``.
     """
-    if s == 0.0:
+    if isinstance(s, (int, float)):
+        if not 0.0 <= float(s) <= 1.0:
+            raise ValueError(f"stiffness must be in [0, 1], got {s}")
+        return (float(s),) * len(ARM_JOINTS)
+    seq = tuple(float(x) for x in s)
+    if len(seq) != len(ARM_JOINTS):
+        raise ValueError(
+            f"per-joint stiffness must have {len(ARM_JOINTS)} values (one "
+            f"per joint, excluding the gripper), got {len(seq)}"
+        )
+    for i, x in enumerate(seq):
+        if not 0.0 <= x <= 1.0:
+            raise ValueError(
+                f"stiffness[{i}] ({ARM_JOINTS[i].value}) must be in [0, 1], got {x}"
+            )
+    return seq
+
+
+def _apply_stiffness(arm: ArmConfig, s: float | Sequence[float]) -> ArmConfig:
+    """Return ``arm`` with each of the 7 joints blended toward
+    :data:`_STIFF_GAINS` by factors ``s`` ∈ ``[0, 1]``.
+
+    ``s`` may be a scalar (applied to every joint) or a 7-tuple of per-joint
+    factors in :data:`almond_axol.shared.ARM_JOINTS` order. An all-zero
+    blend returns ``arm`` unchanged.
+    """
+    factors = _normalize_stiffness(s)
+    if all(f == 0.0 for f in factors):
         return arm
     return replace(
         arm,
-        shoulder_1=_blend_joint(arm.shoulder_1, *_STIFF_GAINS.shoulder_1, s),
-        shoulder_2=_blend_joint(arm.shoulder_2, *_STIFF_GAINS.shoulder_2, s),
-        shoulder_3=_blend_joint(arm.shoulder_3, *_STIFF_GAINS.shoulder_3, s),
-        elbow=_blend_joint(arm.elbow, *_STIFF_GAINS.elbow, s),
-        wrist_1=_blend_joint(arm.wrist_1, *_STIFF_GAINS.wrist_1, s),
-        wrist_2=_blend_joint(arm.wrist_2, *_STIFF_GAINS.wrist_2, s),
-        wrist_3=_blend_joint(arm.wrist_3, *_STIFF_GAINS.wrist_3, s),
+        shoulder_1=_blend_joint(arm.shoulder_1, *_STIFF_GAINS.shoulder_1, factors[0]),
+        shoulder_2=_blend_joint(arm.shoulder_2, *_STIFF_GAINS.shoulder_2, factors[1]),
+        shoulder_3=_blend_joint(arm.shoulder_3, *_STIFF_GAINS.shoulder_3, factors[2]),
+        elbow=_blend_joint(arm.elbow, *_STIFF_GAINS.elbow, factors[3]),
+        wrist_1=_blend_joint(arm.wrist_1, *_STIFF_GAINS.wrist_1, factors[4]),
+        wrist_2=_blend_joint(arm.wrist_2, *_STIFF_GAINS.wrist_2, factors[5]),
+        wrist_3=_blend_joint(arm.wrist_3, *_STIFF_GAINS.wrist_3, factors[6]),
     )
 
 
@@ -373,21 +408,29 @@ class AxolConfig:
     bypass either default.
 
     Attributes:
-        left:         Per-joint config for the left arm.
-        right:        Per-joint config for the right arm.
-        max_step_rad: Maximum allowed change in any arm joint (rad) between
-                      consecutive ``motion_control`` calls. Commands that
-                      exceed this are dropped and a warning is logged. Set
-                      to ``float('inf')`` to disable.
-        stiffness:    Compliance ↔ stiffness blend in ``[0, 1]``. ``0``
-                      (default) keeps the per-joint compliant gains; ``1``
-                      restores the pre-tuning industrial gains in
-                      :data:`_STIFF_GAINS`. ``kp`` / ``kd`` interpolate
-                      geometrically (log-space); ``j_eff`` / ``kd_soft``
-                      scale linearly to 0 at ``s=1``. The blend is baked
-                      into ``left`` / ``right`` at construction time —
-                      mutate ``stiffness`` after the fact has no effect,
-                      and ``replace()`` would re-apply it (don't).
+        left:            Per-joint config for the left arm.
+        right:           Per-joint config for the right arm.
+        max_step_rad:    Maximum allowed change in any arm joint (rad)
+                         between consecutive ``motion_control`` calls.
+                         Commands that exceed this are dropped and a warning
+                         is logged. Set to ``float('inf')`` to disable.
+        left_stiffness:  Compliance ↔ stiffness blend for the **left** arm
+                         in ``[0, 1]``. A scalar applies the same blend to
+                         every joint; a 7-tuple sets each joint
+                         individually, in
+                         :data:`almond_axol.shared.ARM_JOINTS` order
+                         (shoulder_1, shoulder_2, shoulder_3, elbow,
+                         wrist_1, wrist_2, wrist_3 — the gripper is not
+                         blended). ``0`` (default) keeps the per-joint
+                         compliant gains; ``1`` restores the pre-tuning
+                         industrial gains in :data:`_STIFF_GAINS`. ``kp``
+                         / ``kd`` interpolate geometrically (log-space);
+                         ``j_eff`` / ``kd_soft`` scale linearly to 0 at
+                         ``s=1``. The blend is baked into ``left`` at
+                         construction time — mutating
+                         ``left_stiffness`` after the fact has no effect,
+                         and ``replace()`` would re-apply it (don't).
+        right_stiffness: Same, for the **right** arm.
     """
 
     left: ArmConfig = field(
@@ -397,11 +440,9 @@ class AxolConfig:
         default_factory=lambda: _build_arm(_RIGHT_FRICTION, is_left=False)
     )
     max_step_rad: float = 0.5
-    stiffness: float = 0.0
+    left_stiffness: float | Sequence[float] = 0.0
+    right_stiffness: float | Sequence[float] = 0.0
 
     def __post_init__(self) -> None:
-        if not 0.0 <= self.stiffness <= 1.0:
-            raise ValueError(f"stiffness must be in [0, 1], got {self.stiffness}")
-        if self.stiffness > 0.0:
-            self.left = _apply_stiffness(self.left, self.stiffness)
-            self.right = _apply_stiffness(self.right, self.stiffness)
+        self.left = _apply_stiffness(self.left, self.left_stiffness)
+        self.right = _apply_stiffness(self.right, self.right_stiffness)

--- a/almond_axol/zed/config.py
+++ b/almond_axol/zed/config.py
@@ -25,7 +25,7 @@ class ZedConfig:
         overhead_port:    Streaming port for the overhead camera (default 30000).
         left_arm_port:    Streaming port for the left-arm camera (default 30002).
         right_arm_port:   Streaming port for the right-arm camera (default 30004).
-        resolution:       Capture resolution for all cameras (default HD1080).
+        resolution:       Capture resolution for all cameras (default SVGA).
         fps:              Capture frame rate for all cameras (default 60).
         bitrate:          HEVC encoding bitrate in kbits/s (default 8000).
     """
@@ -36,7 +36,7 @@ class ZedConfig:
     overhead_port: int = 30000
     left_arm_port: int = 30002
     right_arm_port: int = 30004
-    resolution: sl.RESOLUTION = field(default_factory=lambda: sl.RESOLUTION.HD1080)
+    resolution: sl.RESOLUTION = field(default_factory=lambda: sl.RESOLUTION.SVGA)
     fps: int = 60
     bitrate: int = 8000
 

--- a/almond_axol/zed/streamer.py
+++ b/almond_axol/zed/streamer.py
@@ -145,6 +145,7 @@ class ZedStreamer:
         stream_params.codec = sl.STREAMING_CODEC.H265
         stream_params.bitrate = self._config.bitrate
         stream_params.port = port
+        stream_params.target_framerate = self._config.fps
 
         err = zed.enable_streaming(stream_params)
         if err != sl.ERROR_CODE.SUCCESS:


### PR DESCRIPTION
- more teleop controls
- data sync

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes the `collect-data` recording pipeline with new threading/timestamp alignment logic and adds a CLI that spawns privileged PTP subprocesses, which could affect dataset correctness and runtime stability on real hardware.
> 
> **Overview**
> **Data capture is reworked to improve timing alignment and control-loop performance.** `collect-data` now publishes joint/action snapshots at `--teleop-hz` and records frames on a dedicated capture thread at `--fps`, blocking on `ZedCamera.read_at_or_after(T)` to align camera frames to the sender’s exposure timeline; it also enables streaming video encoding and removes the empty dataset directory on shutdown if no episodes were saved.
> 
> **Control/config knobs are expanded and made per-arm.** CLI flags switch from a single `--gripper-torque-limit` to `--left/--right-gripper-torque-limit`, and replace global `--stiffness` with `--left/--right-stiffness` supporting scalar or per-joint values; `AxolConfig` is updated accordingly to apply stiffness per arm/joint.
> 
> **ZED timestamping + clock sync support is added.** `ZedCamera` now tracks both capture and receive timestamps, adds `read_latest_with_ts()` and `read_at_or_after()`, and logs a startup latency/clock-skew canary; a new `axol zed.sync-clocks` command runs PTP (`ptp4l`/`phc2sys`) with optional auto-install and hardware timestamping detection. Defaults are adjusted (e.g., ZED resolution default `SVGA`, streamer sets target framerate), and docs add/refresh related guidance plus `tune.repeatability` now forces max stiffness and drops its stiffness flag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6079171af91e22827f5ea4f91a344f4f740226b5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->