### PR TITLE
update run policy & fix jitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,29 +228,44 @@ Dataset frame capture runs on a dedicated thread decoupled from the teleop contr
 
 ### `run-policy`
 
-Runs a trained policy autonomously on the robot using three ZED cameras. Between episodes, prompts the operator via stdin to save (`Enter`), re-record (`r`), or quit (`q`).
+Runs a trained policy autonomously on the robot using three ZED cameras and LeRobot's async inference (`lerobot.async_inference`). A `PolicyServer` is launched in a child process on localhost and the parent drives a thin `RobotClient` subclass that streams observations to it and consumes the returned action chunks. Type `s` on stdin to save the rollout and end the episode, `r` to discard and re-record, or `q` to discard and quit. `--episode-time-s` is a safety cap that falls back to the same `[Enter]=save / r / q` prompt when no key has been pressed.
 
 | Flag | Description |
 |---|---|
 | `--policy PATH_OR_REPO` | Local checkpoint path or HuggingFace repo ID (required) |
+| `--policy-type {act,smolvla,diffusion,tdmpc,vqbet,pi0,pi05,groot}` | Policy architecture; must match the checkpoint at `--policy` (required) |
 | `--task TEXT` | Natural language task description (required) |
-| `--episode-time-s INT` | Max duration per episode in seconds (default: 30) |
-| `--fps INT` | Control loop frame rate (default: 60) |
+| `--episode-time-s INT` | Safety cap on episode duration in seconds (default: 120). Episodes normally end on operator keypress |
+| `--fps INT` | Control loop frame rate (default: 60). Must match the fps the policy was trained on |
 | `--repo-id <user>/<dataset>` | Optional dataset repo ID to save rollouts |
 | `--root PATH` | Local dataset root (default: `$HF_LEROBOT_HOME`) |
 | `--push-to-hub` | Push rollout dataset to HuggingFace Hub when done |
+| `--device STR` | PyTorch device for policy inference (default: `cuda`) |
+| `--server-port INT` | Port for the localhost `PolicyServer` child process (default: 8765) |
+| `--actions-per-chunk INT` | Number of actions returned per inference call (default: 50); capped by the policy's max action horizon |
+| `--chunk-size-threshold FLOAT` | Trigger a fresh observation when the action queue drops to this fraction of a chunk (default: 0.9) |
+| `--aggregate-fn {temporal_ensemble,weighted_average,latest_only,average,conservative}` | Action chunk aggregation strategy (default: `temporal_ensemble`, ACT Algorithm 2; gripper indices take the newest chunk). The other choices are upstream scalar blends |
+| `--temporal-ensemble-coeff K` | Decay coefficient for `temporal_ensemble` (default: 0.01, ACT paper). `wᵢ = exp(-K·i)`, `i=0` oldest chunk; `K>0` smoother, `K=0` uniform, `K<0` more reactive |
 | `--zed-host IP` | IP address of the ZED camera streamer (default: `192.168.10.1`) |
 | `--zed-iface IFACE` | Network interface to configure for the ZED link (e.g. `eth0`); assigns `192.168.10.2/24`, requires `sudo` |
-| `--gripper-torque-limit FLOAT` | Max gripper torque (Nm) in POSITION_FORCE mode, applied to both grippers (default: 1.0) |
+| `--left-gripper-torque-limit FLOAT` | Max torque (Nm) for the left gripper in POSITION_FORCE mode (default: 1.0) |
+| `--right-gripper-torque-limit FLOAT` | Max torque (Nm) for the right gripper in POSITION_FORCE mode (default: 1.0) |
+| `--left-stiffness S\|S,S,...` | Compliance↔stiffness blend for the left arm in `[0, 1]`. Scalar or 7 comma-separated values (one per arm joint, in `Joint` enum order). `0` (default) = fully compliant; `1` = pre-tuning industrial gains. Should match the value used at data collection time. See [`AxolConfig.left_stiffness`](#almond_axolrobot). |
+| `--right-stiffness S\|S,S,...` | Same, for the right arm. |
 | `--rerun-ip IP` | IP of a Rerun viewer on your local machine for live visualization |
 | `--rerun-port INT` | Rerun viewer port (default: 9876); only used when `--rerun-ip` is set |
-| `--device STR` | PyTorch device for inference (default: `cuda`) |
 | `--log-level {DEBUG,INFO,WARNING,ERROR}` | Default: `INFO` |
 
 ```bash
-axol run-policy --policy myorg/pick-place-policy --task "Pick the red cube"
-axol run-policy --policy ./checkpoints/epoch_100 --task "Stack blocks" --episode-time-s 20 --device cpu
+axol run-policy --policy myorg/pick-place-policy --policy-type act --task "Pick the red cube"
+axol run-policy --policy ./checkpoints/epoch_100 --policy-type smolvla --task "Stack blocks" --device cpu
+axol run-policy --policy myorg/pick-place-policy --policy-type act --task "Pick the red cube" \
+    --repo-id myorg/pick-place-rollouts --left-stiffness 0.5 --right-stiffness 0.5
 ```
+
+If `--repo-id` is supplied, each saved episode is appended to a LeRobot-format dataset using the same resume/refuse/wipe semantics as `collect-data` (resume a complete dataset, refuse an incomplete one, wipe a leftover empty directory). Between episodes the arms return to the rest pose via a collision-aware IK trajectory planned in a worker subprocess, mirroring the reset path used by `collect-data`.
+
+Action chunk aggregation defaults to ACT's Algorithm 2 (`temporal_ensemble`): every future timestep covered by the buffered chunks is the exponentially-weighted average across those chunks, with the gripper indices snapped to the newest contributing chunk so bang-bang grasp commands aren't smeared. The control loop and observation send run on separate threads — decoupling the ~60-70 ms ZED-read + gRPC send from the 60 Hz action stream that would otherwise collapse to ~27 Hz on the upstream single-threaded design.
 
 ---
 

--- a/almond_axol/cli/collect_data.py
+++ b/almond_axol/cli/collect_data.py
@@ -29,7 +29,7 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable
 
-from ..shared import ARM_JOINTS
+from ..shared import ARM_JOINTS, parse_stiffness
 
 if TYPE_CHECKING:
     from lerobot.datasets.lerobot_dataset import LeRobotDataset
@@ -211,41 +211,6 @@ class _CaptureThread(threading.Thread):
             tick += 1
 
 
-def _parse_stiffness(value: str) -> float | tuple[float, ...]:
-    """Parse a ``--*-stiffness`` value into a scalar or 7-tuple.
-
-    Accepts a single number in ``[0, 1]`` (applied to all arm joints) or
-    ``len(ARM_JOINTS)`` comma-separated numbers in ``[0, 1]`` — one per
-    joint in :data:`almond_axol.shared.ARM_JOINTS` order (gripper excluded).
-    """
-    parts = [p.strip() for p in value.split(",")]
-
-    def _parse_one(raw: str, label: str) -> float:
-        try:
-            x = float(raw)
-        except ValueError as exc:
-            raise argparse.ArgumentTypeError(
-                f"stiffness{label} is not a number: {raw!r}"
-            ) from exc
-        if not 0.0 <= x <= 1.0:
-            raise argparse.ArgumentTypeError(
-                f"stiffness{label} must be in [0, 1], got {x}"
-            )
-        return x
-
-    if len(parts) == 1:
-        return _parse_one(parts[0], "")
-    if len(parts) != len(ARM_JOINTS):
-        raise argparse.ArgumentTypeError(
-            f"stiffness must be a single value or {len(ARM_JOINTS)} "
-            f"comma-separated values (one per joint: "
-            f"{', '.join(j.value for j in ARM_JOINTS)}), got {len(parts)}"
-        )
-    return tuple(
-        _parse_one(p, f"[{i}={ARM_JOINTS[i].value}]") for i, p in enumerate(parts)
-    )
-
-
 def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
     p = subparsers.add_parser("collect-data", help="Record teleoperation episodes.")
     p.add_argument(
@@ -317,14 +282,14 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[
     stiffness_metavar = "S|" + ",".join("S" for _ in ARM_JOINTS)
     p.add_argument(
         "--left-stiffness",
-        type=_parse_stiffness,
+        type=parse_stiffness,
         default=0.0,
         metavar=stiffness_metavar,
         help=stiffness_help.format(side="left", attr="left_stiffness"),
     )
     p.add_argument(
         "--right-stiffness",
-        type=_parse_stiffness,
+        type=parse_stiffness,
         default=0.0,
         metavar=stiffness_metavar,
         help=stiffness_help.format(side="right", attr="right_stiffness"),

--- a/almond_axol/cli/run_policy.py
+++ b/almond_axol/cli/run_policy.py
@@ -2,28 +2,18 @@
 axol run-policy
 
 Run a trained policy on the Axol robot with three ZED cameras using
-LeRobot's async inference (``lerobot.async_inference``).
+LeRobot's async inference (``lerobot.async_inference``). A ``PolicyServer``
+is auto-launched in a child process on localhost and the parent drives an
+``AxolRobotClient`` (a thin ``RobotClient`` subclass) that streams
+observations to it and consumes the returned action chunks. Cameras and
+joints are sampled via ``ZedCamera.read_at_or_after(now)`` so every
+inference observation is global-timestamp aligned the same way the
+training data is (see ``AxolRobot.get_observation``).
 
-Architecture
-============
-A ``PolicyServer`` is auto-launched in a child process on localhost. The
-parent process drives an ``AxolRobotClient`` (a thin subclass of LeRobot's
-``RobotClient``) that streams observations to the server and consumes the
-action chunks the server returns. Cameras + joints are sampled via
-``ZedCamera.read_at_or_after(now)`` (see ``AxolRobot.get_observation``) so
-each inference observation is global-timestamp aligned the same way the
-training data is.
-
-Episode termination
-===================
-Each episode runs until the operator presses a key:
-
-    s  → end + save  (writes the rollout to ``--repo-id`` when set)
-    r  → end + rerecord (discard buffer)
-    q  → end + quit  (discard buffer, exit ``axol run-policy``)
-
-``--episode-time-s`` is kept as a safety cap: when it fires the operator
-gets the same ``[Enter]=save / r / q`` prompt as before.
+Each episode runs until the operator types ``s`` (save), ``r`` (rerecord
++ discard), or ``q`` (quit + discard) on stdin. ``--episode-time-s`` is a
+safety cap that falls back to the same ``[Enter]=save / r / q`` prompt
+when no key has been pressed.
 """
 
 from __future__ import annotations
@@ -66,10 +56,7 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[
             "pi05",
             "groot",
         ],
-        help=(
-            "Policy architecture as registered in lerobot.async_inference "
-            "(must match the checkpoint at --policy)."
-        ),
+        help="Policy architecture; must match the checkpoint at --policy.",
     )
     p.add_argument("--task", required=True, help="Natural language task description.")
     p.add_argument(
@@ -78,8 +65,7 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[
         default=120,
         help=(
             "Safety cap on episode duration in seconds (default: 120). "
-            "Episodes normally end on operator keypress; this only fires if "
-            "the operator never signals s/r/q."
+            "Episodes normally end on operator keypress (s/r/q)."
         ),
     )
     p.add_argument(
@@ -87,8 +73,8 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[
         type=int,
         default=60,
         help=(
-            "Control loop frame rate (default: 60, matching collect-data). "
-            "Must match the fps the policy was trained on."
+            "Control loop frame rate (default: 60). Must match the fps "
+            "the policy was trained on."
         ),
     )
     p.add_argument(
@@ -131,16 +117,9 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[
         type=float,
         default=0.9,
         help=(
-            "Send a fresh observation to the server when the local "
-            "action queue drops to this fraction of a full chunk "
-            "(default: 0.9). Upstream lerobot defaults to 0.5 because "
-            "obs send and action pops share a thread there; on Axol "
-            "obs send runs on a dedicated thread (see "
-            "AxolRobotClient._observation_loop) so a higher threshold "
-            "is strictly better — it triggers the next obs while the "
-            "queue still has plenty of margin, so a fresh chunk almost "
-            "always lands before the queue drains and the arm doesn't "
-            "freeze waiting at chunk boundaries."
+            "Trigger a fresh observation when the action queue drops to "
+            "this fraction of a full chunk (default: 0.9). Higher than "
+            "upstream's 0.5 because obs send runs on its own thread here."
         ),
     )
     p.add_argument(
@@ -154,15 +133,9 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[
             "conservative",
         ],
         help=(
-            "Action chunk aggregation strategy (default: "
-            "temporal_ensemble). temporal_ensemble is ACT's Algorithm 2: "
-            "every future timestep is the exponentially-weighted average "
-            "of all buffered chunks covering it (see "
-            "--temporal-ensemble-coeff), with the gripper indices "
-            "carved out to use the newest chunk's value so bang-bang "
-            "grasps aren't smeared. The other choices are the upstream "
-            "lerobot scalar blends, applied uniformly across all 16 "
-            "action components."
+            "Action chunk aggregation strategy (default: temporal_ensemble, "
+            "ACT Algorithm 2; gripper indices take the newest chunk). The "
+            "other choices are upstream scalar blends applied uniformly."
         ),
     )
     p.add_argument(
@@ -172,11 +145,8 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[
         metavar="K",
         help=(
             "Decay coefficient for --aggregate-fn temporal_ensemble "
-            "(default: 0.01, matching the ACT paper). Weights are "
-            "wᵢ = exp(-K·i), i=0 is the oldest buffered chunk; K>0 "
-            "favors older chunks (smoother), K=0 averages uniformly, "
-            "K<0 favors newer chunks (more reactive). Ignored for "
-            "other --aggregate-fn values."
+            "(default: 0.01, ACT paper). wᵢ = exp(-K·i), i=0 oldest chunk; "
+            "K>0 smoother, K=0 uniform, K<0 more reactive."
         ),
     )
     p.add_argument(
@@ -257,14 +227,8 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[
 def run(args: argparse.Namespace) -> None:
     logging.basicConfig(level=getattr(logging, args.log_level))
 
-    # Hardware errors bubble up from inside ``_run`` — either at
-    # connect time (motor unresponsive: ``MotorError``) or mid-episode
-    # (CAN socket faults like "Transmit buffer full": ``CanError``).
-    # Catch them here so we exit with a brief error and a non-zero
-    # status instead of dumping a multi-frame traceback for what is
-    # really an operator-actionable hardware fault. ``_run``'s own
-    # ``finally`` has already torn down the robot + policy server by
-    # the time we get here.
+    # Translate operator-actionable hardware faults into a clean non-zero
+    # exit instead of a multi-frame traceback.
     import sys
 
     import can
@@ -305,17 +269,11 @@ class _IKResetController:
     """Collision-aware return-to-rest, backed by an IK worker subprocess.
 
     Mirrors the reset path used by ``AxolVRTeleop`` (collect-data) but
-    without the VR server. ``start()`` spawns ``run_ik_worker`` in a
-    ``spawn``-mode subprocess; it imports JAX, JITs the IK solver
-    (~10-20 s), and reports ``("ready", ...)``. ``wait_ready()`` blocks on
-    that message. ``return_to_rest()`` then asks the worker for a
-    collision-aware joint-space trajectory from the current pose to the
-    rest pose and plays it back through a ``ResetInterpolator`` while
-    streaming each waypoint to the impedance controller.
-
-    Spawn it before ``client.start()`` so the IK JIT overlaps with the
-    policy load — by the time we actually need a rest move, the worker is
-    typically already ready.
+    without the VR server. ``start()`` spawns ``run_ik_worker`` (JAX +
+    JITed solver, ~10-20 s); ``wait_ready()`` blocks on the handshake;
+    ``return_to_rest()`` plans a joint-space trajectory and streams its
+    waypoints to the impedance controller. Spawn before ``client.start()``
+    so the IK JIT overlaps with the policy load.
     """
 
     def __init__(self) -> None:
@@ -332,7 +290,7 @@ class _IKResetController:
         self._ready = False
 
     def start(self) -> None:
-        """Spawn the IK worker subprocess. Non-blocking — call wait_ready()."""
+        """Spawn the IK worker subprocess. Non-blocking; pair with ``wait_ready``."""
         import multiprocessing as mp
 
         from ..teleop.worker import run_ik_worker
@@ -489,8 +447,11 @@ class _ActionPublisher:
 
 
 class _RolloutCaptureThread(threading.Thread):
-    """Tick at ``fps`` Hz, sample one global-timestamp-aligned observation per
-    tick, pair it with the latest executed action, and append a dataset row.
+    """Tick at ``fps`` Hz and append one ``(obs, action)`` row per tick.
+
+    Each tick samples a global-timestamp-aligned observation via
+    ``AxolRobot.get_observation`` and pairs it with the latest action
+    published by ``AxolRobotClient.control_loop_action``.
     """
 
     def __init__(
@@ -614,21 +575,12 @@ def _wait_for_port(host: str, port: int, timeout: float = 30.0) -> None:
 def _serve_policy_server(server_cfg_dict: dict[str, Any]) -> None:
     """Entry point for the policy-server child process.
 
-    Lives in the parent module so it's picklable by ``mp.get_context('spawn')``
-    on macOS/Linux. Re-imports lerobot inside the child to avoid sharing
-    CUDA/JAX state with the parent.
+    Lives at module scope so it's picklable by ``mp.get_context('spawn')``.
+    SIGINT is ignored so Ctrl+C in the parent terminal doesn't dump a gRPC
+    traceback; the parent explicitly terminates the server during cleanup.
 
-    The child ignores SIGINT so Ctrl+C in the controlling terminal doesn't
-    dump a gRPC traceback from this process; the parent explicitly
-    terminates the server during its cleanup path.
-
-    Before serving we monkey-patch ``policy_server.observations_similar``
-    to always return ``False``. The upstream default uses a 1-rad L2
-    joint-state tolerance to drop "too similar" observations, which on
-    Axol's 16-DOF arms at 60 Hz drops nearly every observation — a fresh
-    chunk only lands every ~2 s, the action queue runs dry, and the arm
-    freezes for ~135 ms at every chunk boundary. The filter has no
-    config knob on ``PolicyServerConfig`` so we patch the module symbol.
+    Args:
+        server_cfg_dict: ``PolicyServerConfig`` keyword arguments.
     """
     import signal
 
@@ -636,6 +588,9 @@ def _serve_policy_server(server_cfg_dict: dict[str, Any]) -> None:
 
     from lerobot.async_inference import policy_server as _ps
 
+    # Upstream's 1-rad L2 similarity filter drops nearly every observation
+    # on Axol's 16-DOF arms at 60 Hz, starving the action queue. There is
+    # no config knob, so patch the module symbol before ``serve``.
     _ps.observations_similar = lambda *args, **kwargs: False
 
     from lerobot.async_inference.configs import PolicyServerConfig
@@ -659,8 +614,14 @@ def _build_axol_robot_client(
 ) -> Any:
     """Construct an ``AxolRobotClient`` against an already-connected robot.
 
-    Defined as a helper so the heavy lerobot imports happen lazily inside
-    ``_run`` and we don't pay the import cost at CLI parse time.
+    Wrapped in a helper so the lerobot imports stay lazy.
+
+    Args:
+        config: Built ``RobotClientConfig``.
+        robot: Connected ``AxolRobot`` instance, reused across episodes.
+        publisher: Sink for executed actions, drained by the capture thread.
+        aggregate_strategy: One of the ``--aggregate-fn`` choices.
+        temporal_ensemble_coeff: Decay coefficient for temporal_ensemble.
     """
     import threading as _threading
     from queue import Queue
@@ -676,41 +637,33 @@ def _build_axol_robot_client(
     from lerobot.transport.utils import grpc_channel_options
 
     class AxolRobotClient(RobotClient):  # type: ignore[misc, valid-type]
-        """RobotClient that reuses a pre-connected AxolRobot.
+        """``RobotClient`` adapted to reuse a pre-connected ``AxolRobot``.
 
-        Three overrides relative to upstream ``RobotClient``:
+        Diverges from upstream in three places:
 
         - ``_aggregate_action_queues`` dispatches to a vectorized
-          ``temporal_ensemble`` (ACT-style smoothing) when selected,
-          otherwise falls through to upstream's scalar blends. The
-          final queue swap is gated by ``_install_future_queue`` to
-          stop the control thread from re-popping a just-executed
-          timestep.
-        - ``control_loop`` runs *only* action pops; observation capture
-          + send is moved to ``_observation_loop`` so the 60-70 ms
-          ZED-read + pickle + gRPC round-trip can't stall the 60 Hz
-          control stream.
+          ``temporal_ensemble`` (ACT smoothing) when selected, otherwise
+          falls through to the scalar blends. The final queue swap goes
+          through ``_install_future_queue`` to avoid re-popping a
+          just-executed timestep.
+        - ``control_loop`` only pops actions; observation capture + send
+          moves to ``_observation_loop`` so the ~60-70 ms ZED read + gRPC
+          send can't stall the 60 Hz action stream.
         - ``control_loop_action`` updates ``latest_action`` atomically
-          with the queue pop (upstream does the update *after* the
-          ~5-10 ms ``robot.send_action`` call, leaving a window for the
-          aggregator to re-insert the popped timestep).
+          with the queue pop (upstream updates it after ``send_action``,
+          which leaves a re-pop race for the aggregator).
 
-        We also skip ``make_robot_from_config + robot.connect()`` so
-        re-recording an episode doesn't pay the camera reconnect cost,
-        publish executed actions through ``_ActionPublisher`` for the
-        dataset capture thread, and override ``stop()`` to tear down
-        just the gRPC channel (the robot is shared across episodes).
-
-        We do not post-filter the action stream: training data is
-        already EMA + TrapezoidalFilter-smoothed in ``collect_data``,
-        so the trained policy already emits smoothed commands.
+        The constructor also skips ``make_robot_from_config`` / connect so
+        re-recording doesn't pay the camera reconnect cost, publishes
+        executed actions to ``_ActionPublisher``, and ``stop()`` tears
+        down only the gRPC channel (the robot is shared across episodes).
+        No post-filter is applied: training actions are already
+        EMA + trapezoidal-filtered in ``collect_data``.
         """
 
-        # Action layout (see ``robot_axol._JOINTS = list(Joint)``,
-        # ``Joint.GRIPPER`` is last in each arm). Used by
-        # ``_temporal_ensemble_aggregate``: gripper joints always take
-        # the newest chunk's value so bang-bang grasp signals aren't
-        # smeared.
+        # Indices of the gripper joints in the 16-element action vector.
+        # ``_temporal_ensemble_aggregate`` snaps these to the newest
+        # contributing chunk so bang-bang grasps aren't smeared.
         _GRIPPER_INDICES = (7, 15)
 
         def __init__(  # type: ignore[no-untyped-def]
@@ -726,19 +679,13 @@ def _build_axol_robot_client(
             self._publisher = publisher
             self._aggregate_strategy = aggregate_strategy
             self._temporal_ensemble_coeff = float(temporal_ensemble_coeff)
-            # ``temporal_ensemble`` buffer: ``(origin, packed_actions,
-            # timestamp)`` per chunk, sorted oldest-first.
-            # ``packed_actions`` is a ``(chunk_size, action_dim)`` tensor
-            # so the aggregation can run as a single batched op.
+            # ``(origin, packed_actions, timestamp)`` per chunk, sorted
+            # oldest-first. ``packed_actions`` is a (chunk_size, action_dim)
+            # tensor so aggregation runs as one batched op.
             self._chunk_buffer: list[tuple[int, Any, float]] = []
-            # WARN-once flag so a chronic race fires one informational
-            # log line per episode instead of spamming.
             self._race_fix_warned: bool = False
-            # Set by ``control_loop`` when an unhandled exception escapes
-            # the per-tick work (typically a hardware fault like a CAN
-            # transmit-buffer overflow). The episode supervisor watches
-            # this and tears the whole run down without prompting to
-            # save the partial recording.
+            # Surfaces unhandled control-loop exceptions (typically CAN
+            # faults) to the episode supervisor for an immediate teardown.
             self.fatal_error: BaseException | None = None
 
             lerobot_features = map_robot_keys_to_lerobot_features(self.robot)
@@ -770,8 +717,7 @@ def _build_axol_robot_client(
             self.action_queue = Queue()
             self.action_queue_lock = _threading.Lock()
             self.action_queue_size = []
-            # 3 threads sync at episode start: action receiver, control
-            # loop, observation loop.
+            # Receiver + control + observation threads sync at episode start.
             self.start_barrier = _threading.Barrier(3)
             self.fps_tracker = FPSTracker(target_fps=self.config.fps)
             self.must_go = _threading.Event()
@@ -796,16 +742,16 @@ def _build_axol_robot_client(
                 self._publisher.reset()
 
         def _install_future_queue(self, future_queue) -> None:  # type: ignore[no-untyped-def]
-            """Atomically swap in ``future_queue``, filtering out any
-            timestep already popped by the control thread.
+            """Swap in ``future_queue``, dropping already-executed timesteps.
 
-            Even when the aggregator re-reads ``latest_action`` while
-            building the future queue, the control thread can pop more
-            actions between that read and the swap. We hold
-            ``action_queue_lock`` here and re-filter against the live
-            ``latest_action`` so the post-swap queue cannot contain
-            already-executed timesteps — which would otherwise let the
-            next pop walk ``latest_action`` backwards and snap the arm.
+            The control thread can pop further actions between the
+            aggregator reading ``latest_action`` and the queue swap. Holding
+            ``action_queue_lock`` while re-filtering against the live
+            ``latest_action`` prevents the post-swap queue from walking
+            ``latest_action`` backwards and snapping the arm.
+
+            Args:
+                future_queue: Newly aggregated action queue to install.
             """
             with self.action_queue_lock:
                 with self.latest_action_lock:
@@ -829,33 +775,20 @@ def _build_axol_robot_client(
                 )
 
         def _temporal_ensemble_aggregate(self, incoming_actions):  # type: ignore[no-untyped-def]
-            """ACT-paper Algorithm 2: each future timestep is the
-            exponentially-weighted average of all buffered chunks that
-            cover it.
+            """Aggregate buffered chunks with ACT Algorithm 2.
 
-            On every incoming chunk we (1) append it to the buffer
-            (sorted oldest origin first), (2) drop chunks whose entire
-            range has been executed, then (3) rebuild the action queue
-            so every future timestep ``ts > latest_action`` covered by
-            at least one buffered chunk gets::
+            Each future timestep ``ts > latest_action`` covered by at
+            least one buffered chunk gets ``commanded[ts] = Σ wᵢ ·
+            chunkᵢ[ts] / Σ wᵢ`` with ``wᵢ = exp(-coeff · i)`` and
+            ``i = 0`` the oldest chunk. ``_GRIPPER_INDICES`` bypass the
+            average and snap to the newest contributing chunk's value.
+            The rebuild is one batched op over an
+            ``(n_chunks, n_ts, action_dim)`` grid, sub-ms even with
+            ~20 chunks in flight.
 
-                commanded[ts] = Σ wᵢ · chunkᵢ[ts] / Σ wᵢ
-
-            with ``wᵢ = exp(-coeff · i)``, ``i=0`` the oldest buffered
-            chunk. The rebuild is one batched op over an
-            ``(n_chunks, n_ts, action_dim)`` grid + mask — sub-ms even
-            with 20 chunks in flight, so the aggregation thread doesn't
-            hold the GIL long enough to perturb the 60 Hz action
-            stream.
-
-            Coefficient intuition (matches ``ACTTemporalEnsembler``):
-            ``coeff=0`` → uniform average; ``coeff>0`` weights older
-            chunks more (smoother, more inertia; ACT default 0.01);
-            ``coeff<0`` weights newer chunks more.
-
-            Gripper indices in ``_GRIPPER_INDICES`` skip the average
-            and take the newest contributing chunk's value so
-            bang-bang grasp commands aren't smeared over ~50 ticks.
+            Args:
+                incoming_actions: Latest action chunk from the policy
+                    server. Empty input is a no-op.
             """
             import torch
             from lerobot.async_inference.helpers import TimedAction
@@ -863,11 +796,9 @@ def _build_axol_robot_client(
             if not incoming_actions:
                 return
 
-            # Pack the incoming chunk into a contiguous tensor laid out
-            # by ascending timestep. Origin = smallest timestep = the
-            # ``obs.timestep`` the server saw. Fail loudly if timesteps
-            # aren't contiguous (upstream always emits contiguous chunks
-            # via ``_time_action_chunk``).
+            # Pack into a tensor sorted by ascending timestep. Upstream
+            # always emits contiguous chunks via ``_time_action_chunk``;
+            # fail loudly if that invariant is violated.
             sorted_incoming = sorted(incoming_actions, key=lambda a: a.get_timestep())
             new_origin = sorted_incoming[0].get_timestep()
             chunk_size = len(sorted_incoming)
@@ -904,8 +835,7 @@ def _build_axol_robot_client(
                 self._install_future_queue(Queue())
                 return
 
-            # Grid spans every future timestep covered by at least one
-            # buffered chunk: [latest_action+1, max(origin+size-1)].
+            # Grid: every future timestep covered by ≥1 buffered chunk.
             grid_min_ts = latest_action + 1
             grid_max_ts = max(
                 origin + packed.shape[0] - 1 for origin, packed, _ in self._chunk_buffer
@@ -919,9 +849,7 @@ def _build_axol_robot_client(
             device = sample.device
             action_dim = sample.shape[0]
 
-            # Assemble the (n_chunks, n_ts, action_dim) action grid via
-            # one slice copy per chunk. ``mask`` is 1.0 wherever a
-            # chunk contributes to a grid cell.
+            # ``mask[ci, ts]`` is 1.0 where chunk ``ci`` covers ``ts``.
             action_grid = torch.zeros(
                 (n_chunks, n_ts, action_dim), dtype=dtype, device=device
             )
@@ -939,7 +867,6 @@ def _build_axol_robot_client(
                 action_grid[ci, dst_start:dst_stop] = packed[src_start:src_stop]
                 mask[ci, dst_start:dst_stop] = 1.0
 
-            # One batched weighted sum across chunks for every ts.
             coeff = self._temporal_ensemble_coeff
             chunk_weights = torch.exp(
                 -coeff * torch.arange(n_chunks, dtype=dtype, device=device)
@@ -950,16 +877,14 @@ def _build_axol_robot_client(
                 dim=0
             ) / norm.unsqueeze(-1)  # (n_ts, action_dim)
 
-            # Gripper carve-out: pick the newest contributing chunk per
-            # ts via a reverse-cumsum one-hot (cheaper than ``torch.max``
-            # on tiny CPU tensors, which has surprisingly large dispatch
-            # overhead).
+            # Gripper carve-out: snap to the newest contributing chunk via
+            # a reverse-cumsum one-hot (cheaper than ``torch.max`` on tiny
+            # CPU tensors).
             reverse_cumsum = mask.flip(0).cumsum(dim=0).flip(0)
             newest_mask = mask * (reverse_cumsum == 1).to(dtype)
             for gidx in self._GRIPPER_INDICES:
                 ensembled[:, gidx] = (action_grid[:, :, gidx] * newest_mask).sum(dim=0)
 
-            # Emit only ts that had at least one contributor.
             contributed_indices = (
                 mask.any(dim=0).nonzero(as_tuple=False).flatten().tolist()
             )
@@ -975,24 +900,18 @@ def _build_axol_robot_client(
             self._install_future_queue(future_queue)
 
         def _aggregate_action_queues(self, incoming_actions, aggregate_fn=None):  # type: ignore[no-untyped-def]
-            """Dispatch to ``temporal_ensemble`` when selected;
-            otherwise fall through to upstream's scalar blends."""
+            """Dispatch ``temporal_ensemble`` locally, else upstream scalar blends."""
             if self._aggregate_strategy == "temporal_ensemble":
                 return self._temporal_ensemble_aggregate(incoming_actions)
             return super()._aggregate_action_queues(incoming_actions, aggregate_fn)
 
         def control_loop_action(self, verbose: bool = False):  # type: ignore[no-untyped-def]
-            """Pop the next action, set ``latest_action`` atomically with
-            the pop, send to the robot.
+            """Pop the next action, advance ``latest_action``, send to robot.
 
-            Upstream's order is (1) pop, (2) release lock + send (~5-10
-            ms), (3) update ``latest_action``. Between (2) and (3) the
-            popped timestep is gone from the queue but ``latest_action``
-            still reports the previous one, so a concurrent aggregator
-            pass can re-insert the popped timestep with a freshly
-            re-ensembled action. At 60 Hz that race fires ~0.8/s. We
-            close it by updating ``latest_action`` inside the same lock
-            block as the pop.
+            ``latest_action`` is updated inside the queue lock so the
+            aggregator can never see a stale value and re-insert a
+            just-popped timestep — a race that fires ~0.8/s at 60 Hz with
+            upstream's pop-then-update ordering.
             """
             with self.action_queue_lock:
                 self.action_queue_size.append(self.action_queue.qsize())
@@ -1017,21 +936,13 @@ def _build_axol_robot_client(
             return performed
 
         def control_loop(self, task, verbose: bool = False):  # type: ignore[no-untyped-def,override]
-            """Action-only control loop; ``_observation_loop`` runs in
-            parallel.
+            """Action-only control loop; obs send is on ``_observation_loop``.
 
-            The upstream loop interleaves action pops (microseconds)
-            with ``control_loop_observation`` (60-70 ms on Axol: three
-            ZED reads + pickle + gRPC streaming) on a single thread.
-            Every time the queue drops below ``chunk_size_threshold``
-            the obs send blocks action pops for a full ZED frame
-            interval, collapsing the 60 Hz target to ~27 Hz. Decoupling
-            the obs send lets the action stream run at the target rate.
-
-            Any unhandled exception (typically a hardware fault like a
-            CAN transmit-buffer overflow inside ``robot.send_action``)
-            is captured in ``self.fatal_error`` and triggers shutdown so
-            the episode supervisor can tear down cleanly.
+            Upstream interleaves microsecond action pops with the 60-70 ms
+            obs send on one thread, collapsing 60 Hz down to ~27 Hz on
+            Axol. Decoupling restores the target rate. Unhandled
+            exceptions (typically CAN faults from ``send_action``) are
+            captured in ``self.fatal_error`` and trigger shutdown.
             """
             self.start_barrier.wait()
             self.logger.info("Action-only control loop starting (obs send decoupled)")
@@ -1051,12 +962,10 @@ def _build_axol_robot_client(
                 self.shutdown_event.set()
 
         def _observation_loop(self, task, verbose: bool = False):  # type: ignore[no-untyped-def]
-            """Dedicated thread for observation capture + send.
+            """Dedicated thread: capture and send observations.
 
-            When the action queue is at or below
-            ``_ready_to_send_observation``'s threshold, fire
-            ``control_loop_observation`` (camera read + pickle + gRPC
-            stream). Otherwise sleep one tick.
+            Fires ``control_loop_observation`` once the action queue
+            drops to ``chunk_size_threshold``; sleeps one tick otherwise.
             """
             self.start_barrier.wait()
             self.logger.info("Observation loop thread starting")
@@ -1144,7 +1053,6 @@ def _run(
     axol_config.left.gripper.torque_limit = left_gripper_torque_limit
     axol_config.right.gripper.torque_limit = right_gripper_torque_limit
 
-    # Build robot with 3 ZED cameras — resolution/FPS auto-detected from stream
     robot_config = AxolRobotConfig(
         cameras={
             "overhead": ZedCameraConfig(host=zed_host, port=30000),
@@ -1156,9 +1064,9 @@ def _run(
     robot = AxolRobot(robot_config)
     _, robot_action_proc, robot_obs_proc = make_default_processors()
 
-    # Dataset features are derived from the camera configs (width/height) and
-    # joint enum, both static, so the dataset can be built before the robot
-    # is connected. This lets us load the policy first (see below).
+    # Dataset features come from static camera configs + joint enum, so the
+    # dataset can be constructed before the robot connects — letting us load
+    # the policy first (see PolicyServer spawn below).
     dataset: "LeRobotDataset | None" = None
     dataset_root: Path | None = None
     resumed_dataset = False
@@ -1171,11 +1079,7 @@ def _run(
             and (meta / "tasks.parquet").exists()
             and (meta / "episodes").is_dir()
         )
-        # Mirror collect-data:
-        #   - complete dataset  → resume (append new rollouts)
-        #   - incomplete dataset (info.json but missing tasks.parquet / episodes/)
-        #                       → refuse, force explicit rm -rf
-        #   - empty leftover dir (no info.json) → wipe so create() can mkdir
+        # Mirror collect-data's resume/refuse/wipe decision tree.
         if has_info and not is_complete:
             raise RuntimeError(
                 f"Incomplete dataset found at {dataset_root} (missing "
@@ -1210,14 +1114,9 @@ def _run(
     if rerun_ip:
         init_rerun(session_name="axol_run_policy", ip=rerun_ip, port=rerun_port)
 
-    # --- Launch PolicyServer in a child process on localhost --------------
-    # Important: we spawn the server and fully load the policy BEFORE
-    # connecting cameras. The model download + CUDA load is a ~15s spike of
-    # network + GPU activity; if the ZED streams are already open during
-    # that window the streams can get briefly disrupted, and (without async
-    # recovery) ``grab()`` blocks indefinitely waiting for the connection
-    # to recover. Connecting cameras after the policy is ready avoids
-    # walking into that contention window in the first place.
+    # Spawn the policy server and load the policy BEFORE connecting cameras:
+    # the model download + CUDA load is a ~15 s network + GPU spike that can
+    # disrupt already-open ZED streams.
     server_cfg_dict = {
         "host": "127.0.0.1",
         "port": server_port,
@@ -1233,10 +1132,7 @@ def _run(
     server_proc.start()
     log_say(f"Started PolicyServer on 127.0.0.1:{server_port} (pid={server_proc.pid}).")
 
-    # Spawn the IK worker in parallel with the policy server so JAX JIT
-    # compilation overlaps with policy load. The worker plans collision-aware
-    # return-to-rest trajectories; we wait for the "ready" handshake on first
-    # use (return_to_rest).
+    # Spawn the IK worker in parallel so JAX JIT overlaps with policy load.
     reset_controller = _IKResetController()
     reset_controller.start()
     log_say("Started IK reset worker (collision-aware return-to-rest).")
@@ -1246,10 +1142,9 @@ def _run(
     try:
         _wait_for_port("127.0.0.1", server_port, timeout=30.0)
 
-        # temporal_ensemble lives in our ``_aggregate_action_queues``
-        # override; ``RobotClientConfig`` still needs a name from its
-        # own registry so we pass ``latest_only`` as a placeholder that
-        # we short-circuit before it's ever called.
+        # ``RobotClientConfig`` requires a name from upstream's registry;
+        # ``temporal_ensemble`` is handled in our override so pass a
+        # placeholder that the dispatcher short-circuits.
         if aggregate_fn == "temporal_ensemble":
             log_say(
                 f"Aggregation: temporal_ensemble "
@@ -1285,7 +1180,6 @@ def _run(
         if not client.start():
             raise RuntimeError("Failed to connect to policy server / load policy.")
 
-        # Policy is now resident on cuda — safe to connect cameras.
         log_say("Connecting robot...")
         robot.connect()
 
@@ -1317,9 +1211,7 @@ def _run(
                 name="axol-control-loop",
                 daemon=True,
             )
-            # Dedicated obs send thread (see AxolRobotClient.control_loop
-            # for why: the upstream design runs obs send on the control
-            # thread, which stalls 60 Hz down to ~27 Hz).
+            # Decoupled from the control thread — see AxolRobotClient.control_loop.
             obs_thread = threading.Thread(
                 target=client._observation_loop,
                 args=(task,),
@@ -1372,11 +1264,8 @@ def _run(
                         timed_out = True
                         break
                     if client.fatal_error is not None:
-                        # Hardware fault (e.g. CAN transmit-buffer full)
-                        # raised out of the control loop. Drop the
-                        # episode entirely and exit the run — no save
-                        # prompt, no rerecord, the operator needs to
-                        # check the robot.
+                        # Hardware fault from the control loop — drop the
+                        # episode and exit the run.
                         log_say(
                             f"Fatal error in control loop: "
                             f"{client.fatal_error!r}. Aborting run without "
@@ -1396,9 +1285,7 @@ def _run(
             control_thread.join(timeout=5.0)
             receiver_thread.join(timeout=5.0)
             obs_thread.join(timeout=5.0)
-            # The stdin watcher blocks on select with a short timeout, so
-            # it will wake up on its own; don't join (it may still be in
-            # select if the user never typed anything).
+            # ``stdin_thread`` wakes itself via ``select``; don't join.
 
             if interrupted:
                 break
@@ -1448,20 +1335,15 @@ def _run(
             except (EOFError, KeyboardInterrupt):
                 break
 
-        # Re-raise a control-loop hardware fault (e.g. CAN transmit
-        # buffer full) so ``run()`` exits the CLI with a non-zero
-        # status. The ``finally`` block below still runs first and
-        # tears the robot / server down cleanly.
+        # Re-raise the control-loop fault so ``run()`` exits non-zero.
         if client is not None and client.fatal_error is not None:
             raise client.fatal_error
 
     except KeyboardInterrupt:
         pass
     finally:
-        # Ignore SIGINT during cleanup so an impatient second Ctrl+C
-        # doesn't abort partway through robot.disconnect() / server
-        # teardown and leave hardware in a weird state. We restore the
-        # default handler at the end of this block.
+        # Ignore SIGINT during cleanup so a second Ctrl+C can't abort
+        # partway through disconnect/teardown. Restored at end of block.
         import signal
 
         try:
@@ -1475,12 +1357,9 @@ def _run(
                 client.stop()
             except Exception:  # noqa: BLE001
                 pass
-        # Always attempt disconnect — ``robot.connect()`` starts the
-        # asyncio event-loop thread *before* the motor-enable step, so a
-        # MotorError during enable leaves the loop thread and any
-        # already-opened CAN buses dangling. ``disconnect()`` is
-        # null-safe and idempotent, so this is fine even if connect
-        # never even started.
+        # ``disconnect()`` is null-safe and idempotent; always call it so a
+        # ``connect()`` that bailed mid-enable doesn't leak the asyncio
+        # event-loop thread or any already-opened CAN buses.
         try:
             robot.disconnect()
         except Exception:  # noqa: BLE001
@@ -1491,7 +1370,6 @@ def _run(
         except Exception:  # noqa: BLE001
             pass
 
-        # Tear down the server child process.
         if server_proc.is_alive():
             server_proc.terminate()
             server_proc.join(timeout=5.0)
@@ -1504,15 +1382,14 @@ def _run(
             if push_to_hub and episodes_recorded > 0:
                 dataset.push_to_hub()
 
+        # Auto-wipe only a freshly-created, never-written dataset. Resumed
+        # datasets already have saved rollouts on disk and must be kept.
         if (
             dataset_root is not None
             and not resumed_dataset
             and episodes_recorded == 0
             and dataset_root.exists()
         ):
-            # Only auto-wipe a freshly-created dataset that ended up empty.
-            # A resumed dataset already has saved rollouts on disk that we
-            # must never clobber, even if this session added zero new ones.
             try:
                 shutil.rmtree(dataset_root)
                 log_say(f"No episodes saved — removed empty dataset at {dataset_root}.")
@@ -1521,9 +1398,8 @@ def _run(
                     "Failed to remove empty dataset at %s: %s", dataset_root, exc
                 )
 
-        # Restore the default SIGINT handler so the user can still kill
-        # the process if any non-daemon thread we don't control (e.g. a
-        # leaked driver thread) is keeping the interpreter alive.
+        # Restore the default handler so Ctrl+C can still kill any leaked
+        # non-daemon thread keeping the interpreter alive.
         try:
             signal.signal(signal.SIGINT, signal.SIG_DFL)
         except (ValueError, OSError):

--- a/almond_axol/cli/run_policy.py
+++ b/almond_axol/cli/run_policy.py
@@ -621,11 +621,9 @@ def _run(
     robot = AxolRobot(robot_config)
     _, robot_action_proc, robot_obs_proc = make_default_processors()
 
-    # Connect first so cameras auto-detect resolution; dataset features are
-    # then derived from the live robot.
-    robot.connect()
-
-    # Optional rollout dataset
+    # Dataset features are derived from the camera configs (width/height) and
+    # joint enum, both static, so the dataset can be built before the robot
+    # is connected. This lets us load the policy first (see below).
     dataset: "LeRobotDataset | None" = None
     if repo_id:
         action_features = hw_to_dataset_features(robot.action_features, ACTION)
@@ -644,6 +642,13 @@ def _run(
         init_rerun(session_name="axol_run_policy", ip=rerun_ip, port=rerun_port)
 
     # --- Launch PolicyServer in a child process on localhost --------------
+    # Important: we spawn the server and fully load the policy BEFORE
+    # connecting cameras. The model download + CUDA load is a ~15s spike of
+    # network + GPU activity; if the ZED streams are already open during
+    # that window the streams can get briefly disrupted, and (without async
+    # recovery) ``grab()`` blocks indefinitely waiting for the connection
+    # to recover. Connecting cameras after the policy is ready avoids
+    # walking into that contention window in the first place.
     server_cfg_dict = {
         "host": "127.0.0.1",
         "port": server_port,
@@ -661,6 +666,7 @@ def _run(
 
     client = None
     episodes_recorded = 0
+    robot_connected = False
     try:
         _wait_for_port("127.0.0.1", server_port, timeout=30.0)
 
@@ -685,6 +691,18 @@ def _run(
         log_say("Loading policy on server (one-time)...")
         if not client.start():
             raise RuntimeError("Failed to connect to policy server / load policy.")
+
+        # Policy is now resident on cuda — safe to connect cameras.
+        log_say("Connecting robot...")
+        robot.connect()
+        robot_connected = True
+
+        log_say("Returning to rest pose.")
+        _move_to_rest(robot, fps)
+        try:
+            input("Reset the scene, then press Enter to start the first episode.")
+        except (EOFError, KeyboardInterrupt):
+            return
 
         while True:
             log_say(f"Episode {episodes_recorded + 1}: starting in 1s.")
@@ -828,10 +846,11 @@ def _run(
                 client.stop()
             except Exception:  # noqa: BLE001
                 pass
-        try:
-            robot.disconnect()
-        except Exception:  # noqa: BLE001
-            pass
+        if robot_connected:
+            try:
+                robot.disconnect()
+            except Exception:  # noqa: BLE001
+                pass
 
         # Tear down the server child process.
         if server_proc.is_alive():

--- a/almond_axol/cli/run_policy.py
+++ b/almond_axol/cli/run_policy.py
@@ -129,17 +129,55 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[
     p.add_argument(
         "--chunk-size-threshold",
         type=float,
-        default=0.5,
+        default=0.9,
         help=(
-            "Send a fresh observation to the server when the local action queue "
-            "drops to this fraction of a full chunk (default: 0.5)."
+            "Send a fresh observation to the server when the local "
+            "action queue drops to this fraction of a full chunk "
+            "(default: 0.9). Upstream lerobot defaults to 0.5 because "
+            "obs send and action pops share a thread there; on Axol "
+            "obs send runs on a dedicated thread (see "
+            "AxolRobotClient._observation_loop) so a higher threshold "
+            "is strictly better — it triggers the next obs while the "
+            "queue still has plenty of margin, so a fresh chunk almost "
+            "always lands before the queue drains and the arm doesn't "
+            "freeze waiting at chunk boundaries."
         ),
     )
     p.add_argument(
         "--aggregate-fn",
-        default="weighted_average",
-        choices=["weighted_average", "latest_only", "average", "conservative"],
-        help="Action chunk aggregation function (default: weighted_average).",
+        default="temporal_ensemble",
+        choices=[
+            "temporal_ensemble",
+            "weighted_average",
+            "latest_only",
+            "average",
+            "conservative",
+        ],
+        help=(
+            "Action chunk aggregation strategy (default: "
+            "temporal_ensemble). temporal_ensemble is ACT's Algorithm 2: "
+            "every future timestep is the exponentially-weighted average "
+            "of all buffered chunks covering it (see "
+            "--temporal-ensemble-coeff), with the gripper indices "
+            "carved out to use the newest chunk's value so bang-bang "
+            "grasps aren't smeared. The other choices are the upstream "
+            "lerobot scalar blends, applied uniformly across all 16 "
+            "action components."
+        ),
+    )
+    p.add_argument(
+        "--temporal-ensemble-coeff",
+        type=float,
+        default=0.01,
+        metavar="K",
+        help=(
+            "Decay coefficient for --aggregate-fn temporal_ensemble "
+            "(default: 0.01, matching the ACT paper). Weights are "
+            "wᵢ = exp(-K·i), i=0 is the oldest buffered chunk; K>0 "
+            "favors older chunks (smoother), K=0 averages uniformly, "
+            "K<0 favors newer chunks (more reactive). Ignored for "
+            "other --aggregate-fn values."
+        ),
     )
     p.add_argument(
         "--zed-host",
@@ -218,29 +256,49 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[
 
 def run(args: argparse.Namespace) -> None:
     logging.basicConfig(level=getattr(logging, args.log_level))
-    _run(
-        policy_path=args.policy,
-        policy_type=args.policy_type,
-        task=args.task,
-        episode_time_s=args.episode_time_s,
-        fps=args.fps,
-        repo_id=args.repo_id,
-        root=args.root,
-        push_to_hub=args.push_to_hub,
-        device=args.device,
-        server_port=args.server_port,
-        actions_per_chunk=args.actions_per_chunk,
-        chunk_size_threshold=args.chunk_size_threshold,
-        aggregate_fn=args.aggregate_fn,
-        zed_host=args.zed_host,
-        zed_iface=args.zed_iface,
-        left_gripper_torque_limit=args.left_gripper_torque_limit,
-        right_gripper_torque_limit=args.right_gripper_torque_limit,
-        left_stiffness=args.left_stiffness,
-        right_stiffness=args.right_stiffness,
-        rerun_ip=args.rerun_ip,
-        rerun_port=args.rerun_port,
-    )
+
+    # Hardware errors bubble up from inside ``_run`` — either at
+    # connect time (motor unresponsive: ``MotorError``) or mid-episode
+    # (CAN socket faults like "Transmit buffer full": ``CanError``).
+    # Catch them here so we exit with a brief error and a non-zero
+    # status instead of dumping a multi-frame traceback for what is
+    # really an operator-actionable hardware fault. ``_run``'s own
+    # ``finally`` has already torn down the robot + policy server by
+    # the time we get here.
+    import sys
+
+    import can
+
+    from ..motor.errors import MotorError
+
+    try:
+        _run(
+            policy_path=args.policy,
+            policy_type=args.policy_type,
+            task=args.task,
+            episode_time_s=args.episode_time_s,
+            fps=args.fps,
+            repo_id=args.repo_id,
+            root=args.root,
+            push_to_hub=args.push_to_hub,
+            device=args.device,
+            server_port=args.server_port,
+            actions_per_chunk=args.actions_per_chunk,
+            chunk_size_threshold=args.chunk_size_threshold,
+            aggregate_fn=args.aggregate_fn,
+            temporal_ensemble_coeff=args.temporal_ensemble_coeff,
+            zed_host=args.zed_host,
+            zed_iface=args.zed_iface,
+            left_gripper_torque_limit=args.left_gripper_torque_limit,
+            right_gripper_torque_limit=args.right_gripper_torque_limit,
+            left_stiffness=args.left_stiffness,
+            right_stiffness=args.right_stiffness,
+            rerun_ip=args.rerun_ip,
+            rerun_port=args.rerun_port,
+        )
+    except (MotorError, can.CanError) as exc:
+        _logger.error("Robot hardware error: %s. Exiting.", exc)
+        sys.exit(1)
 
 
 class _IKResetController:
@@ -563,10 +621,23 @@ def _serve_policy_server(server_cfg_dict: dict[str, Any]) -> None:
     The child ignores SIGINT so Ctrl+C in the controlling terminal doesn't
     dump a gRPC traceback from this process; the parent explicitly
     terminates the server during its cleanup path.
+
+    Before serving we monkey-patch ``policy_server.observations_similar``
+    to always return ``False``. The upstream default uses a 1-rad L2
+    joint-state tolerance to drop "too similar" observations, which on
+    Axol's 16-DOF arms at 60 Hz drops nearly every observation — a fresh
+    chunk only lands every ~2 s, the action queue runs dry, and the arm
+    freezes for ~135 ms at every chunk boundary. The filter has no
+    config knob on ``PolicyServerConfig`` so we patch the module symbol.
     """
     import signal
 
     signal.signal(signal.SIGINT, signal.SIG_IGN)
+
+    from lerobot.async_inference import policy_server as _ps
+
+    _ps.observations_similar = lambda *args, **kwargs: False
+
     from lerobot.async_inference.configs import PolicyServerConfig
     from lerobot.async_inference.policy_server import serve
 
@@ -579,7 +650,12 @@ def _serve_policy_server(server_cfg_dict: dict[str, Any]) -> None:
 
 
 def _build_axol_robot_client(
-    *, config: Any, robot: "AxolRobot", publisher: _ActionPublisher
+    *,
+    config: Any,
+    robot: "AxolRobot",
+    publisher: _ActionPublisher,
+    aggregate_strategy: str = "temporal_ensemble",
+    temporal_ensemble_coeff: float = 0.01,
 ) -> Any:
     """Construct an ``AxolRobotClient`` against an already-connected robot.
 
@@ -602,18 +678,68 @@ def _build_axol_robot_client(
     class AxolRobotClient(RobotClient):  # type: ignore[misc, valid-type]
         """RobotClient that reuses a pre-connected AxolRobot.
 
-        - Skips ``make_robot_from_config(...)`` and ``robot.connect()`` so we
-          don't pay the camera reconnect cost between episodes.
-        - Publishes each executed action to ``_ActionPublisher`` for the
-          dataset capture thread.
-        - Overrides ``stop()`` to tear down the gRPC channel without
-          disconnecting the shared robot.
+        Three overrides relative to upstream ``RobotClient``:
+
+        - ``_aggregate_action_queues`` dispatches to a vectorized
+          ``temporal_ensemble`` (ACT-style smoothing) when selected,
+          otherwise falls through to upstream's scalar blends. The
+          final queue swap is gated by ``_install_future_queue`` to
+          stop the control thread from re-popping a just-executed
+          timestep.
+        - ``control_loop`` runs *only* action pops; observation capture
+          + send is moved to ``_observation_loop`` so the 60-70 ms
+          ZED-read + pickle + gRPC round-trip can't stall the 60 Hz
+          control stream.
+        - ``control_loop_action`` updates ``latest_action`` atomically
+          with the queue pop (upstream does the update *after* the
+          ~5-10 ms ``robot.send_action`` call, leaving a window for the
+          aggregator to re-insert the popped timestep).
+
+        We also skip ``make_robot_from_config + robot.connect()`` so
+        re-recording an episode doesn't pay the camera reconnect cost,
+        publish executed actions through ``_ActionPublisher`` for the
+        dataset capture thread, and override ``stop()`` to tear down
+        just the gRPC channel (the robot is shared across episodes).
+
+        We do not post-filter the action stream: training data is
+        already EMA + TrapezoidalFilter-smoothed in ``collect_data``,
+        so the trained policy already emits smoothed commands.
         """
 
-        def __init__(self, config, robot, publisher):  # type: ignore[no-untyped-def]
+        # Action layout (see ``robot_axol._JOINTS = list(Joint)``,
+        # ``Joint.GRIPPER`` is last in each arm). Used by
+        # ``_temporal_ensemble_aggregate``: gripper joints always take
+        # the newest chunk's value so bang-bang grasp signals aren't
+        # smeared.
+        _GRIPPER_INDICES = (7, 15)
+
+        def __init__(  # type: ignore[no-untyped-def]
+            self,
+            config,
+            robot,
+            publisher,
+            aggregate_strategy,
+            temporal_ensemble_coeff,
+        ):
             self.config = config
             self.robot = robot
             self._publisher = publisher
+            self._aggregate_strategy = aggregate_strategy
+            self._temporal_ensemble_coeff = float(temporal_ensemble_coeff)
+            # ``temporal_ensemble`` buffer: ``(origin, packed_actions,
+            # timestamp)`` per chunk, sorted oldest-first.
+            # ``packed_actions`` is a ``(chunk_size, action_dim)`` tensor
+            # so the aggregation can run as a single batched op.
+            self._chunk_buffer: list[tuple[int, Any, float]] = []
+            # WARN-once flag so a chronic race fires one informational
+            # log line per episode instead of spamming.
+            self._race_fix_warned: bool = False
+            # Set by ``control_loop`` when an unhandled exception escapes
+            # the per-tick work (typically a hardware fault like a CAN
+            # transmit-buffer overflow). The episode supervisor watches
+            # this and tears the whole run down without prompting to
+            # save the partial recording.
+            self.fatal_error: BaseException | None = None
 
             lerobot_features = map_robot_keys_to_lerobot_features(self.robot)
 
@@ -644,35 +770,305 @@ def _build_axol_robot_client(
             self.action_queue = Queue()
             self.action_queue_lock = _threading.Lock()
             self.action_queue_size = []
-            self.start_barrier = _threading.Barrier(2)
+            # 3 threads sync at episode start: action receiver, control
+            # loop, observation loop.
+            self.start_barrier = _threading.Barrier(3)
             self.fps_tracker = FPSTracker(target_fps=self.config.fps)
             self.must_go = _threading.Event()
             self.must_go.set()
 
         def reset_episode_state(self) -> None:
-            """Reset queues + flags so threads can run a fresh episode.
-
-            Recreates ``start_barrier`` (so two new threads can synchronize)
-            and clears any leftover action queue entries.
-            """
+            """Reset queues + flags so threads can run a fresh episode."""
             with self.action_queue_lock:
                 self.action_queue = Queue()
                 self.action_queue_size = []
+                self._chunk_buffer = []
             with self.latest_action_lock:
                 self.latest_action = -1
             self.action_chunk_size = -1
             self.must_go.set()
             self.fps_tracker.reset()
             self.shutdown_event.clear()
-            self.start_barrier = _threading.Barrier(2)
+            self.start_barrier = _threading.Barrier(3)
+            self._race_fix_warned = False
+            self.fatal_error = None
             if self._publisher is not None:
                 self._publisher.reset()
 
+        def _install_future_queue(self, future_queue) -> None:  # type: ignore[no-untyped-def]
+            """Atomically swap in ``future_queue``, filtering out any
+            timestep already popped by the control thread.
+
+            Even when the aggregator re-reads ``latest_action`` while
+            building the future queue, the control thread can pop more
+            actions between that read and the swap. We hold
+            ``action_queue_lock`` here and re-filter against the live
+            ``latest_action`` so the post-swap queue cannot contain
+            already-executed timesteps — which would otherwise let the
+            next pop walk ``latest_action`` backwards and snap the arm.
+            """
+            with self.action_queue_lock:
+                with self.latest_action_lock:
+                    live_latest = self.latest_action
+                filtered = Queue()
+                dropped = 0
+                while not future_queue.empty():
+                    ta = future_queue.get_nowait()
+                    if ta.get_timestep() > live_latest:
+                        filtered.put(ta)
+                    else:
+                        dropped += 1
+                self.action_queue = filtered
+            if dropped and not self._race_fix_warned:
+                self._race_fix_warned = True
+                _logger.warning(
+                    "Aggregator race fix engaged: %d timestep(s) popped "
+                    "during aggregation were filtered out of the new "
+                    "queue (informational; fix handled it).",
+                    dropped,
+                )
+
+        def _temporal_ensemble_aggregate(self, incoming_actions):  # type: ignore[no-untyped-def]
+            """ACT-paper Algorithm 2: each future timestep is the
+            exponentially-weighted average of all buffered chunks that
+            cover it.
+
+            On every incoming chunk we (1) append it to the buffer
+            (sorted oldest origin first), (2) drop chunks whose entire
+            range has been executed, then (3) rebuild the action queue
+            so every future timestep ``ts > latest_action`` covered by
+            at least one buffered chunk gets::
+
+                commanded[ts] = Σ wᵢ · chunkᵢ[ts] / Σ wᵢ
+
+            with ``wᵢ = exp(-coeff · i)``, ``i=0`` the oldest buffered
+            chunk. The rebuild is one batched op over an
+            ``(n_chunks, n_ts, action_dim)`` grid + mask — sub-ms even
+            with 20 chunks in flight, so the aggregation thread doesn't
+            hold the GIL long enough to perturb the 60 Hz action
+            stream.
+
+            Coefficient intuition (matches ``ACTTemporalEnsembler``):
+            ``coeff=0`` → uniform average; ``coeff>0`` weights older
+            chunks more (smoother, more inertia; ACT default 0.01);
+            ``coeff<0`` weights newer chunks more.
+
+            Gripper indices in ``_GRIPPER_INDICES`` skip the average
+            and take the newest contributing chunk's value so
+            bang-bang grasp commands aren't smeared over ~50 ticks.
+            """
+            import torch
+            from lerobot.async_inference.helpers import TimedAction
+
+            if not incoming_actions:
+                return
+
+            # Pack the incoming chunk into a contiguous tensor laid out
+            # by ascending timestep. Origin = smallest timestep = the
+            # ``obs.timestep`` the server saw. Fail loudly if timesteps
+            # aren't contiguous (upstream always emits contiguous chunks
+            # via ``_time_action_chunk``).
+            sorted_incoming = sorted(incoming_actions, key=lambda a: a.get_timestep())
+            new_origin = sorted_incoming[0].get_timestep()
+            chunk_size = len(sorted_incoming)
+            sample = sorted_incoming[0].get_action()
+            new_packed = torch.empty(
+                (chunk_size, sample.shape[0]),
+                dtype=sample.dtype,
+                device=sample.device,
+            )
+            for offset, ta in enumerate(sorted_incoming):
+                if ta.get_timestep() != new_origin + offset:
+                    raise RuntimeError(
+                        "temporal_ensemble: incoming chunk timesteps are "
+                        f"non-contiguous (expected {new_origin + offset}, "
+                        f"got {ta.get_timestep()} at offset {offset})"
+                    )
+                new_packed[offset] = ta.get_action()
+            new_timestamp = sorted_incoming[0].get_timestamp()
+
+            self._chunk_buffer.append((new_origin, new_packed, new_timestamp))
+            self._chunk_buffer.sort(key=lambda entry: entry[0])
+
+            with self.latest_action_lock:
+                latest_action = self.latest_action
+
+            # Drop chunks whose entire range has already been executed.
+            self._chunk_buffer = [
+                entry
+                for entry in self._chunk_buffer
+                if entry[0] + entry[1].shape[0] - 1 > latest_action
+            ]
+            n_chunks = len(self._chunk_buffer)
+            if n_chunks == 0:
+                self._install_future_queue(Queue())
+                return
+
+            # Grid spans every future timestep covered by at least one
+            # buffered chunk: [latest_action+1, max(origin+size-1)].
+            grid_min_ts = latest_action + 1
+            grid_max_ts = max(
+                origin + packed.shape[0] - 1 for origin, packed, _ in self._chunk_buffer
+            )
+            if grid_min_ts > grid_max_ts:
+                self._install_future_queue(Queue())
+                return
+
+            n_ts = grid_max_ts - grid_min_ts + 1
+            dtype = sample.dtype
+            device = sample.device
+            action_dim = sample.shape[0]
+
+            # Assemble the (n_chunks, n_ts, action_dim) action grid via
+            # one slice copy per chunk. ``mask`` is 1.0 wherever a
+            # chunk contributes to a grid cell.
+            action_grid = torch.zeros(
+                (n_chunks, n_ts, action_dim), dtype=dtype, device=device
+            )
+            mask = torch.zeros((n_chunks, n_ts), dtype=dtype, device=device)
+            for ci, (origin, packed, _) in enumerate(self._chunk_buffer):
+                chunk_max = origin + packed.shape[0] - 1
+                lo = max(origin, grid_min_ts)
+                hi = min(chunk_max, grid_max_ts)
+                if lo > hi:
+                    continue
+                src_start = lo - origin
+                src_stop = hi - origin + 1
+                dst_start = lo - grid_min_ts
+                dst_stop = hi - grid_min_ts + 1
+                action_grid[ci, dst_start:dst_stop] = packed[src_start:src_stop]
+                mask[ci, dst_start:dst_stop] = 1.0
+
+            # One batched weighted sum across chunks for every ts.
+            coeff = self._temporal_ensemble_coeff
+            chunk_weights = torch.exp(
+                -coeff * torch.arange(n_chunks, dtype=dtype, device=device)
+            )
+            weighted_mask = chunk_weights.unsqueeze(1) * mask  # (n_chunks, n_ts)
+            norm = weighted_mask.sum(dim=0).clamp(min=1e-12)
+            ensembled = (action_grid * weighted_mask.unsqueeze(-1)).sum(
+                dim=0
+            ) / norm.unsqueeze(-1)  # (n_ts, action_dim)
+
+            # Gripper carve-out: pick the newest contributing chunk per
+            # ts via a reverse-cumsum one-hot (cheaper than ``torch.max``
+            # on tiny CPU tensors, which has surprisingly large dispatch
+            # overhead).
+            reverse_cumsum = mask.flip(0).cumsum(dim=0).flip(0)
+            newest_mask = mask * (reverse_cumsum == 1).to(dtype)
+            for gidx in self._GRIPPER_INDICES:
+                ensembled[:, gidx] = (action_grid[:, :, gidx] * newest_mask).sum(dim=0)
+
+            # Emit only ts that had at least one contributor.
+            contributed_indices = (
+                mask.any(dim=0).nonzero(as_tuple=False).flatten().tolist()
+            )
+            future_queue = Queue()
+            for ti in contributed_indices:
+                future_queue.put(
+                    TimedAction(
+                        timestamp=new_timestamp,
+                        timestep=grid_min_ts + ti,
+                        action=ensembled[ti].clone(),
+                    )
+                )
+            self._install_future_queue(future_queue)
+
+        def _aggregate_action_queues(self, incoming_actions, aggregate_fn=None):  # type: ignore[no-untyped-def]
+            """Dispatch to ``temporal_ensemble`` when selected;
+            otherwise fall through to upstream's scalar blends."""
+            if self._aggregate_strategy == "temporal_ensemble":
+                return self._temporal_ensemble_aggregate(incoming_actions)
+            return super()._aggregate_action_queues(incoming_actions, aggregate_fn)
+
         def control_loop_action(self, verbose: bool = False):  # type: ignore[no-untyped-def]
-            performed = super().control_loop_action(verbose)
+            """Pop the next action, set ``latest_action`` atomically with
+            the pop, send to the robot.
+
+            Upstream's order is (1) pop, (2) release lock + send (~5-10
+            ms), (3) update ``latest_action``. Between (2) and (3) the
+            popped timestep is gone from the queue but ``latest_action``
+            still reports the previous one, so a concurrent aggregator
+            pass can re-insert the popped timestep with a freshly
+            re-ensembled action. At 60 Hz that race fires ~0.8/s. We
+            close it by updating ``latest_action`` inside the same lock
+            block as the pop.
+            """
+            with self.action_queue_lock:
+                self.action_queue_size.append(self.action_queue.qsize())
+                timed_action = self.action_queue.get_nowait()
+                with self.latest_action_lock:
+                    self.latest_action = timed_action.get_timestep()
+                qs_after = self.action_queue.qsize()
+
+            performed = self.robot.send_action(
+                self._action_tensor_to_action_dict(timed_action.get_action())
+            )
+
+            if verbose:
+                self.logger.debug(
+                    f"Ts={timed_action.get_timestamp()} | "
+                    f"Action #{timed_action.get_timestep()} performed | "
+                    f"Queue size: {qs_after}"
+                )
+
             if self._publisher is not None and performed is not None:
                 self._publisher.publish(performed)
             return performed
+
+        def control_loop(self, task, verbose: bool = False):  # type: ignore[no-untyped-def,override]
+            """Action-only control loop; ``_observation_loop`` runs in
+            parallel.
+
+            The upstream loop interleaves action pops (microseconds)
+            with ``control_loop_observation`` (60-70 ms on Axol: three
+            ZED reads + pickle + gRPC streaming) on a single thread.
+            Every time the queue drops below ``chunk_size_threshold``
+            the obs send blocks action pops for a full ZED frame
+            interval, collapsing the 60 Hz target to ~27 Hz. Decoupling
+            the obs send lets the action stream run at the target rate.
+
+            Any unhandled exception (typically a hardware fault like a
+            CAN transmit-buffer overflow inside ``robot.send_action``)
+            is captured in ``self.fatal_error`` and triggers shutdown so
+            the episode supervisor can tear down cleanly.
+            """
+            self.start_barrier.wait()
+            self.logger.info("Action-only control loop starting (obs send decoupled)")
+            try:
+                while self.running:
+                    control_loop_start = time.perf_counter()
+                    if self.actions_available():
+                        self.control_loop_action(verbose)
+                    elapsed = time.perf_counter() - control_loop_start
+                    time.sleep(max(0.0, self.config.environment_dt - elapsed))
+            except Exception as exc:  # noqa: BLE001
+                self.logger.error(
+                    f"Control loop hit an unhandled exception ({exc!r}); "
+                    "signalling shutdown so the episode tears down."
+                )
+                self.fatal_error = exc
+                self.shutdown_event.set()
+
+        def _observation_loop(self, task, verbose: bool = False):  # type: ignore[no-untyped-def]
+            """Dedicated thread for observation capture + send.
+
+            When the action queue is at or below
+            ``_ready_to_send_observation``'s threshold, fire
+            ``control_loop_observation`` (camera read + pickle + gRPC
+            stream). Otherwise sleep one tick.
+            """
+            self.start_barrier.wait()
+            self.logger.info("Observation loop thread starting")
+            while self.running:
+                try:
+                    if self._ready_to_send_observation():
+                        self.control_loop_observation(task, verbose)
+                    else:
+                        time.sleep(self.config.environment_dt)
+                except Exception as exc:  # noqa: BLE001
+                    self.logger.error(f"Observation loop error: {exc!r}; continuing")
+                    time.sleep(self.config.environment_dt)
 
         def stop(self) -> None:  # type: ignore[override]
             self.shutdown_event.set()
@@ -682,7 +1078,13 @@ def _build_axol_robot_client(
                 pass
             self.logger.debug("AxolRobotClient channel closed (robot left connected)")
 
-    return AxolRobotClient(config, robot, publisher)
+    return AxolRobotClient(
+        config,
+        robot,
+        publisher,
+        aggregate_strategy,
+        temporal_ensemble_coeff,
+    )
 
 
 # ----------------------------------------------------------------------
@@ -702,8 +1104,9 @@ def _run(
     device: str,
     server_port: int = 8765,
     actions_per_chunk: int = 50,
-    chunk_size_threshold: float = 0.5,
+    chunk_size_threshold: float = 0.9,
     aggregate_fn: str = "weighted_average",
+    temporal_ensemble_coeff: float = 0.01,
     zed_host: str = "192.168.10.1",
     zed_iface: str | None = None,
     left_gripper_torque_limit: float = 1.0,
@@ -840,10 +1243,20 @@ def _run(
 
     client = None
     episodes_recorded = 0
-    robot_connected = False
     try:
         _wait_for_port("127.0.0.1", server_port, timeout=30.0)
 
+        # temporal_ensemble lives in our ``_aggregate_action_queues``
+        # override; ``RobotClientConfig`` still needs a name from its
+        # own registry so we pass ``latest_only`` as a placeholder that
+        # we short-circuit before it's ever called.
+        if aggregate_fn == "temporal_ensemble":
+            log_say(
+                f"Aggregation: temporal_ensemble "
+                f"(coeff={temporal_ensemble_coeff:+.3f}, ACT default 0.01)."
+            )
+        else:
+            log_say(f"Aggregation: {aggregate_fn}.")
         client_cfg = RobotClientConfig(
             robot=robot_config,
             policy_type=policy_type,
@@ -855,11 +1268,17 @@ def _run(
             client_device="cpu",
             chunk_size_threshold=chunk_size_threshold,
             fps=fps,
-            aggregate_fn_name=aggregate_fn,
+            aggregate_fn_name=(
+                "latest_only" if aggregate_fn == "temporal_ensemble" else aggregate_fn
+            ),
         )
         publisher = _ActionPublisher()
         client = _build_axol_robot_client(
-            config=client_cfg, robot=robot, publisher=publisher
+            config=client_cfg,
+            robot=robot,
+            publisher=publisher,
+            aggregate_strategy=aggregate_fn,
+            temporal_ensemble_coeff=temporal_ensemble_coeff,
         )
 
         log_say("Loading policy on server (one-time)...")
@@ -869,7 +1288,6 @@ def _run(
         # Policy is now resident on cuda — safe to connect cameras.
         log_say("Connecting robot...")
         robot.connect()
-        robot_connected = True
 
         log_say("Returning to rest pose.")
         reset_controller.return_to_rest(robot)
@@ -897,6 +1315,15 @@ def _run(
                 target=client.control_loop,
                 args=(task,),
                 name="axol-control-loop",
+                daemon=True,
+            )
+            # Dedicated obs send thread (see AxolRobotClient.control_loop
+            # for why: the upstream design runs obs send on the control
+            # thread, which stalls 60 Hz down to ~27 Hz).
+            obs_thread = threading.Thread(
+                target=client._observation_loop,
+                args=(task,),
+                name="axol-obs-loop",
                 daemon=True,
             )
 
@@ -929,6 +1356,7 @@ def _run(
 
             receiver_thread.start()
             control_thread.start()
+            obs_thread.start()
             if capture is not None:
                 capture.start()
             stdin_thread.start()
@@ -943,12 +1371,16 @@ def _run(
                     if time.perf_counter() >= deadline:
                         timed_out = True
                         break
-                    if not control_thread.is_alive() and not receiver_thread.is_alive():
-                        # Both inference threads died unexpectedly; abort
-                        # the episode and surface to the operator.
-                        _logger.warning(
-                            "Control/receiver threads exited before any "
-                            "end signal; aborting episode."
+                    if client.fatal_error is not None:
+                        # Hardware fault (e.g. CAN transmit-buffer full)
+                        # raised out of the control loop. Drop the
+                        # episode entirely and exit the run — no save
+                        # prompt, no rerecord, the operator needs to
+                        # check the robot.
+                        log_say(
+                            f"Fatal error in control loop: "
+                            f"{client.fatal_error!r}. Aborting run without "
+                            "saving the current episode."
                         )
                         break
                     time.sleep(0.1)
@@ -963,11 +1395,16 @@ def _run(
                 capture.join(timeout=5.0)
             control_thread.join(timeout=5.0)
             receiver_thread.join(timeout=5.0)
+            obs_thread.join(timeout=5.0)
             # The stdin watcher blocks on select with a short timeout, so
             # it will wake up on its own; don't join (it may still be in
             # select if the user never typed anything).
 
             if interrupted:
+                break
+            if client.fatal_error is not None:
+                if dataset is not None:
+                    dataset.clear_episode_buffer()
                 break
 
             choice = stdin_result["choice"]
@@ -1011,13 +1448,20 @@ def _run(
             except (EOFError, KeyboardInterrupt):
                 break
 
+        # Re-raise a control-loop hardware fault (e.g. CAN transmit
+        # buffer full) so ``run()`` exits the CLI with a non-zero
+        # status. The ``finally`` block below still runs first and
+        # tears the robot / server down cleanly.
+        if client is not None and client.fatal_error is not None:
+            raise client.fatal_error
+
     except KeyboardInterrupt:
         pass
     finally:
-        # Ignore further SIGINT during cleanup so an impatient second
-        # Ctrl+C doesn't abort partway through robot.disconnect() / server
-        # teardown and leave hardware in a weird state. Cleanup is the
-        # same path Ctrl+C ("behave like q") needs anyway.
+        # Ignore SIGINT during cleanup so an impatient second Ctrl+C
+        # doesn't abort partway through robot.disconnect() / server
+        # teardown and leave hardware in a weird state. We restore the
+        # default handler at the end of this block.
         import signal
 
         try:
@@ -1031,11 +1475,16 @@ def _run(
                 client.stop()
             except Exception:  # noqa: BLE001
                 pass
-        if robot_connected:
-            try:
-                robot.disconnect()
-            except Exception:  # noqa: BLE001
-                pass
+        # Always attempt disconnect — ``robot.connect()`` starts the
+        # asyncio event-loop thread *before* the motor-enable step, so a
+        # MotorError during enable leaves the loop thread and any
+        # already-opened CAN buses dangling. ``disconnect()`` is
+        # null-safe and idempotent, so this is fine even if connect
+        # never even started.
+        try:
+            robot.disconnect()
+        except Exception:  # noqa: BLE001
+            pass
 
         try:
             reset_controller.stop()
@@ -1071,3 +1520,11 @@ def _run(
                 _logger.warning(
                     "Failed to remove empty dataset at %s: %s", dataset_root, exc
                 )
+
+        # Restore the default SIGINT handler so the user can still kill
+        # the process if any non-daemon thread we don't control (e.g. a
+        # leaked driver thread) is keeping the interpreter alive.
+        try:
+            signal.signal(signal.SIGINT, signal.SIG_DFL)
+        except (ValueError, OSError):
+            pass

--- a/almond_axol/cli/run_policy.py
+++ b/almond_axol/cli/run_policy.py
@@ -559,7 +559,14 @@ def _serve_policy_server(server_cfg_dict: dict[str, Any]) -> None:
     Lives in the parent module so it's picklable by ``mp.get_context('spawn')``
     on macOS/Linux. Re-imports lerobot inside the child to avoid sharing
     CUDA/JAX state with the parent.
+
+    The child ignores SIGINT so Ctrl+C in the controlling terminal doesn't
+    dump a gRPC traceback from this process; the parent explicitly
+    terminates the server during its cleanup path.
     """
+    import signal
+
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
     from lerobot.async_inference.configs import PolicyServerConfig
     from lerobot.async_inference.policy_server import serve
 
@@ -751,36 +758,51 @@ def _run(
     # is connected. This lets us load the policy first (see below).
     dataset: "LeRobotDataset | None" = None
     dataset_root: Path | None = None
+    resumed_dataset = False
     if repo_id:
         dataset_root = Path(root) if root else HF_LEROBOT_HOME / repo_id
         meta = dataset_root / "meta"
         has_info = (meta / "info.json").exists()
-        if has_info:
-            # A previous run-policy invocation saved rollouts here — refuse
-            # to overwrite. (Unlike collect-data, run-policy doesn't resume:
-            # each invocation writes a fresh batch of rollouts.)
+        is_complete = (
+            has_info
+            and (meta / "tasks.parquet").exists()
+            and (meta / "episodes").is_dir()
+        )
+        # Mirror collect-data:
+        #   - complete dataset  → resume (append new rollouts)
+        #   - incomplete dataset (info.json but missing tasks.parquet / episodes/)
+        #                       → refuse, force explicit rm -rf
+        #   - empty leftover dir (no info.json) → wipe so create() can mkdir
+        if has_info and not is_complete:
             raise RuntimeError(
-                f"Rollout dataset already exists at {dataset_root}. "
-                f"Delete the directory and rerun to start fresh:\n"
-                f"  rm -rf {dataset_root}"
+                f"Incomplete dataset found at {dataset_root} (missing "
+                f"tasks.parquet or episodes/). Delete the directory and "
+                f"rerun to start fresh:\n  rm -rf {dataset_root}"
             )
-        if dataset_root.exists():
-            # Empty leftover from a previous failed run — wipe so
-            # LeRobotDataset.create can mkdir(exist_ok=False).
+        if dataset_root.exists() and not is_complete:
             log_say(f"Removing empty dataset directory at {dataset_root}.")
             shutil.rmtree(dataset_root)
 
-        action_features = hw_to_dataset_features(robot.action_features, ACTION)
-        obs_features = hw_to_dataset_features(robot.observation_features, OBS_STR)
-        dataset = LeRobotDataset.create(
-            repo_id=repo_id,
-            fps=fps,
-            root=root,
-            features={**action_features, **obs_features},
-            robot_type=robot.name,
-            use_videos=True,
-            image_writer_threads=4,
-        )
+        if is_complete:
+            log_say(f"Resuming existing dataset at {dataset_root}.")
+            dataset = LeRobotDataset.resume(
+                repo_id=repo_id,
+                root=str(dataset_root),
+                image_writer_threads=4,
+            )
+            resumed_dataset = True
+        else:
+            action_features = hw_to_dataset_features(robot.action_features, ACTION)
+            obs_features = hw_to_dataset_features(robot.observation_features, OBS_STR)
+            dataset = LeRobotDataset.create(
+                repo_id=repo_id,
+                fps=fps,
+                root=root,
+                features={**action_features, **obs_features},
+                robot_type=robot.name,
+                use_videos=True,
+                image_writer_threads=4,
+            )
 
     if rerun_ip:
         init_rerun(session_name="axol_run_policy", ip=rerun_ip, port=rerun_port)
@@ -992,6 +1014,17 @@ def _run(
     except KeyboardInterrupt:
         pass
     finally:
+        # Ignore further SIGINT during cleanup so an impatient second
+        # Ctrl+C doesn't abort partway through robot.disconnect() / server
+        # teardown and leave hardware in a weird state. Cleanup is the
+        # same path Ctrl+C ("behave like q") needs anyway.
+        import signal
+
+        try:
+            signal.signal(signal.SIGINT, signal.SIG_IGN)
+        except (ValueError, OSError):
+            pass
+
         log_say("Stopping.")
         if client is not None:
             try:
@@ -1024,9 +1057,13 @@ def _run(
 
         if (
             dataset_root is not None
+            and not resumed_dataset
             and episodes_recorded == 0
             and dataset_root.exists()
         ):
+            # Only auto-wipe a freshly-created dataset that ended up empty.
+            # A resumed dataset already has saved rollouts on disk that we
+            # must never clobber, even if this session added zero new ones.
             try:
                 shutil.rmtree(dataset_root)
                 log_say(f"No episodes saved — removed empty dataset at {dataset_root}.")

--- a/almond_axol/cli/run_policy.py
+++ b/almond_axol/cli/run_policy.py
@@ -243,31 +243,154 @@ def run(args: argparse.Namespace) -> None:
     )
 
 
-def _move_to_rest(robot: "AxolRobot", fps: int, duration_s: float = 5.0) -> None:
-    """Send the robot to the default rest pose for ``duration_s`` seconds.
+class _IKResetController:
+    """Collision-aware return-to-rest, backed by an IK worker subprocess.
 
-    Uses the rest poses defined in VRTeleopConfig (arm joints) with gripper
-    fully open. The robot's impedance controller smoothly tracks the target.
+    Mirrors the reset path used by ``AxolVRTeleop`` (collect-data) but
+    without the VR server. ``start()`` spawns ``run_ik_worker`` in a
+    ``spawn``-mode subprocess; it imports JAX, JITs the IK solver
+    (~10-20 s), and reports ``("ready", ...)``. ``wait_ready()`` blocks on
+    that message. ``return_to_rest()`` then asks the worker for a
+    collision-aware joint-space trajectory from the current pose to the
+    rest pose and plays it back through a ``ResetInterpolator`` while
+    streaming each waypoint to the impedance controller.
+
+    Spawn it before ``client.start()`` so the IK JIT overlaps with the
+    policy load — by the time we actually need a rest move, the worker is
+    typically already ready.
     """
-    from ..shared import Joint
-    from ..teleop.config import VRTeleopConfig
 
-    cfg = VRTeleopConfig()
-    rest: dict[str, float] = {}
-    for j in Joint:
-        if j in ARM_JOINTS:
-            arm_i = ARM_JOINTS.index(j)
-            rest[f"left_{j.value}.pos"] = float(cfg.rest_pose_left[arm_i])
-            rest[f"right_{j.value}.pos"] = float(cfg.rest_pose_right[arm_i])
-        else:
-            rest[f"left_{j.value}.pos"] = 1.0
-            rest[f"right_{j.value}.pos"] = 1.0
+    def __init__(self) -> None:
+        from ..kinematics.config import KinematicsConfig
+        from ..teleop.config import VRTeleopConfig
 
-    steps = max(1, int(duration_s * fps))
-    for _ in range(steps):
-        t0 = time.perf_counter()
-        robot.send_action(rest)
-        time.sleep(max(0.0, 1.0 / fps - (time.perf_counter() - t0)))
+        self._vr_cfg = VRTeleopConfig()
+        self._kin_cfg = KinematicsConfig()
+        self._proc: Any | None = None
+        self._conn: Any | None = None
+        self._q_init: Any | None = None
+        self._left_indices: list[int] | None = None
+        self._right_indices: list[int] | None = None
+        self._ready = False
+
+    def start(self) -> None:
+        """Spawn the IK worker subprocess. Non-blocking — call wait_ready()."""
+        import multiprocessing as mp
+
+        from ..teleop.worker import run_ik_worker
+
+        ctx = mp.get_context("spawn")
+        parent_conn, child_conn = ctx.Pipe()
+        proc = ctx.Process(
+            target=run_ik_worker,
+            args=(child_conn, self._vr_cfg, self._kin_cfg, None, None),
+            name="axol-ik-worker",
+            daemon=True,
+        )
+        proc.start()
+        child_conn.close()
+        self._proc = proc
+        self._conn = parent_conn
+
+    def wait_ready(self, timeout: float = 60.0) -> None:
+        """Block until the IK worker has finished JIT compilation."""
+        if self._ready:
+            return
+        if self._conn is None:
+            raise RuntimeError("IK reset controller not started")
+        if not self._conn.poll(timeout):
+            raise TimeoutError(
+                f"IK worker did not become ready within {timeout:.1f}s "
+                "(JAX JIT compilation may have stalled)."
+            )
+        msg = self._conn.recv()
+        if not (isinstance(msg, tuple) and msg[0] == "ready"):
+            raise RuntimeError(f"Unexpected IK worker handshake: {msg!r}")
+        import numpy as np
+
+        _, q_init, left_indices, right_indices, _startup_traj = msg
+        self._q_init = np.asarray(q_init, dtype=np.float32)
+        self._left_indices = [int(i) for i in left_indices]
+        self._right_indices = [int(i) for i in right_indices]
+        self._ready = True
+
+    def return_to_rest(self, robot: "AxolRobot") -> None:
+        """Plan and play a collision-aware trajectory to the rest pose."""
+        import numpy as np
+
+        from ..shared import Joint
+        from ..teleop.filter import ResetInterpolator
+
+        self.wait_ready()
+        assert self._conn is not None
+        assert self._q_init is not None
+        assert self._left_indices is not None
+        assert self._right_indices is not None
+
+        pos_l, pos_r = robot.positions
+        pos_l = np.asarray(pos_l, dtype=np.float32)
+        pos_r = np.asarray(pos_r, dtype=np.float32)
+
+        q_current = self._q_init.copy()
+        for i, gi in enumerate(self._left_indices):
+            q_current[gi] = float(pos_l[i])
+        for i, gi in enumerate(self._right_indices):
+            q_current[gi] = float(pos_r[i])
+
+        self._conn.send(("reset", q_current))
+        result = self._conn.recv()
+        if not (isinstance(result, tuple) and result[0] == "reset_traj"):
+            raise RuntimeError(f"Unexpected IK worker response: {result!r}")
+        _, _q_rest, traj = result
+        if not traj:
+            _logger.warning("IK worker returned an empty reset trajectory; skipping.")
+            return
+
+        interp = ResetInterpolator()
+        interp.set_trajectory(traj, float(pos_l[7]), float(pos_r[7]))
+
+        joints = list(Joint)
+        play_hz = float(self._vr_cfg.frequency)
+        period = 1.0 / play_hz
+        while interp.is_active():
+            t0 = time.perf_counter()
+            new_q, l_grip, r_grip, _done = interp.step()
+            if new_q is None:
+                break
+            arm_left = np.asarray(new_q)[self._left_indices]
+            arm_right = np.asarray(new_q)[self._right_indices]
+            action: dict[str, float] = {}
+            for j in joints:
+                if j in ARM_JOINTS:
+                    ai = ARM_JOINTS.index(j)
+                    action[f"left_{j.value}.pos"] = float(arm_left[ai])
+                    action[f"right_{j.value}.pos"] = float(arm_right[ai])
+                else:
+                    action[f"left_{j.value}.pos"] = float(l_grip)
+                    action[f"right_{j.value}.pos"] = float(r_grip)
+            robot.send_action(action)
+            time.sleep(max(0.0, period - (time.perf_counter() - t0)))
+
+    def stop(self) -> None:
+        """Signal shutdown, close the pipe, and reap the subprocess."""
+        if self._conn is not None:
+            try:
+                self._conn.send(None)
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                self._conn.close()
+            except Exception:  # noqa: BLE001
+                pass
+            self._conn = None
+        if self._proc is not None:
+            self._proc.join(timeout=3.0)
+            if self._proc.is_alive():
+                self._proc.terminate()
+                self._proc.join(timeout=2.0)
+            if self._proc.is_alive():
+                self._proc.kill()
+            self._proc = None
 
 
 # ----------------------------------------------------------------------
@@ -584,11 +707,13 @@ def _run(
     rerun_port: int = 9876,
 ) -> None:
     import multiprocessing as mp
+    import shutil
+    from pathlib import Path
 
     from lerobot.async_inference.configs import RobotClientConfig
     from lerobot.datasets.lerobot_dataset import LeRobotDataset
     from lerobot.processor import make_default_processors
-    from lerobot.utils.constants import ACTION, OBS_STR
+    from lerobot.utils.constants import ACTION, HF_LEROBOT_HOME, OBS_STR
     from lerobot.utils.feature_utils import hw_to_dataset_features
     from lerobot.utils.utils import log_say
     from lerobot.utils.visualization_utils import init_rerun
@@ -625,7 +750,26 @@ def _run(
     # joint enum, both static, so the dataset can be built before the robot
     # is connected. This lets us load the policy first (see below).
     dataset: "LeRobotDataset | None" = None
+    dataset_root: Path | None = None
     if repo_id:
+        dataset_root = Path(root) if root else HF_LEROBOT_HOME / repo_id
+        meta = dataset_root / "meta"
+        has_info = (meta / "info.json").exists()
+        if has_info:
+            # A previous run-policy invocation saved rollouts here — refuse
+            # to overwrite. (Unlike collect-data, run-policy doesn't resume:
+            # each invocation writes a fresh batch of rollouts.)
+            raise RuntimeError(
+                f"Rollout dataset already exists at {dataset_root}. "
+                f"Delete the directory and rerun to start fresh:\n"
+                f"  rm -rf {dataset_root}"
+            )
+        if dataset_root.exists():
+            # Empty leftover from a previous failed run — wipe so
+            # LeRobotDataset.create can mkdir(exist_ok=False).
+            log_say(f"Removing empty dataset directory at {dataset_root}.")
+            shutil.rmtree(dataset_root)
+
         action_features = hw_to_dataset_features(robot.action_features, ACTION)
         obs_features = hw_to_dataset_features(robot.observation_features, OBS_STR)
         dataset = LeRobotDataset.create(
@@ -664,6 +808,14 @@ def _run(
     server_proc.start()
     log_say(f"Started PolicyServer on 127.0.0.1:{server_port} (pid={server_proc.pid}).")
 
+    # Spawn the IK worker in parallel with the policy server so JAX JIT
+    # compilation overlaps with policy load. The worker plans collision-aware
+    # return-to-rest trajectories; we wait for the "ready" handshake on first
+    # use (return_to_rest).
+    reset_controller = _IKResetController()
+    reset_controller.start()
+    log_say("Started IK reset worker (collision-aware return-to-rest).")
+
     client = None
     episodes_recorded = 0
     robot_connected = False
@@ -698,7 +850,7 @@ def _run(
         robot_connected = True
 
         log_say("Returning to rest pose.")
-        _move_to_rest(robot, fps)
+        reset_controller.return_to_rest(robot)
         try:
             input("Reset the scene, then press Enter to start the first episode.")
         except (EOFError, KeyboardInterrupt):
@@ -818,7 +970,7 @@ def _run(
                 if dataset is not None:
                     dataset.clear_episode_buffer()
                 log_say("Returning to rest pose.")
-                _move_to_rest(robot, fps)
+                reset_controller.return_to_rest(robot)
                 try:
                     input("Reset the scene, then press Enter to start.")
                 except (EOFError, KeyboardInterrupt):
@@ -831,7 +983,7 @@ def _run(
             episodes_recorded += 1
             log_say(f"Saved episode {episodes_recorded}.")
             log_say("Returning to rest pose.")
-            _move_to_rest(robot, fps)
+            reset_controller.return_to_rest(robot)
             try:
                 input("Reset the scene, then press Enter to start the next episode.")
             except (EOFError, KeyboardInterrupt):
@@ -852,6 +1004,11 @@ def _run(
             except Exception:  # noqa: BLE001
                 pass
 
+        try:
+            reset_controller.stop()
+        except Exception:  # noqa: BLE001
+            pass
+
         # Tear down the server child process.
         if server_proc.is_alive():
             server_proc.terminate()
@@ -864,3 +1021,16 @@ def _run(
             dataset.finalize()
             if push_to_hub and episodes_recorded > 0:
                 dataset.push_to_hub()
+
+        if (
+            dataset_root is not None
+            and episodes_recorded == 0
+            and dataset_root.exists()
+        ):
+            try:
+                shutil.rmtree(dataset_root)
+                log_say(f"No episodes saved — removed empty dataset at {dataset_root}.")
+            except OSError as exc:
+                _logger.warning(
+                    "Failed to remove empty dataset at %s: %s", dataset_root, exc
+                )

--- a/almond_axol/cli/run_policy.py
+++ b/almond_axol/cli/run_policy.py
@@ -35,6 +35,8 @@ import threading
 import time
 from typing import TYPE_CHECKING, Any, Callable
 
+from ..shared import ARM_JOINTS, parse_stiffness
+
 if TYPE_CHECKING:
     from lerobot.datasets.lerobot_dataset import LeRobotDataset
     from lerobot.types import RobotAction
@@ -155,10 +157,40 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[
         ),
     )
     p.add_argument(
-        "--gripper-torque-limit",
+        "--left-gripper-torque-limit",
         type=float,
         default=1.0,
-        help="Max output torque (Nm) for the gripper in POSITION_FORCE mode (default: 1.0).",
+        help="Max output torque (Nm) for the left gripper in POSITION_FORCE mode (default: 1.0).",
+    )
+    p.add_argument(
+        "--right-gripper-torque-limit",
+        type=float,
+        default=1.0,
+        help="Max output torque (Nm) for the right gripper in POSITION_FORCE mode (default: 1.0).",
+    )
+    stiffness_help = (
+        "Compliance ↔ stiffness blend in [0, 1] for the {side} arm. "
+        f"Either a single value applied to all {len(ARM_JOINTS)} joints, "
+        f"or {len(ARM_JOINTS)} comma-separated values (one per joint, in "
+        f"order: {', '.join(j.value for j in ARM_JOINTS)}; gripper "
+        "excluded). 0 (default) is fully compliant; 1 restores the "
+        "pre-tuning industrial gains. See AxolConfig.{attr}. Should match "
+        "the values used at data collection time."
+    )
+    stiffness_metavar = "S|" + ",".join("S" for _ in ARM_JOINTS)
+    p.add_argument(
+        "--left-stiffness",
+        type=parse_stiffness,
+        default=0.0,
+        metavar=stiffness_metavar,
+        help=stiffness_help.format(side="left", attr="left_stiffness"),
+    )
+    p.add_argument(
+        "--right-stiffness",
+        type=parse_stiffness,
+        default=0.0,
+        metavar=stiffness_metavar,
+        help=stiffness_help.format(side="right", attr="right_stiffness"),
     )
     p.add_argument(
         "--rerun-ip",
@@ -202,7 +234,10 @@ def run(args: argparse.Namespace) -> None:
         aggregate_fn=args.aggregate_fn,
         zed_host=args.zed_host,
         zed_iface=args.zed_iface,
-        gripper_torque_limit=args.gripper_torque_limit,
+        left_gripper_torque_limit=args.left_gripper_torque_limit,
+        right_gripper_torque_limit=args.right_gripper_torque_limit,
+        left_stiffness=args.left_stiffness,
+        right_stiffness=args.right_stiffness,
         rerun_ip=args.rerun_ip,
         rerun_port=args.rerun_port,
     )
@@ -214,7 +249,7 @@ def _move_to_rest(robot: "AxolRobot", fps: int, duration_s: float = 5.0) -> None
     Uses the rest poses defined in VRTeleopConfig (arm joints) with gripper
     fully open. The robot's impedance controller smoothly tracks the target.
     """
-    from ..shared import ARM_JOINTS, Joint
+    from ..shared import Joint
     from ..teleop.config import VRTeleopConfig
 
     cfg = VRTeleopConfig()
@@ -541,7 +576,10 @@ def _run(
     aggregate_fn: str = "weighted_average",
     zed_host: str = "192.168.10.1",
     zed_iface: str | None = None,
-    gripper_torque_limit: float = 1.0,
+    left_gripper_torque_limit: float = 1.0,
+    right_gripper_torque_limit: float = 1.0,
+    left_stiffness: float | tuple[float, ...] = 0.0,
+    right_stiffness: float | tuple[float, ...] = 0.0,
     rerun_ip: str | None = None,
     rerun_port: int = 9876,
 ) -> None:
@@ -564,9 +602,12 @@ def _run(
     if zed_iface:
         setup_link_ip(zed_iface, "192.168.10.2/24")
 
-    axol_config = AxolConfig()
-    axol_config.left.gripper.torque_limit = gripper_torque_limit
-    axol_config.right.gripper.torque_limit = gripper_torque_limit
+    axol_config = AxolConfig(
+        left_stiffness=left_stiffness,
+        right_stiffness=right_stiffness,
+    )
+    axol_config.left.gripper.torque_limit = left_gripper_torque_limit
+    axol_config.right.gripper.torque_limit = right_gripper_torque_limit
 
     # Build robot with 3 ZED cameras — resolution/FPS auto-detected from stream
     robot_config = AxolRobotConfig(

--- a/almond_axol/cli/run_policy.py
+++ b/almond_axol/cli/run_policy.py
@@ -1105,7 +1105,7 @@ def _run(
     server_port: int = 8765,
     actions_per_chunk: int = 50,
     chunk_size_threshold: float = 0.9,
-    aggregate_fn: str = "weighted_average",
+    aggregate_fn: str = "temporal_ensemble",
     temporal_ensemble_coeff: float = 0.01,
     zed_host: str = "192.168.10.1",
     zed_iface: str | None = None,

--- a/almond_axol/cli/run_policy.py
+++ b/almond_axol/cli/run_policy.py
@@ -1,14 +1,47 @@
 """
 axol run-policy
 
-Run a trained policy on the Axol robot with three ZED cameras.
-The policy drives actions autonomously for a fixed duration per episode.
-After each episode the operator is prompted to save, rerecord, or quit,
-giving them time to reset the scene. Runs until Ctrl+C or 'q'.
+Run a trained policy on the Axol robot with three ZED cameras using
+LeRobot's async inference (``lerobot.async_inference``).
+
+Architecture
+============
+A ``PolicyServer`` is auto-launched in a child process on localhost. The
+parent process drives an ``AxolRobotClient`` (a thin subclass of LeRobot's
+``RobotClient``) that streams observations to the server and consumes the
+action chunks the server returns. Cameras + joints are sampled via
+``ZedCamera.read_at_or_after(now)`` (see ``AxolRobot.get_observation``) so
+each inference observation is global-timestamp aligned the same way the
+training data is.
+
+Episode termination
+===================
+Each episode runs until the operator presses a key:
+
+    s  → end + save  (writes the rollout to ``--repo-id`` when set)
+    r  → end + rerecord (discard buffer)
+    q  → end + quit  (discard buffer, exit ``axol run-policy``)
+
+``--episode-time-s`` is kept as a safety cap: when it fires the operator
+gets the same ``[Enter]=save / r / q`` prompt as before.
 """
+
+from __future__ import annotations
 
 import argparse
 import logging
+import socket
+import threading
+import time
+from typing import TYPE_CHECKING, Any, Callable
+
+if TYPE_CHECKING:
+    from lerobot.datasets.lerobot_dataset import LeRobotDataset
+    from lerobot.types import RobotAction
+
+    from ..lerobot.robot.robot_axol import AxolRobot
+
+_logger = logging.getLogger(__name__)
 
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
@@ -18,15 +51,43 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[
         required=True,
         help="Local path or HuggingFace repo ID of the trained policy checkpoint.",
     )
+    p.add_argument(
+        "--policy-type",
+        required=True,
+        choices=[
+            "act",
+            "smolvla",
+            "diffusion",
+            "tdmpc",
+            "vqbet",
+            "pi0",
+            "pi05",
+            "groot",
+        ],
+        help=(
+            "Policy architecture as registered in lerobot.async_inference "
+            "(must match the checkpoint at --policy)."
+        ),
+    )
     p.add_argument("--task", required=True, help="Natural language task description.")
     p.add_argument(
         "--episode-time-s",
         type=int,
-        default=30,
-        help="Max duration of each episode in seconds (default: 30).",
+        default=120,
+        help=(
+            "Safety cap on episode duration in seconds (default: 120). "
+            "Episodes normally end on operator keypress; this only fires if "
+            "the operator never signals s/r/q."
+        ),
     )
     p.add_argument(
-        "--fps", type=int, default=60, help="Control loop frame rate (default: 60)."
+        "--fps",
+        type=int,
+        default=60,
+        help=(
+            "Control loop frame rate (default: 60, matching collect-data). "
+            "Must match the fps the policy was trained on."
+        ),
     )
     p.add_argument(
         "--repo-id",
@@ -47,6 +108,36 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[
         "--device",
         default="cuda",
         help="Torch device for policy inference (default: cuda).",
+    )
+    p.add_argument(
+        "--server-port",
+        type=int,
+        default=8765,
+        help="Port for the localhost PolicyServer child process (default: 8765).",
+    )
+    p.add_argument(
+        "--actions-per-chunk",
+        type=int,
+        default=50,
+        help=(
+            "Number of actions returned per inference call (default: 50). "
+            "Capped by the policy's max action horizon."
+        ),
+    )
+    p.add_argument(
+        "--chunk-size-threshold",
+        type=float,
+        default=0.5,
+        help=(
+            "Send a fresh observation to the server when the local action queue "
+            "drops to this fraction of a full chunk (default: 0.5)."
+        ),
+    )
+    p.add_argument(
+        "--aggregate-fn",
+        default="weighted_average",
+        choices=["weighted_average", "latest_only", "average", "conservative"],
+        help="Action chunk aggregation function (default: weighted_average).",
     )
     p.add_argument(
         "--zed-host",
@@ -97,6 +188,7 @@ def run(args: argparse.Namespace) -> None:
     logging.basicConfig(level=getattr(logging, args.log_level))
     _run(
         policy_path=args.policy,
+        policy_type=args.policy_type,
         task=args.task,
         episode_time_s=args.episode_time_s,
         fps=args.fps,
@@ -104,6 +196,10 @@ def run(args: argparse.Namespace) -> None:
         root=args.root,
         push_to_hub=args.push_to_hub,
         device=args.device,
+        server_port=args.server_port,
+        actions_per_chunk=args.actions_per_chunk,
+        chunk_size_threshold=args.chunk_size_threshold,
+        aggregate_fn=args.aggregate_fn,
         zed_host=args.zed_host,
         zed_iface=args.zed_iface,
         gripper_torque_limit=args.gripper_torque_limit,
@@ -112,14 +208,12 @@ def run(args: argparse.Namespace) -> None:
     )
 
 
-def _move_to_rest(robot, fps: int, duration_s: float = 5.0) -> None:
+def _move_to_rest(robot: "AxolRobot", fps: int, duration_s: float = 5.0) -> None:
     """Send the robot to the default rest pose for ``duration_s`` seconds.
 
     Uses the rest poses defined in VRTeleopConfig (arm joints) with gripper
     fully open. The robot's impedance controller smoothly tracks the target.
     """
-    import time
-
     from ..shared import ARM_JOINTS, Joint
     from ..teleop.config import VRTeleopConfig
 
@@ -141,8 +235,299 @@ def _move_to_rest(robot, fps: int, duration_s: float = 5.0) -> None:
         time.sleep(max(0.0, 1.0 / fps - (time.perf_counter() - t0)))
 
 
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+
+class _ActionPublisher:
+    """Thread-safe single-slot publisher for the most recently executed action.
+
+    Updated by ``AxolRobotClient.control_loop_action`` after every
+    ``robot.send_action`` call, read by ``_RolloutCaptureThread`` to pair
+    each dataset frame with the action that drove the robot at that tick.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._latest: "RobotAction | None" = None
+        self._first_event = threading.Event()
+
+    def publish(self, action: "RobotAction") -> None:
+        snap = dict(action)
+        with self._lock:
+            self._latest = snap
+        self._first_event.set()
+
+    def latest(self) -> "RobotAction | None":
+        with self._lock:
+            return None if self._latest is None else dict(self._latest)
+
+    def wait_for_first(self, timeout: float) -> bool:
+        return self._first_event.wait(timeout=timeout)
+
+    def reset(self) -> None:
+        with self._lock:
+            self._latest = None
+        self._first_event.clear()
+
+
+class _RolloutCaptureThread(threading.Thread):
+    """Tick at ``fps`` Hz, sample one global-timestamp-aligned observation per
+    tick, pair it with the latest executed action, and append a dataset row.
+    """
+
+    def __init__(
+        self,
+        *,
+        publisher: _ActionPublisher,
+        robot: "AxolRobot",
+        dataset: "LeRobotDataset",
+        robot_obs_proc: Callable[[Any], Any],
+        fps: int,
+        task: str,
+        rerun_ip: str | None,
+    ) -> None:
+        super().__init__(name="axol-rollout-capture", daemon=True)
+        self.publisher = publisher
+        self.robot = robot
+        self.dataset = dataset
+        self.robot_obs_proc = robot_obs_proc
+        self.fps = fps
+        self.task = task
+        self.rerun_ip = rerun_ip
+        self.stop_event = threading.Event()
+
+    def run(self) -> None:
+        from lerobot.utils.constants import ACTION, OBS_STR
+        from lerobot.utils.feature_utils import build_dataset_frame
+        from lerobot.utils.visualization_utils import log_rerun_data
+
+        if not self.publisher.wait_for_first(timeout=10.0):
+            _logger.warning(
+                "Rollout capture thread saw no action snapshot within 10s; exiting."
+            )
+            return
+        if self.stop_event.is_set():
+            return
+
+        frame_interval = 1.0 / self.fps
+        recording_start = time.perf_counter()
+        tick = 0
+
+        while not self.stop_event.is_set():
+            target_perf_ts = recording_start + tick * frame_interval
+
+            wait_s = target_perf_ts - time.perf_counter()
+            if wait_s > 0 and self.stop_event.wait(timeout=wait_s):
+                return
+
+            try:
+                obs = self.robot.get_observation()
+            except Exception as exc:  # noqa: BLE001
+                _logger.warning(
+                    "Capture tick %d: get_observation failed (%s).", tick, exc
+                )
+                tick += 1
+                continue
+
+            action = self.publisher.latest()
+            if action is None:
+                tick += 1
+                continue
+
+            obs_processed = self.robot_obs_proc(obs)
+            obs_frame = build_dataset_frame(
+                self.dataset.features, obs_processed, prefix=OBS_STR
+            )
+            act_frame = build_dataset_frame(
+                self.dataset.features, action, prefix=ACTION
+            )
+            if self.stop_event.is_set():
+                return
+            self.dataset.add_frame({**obs_frame, **act_frame, "task": self.task})
+
+            if self.rerun_ip:
+                log_rerun_data(observation=obs_processed, action=action)
+
+            tick += 1
+
+
+def _stdin_watcher(
+    stop_event: threading.Event,
+    result: dict[str, str | None],
+) -> None:
+    """Watch stdin for ``s`` / ``r`` / ``q`` on its own line.
+
+    Uses ``select.select`` so it never blocks past the stop event. Sets
+    ``result["choice"]`` to the first valid keystroke received.
+    """
+    import select
+    import sys
+
+    while not stop_event.is_set():
+        ready, _, _ = select.select([sys.stdin], [], [], 0.25)
+        if not ready:
+            continue
+        line = sys.stdin.readline()
+        if not line:
+            return
+        ch = line.strip().lower()
+        if ch in ("s", "r", "q"):
+            result["choice"] = ch
+            return
+
+
+def _wait_for_port(host: str, port: int, timeout: float = 30.0) -> None:
+    """Block until ``host:port`` accepts a TCP connection or ``timeout`` elapses."""
+    deadline = time.perf_counter() + timeout
+    last_exc: Exception | None = None
+    while time.perf_counter() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=1.0):
+                return
+        except OSError as exc:
+            last_exc = exc
+            time.sleep(0.25)
+    raise TimeoutError(
+        f"PolicyServer at {host}:{port} did not become reachable within "
+        f"{timeout:.1f}s (last error: {last_exc!r})."
+    )
+
+
+def _serve_policy_server(server_cfg_dict: dict[str, Any]) -> None:
+    """Entry point for the policy-server child process.
+
+    Lives in the parent module so it's picklable by ``mp.get_context('spawn')``
+    on macOS/Linux. Re-imports lerobot inside the child to avoid sharing
+    CUDA/JAX state with the parent.
+    """
+    from lerobot.async_inference.configs import PolicyServerConfig
+    from lerobot.async_inference.policy_server import serve
+
+    serve(PolicyServerConfig(**server_cfg_dict))
+
+
+# ----------------------------------------------------------------------
+# AxolRobotClient: thin RobotClient subclass that reuses our connected robot
+# ----------------------------------------------------------------------
+
+
+def _build_axol_robot_client(
+    *, config: Any, robot: "AxolRobot", publisher: _ActionPublisher
+) -> Any:
+    """Construct an ``AxolRobotClient`` against an already-connected robot.
+
+    Defined as a helper so the heavy lerobot imports happen lazily inside
+    ``_run`` and we don't pay the import cost at CLI parse time.
+    """
+    import threading as _threading
+    from queue import Queue
+
+    import grpc
+    from lerobot.async_inference.helpers import (
+        FPSTracker,
+        RemotePolicyConfig,
+        map_robot_keys_to_lerobot_features,
+    )
+    from lerobot.async_inference.robot_client import RobotClient
+    from lerobot.transport import services_pb2_grpc
+    from lerobot.transport.utils import grpc_channel_options
+
+    class AxolRobotClient(RobotClient):  # type: ignore[misc, valid-type]
+        """RobotClient that reuses a pre-connected AxolRobot.
+
+        - Skips ``make_robot_from_config(...)`` and ``robot.connect()`` so we
+          don't pay the camera reconnect cost between episodes.
+        - Publishes each executed action to ``_ActionPublisher`` for the
+          dataset capture thread.
+        - Overrides ``stop()`` to tear down the gRPC channel without
+          disconnecting the shared robot.
+        """
+
+        def __init__(self, config, robot, publisher):  # type: ignore[no-untyped-def]
+            self.config = config
+            self.robot = robot
+            self._publisher = publisher
+
+            lerobot_features = map_robot_keys_to_lerobot_features(self.robot)
+
+            self.server_address = config.server_address
+            self.policy_config = RemotePolicyConfig(
+                config.policy_type,
+                config.pretrained_name_or_path,
+                lerobot_features,
+                config.actions_per_chunk,
+                config.policy_device,
+            )
+
+            self.channel = grpc.insecure_channel(
+                self.server_address,
+                grpc_channel_options(initial_backoff=f"{config.environment_dt:.4f}s"),
+            )
+            self.stub = services_pb2_grpc.AsyncInferenceStub(self.channel)
+            self.logger = RobotClient.logger
+            self.logger.info(
+                f"AxolRobotClient connecting to server at {self.server_address}"
+            )
+
+            self.shutdown_event = _threading.Event()
+            self.latest_action_lock = _threading.Lock()
+            self.latest_action = -1
+            self.action_chunk_size = -1
+            self._chunk_size_threshold = config.chunk_size_threshold
+            self.action_queue = Queue()
+            self.action_queue_lock = _threading.Lock()
+            self.action_queue_size = []
+            self.start_barrier = _threading.Barrier(2)
+            self.fps_tracker = FPSTracker(target_fps=self.config.fps)
+            self.must_go = _threading.Event()
+            self.must_go.set()
+
+        def reset_episode_state(self) -> None:
+            """Reset queues + flags so threads can run a fresh episode.
+
+            Recreates ``start_barrier`` (so two new threads can synchronize)
+            and clears any leftover action queue entries.
+            """
+            with self.action_queue_lock:
+                self.action_queue = Queue()
+                self.action_queue_size = []
+            with self.latest_action_lock:
+                self.latest_action = -1
+            self.action_chunk_size = -1
+            self.must_go.set()
+            self.fps_tracker.reset()
+            self.shutdown_event.clear()
+            self.start_barrier = _threading.Barrier(2)
+            if self._publisher is not None:
+                self._publisher.reset()
+
+        def control_loop_action(self, verbose: bool = False):  # type: ignore[no-untyped-def]
+            performed = super().control_loop_action(verbose)
+            if self._publisher is not None and performed is not None:
+                self._publisher.publish(performed)
+            return performed
+
+        def stop(self) -> None:  # type: ignore[override]
+            self.shutdown_event.set()
+            try:
+                self.channel.close()
+            except Exception:  # noqa: BLE001
+                pass
+            self.logger.debug("AxolRobotClient channel closed (robot left connected)")
+
+    return AxolRobotClient(config, robot, publisher)
+
+
+# ----------------------------------------------------------------------
+# Main
+# ----------------------------------------------------------------------
+
+
 def _run(
     policy_path: str,
+    policy_type: str,
     task: str,
     episode_time_s: int,
     fps: int,
@@ -150,22 +535,25 @@ def _run(
     root: str | None,
     push_to_hub: bool,
     device: str,
+    server_port: int = 8765,
+    actions_per_chunk: int = 50,
+    chunk_size_threshold: float = 0.5,
+    aggregate_fn: str = "weighted_average",
     zed_host: str = "192.168.10.1",
     zed_iface: str | None = None,
     gripper_torque_limit: float = 1.0,
     rerun_ip: str | None = None,
     rerun_port: int = 9876,
 ) -> None:
-    import time
+    import multiprocessing as mp
 
+    from lerobot.async_inference.configs import RobotClientConfig
     from lerobot.datasets.lerobot_dataset import LeRobotDataset
-    from lerobot.policies.factory import make_pre_post_processors
-    from lerobot.policies.pretrained import PreTrainedPolicy
     from lerobot.processor import make_default_processors
     from lerobot.utils.constants import ACTION, OBS_STR
-    from lerobot.utils.feature_utils import build_dataset_frame, hw_to_dataset_features
+    from lerobot.utils.feature_utils import hw_to_dataset_features
     from lerobot.utils.utils import log_say
-    from lerobot.utils.visualization_utils import init_rerun, log_rerun_data
+    from lerobot.utils.visualization_utils import init_rerun
 
     from ..lerobot.camera.configuration_zed import ZedCameraConfig
     from ..lerobot.robot.config_axol import AxolRobotConfig
@@ -175,12 +563,6 @@ def _run(
 
     if zed_iface:
         setup_link_ip(zed_iface, "192.168.10.2/24")
-
-    # Load policy
-    policy = PreTrainedPolicy.from_pretrained(policy_path)
-    policy.config.device = device
-    policy.to(device)
-    policy.eval()
 
     axol_config = AxolConfig()
     axol_config.left.gripper.torque_limit = gripper_torque_limit
@@ -196,20 +578,14 @@ def _run(
         axol_config=axol_config,
     )
     robot = AxolRobot(robot_config)
-
-    # Policy pre/post processors — normalization stats loaded from checkpoint
-    preprocessor, postprocessor = make_pre_post_processors(
-        policy_cfg=policy.config,
-        pretrained_path=policy_path,
-        preprocessor_overrides={"device_processor": {"device": device}},
-    )
     _, robot_action_proc, robot_obs_proc = make_default_processors()
 
-    # Connect first so cameras auto-detect resolution, then build dataset features
+    # Connect first so cameras auto-detect resolution; dataset features are
+    # then derived from the live robot.
     robot.connect()
 
-    # Dataset (optional — only created if --repo-id is specified)
-    dataset = None
+    # Optional rollout dataset
+    dataset: "LeRobotDataset | None" = None
     if repo_id:
         action_features = hw_to_dataset_features(robot.action_features, ACTION)
         obs_features = hw_to_dataset_features(robot.observation_features, OBS_STR)
@@ -226,75 +602,205 @@ def _run(
     if rerun_ip:
         init_rerun(session_name="axol_run_policy", ip=rerun_ip, port=rerun_port)
 
+    # --- Launch PolicyServer in a child process on localhost --------------
+    server_cfg_dict = {
+        "host": "127.0.0.1",
+        "port": server_port,
+        "fps": fps,
+    }
+    ctx = mp.get_context("spawn")
+    server_proc = ctx.Process(
+        target=_serve_policy_server,
+        args=(server_cfg_dict,),
+        name="axol-policy-server",
+        daemon=True,
+    )
+    server_proc.start()
+    log_say(f"Started PolicyServer on 127.0.0.1:{server_port} (pid={server_proc.pid}).")
+
+    client = None
     episodes_recorded = 0
     try:
-        while True:
-            log_say(f"Running episode {episodes_recorded + 1}.")
+        _wait_for_port("127.0.0.1", server_port, timeout=30.0)
 
-            if dataset:
+        client_cfg = RobotClientConfig(
+            robot=robot_config,
+            policy_type=policy_type,
+            pretrained_name_or_path=policy_path,
+            actions_per_chunk=actions_per_chunk,
+            task=task,
+            server_address=f"127.0.0.1:{server_port}",
+            policy_device=device,
+            client_device="cpu",
+            chunk_size_threshold=chunk_size_threshold,
+            fps=fps,
+            aggregate_fn_name=aggregate_fn,
+        )
+        publisher = _ActionPublisher()
+        client = _build_axol_robot_client(
+            config=client_cfg, robot=robot, publisher=publisher
+        )
+
+        log_say("Loading policy on server (one-time)...")
+        if not client.start():
+            raise RuntimeError("Failed to connect to policy server / load policy.")
+
+        while True:
+            log_say(f"Episode {episodes_recorded + 1}: starting in 1s.")
+            time.sleep(1.0)
+
+            if dataset is not None:
                 dataset.clear_episode_buffer()
 
-            deadline = time.perf_counter() + episode_time_s
-            while time.perf_counter() < deadline:
-                t0 = time.perf_counter()
+            client.reset_episode_state()
+            publisher.reset()
 
-                # TODO: swap in `ZedCamera.read_at_or_after(t0)` so inference
-                # uses the same sender-clock-aligned camera/joint pairing as
-                # the training data — `read_latest()` introduces a ~1 frame
-                # skew vs training.
-                obs = robot.get_observation()
-                obs_processed = robot_obs_proc(obs)
-
-                policy_input = preprocessor(obs_processed)
-                policy_action = policy.select_action(policy_input)
-                act_processed = postprocessor(policy_action)
-                robot.send_action(robot_action_proc((act_processed, obs)))
-
-                if dataset:
-                    obs_frame = build_dataset_frame(
-                        dataset.features, obs_processed, prefix=OBS_STR
-                    )
-                    act_frame = build_dataset_frame(
-                        dataset.features, act_processed, prefix=ACTION
-                    )
-                    dataset.add_frame({**obs_frame, **act_frame, "task": task})
-
-                if rerun_ip:
-                    log_rerun_data(observation=obs_processed, action=act_processed)
-
-                time.sleep(max(0.0, 1 / fps - (time.perf_counter() - t0)))
-
-            choice = (
-                input("Episode done. [Enter]=save, r=rerecord, q=quit: ")
-                .strip()
-                .lower()
+            receiver_thread = threading.Thread(
+                target=client.receive_actions,
+                name="axol-recv-actions",
+                daemon=True,
+            )
+            control_thread = threading.Thread(
+                target=client.control_loop,
+                args=(task,),
+                name="axol-control-loop",
+                daemon=True,
             )
 
+            capture: _RolloutCaptureThread | None = None
+            if dataset is not None:
+                capture = _RolloutCaptureThread(
+                    publisher=publisher,
+                    robot=robot,
+                    dataset=dataset,
+                    robot_obs_proc=robot_obs_proc,
+                    fps=fps,
+                    task=task,
+                    rerun_ip=rerun_ip,
+                )
+
+            stdin_stop = threading.Event()
+            stdin_result: dict[str, str | None] = {"choice": None}
+            stdin_thread = threading.Thread(
+                target=_stdin_watcher,
+                args=(stdin_stop, stdin_result),
+                name="axol-stdin-watcher",
+                daemon=True,
+            )
+
+            print(
+                f"  Press s=save+end, r=rerecord+end, q=quit "
+                f"(safety cap {episode_time_s}s).",
+                flush=True,
+            )
+
+            receiver_thread.start()
+            control_thread.start()
+            if capture is not None:
+                capture.start()
+            stdin_thread.start()
+
+            deadline = time.perf_counter() + episode_time_s
+            timed_out = False
+            interrupted = False
+            try:
+                while True:
+                    if stdin_result["choice"] is not None:
+                        break
+                    if time.perf_counter() >= deadline:
+                        timed_out = True
+                        break
+                    if not control_thread.is_alive() and not receiver_thread.is_alive():
+                        # Both inference threads died unexpectedly; abort
+                        # the episode and surface to the operator.
+                        _logger.warning(
+                            "Control/receiver threads exited before any "
+                            "end signal; aborting episode."
+                        )
+                        break
+                    time.sleep(0.1)
+            except KeyboardInterrupt:
+                interrupted = True
+
+            # Tear down per-episode threads (server + client stay alive).
+            stdin_stop.set()
+            client.shutdown_event.set()
+            if capture is not None:
+                capture.stop_event.set()
+                capture.join(timeout=5.0)
+            control_thread.join(timeout=5.0)
+            receiver_thread.join(timeout=5.0)
+            # The stdin watcher blocks on select with a short timeout, so
+            # it will wake up on its own; don't join (it may still be in
+            # select if the user never typed anything).
+
+            if interrupted:
+                break
+
+            choice = stdin_result["choice"]
+            if timed_out:
+                try:
+                    raw = input(
+                        f"Episode time cap ({episode_time_s}s) reached. "
+                        "[Enter]=save, r=rerecord, q=quit: "
+                    )
+                except (EOFError, KeyboardInterrupt):
+                    break
+                raw = raw.strip().lower()
+                choice = "q" if raw == "q" else ("r" if raw == "r" else "s")
+
             if choice == "q":
+                if dataset is not None:
+                    dataset.clear_episode_buffer()
                 break
 
             if choice == "r":
                 log_say("Re-recording episode.")
-                if dataset:
+                if dataset is not None:
                     dataset.clear_episode_buffer()
                 log_say("Returning to rest pose.")
                 _move_to_rest(robot, fps)
-                input("Reset the scene, then press Enter to start.")
+                try:
+                    input("Reset the scene, then press Enter to start.")
+                except (EOFError, KeyboardInterrupt):
+                    break
                 continue
 
-            if dataset:
+            # choice == "s"
+            if dataset is not None:
                 dataset.save_episode()
             episodes_recorded += 1
+            log_say(f"Saved episode {episodes_recorded}.")
             log_say("Returning to rest pose.")
             _move_to_rest(robot, fps)
-            input("Reset the scene, then press Enter to start the next episode.")
+            try:
+                input("Reset the scene, then press Enter to start the next episode.")
+            except (EOFError, KeyboardInterrupt):
+                break
 
     except KeyboardInterrupt:
         pass
     finally:
         log_say("Stopping.")
-        robot.disconnect()
-        if dataset:
+        if client is not None:
+            try:
+                client.stop()
+            except Exception:  # noqa: BLE001
+                pass
+        try:
+            robot.disconnect()
+        except Exception:  # noqa: BLE001
+            pass
+
+        # Tear down the server child process.
+        if server_proc.is_alive():
+            server_proc.terminate()
+            server_proc.join(timeout=5.0)
+            if server_proc.is_alive():
+                server_proc.kill()
+                server_proc.join(timeout=2.0)
+
+        if dataset is not None:
             dataset.finalize()
             if push_to_hub and episodes_recorded > 0:
                 dataset.push_to_hub()

--- a/almond_axol/cli/teleop.py
+++ b/almond_axol/cli/teleop.py
@@ -9,43 +9,7 @@ import asyncio
 import logging
 import socket
 
-from ..shared import ARM_JOINTS
-
-
-def _parse_stiffness(value: str) -> float | tuple[float, ...]:
-    """Parse a ``--*-stiffness`` value.
-
-    Accepts either a single number in ``[0, 1]`` (applied to all arm
-    joints) or exactly ``len(ARM_JOINTS)`` comma-separated numbers in
-    ``[0, 1]`` — one per joint in :data:`almond_axol.shared.ARM_JOINTS`
-    order (the gripper is not blended).
-    """
-    parts = [p.strip() for p in value.split(",")]
-
-    def _parse_one(raw: str, label: str) -> float:
-        try:
-            x = float(raw)
-        except ValueError as exc:
-            raise argparse.ArgumentTypeError(
-                f"stiffness{label} is not a number: {raw!r}"
-            ) from exc
-        if not 0.0 <= x <= 1.0:
-            raise argparse.ArgumentTypeError(
-                f"stiffness{label} must be in [0, 1], got {x}"
-            )
-        return x
-
-    if len(parts) == 1:
-        return _parse_one(parts[0], "")
-    if len(parts) != len(ARM_JOINTS):
-        raise argparse.ArgumentTypeError(
-            f"stiffness must be a single value or {len(ARM_JOINTS)} "
-            f"comma-separated values (one per joint: "
-            f"{', '.join(j.value for j in ARM_JOINTS)}), got {len(parts)}"
-        )
-    return tuple(
-        _parse_one(p, f"[{i}={ARM_JOINTS[i].value}]") for i, p in enumerate(parts)
-    )
+from ..shared import ARM_JOINTS, parse_stiffness
 
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
@@ -89,14 +53,14 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[
     stiffness_metavar = "S|" + ",".join("S" for _ in ARM_JOINTS)
     p.add_argument(
         "--left-stiffness",
-        type=_parse_stiffness,
+        type=parse_stiffness,
         default=0.0,
         metavar=stiffness_metavar,
         help=stiffness_help.format(side="left", attr="left_stiffness"),
     )
     p.add_argument(
         "--right-stiffness",
-        type=_parse_stiffness,
+        type=parse_stiffness,
         default=0.0,
         metavar=stiffness_metavar,
         help=stiffness_help.format(side="right", attr="right_stiffness"),

--- a/almond_axol/lerobot/camera/camera_zed.py
+++ b/almond_axol/lerobot/camera/camera_zed.py
@@ -98,6 +98,13 @@ class ZedCamera(Camera):
         zed = sl.CameraOne()
         init_params = sl.InitParametersOne()
         init_params.set_from_stream(self.config.host, self.config.port)
+        # Without async recovery, a briefly disrupted stream (e.g. transient
+        # packet loss while another process loads a model onto CUDA) makes
+        # ``grab()`` block indefinitely until the connection is restored,
+        # which silently freezes ``latest_*_perf_ts``. With async recovery
+        # ``grab()`` returns CAMERA_REBOOTING quickly and the SDK reconnects
+        # in the background, so our read loop can keep retrying.
+        init_params.async_grab_camera_recovery = True
 
         err = zed.open(init_params)
         if err != sl.ERROR_CODE.SUCCESS:
@@ -225,13 +232,38 @@ class ZedCamera(Camera):
 
         image = sl.Mat()
         failure_count = 0
+        grab_failure_streak = 0
+        last_grab_warning_perf = 0.0
 
         while not self.stop_event.is_set():
             try:
                 err = self.zed.grab()
                 if err != sl.ERROR_CODE.SUCCESS:
-                    _logger.debug(f"{self} grab returned {err}, skipping frame.")
+                    grab_failure_streak += 1
+                    # Throttled WARN so silent freezes are visible at INFO
+                    # level; previously this was DEBUG-only and got swallowed.
+                    now = time.perf_counter()
+                    if now - last_grab_warning_perf >= 1.0:
+                        _logger.warning(
+                            "%s grab returned %s (%d consecutive failures); "
+                            "stream is recovering in the background.",
+                            self,
+                            err,
+                            grab_failure_streak,
+                        )
+                        last_grab_warning_perf = now
+                    # Backoff so a persistent failure doesn't pin a CPU.
+                    if self.stop_event.wait(timeout=0.05):
+                        return
                     continue
+
+                if grab_failure_streak > 0:
+                    _logger.info(
+                        "%s grab recovered after %d failed attempts.",
+                        self,
+                        grab_failure_streak,
+                    )
+                    grab_failure_streak = 0
 
                 self.zed.retrieve_image(image)
                 raw = image.get_data()  # BGRA uint8 (height, width, 4)

--- a/almond_axol/lerobot/robot/robot_axol.py
+++ b/almond_axol/lerobot/robot/robot_axol.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import threading
+import time
 
 import numpy as np
 from lerobot.cameras.utils import make_cameras_from_configs
@@ -223,10 +224,21 @@ class AxolRobot(Robot):
 
     @check_if_not_connected
     def get_observation(self) -> RobotObservation:
-        """Return cached joint positions and latest camera frames."""
+        """Return cached joint positions and timestamp-aligned camera frames.
+
+        Cameras are sampled with :meth:`ZedCamera.read_at_or_after` against a
+        shared ``time.perf_counter()`` target so every frame in the
+        observation shares the sender-clock instant — matching the alignment
+        guarantee that ``collect-data`` writes into the training dataset. If a
+        camera fails to produce a qualifying frame within ``timeout_ms``, we
+        fall back to ``read_latest()`` so a single stale stream doesn't stall
+        inference.
+        """
         assert self._axol is not None
         assert self._axol.left is not None
         assert self._axol.right is not None
+
+        target_ts = time.perf_counter()
 
         left_pos = self._axol.left.positions  # np.ndarray (8,), from telemetry cache
         right_pos = self._axol.right.positions
@@ -246,7 +258,22 @@ class AxolRobot(Robot):
                 obs[key] = float(right_trq[i])
 
         for cam_key, cam in self.cameras.items():
-            obs[cam_key] = cam.read_latest()
+            cam_fps = getattr(cam, "fps", None) or 30
+            timeout_ms = int(2 * 1000.0 / cam_fps + 200)
+            try:
+                frame, _cap_ts, _recv_ts = cam.read_at_or_after(  # type: ignore[attr-defined]
+                    target_ts, timeout_ms=timeout_ms
+                )
+            except (TimeoutError, RuntimeError) as exc:
+                _logger.debug(
+                    "get_observation: %s read_at_or_after(%.6f) failed (%s); "
+                    "falling back to read_latest().",
+                    cam_key,
+                    target_ts,
+                    exc,
+                )
+                frame = cam.read_latest()
+            obs[cam_key] = frame
 
         return obs
 

--- a/almond_axol/shared.py
+++ b/almond_axol/shared.py
@@ -1,5 +1,6 @@
 """Shared constants and utilities for the Almond Axol robot."""
 
+import argparse
 import logging
 import subprocess
 import sys
@@ -52,6 +53,44 @@ CAN_LEFT = "can_alm_axol_l"
 CAN_RIGHT = "can_alm_axol_r"
 
 ARM_JOINTS: list[Joint] = [j for j in Joint if j != Joint.GRIPPER]
+
+
+def parse_stiffness(value: str) -> float | tuple[float, ...]:
+    """Parse a ``--*-stiffness`` CLI value into a scalar or 7-tuple.
+
+    Accepts a single number in ``[0, 1]`` (applied to all arm joints) or
+    ``len(ARM_JOINTS)`` comma-separated numbers in ``[0, 1]`` — one per
+    joint in :data:`ARM_JOINTS` order (gripper excluded). Raises
+    :class:`argparse.ArgumentTypeError` so it composes cleanly with
+    ``argparse``'s ``type=`` callable.
+    """
+    parts = [p.strip() for p in value.split(",")]
+
+    def _parse_one(raw: str, label: str) -> float:
+        try:
+            x = float(raw)
+        except ValueError as exc:
+            raise argparse.ArgumentTypeError(
+                f"stiffness{label} is not a number: {raw!r}"
+            ) from exc
+        if not 0.0 <= x <= 1.0:
+            raise argparse.ArgumentTypeError(
+                f"stiffness{label} must be in [0, 1], got {x}"
+            )
+        return x
+
+    if len(parts) == 1:
+        return _parse_one(parts[0], "")
+    if len(parts) != len(ARM_JOINTS):
+        raise argparse.ArgumentTypeError(
+            f"stiffness must be a single value or {len(ARM_JOINTS)} "
+            f"comma-separated values (one per joint: "
+            f"{', '.join(j.value for j in ARM_JOINTS)}), got {len(parts)}"
+        )
+    return tuple(
+        _parse_one(p, f"[{i}={ARM_JOINTS[i].value}]") for i, p in enumerate(parts)
+    )
+
 
 URDF_PATH: Path = Path(__file__).resolve().parent / "kinematics" / "urdf" / "axol.urdf"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
 [project.optional-dependencies]
 cuda = ["jax[cuda13]>=0.9.2"] # CPU is usually faster for the JAX IK solver
 dev = ["opencv-python-headless>=4.13.0.92"]
-lerobot = ["lerobot[dataset,viz]"]
+lerobot = ["lerobot[dataset,viz,async]"]
 sim = ["viser>=1.0.24"]
 
 [tool.uv.sources]

--- a/uv.lock
+++ b/uv.lock
@@ -151,7 +151,7 @@ dev = [
     { name = "opencv-python-headless" },
 ]
 lerobot = [
-    { name = "lerobot", extra = ["dataset", "viz"] },
+    { name = "lerobot", extra = ["async", "dataset", "viz"] },
 ]
 sim = [
     { name = "viser" },
@@ -163,7 +163,7 @@ requires-dist = [
     { name = "jax", specifier = ">=0.9.2" },
     { name = "jax", extras = ["cuda13"], marker = "extra == 'cuda'", specifier = ">=0.9.2" },
     { name = "jaxlie", specifier = ">=1.5.0" },
-    { name = "lerobot", extras = ["dataset", "viz"], marker = "extra == 'lerobot'", git = "https://github.com/huggingface/lerobot.git?rev=b5f65e533270015f33dc2f5f570b27dada96fbb1" },
+    { name = "lerobot", extras = ["dataset", "viz", "async"], marker = "extra == 'lerobot'", git = "https://github.com/huggingface/lerobot.git?rev=b5f65e533270015f33dc2f5f570b27dada96fbb1" },
     { name = "mujoco", specifier = ">=3.8.0" },
     { name = "opencv-python-headless", marker = "extra == 'dev'", specifier = ">=4.13.0.92" },
     { name = "pydantic", specifier = ">=2.12.5" },
@@ -379,6 +379,61 @@ wheels = [
 ]
 
 [[package]]
+name = "contourpy"
+version = "1.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/35/0167aad910bbdb9599272bd96d01a9ec6852f36b9455cf2ca67bd4cc2d23/contourpy-1.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:177fb367556747a686509d6fef71d221a4b198a3905fe824430e5ea0fda54eb5", size = 293257, upload-time = "2025-07-26T12:01:39.367Z" },
+    { url = "https://files.pythonhosted.org/packages/96/e4/7adcd9c8362745b2210728f209bfbcf7d91ba868a2c5f40d8b58f54c509b/contourpy-1.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d002b6f00d73d69333dac9d0b8d5e84d9724ff9ef044fd63c5986e62b7c9e1b1", size = 274034, upload-time = "2025-07-26T12:01:40.645Z" },
+    { url = "https://files.pythonhosted.org/packages/73/23/90e31ceeed1de63058a02cb04b12f2de4b40e3bef5e082a7c18d9c8ae281/contourpy-1.3.3-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:348ac1f5d4f1d66d3322420f01d42e43122f43616e0f194fc1c9f5d830c5b286", size = 334672, upload-time = "2025-07-26T12:01:41.942Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/93/b43d8acbe67392e659e1d984700e79eb67e2acb2bd7f62012b583a7f1b55/contourpy-1.3.3-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:655456777ff65c2c548b7c454af9c6f33f16c8884f11083244b5819cc214f1b5", size = 381234, upload-time = "2025-07-26T12:01:43.499Z" },
+    { url = "https://files.pythonhosted.org/packages/46/3b/bec82a3ea06f66711520f75a40c8fc0b113b2a75edb36aa633eb11c4f50f/contourpy-1.3.3-cp313-cp313-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:644a6853d15b2512d67881586bd03f462c7ab755db95f16f14d7e238f2852c67", size = 385169, upload-time = "2025-07-26T12:01:45.219Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/32/e0f13a1c5b0f8572d0ec6ae2f6c677b7991fafd95da523159c19eff0696a/contourpy-1.3.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4debd64f124ca62069f313a9cb86656ff087786016d76927ae2cf37846b006c9", size = 362859, upload-time = "2025-07-26T12:01:46.519Z" },
+    { url = "https://files.pythonhosted.org/packages/33/71/e2a7945b7de4e58af42d708a219f3b2f4cff7386e6b6ab0a0fa0033c49a9/contourpy-1.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a15459b0f4615b00bbd1e91f1b9e19b7e63aea7483d03d804186f278c0af2659", size = 1332062, upload-time = "2025-07-26T12:01:48.964Z" },
+    { url = "https://files.pythonhosted.org/packages/12/fc/4e87ac754220ccc0e807284f88e943d6d43b43843614f0a8afa469801db0/contourpy-1.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ca0fdcd73925568ca027e0b17ab07aad764be4706d0a925b89227e447d9737b7", size = 1403932, upload-time = "2025-07-26T12:01:51.979Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/2e/adc197a37443f934594112222ac1aa7dc9a98faf9c3842884df9a9d8751d/contourpy-1.3.3-cp313-cp313-win32.whl", hash = "sha256:b20c7c9a3bf701366556e1b1984ed2d0cedf999903c51311417cf5f591d8c78d", size = 185024, upload-time = "2025-07-26T12:01:53.245Z" },
+    { url = "https://files.pythonhosted.org/packages/18/0b/0098c214843213759692cc638fce7de5c289200a830e5035d1791d7a2338/contourpy-1.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:1cadd8b8969f060ba45ed7c1b714fe69185812ab43bd6b86a9123fe8f99c3263", size = 226578, upload-time = "2025-07-26T12:01:54.422Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/9a/2f6024a0c5995243cd63afdeb3651c984f0d2bc727fd98066d40e141ad73/contourpy-1.3.3-cp313-cp313-win_arm64.whl", hash = "sha256:fd914713266421b7536de2bfa8181aa8c699432b6763a0ea64195ebe28bff6a9", size = 193524, upload-time = "2025-07-26T12:01:55.73Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/b3/f8a1a86bd3298513f500e5b1f5fd92b69896449f6cab6a146a5d52715479/contourpy-1.3.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:88df9880d507169449d434c293467418b9f6cbe82edd19284aa0409e7fdb933d", size = 306730, upload-time = "2025-07-26T12:01:57.051Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/11/4780db94ae62fc0c2053909b65dc3246bd7cecfc4f8a20d957ad43aa4ad8/contourpy-1.3.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:d06bb1f751ba5d417047db62bca3c8fde202b8c11fb50742ab3ab962c81e8216", size = 287897, upload-time = "2025-07-26T12:01:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/15/e59f5f3ffdd6f3d4daa3e47114c53daabcb18574a26c21f03dc9e4e42ff0/contourpy-1.3.3-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e4e6b05a45525357e382909a4c1600444e2a45b4795163d3b22669285591c1ae", size = 326751, upload-time = "2025-07-26T12:02:00.343Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/81/03b45cfad088e4770b1dcf72ea78d3802d04200009fb364d18a493857210/contourpy-1.3.3-cp313-cp313t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ab3074b48c4e2cf1a960e6bbeb7f04566bf36b1861d5c9d4d8ac04b82e38ba20", size = 375486, upload-time = "2025-07-26T12:02:02.128Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ba/49923366492ffbdd4486e970d421b289a670ae8cf539c1ea9a09822b371a/contourpy-1.3.3-cp313-cp313t-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6c3d53c796f8647d6deb1abe867daeb66dcc8a97e8455efa729516b997b8ed99", size = 388106, upload-time = "2025-07-26T12:02:03.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/52/5b00ea89525f8f143651f9f03a0df371d3cbd2fccd21ca9b768c7a6500c2/contourpy-1.3.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:50ed930df7289ff2a8d7afeb9603f8289e5704755c7e5c3bbd929c90c817164b", size = 352548, upload-time = "2025-07-26T12:02:05.165Z" },
+    { url = "https://files.pythonhosted.org/packages/32/1d/a209ec1a3a3452d490f6b14dd92e72280c99ae3d1e73da74f8277d4ee08f/contourpy-1.3.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4feffb6537d64b84877da813a5c30f1422ea5739566abf0bd18065ac040e120a", size = 1322297, upload-time = "2025-07-26T12:02:07.379Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/9e/46f0e8ebdd884ca0e8877e46a3f4e633f6c9c8c4f3f6e72be3fe075994aa/contourpy-1.3.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2b7e9480ffe2b0cd2e787e4df64270e3a0440d9db8dc823312e2c940c167df7e", size = 1391023, upload-time = "2025-07-26T12:02:10.171Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/70/f308384a3ae9cd2209e0849f33c913f658d3326900d0ff5d378d6a1422d2/contourpy-1.3.3-cp313-cp313t-win32.whl", hash = "sha256:283edd842a01e3dcd435b1c5116798d661378d83d36d337b8dde1d16a5fc9ba3", size = 196157, upload-time = "2025-07-26T12:02:11.488Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/dd/880f890a6663b84d9e34a6f88cded89d78f0091e0045a284427cb6b18521/contourpy-1.3.3-cp313-cp313t-win_amd64.whl", hash = "sha256:87acf5963fc2b34825e5b6b048f40e3635dd547f590b04d2ab317c2619ef7ae8", size = 240570, upload-time = "2025-07-26T12:02:12.754Z" },
+    { url = "https://files.pythonhosted.org/packages/80/99/2adc7d8ffead633234817ef8e9a87115c8a11927a94478f6bb3d3f4d4f7d/contourpy-1.3.3-cp313-cp313t-win_arm64.whl", hash = "sha256:3c30273eb2a55024ff31ba7d052dde990d7d8e5450f4bbb6e913558b3d6c2301", size = 199713, upload-time = "2025-07-26T12:02:14.4Z" },
+    { url = "https://files.pythonhosted.org/packages/72/8b/4546f3ab60f78c514ffb7d01a0bd743f90de36f0019d1be84d0a708a580a/contourpy-1.3.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fde6c716d51c04b1c25d0b90364d0be954624a0ee9d60e23e850e8d48353d07a", size = 292189, upload-time = "2025-07-26T12:02:16.095Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e1/3542a9cb596cadd76fcef413f19c79216e002623158befe6daa03dbfa88c/contourpy-1.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:cbedb772ed74ff5be440fa8eee9bd49f64f6e3fc09436d9c7d8f1c287b121d77", size = 273251, upload-time = "2025-07-26T12:02:17.524Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/71/f93e1e9471d189f79d0ce2497007731c1e6bf9ef6d1d61b911430c3db4e5/contourpy-1.3.3-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:22e9b1bd7a9b1d652cd77388465dc358dafcd2e217d35552424aa4f996f524f5", size = 335810, upload-time = "2025-07-26T12:02:18.9Z" },
+    { url = "https://files.pythonhosted.org/packages/91/f9/e35f4c1c93f9275d4e38681a80506b5510e9327350c51f8d4a5a724d178c/contourpy-1.3.3-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a22738912262aa3e254e4f3cb079a95a67132fc5a063890e224393596902f5a4", size = 382871, upload-time = "2025-07-26T12:02:20.418Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/71/47b512f936f66a0a900d81c396a7e60d73419868fba959c61efed7a8ab46/contourpy-1.3.3-cp314-cp314-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:afe5a512f31ee6bd7d0dda52ec9864c984ca3d66664444f2d72e0dc4eb832e36", size = 386264, upload-time = "2025-07-26T12:02:21.916Z" },
+    { url = "https://files.pythonhosted.org/packages/04/5f/9ff93450ba96b09c7c2b3f81c94de31c89f92292f1380261bd7195bea4ea/contourpy-1.3.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f64836de09927cba6f79dcd00fdd7d5329f3fccc633468507079c829ca4db4e3", size = 363819, upload-time = "2025-07-26T12:02:23.759Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/a6/0b185d4cc480ee494945cde102cb0149ae830b5fa17bf855b95f2e70ad13/contourpy-1.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1fd43c3be4c8e5fd6e4f2baeae35ae18176cf2e5cced681cca908addf1cdd53b", size = 1333650, upload-time = "2025-07-26T12:02:26.181Z" },
+    { url = "https://files.pythonhosted.org/packages/43/d7/afdc95580ca56f30fbcd3060250f66cedbde69b4547028863abd8aa3b47e/contourpy-1.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6afc576f7b33cf00996e5c1102dc2a8f7cc89e39c0b55df93a0b78c1bd992b36", size = 1404833, upload-time = "2025-07-26T12:02:28.782Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/e2/366af18a6d386f41132a48f033cbd2102e9b0cf6345d35ff0826cd984566/contourpy-1.3.3-cp314-cp314-win32.whl", hash = "sha256:66c8a43a4f7b8df8b71ee1840e4211a3c8d93b214b213f590e18a1beca458f7d", size = 189692, upload-time = "2025-07-26T12:02:30.128Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:cf9022ef053f2694e31d630feaacb21ea24224be1c3ad0520b13d844274614fd", size = 232424, upload-time = "2025-07-26T12:02:31.395Z" },
+    { url = "https://files.pythonhosted.org/packages/18/79/a9416650df9b525737ab521aa181ccc42d56016d2123ddcb7b58e926a42c/contourpy-1.3.3-cp314-cp314-win_arm64.whl", hash = "sha256:95b181891b4c71de4bb404c6621e7e2390745f887f2a026b2d99e92c17892339", size = 198300, upload-time = "2025-07-26T12:02:32.956Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/42/38c159a7d0f2b7b9c04c64ab317042bb6952b713ba875c1681529a2932fe/contourpy-1.3.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:33c82d0138c0a062380332c861387650c82e4cf1747aaa6938b9b6516762e772", size = 306769, upload-time = "2025-07-26T12:02:34.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/6c/26a8205f24bca10974e77460de68d3d7c63e282e23782f1239f226fcae6f/contourpy-1.3.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ea37e7b45949df430fe649e5de8351c423430046a2af20b1c1961cae3afcda77", size = 287892, upload-time = "2025-07-26T12:02:35.807Z" },
+    { url = "https://files.pythonhosted.org/packages/66/06/8a475c8ab718ebfd7925661747dbb3c3ee9c82ac834ccb3570be49d129f4/contourpy-1.3.3-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d304906ecc71672e9c89e87c4675dc5c2645e1f4269a5063b99b0bb29f232d13", size = 326748, upload-time = "2025-07-26T12:02:37.193Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a3/c5ca9f010a44c223f098fccd8b158bb1cb287378a31ac141f04730dc49be/contourpy-1.3.3-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ca658cd1a680a5c9ea96dc61cdbae1e85c8f25849843aa799dfd3cb370ad4fbe", size = 375554, upload-time = "2025-07-26T12:02:38.894Z" },
+    { url = "https://files.pythonhosted.org/packages/80/5b/68bd33ae63fac658a4145088c1e894405e07584a316738710b636c6d0333/contourpy-1.3.3-cp314-cp314t-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ab2fd90904c503739a75b7c8c5c01160130ba67944a7b77bbf36ef8054576e7f", size = 388118, upload-time = "2025-07-26T12:02:40.642Z" },
+    { url = "https://files.pythonhosted.org/packages/40/52/4c285a6435940ae25d7410a6c36bda5145839bc3f0beb20c707cda18b9d2/contourpy-1.3.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b7301b89040075c30e5768810bc96a8e8d78085b47d8be6e4c3f5a0b4ed478a0", size = 352555, upload-time = "2025-07-26T12:02:42.25Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ee/3e81e1dd174f5c7fefe50e85d0892de05ca4e26ef1c9a59c2a57e43b865a/contourpy-1.3.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2a2a8b627d5cc6b7c41a4beff6c5ad5eb848c88255fda4a8745f7e901b32d8e4", size = 1322295, upload-time = "2025-07-26T12:02:44.668Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/b2/6d913d4d04e14379de429057cd169e5e00f6c2af3bb13e1710bcbdb5da12/contourpy-1.3.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:fd6ec6be509c787f1caf6b247f0b1ca598bef13f4ddeaa126b7658215529ba0f", size = 1391027, upload-time = "2025-07-26T12:02:47.09Z" },
+    { url = "https://files.pythonhosted.org/packages/93/8a/68a4ec5c55a2971213d29a9374913f7e9f18581945a7a31d1a39b5d2dfe5/contourpy-1.3.3-cp314-cp314t-win32.whl", hash = "sha256:e74a9a0f5e3fff48fb5a7f2fd2b9b70a3fe014a67522f79b7cca4c0c7e43c9ae", size = 202428, upload-time = "2025-07-26T12:02:48.691Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/96/fd9f641ffedc4fa3ace923af73b9d07e869496c9cc7a459103e6e978992f/contourpy-1.3.3-cp314-cp314t-win_amd64.whl", hash = "sha256:13b68d6a62db8eafaebb8039218921399baf6e47bf85006fd8529f2a08ef33fc", size = 250331, upload-time = "2025-07-26T12:02:50.137Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8c/469afb6465b853afff216f9528ffda78a915ff880ed58813ba4faf4ba0b6/contourpy-1.3.3-cp314-cp314t-win_arm64.whl", hash = "sha256:b7448cb5a725bb1e35ce88771b86fba35ef418952474492cf7c764059933ff8b", size = 203831, upload-time = "2025-07-26T12:02:51.449Z" },
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "12.9.4"
 source = { registry = "https://pypi.org/simple" }
@@ -398,6 +453,15 @@ version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/66/0c02bd330e7d976f83fa68583d6198d76f23581bcbb5c0e98a6148f326e5/cuda_pathfinder-1.5.0-py3-none-any.whl", hash = "sha256:498f90a9e9de36044a7924742aecce11c50c49f735f1bc53e05aa46de9ea4110", size = 49739, upload-time = "2026-03-24T21:14:30.869Z" },
+]
+
+[[package]]
+name = "cycler"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615, upload-time = "2023-10-07T05:32:18.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321, upload-time = "2023-10-07T05:32:16.783Z" },
 ]
 
 [[package]]
@@ -535,6 +599,39 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/b8/00651a0f559862f3bb7d6f7477b192afe3f583cc5e26403b44e59a55ab34/filelock-3.25.2.tar.gz", hash = "sha256:b64ece2b38f4ca29dd3e810287aa8c48182bbecd1ae6e9ae126c9b35f1382694", size = 40480, upload-time = "2026-03-11T20:45:38.487Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/a5/842ae8f0c08b61d6484b52f99a03510a3a72d23141942d216ebe81fefbce/filelock-3.25.2-py3-none-any.whl", hash = "sha256:ca8afb0da15f229774c9ad1b455ed96e85a81373065fb10446672f64444ddf70", size = 26759, upload-time = "2026-03-11T20:45:37.437Z" },
+]
+
+[[package]]
+name = "fonttools"
+version = "4.63.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/69/c97f2c18e0db87d2c7b15da1974dace76ae938f1cfa22e2727a648b7ed43/fonttools-4.63.0.tar.gz", hash = "sha256:caeb583deeb5168e694b65cda8b4ee62abedfa66cf88488734466f2366b9c4e0", size = 3597189, upload-time = "2026-05-14T12:04:30.958Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/8d/d8fec3dcde2963f8c908fb315e5ff2cd0ac34f82394bbbf73a2aa5145ce3/fonttools-4.63.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:cd7e9857e5e63738b9d9fd707bc1f59c8b09e5177726d23664db393c59bb08bd", size = 2876062, upload-time = "2026-05-14T12:03:32.554Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/71/d935dc54e4ff121bfdd11e08702db63a7e6f25af21d8a3d7b7212df53641/fonttools-4.63.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c2a2a42198b696a6f48fad91709afb55176e66a5e566131219dba372fb7f8c59", size = 2424594, upload-time = "2026-05-14T12:03:34.86Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/40/e76320afa1df918e146155ef239b1719ee266092e96f5423bfd075affba1/fonttools-4.63.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e874792a8212b44583ea02189d9e693906b2f78b261f372f95d6c563210ac1d", size = 5024840, upload-time = "2026-05-14T12:03:36.745Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/36/0b805d8c485f872f65a509cbe3b58a5d0d17bee855333b54a150c79d3061/fonttools-4.63.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:22135da48a348785c5e2d5d2d9d6bec5ed44adacbaeb9db12d9493bf6c6bfa68", size = 4975801, upload-time = "2026-05-14T12:03:38.833Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/26/2cee03d0aa083ab022da5c07aff9ed3f689da1defb81ad6917c9627896da/fonttools-4.63.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ccf41f2efdf56994d22d73bef4ced1052161958169428d06ba9724ea9e9a64be", size = 4965009, upload-time = "2026-05-14T12:03:41.494Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/48/cc4b66d9058c0d0982c833fad10127c4b0e9324606aafa41382295ca4102/fonttools-4.63.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9ced0bd02ac751dd6319b0da88aaef24414e3b0dbc32bb4f24944821a3741a27", size = 5105892, upload-time = "2026-05-14T12:03:43.525Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/1f/a98a30a814b9ddef3a2e706025f90b9e0bc94890e6cb15254bc86547d11a/fonttools-4.63.0-cp313-cp313-win32.whl", hash = "sha256:85be818f5506e8a7753153def2c9550178f0ecae6a47b5e0e8dbb23f7cc90380", size = 2291313, upload-time = "2026-05-14T12:03:45.594Z" },
+    { url = "https://files.pythonhosted.org/packages/92/46/5177b01f3b4abfdd4409f31cca4ab279c9343a26efbe9ec78c97fc612e02/fonttools-4.63.0-cp313-cp313-win_amd64.whl", hash = "sha256:ba04cb5891d4c0c21b6da95eda8d7b090021508a294fff33464fc7d241e0856b", size = 2342299, upload-time = "2026-05-14T12:03:47.414Z" },
+    { url = "https://files.pythonhosted.org/packages/27/d2/23d25e3f247b328be58d04a4c9f894178a0d1eda7d42867cfb388adaf416/fonttools-4.63.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fd1e3094f42d806d3d7c79162fc59e5910fcbe3a7360c385b8da969bc4493745", size = 2875338, upload-time = "2026-05-14T12:03:50.052Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/58/7dfa0c761cb3b2964e2a84c4dc986c926a87de0cb9fb60d5b28ded3f2914/fonttools-4.63.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6e528da43bc3791085f8cb6141b1d13e459226790240340fcbb4625649238b03", size = 2422661, upload-time = "2026-05-14T12:03:52.154Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/87/64cfa18a7a1621d17b7f4502b2b0ed8a135a90c3db51ea590ee99043e76b/fonttools-4.63.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b2248c5decb223562f7902ff6325077a073f608ee8e33e88ad88db734eb9f49", size = 5010526, upload-time = "2026-05-14T12:03:54.647Z" },
+    { url = "https://files.pythonhosted.org/packages/36/e1/a8933a72c45a87177fbde2696e0d0755c8c9062f8c077a961c6215fa27b1/fonttools-4.63.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:308f957cdeaf8abe4e5f2f124902ef405448af92c90f80e302a3b771c2e6116b", size = 4923946, upload-time = "2026-05-14T12:03:56.984Z" },
+    { url = "https://files.pythonhosted.org/packages/27/60/872e6e233b8c5e8b41413796ff18b7fe479661bd40147e071b450dfad7a1/fonttools-4.63.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bf00f21eb5fb721dbaf73d1e9da6d02a1af7768f2ebcf9798be98beab8ba90f6", size = 4962489, upload-time = "2026-05-14T12:03:59.443Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c4/83c24f2ec38b90cfda84bf4b1a1f49df80e84a1db4e7ac6e0d41bf23bc39/fonttools-4.63.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c1aaa4b9c75798400ac043ce04d74e7830376c85095a5a6ed7cba2f17a266bf4", size = 5071870, upload-time = "2026-05-14T12:04:02.122Z" },
+    { url = "https://files.pythonhosted.org/packages/de/40/3ae22b60ff1d41ce0bd044b31238cdc72cef99f28b976f1e128ebd618c9b/fonttools-4.63.0-cp314-cp314-win32.whl", hash = "sha256:22693918177bd9ceabec4736d338045f357769416fc6b0b2508eefef75b08616", size = 2295026, upload-time = "2026-05-14T12:04:04.47Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/d4/98078064ccc76b45cb0f6c002452011e93c4bd26f6850344f0951cc1fe89/fonttools-4.63.0-cp314-cp314-win_amd64.whl", hash = "sha256:7d782fac32985914c351556f68ac0855391572bcd87de50e05970d3cd4c96fc5", size = 2347454, upload-time = "2026-05-14T12:04:06.752Z" },
+    { url = "https://files.pythonhosted.org/packages/49/4e/652d1580c5f4e39f7d103b0c793e4773129ad633dce4addd0cf4dfebde02/fonttools-4.63.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6db5140a60a5d731d21ec076745b40a310607731b0a565b50776393188649001", size = 2958152, upload-time = "2026-05-14T12:04:08.706Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/55/ad864c9a9b219f552eb46b32cd7906c466e5a578ba0c3abfcc0fe7413eb6/fonttools-4.63.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7d76edbff9014094dbf03bd2d074709dfa6ec7aba13d838c937a2b33d2d6a86e", size = 2460809, upload-time = "2026-05-14T12:04:10.783Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/2b/0aa8db70f18cf52e49b4ed5ecec68547f981160bf5ded3b5aed6faa0a6f9/fonttools-4.63.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0eac00b9118c3c2f87d272e45341871c5b3066baa3c86897fa634a7c3fb59096", size = 5148649, upload-time = "2026-05-14T12:04:12.747Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/63/18e4369c25043096f1048e0c9915951adc4f842bd81c6b18155824d6fa99/fonttools-4.63.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:51394295f1a51de8b5f30bdb1e1b9a4231536c7064ef5c6e211eec19fa36036f", size = 4932147, upload-time = "2026-05-14T12:04:14.806Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/3f/67f3eac2ffd8a98446c5022f8ed3864eac878a5ff7af8df4c8286dba16cc/fonttools-4.63.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9e12f105d2b6342c559c298afb674006bb2893afc7102dcf8a1b55b0486b4e40", size = 5027237, upload-time = "2026-05-14T12:04:17.675Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ba/4e6214cb38a7b04779e97bb7636de9a5c7f20af7018d03dee0b64c08510a/fonttools-4.63.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:796f27556dbe094c4824f75ca85267e4df776c79036c8441469a4df37038c196", size = 5053933, upload-time = "2026-05-14T12:04:20.818Z" },
+    { url = "https://files.pythonhosted.org/packages/34/3b/214dcc19ee31d3d38fb5ad2755c11ef0514e5dc300bbaf41c0b69f393799/fonttools-4.63.0-cp314-cp314t-win32.whl", hash = "sha256:948428a275741f0b64b113c955425a953314f4b9ab9997f73a72c83e68e569c8", size = 2359326, upload-time = "2026-05-14T12:04:24.22Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/1e/3ff1a9b523058c2eeb6a9d50f5574e2a738200d0d94107d5bc4105e8da3f/fonttools-4.63.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6d4741eb179121cab9eea4cb2393d24492373a260d7945006358c08cfbf45419", size = 2425829, upload-time = "2026-05-14T12:04:26.829Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/47/c99d5268f354002ce80f8d029cd9d7d872969da1de8b93d32de4dc56d6f4/fonttools-4.63.0-py3-none-any.whl", hash = "sha256:445af2eab030a16b9171ea8bdda7ebf7d96bda2df88ee182a464252f6e05e20d", size = 1164562, upload-time = "2026-05-14T12:04:29.092Z" },
 ]
 
 [[package]]
@@ -678,6 +775,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/93/977b9e679e356871d428ae7a1139ec767dd5177bed58a6344b4d2199e00f/glfw-2.10.0-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:cca5158d62189e08792b1ae54f92307a282921a0e7783315b467e21b0a381c88", size = 243480, upload-time = "2026-03-10T17:21:30.538Z" },
     { url = "https://files.pythonhosted.org/packages/f9/bd/cea9569c8f2188b0a104472951420434a3e1f5cf26f5836ef9d7227a1a30/glfw-2.10.0-py2.py3-none-win32.whl", hash = "sha256:5e024509989740e8e7b86cc4aab508195495f79879072b0e1f68bd036a2916ad", size = 552641, upload-time = "2026-03-10T17:21:32.653Z" },
     { url = "https://files.pythonhosted.org/packages/cc/9b/4366ad3e1c0688146c70aa6143584d6a8d88583b9390f106250e25a3d5cd/glfw-2.10.0-py2.py3-none-win_amd64.whl", hash = "sha256:7f787ee8645781f10e8800438ce4357ab38c573ffb191aba380c1e72eba6311c", size = 559423, upload-time = "2026-03-10T17:21:34.766Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.73.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/e8/b43b851537da2e2f03fa8be1aef207e5cbfb1a2e014fbb6b40d24c177cd3/grpcio-1.73.1.tar.gz", hash = "sha256:7fce2cd1c0c1116cf3850564ebfc3264fba75d3c74a7414373f1238ea365ef87", size = 12730355, upload-time = "2025-06-26T01:53:24.622Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/bf/4ca20d1acbefabcaba633ab17f4244cbbe8eca877df01517207bd6655914/grpcio-1.73.1-cp313-cp313-linux_armv7l.whl", hash = "sha256:b310824ab5092cf74750ebd8a8a8981c1810cb2b363210e70d06ef37ad80d4f9", size = 5335615, upload-time = "2025-06-26T01:52:42.896Z" },
+    { url = "https://files.pythonhosted.org/packages/75/ed/45c345f284abec5d4f6d77cbca9c52c39b554397eb7de7d2fcf440bcd049/grpcio-1.73.1-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:8f5a6df3fba31a3485096ac85b2e34b9666ffb0590df0cd044f58694e6a1f6b5", size = 10595497, upload-time = "2025-06-26T01:52:44.695Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/75/bff2c2728018f546d812b755455014bc718f8cdcbf5c84f1f6e5494443a8/grpcio-1.73.1-cp313-cp313-manylinux_2_17_aarch64.whl", hash = "sha256:052e28fe9c41357da42250a91926a3e2f74c046575c070b69659467ca5aa976b", size = 5765321, upload-time = "2025-06-26T01:52:46.871Z" },
+    { url = "https://files.pythonhosted.org/packages/70/3b/14e43158d3b81a38251b1d231dfb45a9b492d872102a919fbf7ba4ac20cd/grpcio-1.73.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1c0bf15f629b1497436596b1cbddddfa3234273490229ca29561209778ebe182", size = 6415436, upload-time = "2025-06-26T01:52:49.134Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/3f/81d9650ca40b54338336fd360f36773be8cb6c07c036e751d8996eb96598/grpcio-1.73.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0ab860d5bfa788c5a021fba264802e2593688cd965d1374d31d2b1a34cacd854", size = 6007012, upload-time = "2025-06-26T01:52:51.076Z" },
+    { url = "https://files.pythonhosted.org/packages/55/f4/59edf5af68d684d0f4f7ad9462a418ac517201c238551529098c9aa28cb0/grpcio-1.73.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:ad1d958c31cc91ab050bd8a91355480b8e0683e21176522bacea225ce51163f2", size = 6105209, upload-time = "2025-06-26T01:52:52.773Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/a8/700d034d5d0786a5ba14bfa9ce974ed4c976936c2748c2bd87aa50f69b36/grpcio-1.73.1-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:f43ffb3bd415c57224c7427bfb9e6c46a0b6e998754bfa0d00f408e1873dcbb5", size = 6753655, upload-time = "2025-06-26T01:52:55.064Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/29/efbd4ac837c23bc48e34bbaf32bd429f0dc9ad7f80721cdb4622144c118c/grpcio-1.73.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:686231cdd03a8a8055f798b2b54b19428cdf18fa1549bee92249b43607c42668", size = 6287288, upload-time = "2025-06-26T01:52:57.33Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/61/c6045d2ce16624bbe18b5d169c1a5ce4d6c3a47bc9d0e5c4fa6a50ed1239/grpcio-1.73.1-cp313-cp313-win32.whl", hash = "sha256:89018866a096e2ce21e05eabed1567479713ebe57b1db7cbb0f1e3b896793ba4", size = 3668151, upload-time = "2025-06-26T01:52:59.405Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/d7/77ac689216daee10de318db5aa1b88d159432dc76a130948a56b3aa671a2/grpcio-1.73.1-cp313-cp313-win_amd64.whl", hash = "sha256:4a68f8c9966b94dff693670a5cf2b54888a48a5011c5d9ce2295a1a1465ee84f", size = 4335747, upload-time = "2025-06-26T01:53:01.233Z" },
 ]
 
 [[package]]
@@ -1030,6 +1145,73 @@ wheels = [
 ]
 
 [[package]]
+name = "kiwisolver"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/67/9c61eccb13f0bdca9307614e782fec49ffdde0f7a2314935d489fa93cd9c/kiwisolver-1.5.0.tar.gz", hash = "sha256:d4193f3d9dc3f6f79aaed0e5637f45d98850ebf01f7ca20e69457f3e8946b66a", size = 103482, upload-time = "2026-03-09T13:15:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/69/024d6711d5ba575aa65d5538042e99964104e97fa153a9f10bc369182bc2/kiwisolver-1.5.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:fd40bb9cd0891c4c3cb1ddf83f8bbfa15731a248fdc8162669405451e2724b09", size = 123166, upload-time = "2026-03-09T13:13:48.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/adbb40df306f587054a348831220812b9b1d787aff714cfbc8556e38fccd/kiwisolver-1.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c0e1403fd7c26d77c1f03e096dc58a5c726503fa0db0456678b8668f76f521e3", size = 66395, upload-time = "2026-03-09T13:13:49.365Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/3a/d0a972b34e1c63e2409413104216cd1caa02c5a37cb668d1687d466c1c45/kiwisolver-1.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dda366d548e89a90d88a86c692377d18d8bd64b39c1fb2b92cb31370e2896bbd", size = 64065, upload-time = "2026-03-09T13:13:50.562Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0a/7b98e1e119878a27ba8618ca1e18b14f992ff1eda40f47bccccf4de44121/kiwisolver-1.5.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:332b4f0145c30b5f5ad9374881133e5aa64320428a57c2c2b61e9d891a51c2f3", size = 1477903, upload-time = "2026-03-09T13:13:52.084Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d8/55638d89ffd27799d5cc3d8aa28e12f4ce7a64d67b285114dbedc8ea4136/kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c50b89ffd3e1a911c69a1dd3de7173c0cd10b130f56222e57898683841e4f96", size = 1278751, upload-time = "2026-03-09T13:13:54.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/97/b4c8d0d18421ecceba20ad8701358453b88e32414e6f6950b5a4bad54e65/kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4db576bb8c3ef9365f8b40fe0f671644de6736ae2c27a2c62d7d8a1b4329f099", size = 1296793, upload-time = "2026-03-09T13:13:56.287Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/10/f862f94b6389d8957448ec9df59450b81bec4abb318805375c401a1e6892/kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0b85aad90cea8ac6797a53b5d5f2e967334fa4d1149f031c4537569972596cb8", size = 1346041, upload-time = "2026-03-09T13:13:58.269Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/6a/f1650af35821eaf09de398ec0bc2aefc8f211f0cda50204c9f1673741ba9/kiwisolver-1.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:d36ca54cb4c6c4686f7cbb7b817f66f5911c12ddb519450bbe86707155028f87", size = 987292, upload-time = "2026-03-09T13:13:59.871Z" },
+    { url = "https://files.pythonhosted.org/packages/de/19/d7fb82984b9238115fe629c915007be608ebd23dc8629703d917dbfaffd4/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:38f4a703656f493b0ad185211ccfca7f0386120f022066b018eb5296d8613e23", size = 2227865, upload-time = "2026-03-09T13:14:01.401Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/b9/46b7f386589fd222dac9e9de9c956ce5bcefe2ee73b4e79891381dda8654/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3ac2360e93cb41be81121755c6462cff3beaa9967188c866e5fce5cf13170859", size = 2324369, upload-time = "2026-03-09T13:14:02.972Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8b/95e237cf3d9c642960153c769ddcbe278f182c8affb20cecc1cc983e7cc5/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c95cab08d1965db3d84a121f1c7ce7479bdd4072c9b3dafd8fecce48a2e6b902", size = 1977989, upload-time = "2026-03-09T13:14:04.503Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/95/980c9df53501892784997820136c01f62bc1865e31b82b9560f980c0e649/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:fc20894c3d21194d8041a28b65622d5b86db786da6e3cfe73f0c762951a61167", size = 2491645, upload-time = "2026-03-09T13:14:06.106Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/900647fd0840abebe1561792c6b31e6a7c0e278fc3973d30572a965ca14c/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7a32f72973f0f950c1920475d5c5ea3d971b81b6f0ec53b8d0a956cc965f22e0", size = 2295237, upload-time = "2026-03-09T13:14:08.891Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8a/be60e3bbcf513cc5a50f4a3e88e1dcecebb79c1ad607a7222877becaa101/kiwisolver-1.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:0bf3acf1419fa93064a4c2189ac0b58e3be7872bf6ee6177b0d4c63dc4cea276", size = 73573, upload-time = "2026-03-09T13:14:12.327Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/d2/64be2e429eb4fca7f7e1c52a91b12663aeaf25de3895e5cca0f47ef2a8d0/kiwisolver-1.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:fa8eb9ecdb7efb0b226acec134e0d709e87a909fa4971a54c0c4f6e88635484c", size = 64998, upload-time = "2026-03-09T13:14:13.469Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/69/ce68dd0c85755ae2de490bf015b62f2cea5f6b14ff00a463f9d0774449ff/kiwisolver-1.5.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:db485b3847d182b908b483b2ed133c66d88d49cacf98fd278fadafe11b4478d1", size = 125700, upload-time = "2026-03-09T13:14:14.636Z" },
+    { url = "https://files.pythonhosted.org/packages/74/aa/937aac021cf9d4349990d47eb319309a51355ed1dbdc9c077cdc9224cb11/kiwisolver-1.5.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:be12f931839a3bdfe28b584db0e640a65a8bcbc24560ae3fdb025a449b3d754e", size = 67537, upload-time = "2026-03-09T13:14:15.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/20/3a87fbece2c40ad0f6f0aefa93542559159c5f99831d596050e8afae7a9f/kiwisolver-1.5.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:16b85d37c2cbb3253226d26e64663f755d88a03439a9c47df6246b35defbdfb7", size = 65514, upload-time = "2026-03-09T13:14:18.035Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7f/f943879cda9007c45e1f7dba216d705c3a18d6b35830e488b6c6a4e7cdf0/kiwisolver-1.5.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4432b835675f0ea7414aab3d37d119f7226d24869b7a829caeab49ebda407b0c", size = 1584848, upload-time = "2026-03-09T13:14:19.745Z" },
+    { url = "https://files.pythonhosted.org/packages/37/f8/4d4f85cc1870c127c88d950913370dd76138482161cd07eabbc450deff01/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b0feb50971481a2cc44d94e88bdb02cdd497618252ae226b8eb1201b957e368", size = 1391542, upload-time = "2026-03-09T13:14:21.54Z" },
+    { url = "https://files.pythonhosted.org/packages/04/0b/65dd2916c84d252b244bd405303220f729e7c17c9d7d33dca6feeff9ffc4/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:56fa888f10d0f367155e76ce849fa1166fc9730d13bd2d65a2aa13b6f5424489", size = 1404447, upload-time = "2026-03-09T13:14:23.205Z" },
+    { url = "https://files.pythonhosted.org/packages/39/5c/2606a373247babce9b1d056c03a04b65f3cf5290a8eac5d7bdead0a17e21/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:940dda65d5e764406b9fb92761cbf462e4e63f712ab60ed98f70552e496f3bf1", size = 1455918, upload-time = "2026-03-09T13:14:24.74Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d1/c6078b5756670658e9192a2ef11e939c92918833d2745f85cd14a6004bdf/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_39_riscv64.whl", hash = "sha256:89fc958c702ee9a745e4700378f5d23fddbc46ff89e8fdbf5395c24d5c1452a3", size = 1072856, upload-time = "2026-03-09T13:14:26.597Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/c8/7def6ddf16eb2b3741d8b172bdaa9af882b03c78e9b0772975408801fa63/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9027d773c4ff81487181a925945743413f6069634d0b122d0b37684ccf4f1e18", size = 2333580, upload-time = "2026-03-09T13:14:28.237Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/87/2ac1fce0eb1e616fcd3c35caa23e665e9b1948bb984f4764790924594128/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:5b233ea3e165e43e35dba1d2b8ecc21cf070b45b65ae17dd2747d2713d942021", size = 2423018, upload-time = "2026-03-09T13:14:30.018Z" },
+    { url = "https://files.pythonhosted.org/packages/67/13/c6700ccc6cc218716bfcda4935e4b2997039869b4ad8a94f364c5a3b8e63/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ce9bf03dad3b46408c08649c6fbd6ca28a9fce0eb32fdfffa6775a13103b5310", size = 2062804, upload-time = "2026-03-09T13:14:32.888Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bd/877056304626943ff0f1f44c08f584300c199b887cb3176cd7e34f1515f1/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:fc4d3f1fb9ca0ae9f97b095963bc6326f1dbfd3779d6679a1e016b9baaa153d3", size = 2597482, upload-time = "2026-03-09T13:14:34.971Z" },
+    { url = "https://files.pythonhosted.org/packages/75/19/c60626c47bf0f8ac5dcf72c6c98e266d714f2fbbfd50cf6dab5ede3aaa50/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f443b4825c50a51ee68585522ab4a1d1257fac65896f282b4c6763337ac9f5d2", size = 2394328, upload-time = "2026-03-09T13:14:36.816Z" },
+    { url = "https://files.pythonhosted.org/packages/47/84/6a6d5e5bb8273756c27b7d810d47f7ef2f1f9b9fd23c9ee9a3f8c75c9cef/kiwisolver-1.5.0-cp313-cp313t-win_arm64.whl", hash = "sha256:893ff3a711d1b515ba9da14ee090519bad4610ed1962fbe298a434e8c5f8db53", size = 68410, upload-time = "2026-03-09T13:14:38.695Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/060f45052f2a01ad5762c8fdecd6d7a752b43400dc29ff75cd47225a40fd/kiwisolver-1.5.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8df31fe574b8b3993cc61764f40941111b25c2d9fea13d3ce24a49907cd2d615", size = 123231, upload-time = "2026-03-09T13:14:41.323Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/a7/78da680eadd06ff35edef6ef68a1ad273bad3e2a0936c9a885103230aece/kiwisolver-1.5.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1d49a49ac4cbfb7c1375301cd1ec90169dfeae55ff84710d782260ce77a75a02", size = 66489, upload-time = "2026-03-09T13:14:42.534Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b2/97980f3ad4fae37dd7fe31626e2bf75fbf8bdf5d303950ec1fab39a12da8/kiwisolver-1.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0cbe94b69b819209a62cb27bdfa5dc2a8977d8de2f89dfd97ba4f53ed3af754e", size = 64063, upload-time = "2026-03-09T13:14:44.759Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f9/b06c934a6aa8bc91f566bd2a214fd04c30506c2d9e2b6b171953216a65b6/kiwisolver-1.5.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:80aa065ffd378ff784822a6d7c3212f2d5f5e9c3589614b5c228b311fd3063ac", size = 1475913, upload-time = "2026-03-09T13:14:46.247Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/f0/f768ae564a710135630672981231320bc403cf9152b5596ec5289de0f106/kiwisolver-1.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e7f886f47ab881692f278ae901039a234e4025a68e6dfab514263a0b1c4ae05", size = 1282782, upload-time = "2026-03-09T13:14:48.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/9f/1de7aad00697325f05238a5f2eafbd487fb637cc27a558b5367a5f37fb7f/kiwisolver-1.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5060731cc3ed12ca3a8b57acd4aeca5bbc2f49216dd0bec1650a1acd89486bcd", size = 1300815, upload-time = "2026-03-09T13:14:50.721Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/c2/297f25141d2e468e0ce7f7a7b92e0cf8918143a0cbd3422c1ad627e85a06/kiwisolver-1.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7a4aa69609f40fce3cbc3f87b2061f042eee32f94b8f11db707b66a26461591a", size = 1347925, upload-time = "2026-03-09T13:14:52.304Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d3/f4c73a02eb41520c47610207b21afa8cdd18fdbf64ffd94674ae21c4812d/kiwisolver-1.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:d168fda2dbff7b9b5f38e693182d792a938c31db4dac3a80a4888de603c99554", size = 991322, upload-time = "2026-03-09T13:14:54.637Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/46/d3f2efef7732fcda98d22bf4ad5d3d71d545167a852ca710a494f4c15343/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:413b820229730d358efd838ecbab79902fe97094565fdc80ddb6b0a18c18a581", size = 2232857, upload-time = "2026-03-09T13:14:56.471Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ec/2d9756bf2b6d26ae4349b8d3662fb3993f16d80c1f971c179ce862b9dbae/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:5124d1ea754509b09e53738ec185584cc609aae4a3b510aaf4ed6aa047ef9303", size = 2329376, upload-time = "2026-03-09T13:14:58.072Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/9f/876a0a0f2260f1bde92e002b3019a5fabc35e0939c7d945e0fa66185eb20/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e4415a8db000bf49a6dd1c478bf70062eaacff0f462b92b0ba68791a905861f9", size = 1982549, upload-time = "2026-03-09T13:14:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/4f/ba3624dfac23a64d54ac4179832860cb537c1b0af06024936e82ca4154a0/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d618fd27420381a4f6044faa71f46d8bfd911bd077c555f7138ed88729bfbe79", size = 2494680, upload-time = "2026-03-09T13:15:01.364Z" },
+    { url = "https://files.pythonhosted.org/packages/39/b7/97716b190ab98911b20d10bf92eca469121ec483b8ce0edd314f51bc85af/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5092eb5b1172947f57d6ea7d89b2f29650414e4293c47707eb499ec07a0ac796", size = 2297905, upload-time = "2026-03-09T13:15:03.925Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/36/4e551e8aa55c9188bca9abb5096805edbf7431072b76e2298e34fd3a3008/kiwisolver-1.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:d76e2d8c75051d58177e762164d2e9ab92886534e3a12e795f103524f221dd8e", size = 75086, upload-time = "2026-03-09T13:15:07.775Z" },
+    { url = "https://files.pythonhosted.org/packages/70/15/9b90f7df0e31a003c71649cf66ef61c3c1b862f48c81007fa2383c8bd8d7/kiwisolver-1.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:fa6248cd194edff41d7ea9425ced8ca3a6f838bfb295f6f1d6e6bb694a8518df", size = 66577, upload-time = "2026-03-09T13:15:09.139Z" },
+    { url = "https://files.pythonhosted.org/packages/17/01/7dc8c5443ff42b38e72731643ed7cf1ed9bf01691ae5cdca98501999ed83/kiwisolver-1.5.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d1ffeb80b5676463d7a7d56acbe8e37a20ce725570e09549fe738e02ca6b7e1e", size = 125794, upload-time = "2026-03-09T13:15:10.525Z" },
+    { url = "https://files.pythonhosted.org/packages/46/8a/b4ebe46ebaac6a303417fab10c2e165c557ddaff558f9699d302b256bc53/kiwisolver-1.5.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bc4d8e252f532ab46a1de9349e2d27b91fce46736a9eedaa37beaca66f574ed4", size = 67646, upload-time = "2026-03-09T13:15:12.016Z" },
+    { url = "https://files.pythonhosted.org/packages/60/35/10a844afc5f19d6f567359bf4789e26661755a2f36200d5d1ed8ad0126e5/kiwisolver-1.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6783e069732715ad0c3ce96dbf21dbc2235ab0593f2baf6338101f70371f4028", size = 65511, upload-time = "2026-03-09T13:15:13.311Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/8a/685b297052dd041dcebce8e8787b58923b6e78acc6115a0dc9189011c44b/kiwisolver-1.5.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7c4c09a490dc4d4a7f8cbee56c606a320f9dc28cf92a7157a39d1ce7676a657", size = 1584858, upload-time = "2026-03-09T13:15:15.103Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/80/04865e3d4638ac5bddec28908916df4a3075b8c6cc101786a96803188b96/kiwisolver-1.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a075bd7bd19c70cf67c8badfa36cf7c5d8de3c9ddb8420c51e10d9c50e94920", size = 1392539, upload-time = "2026-03-09T13:15:16.661Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/01/77a19cacc0893fa13fafa46d1bba06fb4dc2360b3292baf4b56d8e067b24/kiwisolver-1.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bdd3e53429ff02aa319ba59dfe4ceeec345bf46cf180ec2cf6fd5b942e7975e9", size = 1405310, upload-time = "2026-03-09T13:15:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/53/39/bcaf5d0cca50e604cfa9b4e3ae1d64b50ca1ae5b754122396084599ef903/kiwisolver-1.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3cdcb35dc9d807259c981a85531048ede628eabcffb3239adf3d17463518992d", size = 1456244, upload-time = "2026-03-09T13:15:20.444Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/7a/72c187abc6975f6978c3e39b7cf67aeb8b3c0a8f9790aa7fd412855e9e1f/kiwisolver-1.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:70d593af6a6ca332d1df73d519fddb5148edb15cd90d5f0155e3746a6d4fcc65", size = 1073154, upload-time = "2026-03-09T13:15:22.039Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/ca/cf5b25783ebbd59143b4371ed0c8428a278abe68d6d0104b01865b1bbd0f/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:377815a8616074cabbf3f53354e1d040c35815a134e01d7614b7692e4bf8acfa", size = 2334377, upload-time = "2026-03-09T13:15:23.741Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/e5/b1f492adc516796e88751282276745340e2a72dcd0d36cf7173e0daf3210/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0255a027391d52944eae1dbb5d4cc5903f57092f3674e8e544cdd2622826b3f0", size = 2425288, upload-time = "2026-03-09T13:15:25.789Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/e5/9b21fbe91a61b8f409d74a26498706e97a48008bfcd1864373d32a6ba31c/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:012b1eb16e28718fa782b5e61dc6f2da1f0792ca73bd05d54de6cb9561665fc9", size = 2063158, upload-time = "2026-03-09T13:15:27.63Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/02/83f47986138310f95ea95531f851b2a62227c11cbc3e690ae1374fe49f0f/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:0e3aafb33aed7479377e5e9a82e9d4bf87063741fc99fc7ae48b0f16e32bdd6f", size = 2597260, upload-time = "2026-03-09T13:15:29.421Z" },
+    { url = "https://files.pythonhosted.org/packages/07/18/43a5f24608d8c313dd189cf838c8e68d75b115567c6279de7796197cfb6a/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e7a116ae737f0000343218c4edf5bd45893bfeaff0993c0b215d7124c9f77646", size = 2394403, upload-time = "2026-03-09T13:15:31.517Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/b5/98222136d839b8afabcaa943b09bd05888c2d36355b7e448550211d1fca4/kiwisolver-1.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1dd9b0b119a350976a6d781e7278ec7aca0b201e1a9e2d23d9804afecb6ca681", size = 79687, upload-time = "2026-03-09T13:15:33.204Z" },
+    { url = "https://files.pythonhosted.org/packages/99/a2/ca7dc962848040befed12732dff6acae7fb3c4f6fc4272b3f6c9a30b8713/kiwisolver-1.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:58f812017cd2985c21fbffb4864d59174d4903dd66fa23815e74bbc7a0e2dd57", size = 70032, upload-time = "2026-03-09T13:15:34.411Z" },
+]
+
+[[package]]
 name = "lerobot"
 version = "0.5.2"
 source = { git = "https://github.com/huggingface/lerobot.git?rev=b5f65e533270015f33dc2f5f570b27dada96fbb1#b5f65e533270015f33dc2f5f570b27dada96fbb1" }
@@ -1053,6 +1235,12 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+async = [
+    { name = "contourpy" },
+    { name = "grpcio" },
+    { name = "matplotlib" },
+    { name = "protobuf" },
+]
 dataset = [
     { name = "av" },
     { name = "datasets" },
@@ -1268,6 +1456,53 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "matplotlib"
+version = "3.10.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "contourpy" },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/1b/4be5be87d43d327a0cf4de1a56e86f7f84c89312452406cf122efe2839e6/matplotlib-3.10.9.tar.gz", hash = "sha256:fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358", size = 34811233, upload-time = "2026-04-24T00:14:13.539Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/d3/8d4f6afbecb49fc04e060a57c0fce39ea51cc163a6bd87303ccd698e4fa6/matplotlib-3.10.9-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b580440f1ff81a0e34122051a3dfabb7e4b7f9e380629929bde0eff9af72165f", size = 8320331, upload-time = "2026-04-24T00:12:39.688Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d9/9e14bc7564bf92d5ffa801ae5fac819ce74b925dfb55e3ebde61a3bbad3e/matplotlib-3.10.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b1b745c489cd1a77a0dc1120a05dc87af9798faebc913601feb8c73d89bf2d1e", size = 8216461, upload-time = "2026-04-24T00:12:42.494Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/17/4402d0d14ccf1dfc70932600b68097fbbf9c898a4871d2cbbe79c7801a32/matplotlib-3.10.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8f3bcac1ca5ed000a6f4337d47ba67dfddf37ed6a46c15fd7f014997f7bf865f", size = 8790091, upload-time = "2026-04-24T00:12:44.789Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/0b/322aeec06dd9b91411f92028b37d447342770a24392aa4813e317064dad5/matplotlib-3.10.9-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7a8d66a55def891c33147ba3ba9bfcabf0b526a43764c818acbb4525e5ed0838", size = 9605027, upload-time = "2026-04-24T00:12:47.583Z" },
+    { url = "https://files.pythonhosted.org/packages/74/88/5f13482f55e7b00bcfc09838b093c2456e1379978d2a146844aae05350ad/matplotlib-3.10.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d843374407c4017a6403b59c6c81606773d136f3259d5b6da3131bc814542cc2", size = 9671269, upload-time = "2026-04-24T00:12:50.878Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/e0/0840fd2f93da988ec660b8ad1984abe9f25d2aed22a5e394ff1c68c88307/matplotlib-3.10.9-cp313-cp313-win_amd64.whl", hash = "sha256:f4399f64b3e94cd500195490972ae1ee81170df1636fa15364d157d5bdd7b921", size = 8217588, upload-time = "2026-04-24T00:12:53.784Z" },
+    { url = "https://files.pythonhosted.org/packages/47/b9/d706d06dd605c49b9f83a2aed8c13e3e5db70697d7a80b7e3d7915de6b17/matplotlib-3.10.9-cp313-cp313-win_arm64.whl", hash = "sha256:ba7b3b8ef09eab7df0e86e9ae086faa433efbfbdb46afcb3aa16aabf779469a8", size = 8136913, upload-time = "2026-04-24T00:12:56.501Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/45/6e32d96978264c8ca8c4b1010adb955a1a49cfaf314e212bbc8908f04a61/matplotlib-3.10.9-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:09218df8a93712bd6ea133e83a153c755448cf7868316c531cffcc43f69d1cc9", size = 8368019, upload-time = "2026-04-24T00:12:58.896Z" },
+    { url = "https://files.pythonhosted.org/packages/86/0a/c8e3d3bba245f0f7fc424937f8ff7ef77291a36af3edb97ccd78aa93d84f/matplotlib-3.10.9-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:82368699727bfb7b0182e1aa13082e3c08e092fa1a25d3e1fd92405bff96f6d4", size = 8264645, upload-time = "2026-04-24T00:13:01.406Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/aa/5bf5a14fe4fed73a4209a155606f8096ff797aad89c6c35179026571133e/matplotlib-3.10.9-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3225f4e1edcb8c86c884ddf79ebe20ecd0a67d30188f279897554ccd8fded4dc", size = 8802194, upload-time = "2026-04-24T00:13:03.702Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/5e/b4be852d6bba6fd15893fadf91ff26ae49cb91aac789e95dde9d342e664f/matplotlib-3.10.9-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:de2445a0c6690d21b7eb6ce071cebad6d40a2e9bdf10d039074a96ba19797b99", size = 9622684, upload-time = "2026-04-24T00:13:06.647Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/3d/ed428c971139112ef730f62770654d609467346d09d4b62617e1afd68a5a/matplotlib-3.10.9-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:b2b9516251cb89ff618d757daec0e2ed1bf21248013844a853d87ef85ab3081d", size = 9680790, upload-time = "2026-04-24T00:13:10.009Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/09/052e884aaf2b985c63cb79f715f1d5b6a3eaa7de78f6a52b9dbc077d5b53/matplotlib-3.10.9-cp313-cp313t-win_amd64.whl", hash = "sha256:e9fae004b941b23ff2edcf1567a857ed77bafc8086ffa258190462328434faf8", size = 8287571, upload-time = "2026-04-24T00:13:13.087Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/38/ae27288e788c35a4250491422f3db7750366fc8c97d6f36fbdecfc1f5518/matplotlib-3.10.9-cp313-cp313t-win_arm64.whl", hash = "sha256:6b63d9c7c769b88ab81e10dc86e4e0607cf56817b9f9e6cf24b2a5f1693b8e38", size = 8188292, upload-time = "2026-04-24T00:13:15.546Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/e6/3bd8afd04949f02eabc1c17115ea5255e19cacd4d06fc5abdde4eeb0052c/matplotlib-3.10.9-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:172db52c9e683f5d12eaf57f0f54834190e12581fe1cc2a19595a8f5acb4e77d", size = 8321276, upload-time = "2026-04-24T00:13:18.318Z" },
+    { url = "https://files.pythonhosted.org/packages/41/86/86231232fff41c9f8e4a1a7d7a597d349a02527109c3af7d618366122139/matplotlib-3.10.9-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:97e35e8d39ccc85859095e01a53847432ba9a53ddf7986f7a54a11b73d0e143f", size = 8218218, upload-time = "2026-04-24T00:13:20.974Z" },
+    { url = "https://files.pythonhosted.org/packages/85/8f/becc9722cafc64f5d2eb0b7c1bf5f585271c618a45dbd8fabeb021f898b6/matplotlib-3.10.9-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aba1615dabe83188e19d4f75a253c6a08423e04c1425e64039f800050a69de6b", size = 9608145, upload-time = "2026-04-24T00:13:23.228Z" },
+    { url = "https://files.pythonhosted.org/packages/32/5d/f7e914f7d9325abff4057cee62c0fa70263683189f774473cbfb534cd13b/matplotlib-3.10.9-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34cf8167e023ad956c15f36302911d5406bd99a9862c1a8499ea6f7c0e015dc2", size = 9885085, upload-time = "2026-04-24T00:13:25.849Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/fd/fa69f2221534e80cc5772ac2b7d222011a2acafc2ec7216d5dd174c864ae/matplotlib-3.10.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:59476c6d29d612b8e9bb6ce8c5b631be6ba8f9e3a2421f22a02b192c7dd28716", size = 9672358, upload-time = "2026-04-24T00:13:28.906Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/1a/5a4f747a8b271cbb024946d2dd3c913ab5032ba430626f8c3528ada96b4b/matplotlib-3.10.9-cp314-cp314-win_amd64.whl", hash = "sha256:336b9acc64d309063126edcdaca00db9373af3c476bb94388fe9c5a53ad13e6f", size = 8349970, upload-time = "2026-04-24T00:13:31.904Z" },
+    { url = "https://files.pythonhosted.org/packages/64/dc/95d60ecaefe30680a154b52ea96ab4b0dab547f1fd6aa12f5fb655e89cae/matplotlib-3.10.9-cp314-cp314-win_arm64.whl", hash = "sha256:2dc9477819ffd78ad12a20df1d9d6a6bd4fec6aaa9072681465fddca052f1456", size = 8272785, upload-time = "2026-04-24T00:13:34.511Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a0/005d68bc8b8418300ce6591f18586910a8526806e2ab663933d9f20a41e9/matplotlib-3.10.9-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:da4e09638420548f31c354032a6250e473c68e5a4e96899b4844cf39ddea23fe", size = 8367999, upload-time = "2026-04-24T00:13:36.962Z" },
+    { url = "https://files.pythonhosted.org/packages/22/05/1236cc9290be70b2498af20ca348add76e3fffe7f67b477db5133a84f3ea/matplotlib-3.10.9-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:345f6f68ecc8da0ca56fad2ea08fde1a115eda530079eca185d50a7bc3e146c6", size = 8264543, upload-time = "2026-04-24T00:13:39.851Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/c2/071f5a5ff6c5bd63aaaf2f45c811d9bf2ced94bde188d9e1a519e21d0cba/matplotlib-3.10.9-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4edcfbd8565339aa62f1cd4012f7180926fdbe71850f7b0d3c379c175cd6b66c", size = 9622800, upload-time = "2026-04-24T00:13:42.296Z" },
+    { url = "https://files.pythonhosted.org/packages/95/57/da7d1f10a85624b9e7db68e069dd94e58dc41dbf9463c5921632ecbe3661/matplotlib-3.10.9-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6be157fe17fc37cb95ac1d7374cf717ce9259616edec911a78d9d26dae8522d4", size = 9888561, upload-time = "2026-04-24T00:13:45.026Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b2/ef8d6bb59b0edb6c16c968b70f548aa13b54348972def5aa6ac85df67145/matplotlib-3.10.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4e42042d54db34fda4e95a7bd3e5789c2a995d2dad3eb8850232ee534092fbbf", size = 9680884, upload-time = "2026-04-24T00:13:48.066Z" },
+    { url = "https://files.pythonhosted.org/packages/61/1c/d21bfeb9931881ebe96bcfcff27c7ae4b160ae0ec291a714c42641a56d75/matplotlib-3.10.9-cp314-cp314t-win_amd64.whl", hash = "sha256:c27df8b3848f32a83d1767566595e43cfaa4460380974da06f4279a7ec143c39", size = 8432333, upload-time = "2026-04-24T00:13:51.008Z" },
+    { url = "https://files.pythonhosted.org/packages/78/23/92493c3e6e1b635ccfff146f7b99e674808787915420373ac399283764c2/matplotlib-3.10.9-cp314-cp314t-win_arm64.whl", hash = "sha256:a49f1eadc84ca85fd72fa4e89e70e61bf86452df6f971af04b12c60761a0772c", size = 8324785, upload-time = "2026-04-24T00:13:53.633Z" },
 ]
 
 [[package]]
@@ -2025,6 +2260,20 @@ wheels = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "6.31.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/f3/b9655a711b32c19720253f6f06326faf90580834e2e83f840472d752bc8b/protobuf-6.31.1.tar.gz", hash = "sha256:d8cac4c982f0b957a4dc73a80e2ea24fab08e679c0de9deb835f4a12d69aca9a", size = 441797, upload-time = "2025-05-28T19:25:54.947Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/6f/6ab8e4bf962fd5570d3deaa2d5c38f0a363f57b4501047b5ebeb83ab1125/protobuf-6.31.1-cp310-abi3-win32.whl", hash = "sha256:7fa17d5a29c2e04b7d90e5e32388b8bfd0e7107cd8e616feef7ed3fa6bdab5c9", size = 423603, upload-time = "2025-05-28T19:25:41.198Z" },
+    { url = "https://files.pythonhosted.org/packages/44/3a/b15c4347dd4bf3a1b0ee882f384623e2063bb5cf9fa9d57990a4f7df2fb6/protobuf-6.31.1-cp310-abi3-win_amd64.whl", hash = "sha256:426f59d2964864a1a366254fa703b8632dcec0790d8862d30034d8245e1cd447", size = 435283, upload-time = "2025-05-28T19:25:44.275Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c9/b9689a2a250264a84e66c46d8862ba788ee7a641cdca39bccf64f59284b7/protobuf-6.31.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:6f1227473dc43d44ed644425268eb7c2e488ae245d51c6866d19fe158e207402", size = 425604, upload-time = "2025-05-28T19:25:45.702Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a1/7a5a94032c83375e4fe7e7f56e3976ea6ac90c5e85fac8576409e25c39c3/protobuf-6.31.1-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:a40fc12b84c154884d7d4c4ebd675d5b3b5283e155f324049ae396b95ddebc39", size = 322115, upload-time = "2025-05-28T19:25:47.128Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/b1/b59d405d64d31999244643d88c45c8241c58f17cc887e73bcb90602327f8/protobuf-6.31.1-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:4ee898bf66f7a8b0bd21bce523814e6fbd8c6add948045ce958b73af7e8878c6", size = 321070, upload-time = "2025-05-28T19:25:50.036Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/af/ab3c51ab7507a7325e98ffe691d9495ee3d3aa5f589afad65ec920d39821/protobuf-6.31.1-py3-none-any.whl", hash = "sha256:720a6c7e6b77288b85063569baae8536671b39f15cc22037ec7045658d80489e", size = 168724, upload-time = "2025-05-28T19:25:53.926Z" },
+]
+
+[[package]]
 name = "pyarrow"
 version = "24.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2167,6 +2416,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/16/912b7225d56284859cd9a672827f18be43f8012f8b7b932bc4bd959a298e/pyopengl-3.1.10.tar.gz", hash = "sha256:c4a02d6866b54eb119c8e9b3fb04fa835a95ab802dd96607ab4cdb0012df8335", size = 1915580, upload-time = "2025-08-18T02:33:01.76Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/e4/1ba6f44e491c4eece978685230dde56b14d51a0365bc1b774ddaa94d14cd/pyopengl-3.1.10-py3-none-any.whl", hash = "sha256:794a943daced39300879e4e47bd94525280685f42dbb5a998d336cfff151d74f", size = 3194996, upload-time = "2025-08-18T02:32:59.902Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Large refactor of the live robot execution path (new subprocesses, multi-threaded control/observation loops, and new action aggregation), which could affect safety/behavior timing on real hardware despite added safeguards.
> 
> **Overview**
> `axol run-policy` is reworked to use LeRobot `async_inference` with an auto-launched localhost `PolicyServer`, a custom `AxolRobotClient` that decouples action streaming from observation sending, and an ACT-style `temporal_ensemble` chunk aggregator to reduce jitter/freezes at chunk boundaries.
> 
> Rollout saving is revamped: episodes end on `s/r/q` keypress (with `--episode-time-s` as a safety cap), optional dataset capture runs on a dedicated thread using the latest executed action snapshot, and datasets can now be resumed/validated similarly to `collect-data` (including auto-cleanup of empty new datasets).
> 
> Robot robustness is improved via collision-aware return-to-rest using an IK worker subprocess, cleaner handling of hardware errors (exit non-zero without long tracebacks), timestamp-aligned camera sampling in `AxolRobot.get_observation`, and ZED stream resilience (async recovery enabled plus throttled warnings/backoff on grab failures). `--*-stiffness` parsing is deduplicated into `shared.parse_stiffness` and reused across CLIs, and the optional `lerobot` dependency now enables the `async` extra.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00d9c3cde2442bc9d65f3ea534ee18ed75dde115. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->