### PR TITLE
feat(teleop): emit joint torques during teleop + collect-data; record into LeRobot frames

### DIFF
--- a/almond_axol/cli/collect_data.py
+++ b/almond_axol/cli/collect_data.py
@@ -42,7 +42,7 @@ from typing import TYPE_CHECKING, Any, Callable
 
 import numpy as np
 
-from ..shared import ARM_JOINTS, parse_stiffness
+from ..shared import ARM_JOINTS, Joint, parse_stiffness
 
 _TORQUE_JSONL_PATH = "/dev/shm/axol_torque.jsonl"
 _TORQUE_JSONL_HZ = 30.0
@@ -122,6 +122,7 @@ class _CaptureThread(threading.Thread):
         fps: int,
         task: str,
         rerun_ip: str | None,
+        record_torques: bool = False,
     ) -> None:
         super().__init__(name="axol-capture", daemon=True)
         self.publisher = publisher
@@ -131,6 +132,7 @@ class _CaptureThread(threading.Thread):
         self.fps = fps
         self.task = task
         self.rerun_ip = rerun_ip
+        self.record_torques = record_torques
         self.stop_event = threading.Event()
 
     def run(self) -> None:
@@ -210,7 +212,21 @@ class _CaptureThread(threading.Thread):
             )
             if self.stop_event.is_set():
                 return
-            self.dataset.add_frame({**obs_frame, **act_frame, "task": self.task})
+
+            # Joint torques are first-class observation channels for force-
+            # aware policies. Read the cached snapshot from the robot's
+            # telemetry buffer; falls back to zero arrays on transient
+            # errors (handled inside _read_cached_torques) so a CAN miss
+            # never aborts a frame.
+            torque_frame: dict[str, Any] = {}
+            if self.record_torques:
+                left_t, right_t = _read_cached_torques(self.robot)
+                torque_frame[_OBS_TORQUE_LEFT_KEY] = left_t
+                torque_frame[_OBS_TORQUE_RIGHT_KEY] = right_t
+
+            self.dataset.add_frame(
+                {**obs_frame, **act_frame, **torque_frame, "task": self.task}
+            )
 
             if self.rerun_ip:
                 log_rerun_data(observation=obs_processed, action=snap.action)
@@ -585,6 +601,25 @@ def _run(
         )
         torque_writer.start()
 
+    # Joint-torque observations are stored as two dedicated `(8,)` float32
+    # arrays per frame. Adding them as standalone features (instead of
+    # packing into `observation.state` via `observe_torques=True` on the
+    # AxolRobotConfig) keeps the upstream LeRobot scalar-key schema stable
+    # for existing callers and gives downstream policies a clean per-arm
+    # tensor to consume.
+    torque_features = {
+        _OBS_TORQUE_LEFT_KEY: {
+            "dtype": "float32",
+            "shape": (_TORQUE_DOF,),
+            "names": [f"left_{j.value}.trq" for j in list(Joint)],
+        },
+        _OBS_TORQUE_RIGHT_KEY: {
+            "dtype": "float32",
+            "shape": (_TORQUE_DOF,),
+            "names": [f"right_{j.value}.trq" for j in list(Joint)],
+        },
+    }
+
     if is_complete:
         log_say(f"Resuming existing dataset at {dataset_root}.")
         dataset = LeRobotDataset.resume(
@@ -595,14 +630,33 @@ def _run(
             encoder_threads=4,
             vcodec="auto",
         )
+        # Adaptive resume: only embed torques in frames if the resumed
+        # dataset's schema already includes them. Mixing schemas mid-dataset
+        # would break readers and is rejected by validate_frame, so we just
+        # disable the torque embed (the dashboard JSONL tap still works).
+        record_torques = (
+            _OBS_TORQUE_LEFT_KEY in dataset.features
+            and _OBS_TORQUE_RIGHT_KEY in dataset.features
+        )
+        if not record_torques and torque_enabled:
+            _logger.warning(
+                "Resuming dataset %s which lacks %s/%s features; torque will "
+                "NOT be embedded in new frames. Live HUD JSONL still works.",
+                dataset_root,
+                _OBS_TORQUE_LEFT_KEY,
+                _OBS_TORQUE_RIGHT_KEY,
+            )
     else:
         action_features = hw_to_dataset_features(robot.action_features, ACTION)
         obs_features = hw_to_dataset_features(robot.observation_features, OBS_STR)
+        # Torque features are always declared in new datasets — even when
+        # the robot doesn't support telemetry torque, frames carry zero
+        # arrays so the schema stays consistent across the whole dataset.
         dataset = LeRobotDataset.create(
             repo_id=repo_id,
             fps=fps,
             root=root,
-            features={**action_features, **obs_features},
+            features={**action_features, **obs_features, **torque_features},
             robot_type=robot.name,
             use_videos=True,
             image_writer_threads=4,
@@ -610,6 +664,7 @@ def _run(
             encoder_threads=4,
             vcodec="auto",
         )
+        record_torques = True
     pos_l, pos_r = robot.positions
     teleop.connect(q_start_left=pos_l, q_start_right=pos_r)
     teleop_action_proc, robot_action_proc, robot_obs_proc = make_default_processors()
@@ -653,6 +708,7 @@ def _run(
                         fps=fps,
                         task=task,
                         rerun_ip=rerun_ip,
+                        record_torques=record_torques,
                     )
                     capture.start()
                     log_say("Recording started.")

--- a/almond_axol/cli/collect_data.py
+++ b/almond_axol/cli/collect_data.py
@@ -18,10 +18,21 @@ The teleop loop runs at ``--teleop-hz`` and publishes the latest
 ``ZedCamera.read_at_or_after(T_n)`` per camera so every recorded frame
 shares the sender-clock instant ``T_n`` with the joint sample, then writes
 the dataset row off the hot control loop.
+
+Joint-torque telemetry is upgraded after ``robot.connect()`` so cached
+torques are available to two consumers in lockstep: a daemon thread
+``_TorqueJsonlWriter`` that streams one JSON line per cycle to
+``/dev/shm/axol_torque.jsonl`` (consumed by the dashboard's force HUD over
+SSE), and the per-frame dataset writer in ``_CaptureThread`` which embeds
+joint torques into every recorded LeRobot frame under
+``observation.torque.left`` and ``observation.torque.right``.
 """
 
 import argparse
+import asyncio
+import json
 import logging
+import os
 import shutil
 import socket
 import threading
@@ -29,7 +40,15 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable
 
+import numpy as np
+
 from ..shared import ARM_JOINTS, parse_stiffness
+
+_TORQUE_JSONL_PATH = "/dev/shm/axol_torque.jsonl"
+_TORQUE_JSONL_HZ = 30.0
+_TORQUE_DOF = 8  # joints per arm (7 arm joints + gripper) — matches Joint enum
+_OBS_TORQUE_LEFT_KEY = "observation.torque.left"
+_OBS_TORQUE_RIGHT_KEY = "observation.torque.right"
 
 if TYPE_CHECKING:
     from lerobot.datasets.lerobot_dataset import LeRobotDataset
@@ -209,6 +228,135 @@ class _CaptureThread(threading.Thread):
                 )
 
             tick += 1
+
+
+def _read_cached_torques(
+    robot: "AxolRobot",
+) -> tuple[np.ndarray, np.ndarray]:
+    """Read the latest cached torques from both arms.
+
+    Returns ``(left, right)`` each shape ``(_TORQUE_DOF,)`` of float32. Falls
+    back to zero arrays per arm on any error (transient CAN miss, telemetry
+    not started yet, robot subclass without torque support).
+
+    Reads :attr:`AxolArm.torques` directly from the telemetry cache; safe to
+    call from any thread (numpy snapshot per call).
+    """
+    left = np.zeros(_TORQUE_DOF, dtype=np.float32)
+    right = np.zeros(_TORQUE_DOF, dtype=np.float32)
+    axol = getattr(robot, "_axol", None)
+    if axol is None:
+        return left, right
+    try:
+        if axol.left is not None:
+            left = np.asarray(axol.left.torques, dtype=np.float32)
+    except Exception:
+        pass
+    try:
+        if axol.right is not None:
+            right = np.asarray(axol.right.torques, dtype=np.float32)
+    except Exception:
+        pass
+    return left, right
+
+
+class _TorqueJsonlWriter(threading.Thread):
+    """Daemon thread streaming joint torques to ``/dev/shm/axol_torque.jsonl``.
+
+    Reads the cached torques from the underlying ``Axol`` driver at
+    ``_TORQUE_JSONL_HZ`` and writes one JSON line per cycle so the dashboard
+    force HUD can render the live values over SSE. Line schema mirrors
+    ``axol-ui/torque_publisher.py``::
+
+        {"ts": <float>, "left": [8 floats], "right": [8 floats]}
+
+    On any per-cycle error the writer silently drops the sample and
+    continues — torque streaming must never block or crash recording.
+    """
+
+    def __init__(self, robot: "AxolRobot", path: str, hz: float) -> None:
+        super().__init__(name="axol-torque-jsonl", daemon=True)
+        self.robot = robot
+        self.path = path
+        self.hz = hz
+        self.stop_event = threading.Event()
+        self._fh = None
+
+    def run(self) -> None:
+        period = 1.0 / self.hz
+        try:
+            os.makedirs(os.path.dirname(self.path), exist_ok=True)
+            # Line-buffered so each sample is immediately visible to SSE.
+            self._fh = open(self.path, "w", buffering=1)
+        except Exception as exc:
+            _logger.warning(
+                "Failed to open torque JSONL %s: %s", self.path, exc
+            )
+            return
+        try:
+            while not self.stop_event.is_set():
+                cycle_start = time.perf_counter()
+                left, right = _read_cached_torques(self.robot)
+                try:
+                    line = json.dumps(
+                        {
+                            "ts": time.time(),
+                            "left": [float(v) for v in left.tolist()],
+                            "right": [float(v) for v in right.tolist()],
+                        }
+                    )
+                    self._fh.write(line + "\n")
+                except Exception:
+                    # A transient write error must never stop recording.
+                    pass
+                wait_s = period - (time.perf_counter() - cycle_start)
+                if wait_s > 0:
+                    if self.stop_event.wait(timeout=wait_s):
+                        break
+        finally:
+            try:
+                self._fh.close()
+            except Exception:
+                pass
+            self._fh = None
+
+
+def _upgrade_telemetry_to_torque(
+    robot: "AxolRobot", hz: float
+) -> bool:
+    """Restart background telemetry on the connected robot with ``torque=True``.
+
+    ``AxolRobot._connect_async`` already starts telemetry, but with
+    ``torque=self.config.observe_torques`` (default False). We upgrade it
+    here so cached torques are populated for the JSONL writer and the
+    per-frame embed without forcing callers to flip ``observe_torques``
+    (which would also change the upstream LeRobot scalar-key schema).
+
+    Returns True if telemetry was successfully (re)started with torque
+    polling, False otherwise. Failure is silent at INFO level — collect-data
+    must keep working even if the robot subclass lacks torque support.
+    """
+    axol = getattr(robot, "_axol", None)
+    loop = getattr(robot, "_loop", None)
+    if axol is None or loop is None:
+        _logger.info(
+            "Robot has no underlying Axol driver; skipping torque telemetry upgrade."
+        )
+        return False
+    try:
+        asyncio.run_coroutine_threadsafe(
+            axol.start_telemetry(hz, torque=True), loop
+        ).result(timeout=10)
+        return True
+    except (AttributeError, NotImplementedError):
+        _logger.info(
+            "Robot does not support start_telemetry(torque=True); "
+            "torque tap disabled for this session."
+        )
+        return False
+    except Exception as exc:  # pragma: no cover - defensive
+        _logger.warning("Failed to upgrade telemetry to torque=True: %s", exc)
+        return False
 
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
@@ -425,6 +573,18 @@ def _run(
     # which is then used to define the dataset observation features.
     robot.connect()
 
+    # Upgrade telemetry so motor torque is cached on every cycle (no-op on
+    # robot subclasses without torque support). Required for both the dashboard
+    # JSONL tap AND the per-frame torque embed in the recorded dataset.
+    torque_enabled = _upgrade_telemetry_to_torque(robot, _TORQUE_JSONL_HZ)
+
+    torque_writer: _TorqueJsonlWriter | None = None
+    if torque_enabled:
+        torque_writer = _TorqueJsonlWriter(
+            robot, _TORQUE_JSONL_PATH, _TORQUE_JSONL_HZ
+        )
+        torque_writer.start()
+
     if is_complete:
         log_say(f"Resuming existing dataset at {dataset_root}.")
         dataset = LeRobotDataset.resume(
@@ -548,6 +708,10 @@ def _run(
         if capture is not None:
             capture.stop_event.set()
             capture.join()
+
+        if torque_writer is not None:
+            torque_writer.stop_event.set()
+            torque_writer.join(timeout=2.0)
 
         log_say("Stopping.")
 

--- a/almond_axol/cli/teleop.py
+++ b/almond_axol/cli/teleop.py
@@ -2,14 +2,26 @@
 axol teleop --robot [axol|sim]
 
 Run a VR teleoperation session with default parameters.
+
+While teleop runs, a torque-telemetry tap writes one JSON line per cycle to
+``/dev/shm/axol_torque.jsonl`` so the dashboard's force HUD can read joint
+torques without contending with this process for the CAN bus. The tap is a
+no-op on the Sim backend (no torque sensors) and is silent on transient
+read errors so it cannot crash teleop.
 """
 
 import argparse
 import asyncio
+import json
 import logging
+import os
 import socket
+import time
 
 from ..shared import ARM_JOINTS, parse_stiffness
+
+_TORQUE_JSONL_PATH = "/dev/shm/axol_torque.jsonl"
+_TORQUE_HZ = 30.0
 
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
@@ -103,6 +115,44 @@ def run(args: argparse.Namespace) -> None:
     )
 
 
+async def _torque_writer(robot, fh, hz: float) -> None:
+    """Periodically fetch joint torques and append one JSON line per cycle.
+
+    Schema matches /home/twolabs/axol-ui/torque_publisher.py: one line per
+    sample with ``ts``, ``left[8]``, ``right[8]``. The dashboard reads the
+    file via SSE; the FastAPI side trims it as needed.
+
+    Silent on any per-cycle error so a transient telemetry hiccup never
+    crashes teleop. Exits on :class:`asyncio.CancelledError`.
+    """
+    period = 1.0 / hz
+    while True:
+        cycle_start = time.perf_counter()
+        try:
+            left_t, right_t = await robot.get_torques()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            # Don't kill teleop on a telemetry hiccup.
+            left_t = None
+            right_t = None
+
+        try:
+            sample = {
+                "ts": time.time(),
+                "left": [float(v) for v in (left_t if left_t is not None else [])],
+                "right": [float(v) for v in (right_t if right_t is not None else [])],
+            }
+            fh.write(json.dumps(sample) + "\n")
+        except Exception:
+            pass
+
+        try:
+            await asyncio.sleep(max(0.0, period - (time.perf_counter() - cycle_start)))
+        except asyncio.CancelledError:
+            raise
+
+
 async def _run(
     robot_type: str,
     *,
@@ -132,5 +182,58 @@ async def _run(
         axol_config.left.gripper.torque_limit = left_gripper_torque_limit
         axol_config.right.gripper.torque_limit = right_gripper_torque_limit
         robot = Axol(config=axol_config, **kwargs)
+
     async with VRTeleop(robot) as teleop:
-        await teleop.run()
+        # Robot is now enabled by VRTeleop.enable(). Start the torque tap.
+        torque_fh = None
+        torque_task: asyncio.Task[None] | None = None
+        telemetry_started = False
+        try:
+            try:
+                await robot.start_telemetry(hz=_TORQUE_HZ, torque=True)
+                telemetry_started = True
+            except (AttributeError, NotImplementedError):
+                # Sim or any robot subclass without telemetry support.
+                logging.getLogger(__name__).info(
+                    "Robot does not support start_telemetry(torque=True); "
+                    "skipping torque JSONL tap."
+                )
+            except Exception as exc:  # pragma: no cover - defensive
+                logging.getLogger(__name__).warning(
+                    "Failed to start torque telemetry: %s", exc
+                )
+
+            if telemetry_started:
+                try:
+                    os.makedirs(os.path.dirname(_TORQUE_JSONL_PATH), exist_ok=True)
+                    # Line-buffered so each sample is immediately visible to
+                    # the dashboard's SSE tailer.
+                    torque_fh = open(_TORQUE_JSONL_PATH, "w", buffering=1)
+                    torque_task = asyncio.create_task(
+                        _torque_writer(robot, torque_fh, _TORQUE_HZ)
+                    )
+                except Exception as exc:  # pragma: no cover - defensive
+                    logging.getLogger(__name__).warning(
+                        "Failed to open torque JSONL %s: %s",
+                        _TORQUE_JSONL_PATH,
+                        exc,
+                    )
+
+            await teleop.run()
+        finally:
+            if torque_task is not None:
+                torque_task.cancel()
+                try:
+                    await torque_task
+                except (asyncio.CancelledError, Exception):
+                    pass
+            if torque_fh is not None:
+                try:
+                    torque_fh.close()
+                except Exception:
+                    pass
+            if telemetry_started:
+                try:
+                    await robot.stop_telemetry()
+                except Exception:
+                    pass


### PR DESCRIPTION
## Summary

Bring joint torque telemetry into the live teleop/collect-data path so the operator can see force feedback in VR (companion axol-vr ForceHUD PR) AND so future recorded LeRobot datasets carry torque as a first-class observation channel.

## What changes

- `almond_axol/cli/teleop.py` — after `VRTeleop` enables the robot, calls `robot.start_telemetry(hz=30, torque=True)`, opens `/dev/shm/axol_torque.jsonl`, and spawns an asyncio task that writes one JSON line per cycle (`{ts, left[8], right[8]}`). Guards each `get_torques()` call against transient errors. Cancels the task and closes the JSONL on shutdown.

- `almond_axol/cli/collect_data.py`:
  - After `robot.connect()`, calls `_upgrade_telemetry_to_torque(robot)` so the existing `AxolRobot` telemetry channel re-starts with `torque=True` (without forcing `observe_torques=True` on the config — which would change the upstream scalar-key schema).
  - Spawns a daemon `_TorqueJsonlWriter` thread that streams cached torques to `/dev/shm/axol_torque.jsonl` so the dashboard HUD works during recording.
  - Extends `LeRobotDataset.create` features with `observation.torque.left` and `observation.torque.right` (both `float32` shape `(8,)`, names listing each joint).
  - `_CaptureThread` accepts a new `record_torques` flag; when set, attaches the two arrays to every `add_frame()` call alongside the existing `obs_frame` / `act_frame` bundles.
  - Reads come from a new helper `_read_cached_torques(robot)` that returns zero arrays on any error so a transient CAN miss never aborts a frame.

## Why

Previously the only torque path was a standalone `torque_publisher.py` daemon, which conflicts with teleop/collect-data because the CAN bus is exclusive per channel. This patch puts the torque tap inside the process that already owns the bus, eliminating the conflict.

## Backwards compatibility

Both changes are additive:

- Robots that don't implement `start_telemetry(torque=True)` or `get_torques()` are caught and continue without torque (zero arrays in collect-data frames; teleop silently skips the JSONL).
- New datasets always declare the `observation.torque.*` keys and embed zero arrays when telemetry is unavailable — schema is consistent for the lifetime of the dataset.
- Resume of a legacy dataset whose `info.json` lacks the torque features triggers an adaptive fallback (`record_torques=False`); subsequent `add_frame()` calls don't embed torque, so `validate_frame` accepts them. Live HUD JSONL still works regardless.

## Test plan

- [x] Syntax + module import clean (`python -c 'import almond_axol.cli.{teleop,collect_data}'`)
- [x] `axol teleop --help` and `axol collect-data --help` dispatch cleanly
- [x] End-to-end smoke in `/tmp`: `LeRobotDataset.create` + 3 `add_frame` calls + `save_episode` + `finalize` → parquet contains `observation.torque.{left,right}` columns with correct float32 values; `info.json` lists both features with `shape: [8]`
- [x] Reload + index access → `(8,)` tensors round-trip
- [x] Resume of a torque-aware dataset → schema preserved, `add_frame` works
- [x] Resume of a legacy (no-torque) dataset → adaptive guard skips embedding so `add_frame` succeeds
- [x] `_read_cached_torques` zero-fallback on missing `_axol`, missing arm, and exception during `.torques` read
- [ ] Live test: run `axol teleop --robot axol`, verify `/dev/shm/axol_torque.jsonl` grows at ~30 Hz
- [ ] Live test: run `axol collect-data --repo-id test/torque-v0 ...`, record 1 episode, verify `meta/info.json` includes the new feature keys and parquet has 16 torque cols across both arms
- [ ] Dataset integrity: existing toilet-paper-v0 still loads (no schema regression in reader path)

## Companion

axol-vr ForceHUD PR (head-locked torque visualization in WebXR) consumes the same `/dev/shm/axol_torque.jsonl` via dashboard SSE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)