### PR TITLE
fix reset pose

### DIFF
--- a/README.md
+++ b/README.md
@@ -765,7 +765,7 @@ See `teleop --robot axol` in [Teleoperation](#teleoperation) for the equivalent 
 | `pose_min_cutoff` | `1.5` Hz | One Euro Filter tremor cutoff for raw VR poses |
 | `pose_beta` | `5.0` | One Euro Filter speed coefficient (raises cutoff during fast moves) |
 | `reset_speed` | `0.1 rev/s` | Average joint velocity of the worst-case joint during return-to-rest (peak is `1.5×` this) |
-| `reset_min_duration` | `0.5` s | Floor on return-to-rest duration so near-rest starts don't snap home |
+| `reset_min_duration` | `1.5` s | Floor on return-to-rest duration so near-rest starts don't snap home |
 | `rest_pose_left` / `rest_pose_right` | near-zero | Reset target for each arm, shape `(7,)` in `ARM_JOINTS` order |
 
 **Deadman switch behaviour.** Grip is a toggle, not a hold. Press both grip buttons together to enable arm movement; press either grip alone to freeze the arms. A rising edge on the reset button triggers a collision-aware trajectory back to the rest pose.

--- a/README.md
+++ b/README.md
@@ -761,11 +761,11 @@ See `teleop --robot axol` in [Teleoperation](#teleoperation) for the equivalent 
 | `teleop_max_accel` | `3.5 rev/s²` | Trapezoidal filter acceleration cap |
 | `engage_max_vel` | `0.1 rev/s` | Slower velocity limit when the deadman switch is first pressed after a reset |
 | `engage_duration` | `1.0` s | How long `engage_max_vel` is held before restoring `teleop_max_vel` |
-| `startup_max_accel` | `0.3 rev/s²` | Gentler accel during the initial startup move to rest pose |
 | `ik_alpha` | `0.5` | EMA blend factor on IK output; `1.0` disables smoothing |
 | `pose_min_cutoff` | `1.5` Hz | One Euro Filter tremor cutoff for raw VR poses |
 | `pose_beta` | `5.0` | One Euro Filter speed coefficient (raises cutoff during fast moves) |
-| `reset_speed` | `0.1 rev/s` | Speed of the collision-aware return-to-rest trajectory |
+| `reset_speed` | `0.1 rev/s` | Average joint velocity of the worst-case joint during return-to-rest (peak is `1.5×` this) |
+| `reset_min_duration` | `0.5` s | Floor on return-to-rest duration so near-rest starts don't snap home |
 | `rest_pose_left` / `rest_pose_right` | near-zero | Reset target for each arm, shape `(7,)` in `ARM_JOINTS` order |
 
 **Deadman switch behaviour.** Grip is a toggle, not a hold. Press both grip buttons together to enable arm movement; press either grip alone to freeze the arms. A rising edge on the reset button triggers a collision-aware trajectory back to the rest pose.

--- a/almond_axol/cli/tune/repeatability.py
+++ b/almond_axol/cli/tune/repeatability.py
@@ -41,7 +41,7 @@ from ...teleop.trajectory import plan_collision_aware_trajectory
 
 _RATE_HZ = 100.0
 _PLAN_SPEED = 0.1 * np.pi  # rad/s — joint-space speed for the planned trajectory
-_PLAN_MIN_DURATION = 0.5  # seconds — floor matches VRTeleopConfig.reset_min_duration
+_PLAN_MIN_DURATION = 0.5  # seconds — floor on planned trajectory duration
 
 
 # ---------------------------------------------------------------------------

--- a/almond_axol/cli/tune/repeatability.py
+++ b/almond_axol/cli/tune/repeatability.py
@@ -27,24 +27,21 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import functools
 import logging
 import time
 
-import jax
-import jax.numpy as jnp
-import jaxls
 import numpy as np
-import pyroki as pk
 
 from ...kinematics.solver import KinematicsSolver
 from ...robot import Axol
 from ...robot.config import AxolConfig
 from ...shared import ARM_JOINTS, Joint
 from ...teleop.config import VRTeleopConfig
+from ...teleop.trajectory import plan_collision_aware_trajectory
 
 _RATE_HZ = 100.0
 _PLAN_SPEED = 0.1 * np.pi  # rad/s — joint-space speed for the planned trajectory
+_PLAN_MIN_DURATION = 0.5  # seconds — floor matches VRTeleopConfig.reset_min_duration
 
 
 # ---------------------------------------------------------------------------
@@ -89,55 +86,6 @@ def _build_q_touch(solver: KinematicsSolver) -> np.ndarray:
 # ---------------------------------------------------------------------------
 
 
-@functools.partial(jax.jit, static_argnames=("max_iterations",))
-def _solve_path_step(
-    robot: pk.Robot,
-    robot_coll: pk.collision.RobotCollision,
-    q_interp: jax.Array,
-    q_current: jax.Array,
-    rest_weight: float,
-    limit_weight: float,
-    collision_margin: float,
-    collision_weight: float,
-    max_iterations: int,
-) -> jax.Array:
-    """One IK step toward ``q_interp`` with limit + self-collision costs.
-
-    Mirrors :func:`almond_axol.teleop.worker._solve_reset_step` — the
-    trajectory here is generated the same way (smoothstep slerp through
-    pyroki) but as a one-shot offline plan rather than a live feedback
-    loop.
-    """
-    JointVar = robot.joint_var_cls
-    costs = [
-        pk.costs.rest_cost(JointVar(0), rest_pose=q_interp, weight=rest_weight),
-        pk.costs.limit_cost(robot, JointVar(0), weight=limit_weight),
-        pk.costs.self_collision_cost(
-            robot,
-            robot_coll,
-            JointVar(0),
-            margin=collision_margin,
-            weight=collision_weight,
-        ),
-    ]
-    var_joints = JointVar(jnp.array([0]))
-    initial_vals = jaxls.VarValues.make(
-        [var_joints.with_value(q_current[jnp.newaxis, :])]
-    )
-    problem = jaxls.LeastSquaresProblem(costs, [var_joints])
-    solution_vals = problem.analyze().solve(
-        initial_vals=initial_vals,
-        verbose=False,
-        linear_solver="dense_cholesky",
-        trust_region=jaxls.TrustRegionConfig(),
-        termination=jaxls.TerminationConfig(
-            max_iterations=max_iterations,
-            cost_tolerance=1e-2,
-        ),
-    )
-    return solution_vals[var_joints][0]
-
-
 def _plan_trajectory(
     solver: KinematicsSolver,
     q_from: np.ndarray,
@@ -147,41 +95,22 @@ def _plan_trajectory(
 ) -> list[np.ndarray]:
     """Collision-aware joint-space slerp from ``q_from`` to ``q_to``.
 
-    Smoothsteps a linear interpolation in joint space and projects each
-    waypoint with limit + self-collision costs so the body never clips
-    the torso during the arc. Returns one full ``(N,)`` joint vector per
-    control tick at ``rate_hz``.
+    Thin wrapper around :func:`plan_collision_aware_trajectory` — the
+    single source of truth shared with the live reset path. Smoothsteps
+    a linear interpolation in joint space and projects each waypoint
+    with limit + self-collision costs so the body never clips the torso
+    during the arc. Returns one full ``(N,)`` joint vector per control
+    tick at ``rate_hz``.
     """
-    max_dist = float(np.max(np.abs(q_from - q_to)))
-    duration = max(max_dist / speed_rad_s, 0.5)
-    n_steps = max(2, round(duration * rate_hz))
-
-    rest_weight = 50.0
-    limit_weight = 100.0
-    collision_margin = 0.025
-    collision_weight = 100.0
-    max_iters = 10
-
-    traj: list[np.ndarray] = []
-    q = q_from.astype(np.float32).copy()
-    for i in range(n_steps):
-        t = (i + 1) / n_steps
-        alpha = t * t * (3.0 - 2.0 * t)
-        q_interp = (q_from * (1.0 - alpha) + q_to * alpha).astype(np.float32)
-        q_jax = _solve_path_step(
-            solver.robot,
-            solver.robot_coll,
-            jnp.asarray(q_interp),
-            jnp.asarray(q),
-            rest_weight,
-            limit_weight,
-            collision_margin,
-            collision_weight,
-            max_iters,
-        )
-        q = np.asarray(q_jax, dtype=np.float32)
-        traj.append(q.copy())
-    return traj
+    return plan_collision_aware_trajectory(
+        solver.robot,
+        solver.robot_coll,
+        q_from,
+        q_to,
+        speed=speed_rad_s,
+        rate=rate_hz,
+        min_duration=_PLAN_MIN_DURATION,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/almond_axol/lerobot/teleop/teleop_vr.py
+++ b/almond_axol/lerobot/teleop/teleop_vr.py
@@ -463,7 +463,6 @@ class AxolVRTeleop(Teleoperator):
             out[15] = r_grip
             return out
 
-        # ----- Normal teleop: smooth the IK output -----
         l_grip = self._l_grip
         r_grip = self._r_grip
 

--- a/almond_axol/lerobot/teleop/teleop_vr.py
+++ b/almond_axol/lerobot/teleop/teleop_vr.py
@@ -439,18 +439,33 @@ class AxolVRTeleop(Teleoperator):
         if q is None:
             return self._q_out
 
-        l_grip = self._l_grip
-        r_grip = self._r_grip
-
         if self._reset_interp.is_active():
             new_q, l_grip, r_grip, done = self._reset_interp.step()
-            if new_q is not None:
-                q = np.asarray(new_q, dtype=np.float32)
-                if done:
-                    self._q = q.copy()
-                    self._l_grip = l_grip
-                    self._r_grip = r_grip
-                    self._at_rest = True
+            if new_q is None:
+                return self._q_out
+            q = np.asarray(new_q, dtype=np.float32)
+            if done:
+                self._q = q.copy()
+                self._l_grip = l_grip
+                self._r_grip = r_grip
+                self._at_rest = True
+                seed_l = np.append(q[self._left_indices], l_grip)
+                seed_r = np.append(q[self._right_indices], r_grip)
+                self._ema_left.reset(seed=seed_l)
+                self._ema_right.reset(seed=seed_r)
+                self._smooth_left.reset(seed=q[self._left_indices])
+                self._smooth_right.reset(seed=q[self._right_indices])
+
+            out = np.empty(16, dtype=np.float32)
+            out[:7] = q[self._left_indices]
+            out[7] = l_grip
+            out[8:15] = q[self._right_indices]
+            out[15] = r_grip
+            return out
+
+        # ----- Normal teleop: smooth the IK output -----
+        l_grip = self._l_grip
+        r_grip = self._r_grip
 
         ema_l = self._ema_left.update(np.append(q[self._left_indices], l_grip))
         ema_r = self._ema_right.update(np.append(q[self._right_indices], r_grip))
@@ -480,11 +495,6 @@ class AxolVRTeleop(Teleoperator):
         while True:
             t0 = time.perf_counter()
 
-            # Process a pending reset before checking for VR frames so it fires
-            # even without a live headset.  _reset_latched is cleared only in the
-            # finally block — after the IK subprocess responds and the trajectory is
-            # armed — so is_resetting() stays True throughout the async IK call and
-            # the collect_data reset loop cannot exit prematurely.
             if (
                 self._reset_latched
                 and not self._reset_interp.is_active()
@@ -499,13 +509,10 @@ class AxolVRTeleop(Teleoperator):
                             self._reset_interp.set_trajectory(
                                 trajectory, self._l_grip, self._r_grip
                             )
-                            self._ema_left.reset()
-                            self._ema_right.reset()
-                            self._smooth_left.reset()
-                            self._smooth_right.reset()
                             self._teleop_enabled = False
                             self._prev_both = False
                             self._prev_either = False
+                            self._engage_time = None
                             self._at_rest = True
                         self._q = np.asarray(q_default, dtype=np.float32)
                 except Exception as e:

--- a/almond_axol/teleop/config.py
+++ b/almond_axol/teleop/config.py
@@ -27,7 +27,7 @@ class VRTeleopConfig:
         reset_min_duration: Floor (seconds) on the return-to-rest trajectory
             duration. Prevents near-rest starts from snapping home in a
             handful of frames and gives every reset a consistent minimum
-            feel regardless of starting pose. Defaults to ``0.5`` s.
+            feel regardless of starting pose. Defaults to ``1.5`` s.
         reset_rest_weight: Cost weight penalising deviation from the reset
             target pose during collision-aware trajectory generation.
         reset_limit_weight: Cost weight penalising joint-limit violations

--- a/almond_axol/teleop/config.py
+++ b/almond_axol/teleop/config.py
@@ -19,8 +19,15 @@ class VRTeleopConfig:
             ARM_JOINTS order (no gripper). Used as the reset target.
         frequency: Control loop rate in Hz used by :meth:`VRTeleop.run` and
             as waypoint density for reset trajectories.
-        reset_speed: Speed of the reset move in rad/s. Determines the number
-            of trajectory waypoints based on the distance to the rest pose.
+        reset_speed: Average joint velocity (rad/s) of the worst-case joint
+            during a return-to-rest move. The smoothstep profile gives a
+            peak joint velocity of ``1.5 * reset_speed``. Determines the
+            number of trajectory waypoints based on the distance to the
+            rest pose, subject to ``reset_min_duration`` below.
+        reset_min_duration: Floor (seconds) on the return-to-rest trajectory
+            duration. Prevents near-rest starts from snapping home in a
+            handful of frames and gives every reset a consistent minimum
+            feel regardless of starting pose. Defaults to ``0.5`` s.
         reset_rest_weight: Cost weight penalising deviation from the reset
             target pose during collision-aware trajectory generation.
         reset_limit_weight: Cost weight penalising joint-limit violations
@@ -30,11 +37,6 @@ class VRTeleopConfig:
         reset_collision_weight: Cost weight on self-collision penalty during
             reset trajectory generation.
         reset_max_iterations: Maximum solver iterations per reset waypoint.
-        startup_max_accel: Maximum joint acceleration (rad/s²) used only during
-            the initial startup trajectory (current pose → rest pose).  Motors
-            are cold at this point and respond sharply; a gentler ramp avoids
-            the initial jerk.  Restored to ``teleop_max_accel`` once the
-            startup trajectory completes.  Defaults to 0.3 rev/s².
         engage_max_vel: Maximum joint velocity (rad/s) used by the
             trapezoidal filter when the deadman switch is first pressed after a
             rest-pose trajectory (startup or reset).  Slows the transition from
@@ -102,12 +104,12 @@ class VRTeleopConfig:
     )
     frequency: float = 120.0
     reset_speed: float = 0.1 * 2 * math.pi
+    reset_min_duration: float = 1.5
     reset_rest_weight: float = 50.0
     reset_limit_weight: float = 100.0
     reset_collision_margin: float = 0.025
     reset_collision_weight: float = 100.0
     reset_max_iterations: int = 10
-    startup_max_accel: float = 0.3 * 2 * math.pi
     engage_max_vel: float = 0.1 * 2 * math.pi
     engage_duration: float = 1.0
     teleop_max_vel: float = 1.0 * 2 * math.pi

--- a/almond_axol/teleop/teleop.py
+++ b/almond_axol/teleop/teleop.py
@@ -137,7 +137,6 @@ class VRTeleop:
         self._prev_either: bool = False
         self._at_rest: bool = True
         self._engage_time: float | None = None
-        self._startup_complete: bool = False
 
         self._parent_conn: multiprocessing.connection.Connection | None = None
         self._ik_process: multiprocessing.context.SpawnProcess | None = None
@@ -231,8 +230,6 @@ class VRTeleop:
             self._smooth_right.reset(seed=seed_r[:7])
 
         if startup_traj:
-            self._smooth_left.max_accel = self._config.startup_max_accel
-            self._smooth_right.max_accel = self._config.startup_max_accel
             self._reset_interp.set_trajectory(startup_traj, self._l_grip, self._r_grip)
 
         self._ik_stop.clear()
@@ -362,24 +359,35 @@ class VRTeleop:
         if self._q is None:
             return None, None
 
-        q = self._q
-
-        l_grip = self._l_grip
-        r_grip = self._r_grip
-
         if self._reset_interp.is_active():
             new_q, l_grip, r_grip, done = self._reset_interp.step()
-            if new_q is not None:
-                q = np.asarray(new_q, dtype=np.float32)
-                if done:
-                    self._q = q.copy()
-                    self._l_grip = l_grip
-                    self._r_grip = r_grip
-                    self._at_rest = True
-                    if not self._startup_complete:
-                        self._startup_complete = True
-                        self._smooth_left.max_accel = self._config.teleop_max_accel
-                        self._smooth_right.max_accel = self._config.teleop_max_accel
+            if new_q is None:
+                return None, None
+            q = np.asarray(new_q, dtype=np.float32)
+            if done:
+                self._q = q.copy()
+                self._l_grip = l_grip
+                self._r_grip = r_grip
+                self._at_rest = True
+                seed_l = np.append(q[self._left_indices], l_grip)
+                seed_r = np.append(q[self._right_indices], r_grip)
+                self._ema_left.reset(seed=seed_l)
+                self._ema_right.reset(seed=seed_r)
+                self._smooth_left.reset(seed=q[self._left_indices])
+                self._smooth_right.reset(seed=q[self._right_indices])
+
+            left = np.empty(8, dtype=np.float32)
+            left[:7] = q[self._left_indices]
+            left[7] = l_grip
+            right = np.empty(8, dtype=np.float32)
+            right[:7] = q[self._right_indices]
+            right[7] = r_grip
+            return left, right
+
+        # ----- Normal teleop: smooth the IK output -----
+        q = self._q
+        l_grip = self._l_grip
+        r_grip = self._r_grip
 
         ema_l = self._ema_left.update(np.append(q[self._left_indices], l_grip))
         ema_r = self._ema_right.update(np.append(q[self._right_indices], r_grip))
@@ -485,16 +493,17 @@ class VRTeleop:
                         if isinstance(result, tuple) and result[0] == "reset_traj":
                             _, q_default, trajectory = result
                             if trajectory:
+                                # Reset trajectory playback in step() bypasses
+                                # the EMA and trapezoidal filters and reseeds
+                                # them on completion, so there's no filter
+                                # state to clear here.
                                 self._reset_interp.set_trajectory(
                                     trajectory, self._l_grip, self._r_grip
                                 )
-                                self._ema_left.reset()
-                                self._ema_right.reset()
-                                self._smooth_left.reset()
-                                self._smooth_right.reset()
                                 self._teleop_enabled = False
                                 self._prev_both = False
                                 self._prev_either = False
+                                self._engage_time = None
                             self._q = np.asarray(q_default, dtype=np.float32)
                     except Exception as e:
                         _logger.error("Reset error: %s", e)

--- a/almond_axol/teleop/teleop.py
+++ b/almond_axol/teleop/teleop.py
@@ -384,7 +384,6 @@ class VRTeleop:
             right[7] = r_grip
             return left, right
 
-        # ----- Normal teleop: smooth the IK output -----
         q = self._q
         l_grip = self._l_grip
         r_grip = self._r_grip

--- a/almond_axol/teleop/trajectory.py
+++ b/almond_axol/teleop/trajectory.py
@@ -1,0 +1,144 @@
+"""Collision-aware joint-space trajectory planner.
+
+Single source of truth for "return to rest" / "go-to-pose" trajectories
+used by :class:`almond_axol.teleop.worker.IKWorker` (teleop, collect-data,
+run-policy via the IK subprocess) and by
+:mod:`almond_axol.cli.tune.repeatability`.
+
+Each waypoint is a smoothstep-interpolated joint vector projected onto
+the joint-limit / self-collision manifold with a small pyroki least-
+squares solve. Duration is governed by ``speed`` (peak joint velocity is
+``1.5 * speed`` on the worst-case joint) with a hard ``min_duration``
+floor so very-short returns do not snap.
+"""
+
+from __future__ import annotations
+
+import functools
+
+import jax
+import jax.numpy as jnp
+import jaxls
+import numpy as np
+import pyroki as pk
+
+
+@functools.partial(jax.jit, static_argnames=("max_iterations",))
+def solve_path_step(
+    robot: pk.Robot,
+    robot_coll: pk.collision.RobotCollision,
+    q_interp: jax.Array,
+    q_current: jax.Array,
+    rest_weight: float,
+    limit_weight: float,
+    collision_margin: float,
+    collision_weight: float,
+    max_iterations: int,
+) -> jax.Array:
+    """One IK step toward ``q_interp`` with limit + self-collision costs only.
+
+    ``q_interp`` is the smoothstep target for this waypoint; ``q_current``
+    is the previous waypoint (or the starting pose for the first step).
+    Returns the projected joint configuration.
+    """
+    JointVar = robot.joint_var_cls
+    costs = [
+        pk.costs.rest_cost(JointVar(0), rest_pose=q_interp, weight=rest_weight),
+        pk.costs.limit_cost(robot, JointVar(0), weight=limit_weight),
+        pk.costs.self_collision_cost(
+            robot,
+            robot_coll,
+            JointVar(0),
+            margin=collision_margin,
+            weight=collision_weight,
+        ),
+    ]
+    var_joints = JointVar(jnp.array([0]))
+    initial_vals = jaxls.VarValues.make(
+        [var_joints.with_value(q_current[jnp.newaxis, :])]
+    )
+    problem = jaxls.LeastSquaresProblem(costs, [var_joints])
+    solution_vals = problem.analyze().solve(
+        initial_vals=initial_vals,
+        verbose=False,
+        linear_solver="dense_cholesky",
+        trust_region=jaxls.TrustRegionConfig(),
+        termination=jaxls.TerminationConfig(
+            max_iterations=max_iterations,
+            cost_tolerance=1e-2,
+        ),
+    )
+    return solution_vals[var_joints][0]
+
+
+def plan_collision_aware_trajectory(
+    robot: pk.Robot,
+    robot_coll: pk.collision.RobotCollision,
+    q_from: np.ndarray,
+    q_to: np.ndarray,
+    *,
+    speed: float,
+    rate: float,
+    min_duration: float,
+    rest_weight: float = 50.0,
+    limit_weight: float = 100.0,
+    collision_margin: float = 0.025,
+    collision_weight: float = 100.0,
+    max_iterations: int = 10,
+) -> list[np.ndarray]:
+    """Plan a collision-aware joint-space trajectory from ``q_from`` to ``q_to``.
+
+    The motion is smoothstepped in joint space, then projected onto the
+    joint-limit / self-collision manifold by :func:`solve_path_step`. The
+    duration scales with the worst-case joint deviation so the peak joint
+    velocity is ``1.5 * speed`` (the smoothstep peak), but is clamped from
+    below by ``min_duration`` so near-rest starts do not snap home in a
+    handful of frames.
+
+    Args:
+        robot:            pyroki ``Robot`` instance.
+        robot_coll:       pyroki collision model matched to ``robot``.
+        q_from:           Starting joint configuration, shape ``(N,)``.
+        q_to:             Target joint configuration, shape ``(N,)``.
+        speed:            Average joint velocity (rad/s) for the worst-case
+                          joint; peak velocity is ``1.5 * speed``.
+        rate:             Sample rate (Hz) at which waypoints will be played.
+        min_duration:     Floor on the trajectory duration in seconds.
+        rest_weight:      Cost weight pulling each waypoint toward the
+                          smoothstep target.
+        limit_weight:     Cost weight on joint-limit violation.
+        collision_margin: Minimum clearance (m) enforced between collision
+                          bodies.
+        collision_weight: Cost weight on self-collision penalty.
+        max_iterations:   IK solver iterations per waypoint.
+
+    Returns:
+        A list of full ``(N,)`` joint vectors, one per control tick at
+        ``rate`` Hz. Always at least two waypoints long.
+    """
+    q_from = np.asarray(q_from, dtype=np.float32)
+    q_to = np.asarray(q_to, dtype=np.float32)
+    max_dist = float(np.max(np.abs(q_from - q_to)))
+    duration = max(max_dist / speed, min_duration)
+    n_steps = max(2, round(duration * rate))
+
+    trajectory: list[np.ndarray] = []
+    q = q_from.copy()
+    for i in range(n_steps):
+        t = (i + 1) / n_steps
+        alpha = t * t * (3.0 - 2.0 * t)
+        q_interp = (q_from * (1.0 - alpha) + q_to * alpha).astype(np.float32)
+        result = solve_path_step(
+            robot,
+            robot_coll,
+            jnp.asarray(q_interp),
+            jnp.asarray(q),
+            rest_weight,
+            limit_weight,
+            collision_margin,
+            collision_weight,
+            max_iterations,
+        )
+        q = np.asarray(result, dtype=np.float32)
+        trajectory.append(q.copy())
+    return trajectory

--- a/almond_axol/teleop/worker.py
+++ b/almond_axol/teleop/worker.py
@@ -8,23 +8,20 @@ All intermediate computations stay in NumPy; the single JAX boundary is the
 
 from __future__ import annotations
 
-import functools
 import multiprocessing
 import multiprocessing.connection
 import os
 
-import jax
 import jax.numpy as jnp
 import jaxlie
-import jaxls
 import numpy as np
-import pyroki as pk
 
 from ..kinematics.config import KinematicsConfig
 from ..kinematics.solver import KinematicsSolver
 from ..vr.models import VRFrame
 from .config import VRTeleopConfig
 from .filter import OneEuroFilter
+from .trajectory import plan_collision_aware_trajectory
 
 # ---------------------------------------------------------------------------
 # NumPy-only helpers (no JAX dispatch overhead)
@@ -87,55 +84,6 @@ def _relative_target_np(
     R_delta[1, :] = (-A[1, 2], A[1, 1], -A[1, 0])
     R_delta[2, :] = (A[0, 2], -A[0, 1], A[0, 0])
     return new_t.astype(np.float32), (rot_snap_fk @ R_delta).astype(np.float32)
-
-
-# ---------------------------------------------------------------------------
-# JIT-compiled reset step
-# ---------------------------------------------------------------------------
-
-
-@functools.partial(jax.jit, static_argnames=("max_iterations",))
-def _solve_reset_step(
-    robot: pk.Robot,
-    robot_coll: pk.collision.RobotCollision,
-    q_interp: jax.Array,
-    q_current: jax.Array,
-    rest_weight: float,
-    limit_weight: float,
-    collision_margin: float,
-    collision_weight: float,
-    max_iterations: int,
-) -> jax.Array:
-    """One IK step toward ``q_interp`` with limit and self-collision costs only."""
-    JointVar = robot.joint_var_cls
-    costs = [
-        pk.costs.rest_cost(JointVar(0), rest_pose=q_interp, weight=rest_weight),
-        pk.costs.limit_cost(robot, JointVar(0), weight=limit_weight),
-        pk.costs.self_collision_cost(
-            robot,
-            robot_coll,
-            JointVar(0),
-            margin=collision_margin,
-            weight=collision_weight,
-        ),
-    ]
-    var_joints = JointVar(jnp.array([0]))
-    initial_vals = jaxls.VarValues.make(
-        [var_joints.with_value(q_current[jnp.newaxis, :])]
-    )
-    problem = jaxls.LeastSquaresProblem(costs, [var_joints])
-    analyzed = problem.analyze()
-    solution_vals = analyzed.solve(
-        initial_vals=initial_vals,
-        verbose=False,
-        linear_solver="dense_cholesky",
-        trust_region=jaxls.TrustRegionConfig(),
-        termination=jaxls.TerminationConfig(
-            max_iterations=max_iterations,
-            cost_tolerance=1e-2,
-        ),
-    )
-    return solution_vals[var_joints][0]
 
 
 # ---------------------------------------------------------------------------
@@ -327,29 +275,20 @@ class IKWorker:
     ) -> list[np.ndarray]:
         """Collision-aware trajectory. Each item is a full (N,) array in radians."""
         cfg = self._config
-        max_dist_rad = float(np.max(np.abs(q_current - q_target)))
-        duration = max_dist_rad / cfg.reset_speed
-        n_steps = max(1, round(duration * cfg.frequency))
-        trajectory: list[np.ndarray] = []
-        q = np.array(q_current, dtype=np.float32)
-        for i in range(n_steps):
-            t = (i + 1) / n_steps
-            alpha = t * t * (3.0 - 2.0 * t)
-            q_interp = (q_current * (1.0 - alpha) + q_target * alpha).astype(np.float32)
-            result = _solve_reset_step(
-                self._solver.robot,
-                self._solver.robot_coll,
-                jnp.asarray(q_interp),
-                jnp.asarray(q),
-                cfg.reset_rest_weight,
-                cfg.reset_limit_weight,
-                cfg.reset_collision_margin,
-                cfg.reset_collision_weight,
-                cfg.reset_max_iterations,
-            )
-            q = np.array(result, dtype=np.float32)
-            trajectory.append(q.copy())
-        return trajectory
+        return plan_collision_aware_trajectory(
+            self._solver.robot,
+            self._solver.robot_coll,
+            q_current,
+            q_target,
+            speed=cfg.reset_speed,
+            rate=cfg.frequency,
+            min_duration=cfg.reset_min_duration,
+            rest_weight=cfg.reset_rest_weight,
+            limit_weight=cfg.reset_limit_weight,
+            collision_margin=cfg.reset_collision_margin,
+            collision_weight=cfg.reset_collision_weight,
+            max_iterations=cfg.reset_max_iterations,
+        )
 
     def reset(self) -> None:
         """Deactivate the deadman-switch state and clear snap poses and filter state.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches teleoperation reset/trajectory generation and smoothing state, which directly affects commanded joint motion; incorrect defaults (e.g., `reset_min_duration`) or reseeding logic could change reset timing/feel or introduce discontinuities.
> 
> **Overview**
> **Unifies and adjusts reset-to-rest trajectory planning.** Adds `teleop/trajectory.py` as a shared collision-aware smoothstep planner and switches both `IKWorker.compute_reset_trajectory()` and `tune.repeatability` to use it, adding a new `VRTeleopConfig.reset_min_duration` floor and clarifying that `reset_speed` represents *average* (not peak) worst-joint velocity.
> 
> **Fixes reset playback smoothing behavior.** During reset trajectory playback, `VRTeleop.step()` and LeRobot’s `AxolVRTeleop._compute_output()` now bypass EMA/trapezoidal smoothing, then reseed those filters (and clear engage timing) when the trajectory completes to avoid post-reset transients; related docs/README are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92677e8fd73591df959385c820b282c3963adf45. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->