### PR TITLE
fix myactuator brake-release timeout

### DIFF
--- a/almond_axol/motor/myactuator.py
+++ b/almond_axol/motor/myactuator.py
@@ -157,7 +157,7 @@ class MyActuatorMotor(MotorDriver):
     # ------------------------------------------------------------------ #
 
     async def enable(self) -> None:
-        await self._request(self._cmd(_MA_RELEASE_BRAKE))
+        await self._request(self._cmd(_MA_RELEASE_BRAKE), timeout=1.0)
 
     async def disable(self) -> None:
         await self._request(self._cmd(_MA_SHUTDOWN))


### PR DESCRIPTION
## Problem

`MyActuatorMotor.enable()` calls `_request(_cmd(_MA_RELEASE_BRAKE))` with the default `_request` timeout of 100 ms (`almond_axol/motor/myactuator.py:129`). That's appropriate for read-only CAN replies, but the brake-release command also triggers a mechanical action — the electromagnetic brake has to physically disengage before the motor confirms. On our motors we've measured the release taking 50-150 ms; under load or after a cold start it can exceed 100 ms and the request hits its timeout before the brake actually releases.

## Symptom

When the timeout fires early, `enable()` returns a `TimeoutError` (or just propagates depending on call site) and the motor ends up in a half-enabled state where the brake is still engaged but the controller thinks the motor is ready. Subsequent `set_impedance` commands then drive against a locked output → grinding noise, no useful motion.

We hit this intermittently on right-arm startup during VR teleop. Initial diagnosis pointed at encoder drift (we even started a gravity-comp + `motor.set-zero-pos --r --guided` pass), but the underlying cause was the 100 ms timeout firing before the brake released. Bumping just this one request to a 1.0 s timeout cleared the symptom across multiple cold-start cycles.

## Fix

```diff
 async def enable(self) -> None:
-    await self._request(self._cmd(_MA_RELEASE_BRAKE))
+    await self._request(self._cmd(_MA_RELEASE_BRAKE), timeout=1.0)
```

- Scoped to brake release only; all other `_request` callers keep the 100 ms default.
- 1.0 s is conservative — typical release completes in well under 200 ms — but gives headroom for cold motors and gives the failure mode "release didn't happen at all" rather than "release happened too slowly to notice."
- No new dependencies or API changes.

## Testing

- Local cold-start cycle (10 power-on → enable → teleop iterations): brake released cleanly every time after the patch; pre-patch baseline showed 1-3 silent half-enables per 10 cycles on the right arm.
- No regression on warm enables (already fast).
- Disable path unchanged.

Happy to add a CHANGELOG entry if the repo has one.