### PR TITLE
increase upper arm mass

### DIFF
--- a/almond_axol/robot/config.py
+++ b/almond_axol/robot/config.py
@@ -156,7 +156,7 @@ class ArmConfig:
             kp=45.0,
             kd=1.0,
             friction=_ZERO_FRICTION,
-            mass=3.25,
+            mass=3.75,
             com=(0.0, 0.00286547, -0.164964),
         )
     )


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> A single tuned inertial default affects live gravity feedforward on shoulder_3 for all default Axol configs; wrong mass can show up as tracking or holding errors rather than compile failures.
> 
> **Overview**
> Raises the default **`shoulder_3`** link mass in **`ArmConfig`** from **3.25 kg** to **3.75 kg** (+0.5 kg). That value is the inertial for the upper-arm body this joint drives; it is applied to both arms via shared defaults and feeds **gravity feedforward** through **`GravityCompensator`** (URDF inertials overwritten from config). Gains, CoM, and friction are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9040de9315bcd4deebaa5bb8e6abe1adabb936f1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->