### PR TITLE
fix camera stream and inference improvements

### DIFF
--- a/almond_axol/cli/run_policy.py
+++ b/almond_axol/cli/run_policy.py
@@ -1096,6 +1096,9 @@ def _run(
                 repo_id=repo_id,
                 root=str(dataset_root),
                 image_writer_threads=4,
+                streaming_encoding=True,
+                encoder_threads=4,
+                vcodec="auto",
             )
             resumed_dataset = True
         else:
@@ -1109,6 +1112,9 @@ def _run(
                 robot_type=robot.name,
                 use_videos=True,
                 image_writer_threads=4,
+                streaming_encoding=True,
+                encoder_threads=4,
+                vcodec="auto",
             )
 
     if rerun_ip:

--- a/almond_axol/zed/streamer.py
+++ b/almond_axol/zed/streamer.py
@@ -172,6 +172,23 @@ class ZedStreamer:
             )
             return None
 
+        opened_serial = int(zed.get_camera_information().serial_number)
+        if opened_serial != serial:
+            _logger.warning(
+                "%s: requested serial %d (camera_id %d) but SDK opened serial %d",
+                name,
+                serial,
+                camera_id,
+                opened_serial,
+            )
+        else:
+            _logger.info(
+                "%s: opened camera serial %d (camera_id %d)",
+                name,
+                opened_serial,
+                camera_id,
+            )
+
         stream_params = sl.StreamingParameters()
         stream_params.codec = sl.STREAMING_CODEC.H265
         stream_params.bitrate = self._config.bitrate

--- a/almond_axol/zed/streamer.py
+++ b/almond_axol/zed/streamer.py
@@ -89,33 +89,32 @@ class ZedStreamer:
         ]
 
         devices = sl.CameraOne.get_device_list()
-        serial_to_id: dict[int, int] = {
-            int(d.serial_number): int(d.id) for d in devices
-        }
+        available_serials = {int(d.serial_number) for d in devices}
         _logger.info(
             "Detected %d ZED-X One camera(s): %s",
             len(devices),
-            ", ".join(f"serial={int(d.serial_number)} id={int(d.id)}" for d in devices)
-            or "<none>",
+            ", ".join(str(int(d.serial_number)) for d in devices) or "<none>",
         )
 
-        resolved_specs: list[tuple[str, int, int, int]] = []
+        resolved_specs: list[tuple[str, int, int]] = []
         for name, serial, port in specs:
-            camera_id = serial_to_id.get(int(serial))
-            if camera_id is None:
+            if int(serial) not in available_serials:
                 _logger.error(
                     "Requested %s serial %d not found in device list; skipping.",
                     name,
                     serial,
                 )
                 continue
-            resolved_specs.append((name, serial, camera_id, port))
+            resolved_specs.append((name, serial, port))
 
+        # Open cameras sequentially: the ZED SDK's open() + enable_streaming()
+        # path touches shared NVENC state on Jetson and isn't safe to call
+        # concurrently across sl.CameraOne instances.
         loop = asyncio.get_running_loop()
         states: list[_CameraState | None] = []
-        for name, serial, camera_id, port in resolved_specs:
+        for name, serial, port in resolved_specs:
             state = await loop.run_in_executor(
-                None, self._open_camera, name, serial, camera_id, port
+                None, self._open_camera, name, serial, port
             )
             states.append(state)
 
@@ -151,9 +150,7 @@ class ZedStreamer:
     # Internal (runs in thread-pool executor)
     # ------------------------------------------------------------------
 
-    def _open_camera(
-        self, name: str, serial: int, camera_id: int, port: int
-    ) -> _CameraState | None:
+    def _open_camera(self, name: str, serial: int, port: int) -> _CameraState | None:
         zed = sl.CameraOne()
 
         init_params = sl.InitParametersOne()
@@ -163,31 +160,19 @@ class ZedStreamer:
 
         err = zed.open(init_params)
         if err != sl.ERROR_CODE.SUCCESS:
-            _logger.error(
-                "Failed to open %s (serial %d, camera_id %d): %s",
-                name,
-                serial,
-                camera_id,
-                err,
-            )
+            _logger.error("Failed to open %s (serial %d): %s", name, serial, err)
             return None
 
         opened_serial = int(zed.get_camera_information().serial_number)
         if opened_serial != serial:
             _logger.warning(
-                "%s: requested serial %d (camera_id %d) but SDK opened serial %d",
+                "%s: requested serial %d but SDK opened serial %d",
                 name,
                 serial,
-                camera_id,
                 opened_serial,
             )
-        else:
-            _logger.info(
-                "%s: opened camera serial %d (camera_id %d)",
-                name,
-                opened_serial,
-                camera_id,
-            )
+            zed.close()
+            return None
 
         stream_params = sl.StreamingParameters()
         stream_params.codec = sl.STREAMING_CODEC.H265
@@ -218,10 +203,9 @@ class ZedStreamer:
         state.thread = thread
 
         _logger.info(
-            "Streaming %s (serial %d, camera_id %d) on port %d at %s %dfps %dkbps",
+            "Streaming %s (serial %d) on port %d at %s %dfps %dkbps",
             name,
             serial,
-            camera_id,
             port,
             self._config.resolution,
             self._config.fps,

--- a/almond_axol/zed/streamer.py
+++ b/almond_axol/zed/streamer.py
@@ -88,34 +88,42 @@ class ZedStreamer:
             if serial is not None
         ]
 
+        # Resolve each requested serial to its physical GMSL port. On
+        # ZED-X One both set_from_serial_number(serial) and
+        # set_from_camera_id(id) are silently ignored (every open() returns
+        # the first enumerated camera). The selector that actually works on
+        # GMSL2 capture cards is set_from_serial_port(gmsl_port).
         devices = sl.CameraOne.get_device_list()
-        serial_to_id: dict[int, int] = {
-            int(d.serial_number): int(d.id) for d in devices
+        serial_to_gmsl: dict[int, int] = {
+            int(d.serial_number): int(d.gmsl_port) for d in devices
         }
         _logger.info(
             "Detected %d ZED-X One camera(s): %s",
             len(devices),
-            ", ".join(f"serial={int(d.serial_number)} id={int(d.id)}" for d in devices)
+            ", ".join(
+                f"serial={int(d.serial_number)} gmsl_port={int(d.gmsl_port)} id={int(d.id)}"
+                for d in devices
+            )
             or "<none>",
         )
 
         resolved_specs: list[tuple[str, int, int, int]] = []
         for name, serial, port in specs:
-            camera_id = serial_to_id.get(int(serial))
-            if camera_id is None:
+            gmsl_port = serial_to_gmsl.get(int(serial))
+            if gmsl_port is None:
                 _logger.error(
                     "Requested %s serial %d not found in device list; skipping.",
                     name,
                     serial,
                 )
                 continue
-            resolved_specs.append((name, serial, camera_id, port))
+            resolved_specs.append((name, serial, gmsl_port, port))
 
         loop = asyncio.get_running_loop()
         states: list[_CameraState | None] = []
-        for name, serial, camera_id, port in resolved_specs:
+        for name, serial, gmsl_port, port in resolved_specs:
             state = await loop.run_in_executor(
-                None, self._open_camera, name, serial, camera_id, port
+                None, self._open_camera, name, serial, gmsl_port, port
             )
             states.append(state)
 
@@ -152,22 +160,22 @@ class ZedStreamer:
     # ------------------------------------------------------------------
 
     def _open_camera(
-        self, name: str, serial: int, camera_id: int, port: int
+        self, name: str, serial: int, gmsl_port: int, port: int
     ) -> _CameraState | None:
         zed = sl.CameraOne()
 
         init_params = sl.InitParametersOne()
         init_params.camera_resolution = self._config.resolution
         init_params.camera_fps = self._config.fps
-        init_params.input.set_from_camera_id(camera_id)
+        init_params.input.set_from_serial_port(gmsl_port)
 
         err = zed.open(init_params)
         if err != sl.ERROR_CODE.SUCCESS:
             _logger.error(
-                "Failed to open %s (serial %d, camera_id %d): %s",
+                "Failed to open %s (serial %d, gmsl_port %d): %s",
                 name,
                 serial,
-                camera_id,
+                gmsl_port,
                 err,
             )
             return None
@@ -175,18 +183,18 @@ class ZedStreamer:
         opened_serial = int(zed.get_camera_information().serial_number)
         if opened_serial != serial:
             _logger.warning(
-                "%s: requested serial %d (camera_id %d) but SDK opened serial %d",
+                "%s: requested serial %d (gmsl_port %d) but SDK opened serial %d",
                 name,
                 serial,
-                camera_id,
+                gmsl_port,
                 opened_serial,
             )
         else:
             _logger.info(
-                "%s: opened camera serial %d (camera_id %d)",
+                "%s: opened camera serial %d (gmsl_port %d)",
                 name,
                 opened_serial,
-                camera_id,
+                gmsl_port,
             )
 
         stream_params = sl.StreamingParameters()
@@ -218,10 +226,10 @@ class ZedStreamer:
         state.thread = thread
 
         _logger.info(
-            "Streaming %s (serial %d, camera_id %d) on port %d at %s %dfps %dkbps",
+            "Streaming %s (serial %d, gmsl_port %d) on port %d at %s %dfps %dkbps",
             name,
             serial,
-            camera_id,
+            gmsl_port,
             port,
             self._config.resolution,
             self._config.fps,

--- a/almond_axol/zed/streamer.py
+++ b/almond_axol/zed/streamer.py
@@ -159,7 +159,7 @@ class ZedStreamer:
         init_params = sl.InitParametersOne()
         init_params.camera_resolution = self._config.resolution
         init_params.camera_fps = self._config.fps
-        init_params.input.set_from_camera_id(camera_id, sl.BUS_TYPE.GMSL)
+        init_params.set_from_serial_number(serial)
 
         err = zed.open(init_params)
         if err != sl.ERROR_CODE.SUCCESS:

--- a/almond_axol/zed/streamer.py
+++ b/almond_axol/zed/streamer.py
@@ -88,42 +88,34 @@ class ZedStreamer:
             if serial is not None
         ]
 
-        # Resolve each requested serial to its physical GMSL port. On
-        # ZED-X One both set_from_serial_number(serial) and
-        # set_from_camera_id(id) are silently ignored (every open() returns
-        # the first enumerated camera). The selector that actually works on
-        # GMSL2 capture cards is set_from_serial_port(gmsl_port).
         devices = sl.CameraOne.get_device_list()
-        serial_to_gmsl: dict[int, int] = {
-            int(d.serial_number): int(d.gmsl_port) for d in devices
+        serial_to_id: dict[int, int] = {
+            int(d.serial_number): int(d.id) for d in devices
         }
         _logger.info(
             "Detected %d ZED-X One camera(s): %s",
             len(devices),
-            ", ".join(
-                f"serial={int(d.serial_number)} gmsl_port={int(d.gmsl_port)} id={int(d.id)}"
-                for d in devices
-            )
+            ", ".join(f"serial={int(d.serial_number)} id={int(d.id)}" for d in devices)
             or "<none>",
         )
 
         resolved_specs: list[tuple[str, int, int, int]] = []
         for name, serial, port in specs:
-            gmsl_port = serial_to_gmsl.get(int(serial))
-            if gmsl_port is None:
+            camera_id = serial_to_id.get(int(serial))
+            if camera_id is None:
                 _logger.error(
                     "Requested %s serial %d not found in device list; skipping.",
                     name,
                     serial,
                 )
                 continue
-            resolved_specs.append((name, serial, gmsl_port, port))
+            resolved_specs.append((name, serial, camera_id, port))
 
         loop = asyncio.get_running_loop()
         states: list[_CameraState | None] = []
-        for name, serial, gmsl_port, port in resolved_specs:
+        for name, serial, camera_id, port in resolved_specs:
             state = await loop.run_in_executor(
-                None, self._open_camera, name, serial, gmsl_port, port
+                None, self._open_camera, name, serial, camera_id, port
             )
             states.append(state)
 
@@ -160,22 +152,22 @@ class ZedStreamer:
     # ------------------------------------------------------------------
 
     def _open_camera(
-        self, name: str, serial: int, gmsl_port: int, port: int
+        self, name: str, serial: int, camera_id: int, port: int
     ) -> _CameraState | None:
         zed = sl.CameraOne()
 
         init_params = sl.InitParametersOne()
         init_params.camera_resolution = self._config.resolution
         init_params.camera_fps = self._config.fps
-        init_params.input.set_from_serial_port(gmsl_port)
+        init_params.input.set_from_camera_id(camera_id, sl.BUS_TYPE.GMSL)
 
         err = zed.open(init_params)
         if err != sl.ERROR_CODE.SUCCESS:
             _logger.error(
-                "Failed to open %s (serial %d, gmsl_port %d): %s",
+                "Failed to open %s (serial %d, camera_id %d): %s",
                 name,
                 serial,
-                gmsl_port,
+                camera_id,
                 err,
             )
             return None
@@ -183,18 +175,18 @@ class ZedStreamer:
         opened_serial = int(zed.get_camera_information().serial_number)
         if opened_serial != serial:
             _logger.warning(
-                "%s: requested serial %d (gmsl_port %d) but SDK opened serial %d",
+                "%s: requested serial %d (camera_id %d) but SDK opened serial %d",
                 name,
                 serial,
-                gmsl_port,
+                camera_id,
                 opened_serial,
             )
         else:
             _logger.info(
-                "%s: opened camera serial %d (gmsl_port %d)",
+                "%s: opened camera serial %d (camera_id %d)",
                 name,
                 opened_serial,
-                gmsl_port,
+                camera_id,
             )
 
         stream_params = sl.StreamingParameters()
@@ -226,10 +218,10 @@ class ZedStreamer:
         state.thread = thread
 
         _logger.info(
-            "Streaming %s (serial %d, gmsl_port %d) on port %d at %s %dfps %dkbps",
+            "Streaming %s (serial %d, camera_id %d) on port %d at %s %dfps %dkbps",
             name,
             serial,
-            gmsl_port,
+            camera_id,
             port,
             self._config.resolution,
             self._config.fps,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes ZED camera selection/opening behavior and adds streaming video encoding settings during dataset create/resume, which can affect hardware bring-up and rollout recording performance.
> 
> **Overview**
> Improves rollout recording and camera bring-up reliability.
> 
> `run_policy` now enables LeRobot dataset *streaming video encoding* when creating or resuming a dataset (sets `streaming_encoding`, `encoder_threads`, and `vcodec="auto"`) to speed up/streamline video writes during rollouts.
> 
> `ZedStreamer` switches camera resolution from SDK camera IDs to explicit serial-number opens, verifies the SDK actually opened the requested serial, and avoids concurrent camera `open()`/`enable_streaming()` by opening cameras sequentially to prevent Jetson NVENC contention; logging is updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db4df9a1f1182cda4440542ef362ecf3fa5e0309. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->