### PR TITLE
update motor set zero pos flow

### DIFF
--- a/almond_axol/cli/motor/set_zero_pos.py
+++ b/almond_axol/cli/motor/set_zero_pos.py
@@ -5,6 +5,10 @@ Set the zero position of a single motor, or walk every arm joint with
 ``--guided`` and zero each one against its closer end stop. The current
 mechanical position becomes the new zero reference (persisted to flash).
 
+Note: each motor's encoder zero is calibrated at one of the joint's
+mechanical END STOPS, not at the robot's rest position. ``AxolArm`` adds a
+per-joint offset so the public API stays in joint frame (``0`` = rest).
+
 Examples:
     axol motor.set-zero-pos --l --id 0x01
     axol motor.set-zero-pos --r --id 0x06
@@ -144,21 +148,27 @@ async def _calibrate_joint(
             continue
 
         if (1 if delta > 0 else -1) != expected_sign:
-            print(f"    ✗ wrong direction (expected {direction}) — retry.")
-            continue
-
-        mag_diff = abs(abs(delta) - abs(target_rad))
-        if mag_diff > _MAGNITUDE_WARN_RAD:
+            # Wrong direction: rather than restart, send the user to the
+            # correct end stop and zero there on the next Enter.
             print(
-                f"    ⚠  moved {math.degrees(abs(delta)):.1f}°, expected"
-                f" ~{abs(target_deg):.1f}° — make sure you're against the stop."
+                f"    ✗ wrong direction (expected {direction}) — move all the way"
+                f" to the OTHER end stop at {target_deg:+.1f}°."
             )
+            if not _prompt("    then Enter to set zero: "):
+                return False
+            p_end = await motor.get_position()
+            print(f"     end:   {_fmt(p_end)}")
+        else:
+            mag_diff = abs(abs(delta) - abs(target_rad))
+            if mag_diff > _MAGNITUDE_WARN_RAD:
+                print(
+                    f"    ⚠  moved {math.degrees(abs(delta)):.1f}°, expected"
+                    f" ~{abs(target_deg):.1f}° — make sure you're against the stop."
+                )
 
-        if not _prompt(f"    set zero at {_fmt(p_end)}? Enter to confirm: "):
-            return False
-
+        # Right direction → zero immediately, no extra confirmation.
         await motor.set_zero_position()
-        print("    ✓ zeroed.")
+        print(f"    ✓ zeroed at {_fmt(p_end)}.")
         return True
 
 

--- a/almond_axol/motor/motor.py
+++ b/almond_axol/motor/motor.py
@@ -127,7 +127,11 @@ class Motor:
         await self._driver.clear_errors()
 
     async def set_zero_position(self) -> None:
-        """Save the current shaft position as the encoder zero reference."""
+        """Save the current shaft position as the encoder zero reference.
+
+        For arm joints this is calibrated at one of the joint's mechanical
+        end stops, not at the rest position (see ``closer_end_stop``).
+        """
         await self._driver.set_zero_position()
 
     async def set_control_mode(self, mode: ControlMode) -> None:

--- a/almond_axol/robot/axol.py
+++ b/almond_axol/robot/axol.py
@@ -395,6 +395,10 @@ class AxolArm:
     async def set_zero_position(self, joints: list[Joint]) -> None:
         """Save the current shaft position as the encoder zero for the specified joints.
 
+        The encoder zero is calibrated at the joint's mechanical end stop, not
+        at the rest position; ``AxolArm`` applies a per-joint offset so the
+        public API stays in joint frame (``0`` = rest).
+
         Args:
             joints: List of joints to zero.
         """
@@ -937,6 +941,10 @@ class Axol(RobotBase):
         right: list[Joint] | None = None,
     ) -> None:
         """Save the current shaft position as the encoder zero for the specified joints.
+
+        The encoder zero is calibrated at each joint's mechanical end stop, not
+        at the rest position; per-joint offsets keep the public API in joint
+        frame (``0`` = rest).
 
         Args:
             left:  Joints on the left arm to zero. ``None`` skips the arm.

--- a/docs/api/motor.mdx
+++ b/docs/api/motor.mdx
@@ -34,7 +34,7 @@ asyncio.run(main())
 |---|---|
 | `enable()` / `disable()` | Enable motor / engage brake |
 | `clear_errors()` | Clear latched error flags |
-| `set_zero_position()` | Save current position as encoder zero (persisted to flash) |
+| `set_zero_position()` | Save current position as encoder zero (persisted to flash). Calibrated at a mechanical end stop, not the rest position |
 | `set_control_mode(mode)` | Set `ControlMode`; required before mode-specific commands |
 | `get_control_mode()` | Read active mode from hardware (`None` for MyActuator) |
 | `get_position()` | Shaft position (rad); raises if telemetry is active |

--- a/docs/api/robot.mdx
+++ b/docs/api/robot.mdx
@@ -75,7 +75,7 @@ Each returns `(left_array, right_array)` where the absent arm is `None`.
 | `set_positions_velocity(left, right, max_speed)` | Motor built-in position controller |
 | `set_velocity(left, right)` | Motor built-in speed controller |
 | `set_gains(left, right)` | Write PID gains; persisted to flash |
-| `set_zero_position(left, right)` | Save current shaft position as encoder zero |
+| `set_zero_position(left, right)` | Save current shaft position as encoder zero (calibrated at a mechanical end stop, not the rest position) |
 | `set_acceleration(left, right)` | Set per-joint acceleration ramp (rad/s²) |
 
 Individual arms are accessible via `axol.left` and `axol.right` (`AxolArm`), which expose the same methods operating on a single arm.

--- a/docs/cli/motor-set-zero-pos.mdx
+++ b/docs/cli/motor-set-zero-pos.mdx
@@ -5,6 +5,10 @@ description: "Set a motor's zero-position reference to its current mechanical po
 
 Sets the motor's zero-position reference to its current mechanical position (persisted to flash). Damiao motors require a power cycle afterward.
 
+<Warning>
+  Each motor's encoder zero is calibrated at one of the joint's mechanical **end stops**, **not** at the robot's rest position. In `--guided` mode the CLI drives every joint to its closer end stop and zeroes there; in single-`--id` mode you are responsible for holding the joint at the intended end stop before zeroing. `AxolArm` carries a per-joint offset so the public API stays in joint frame (`0` = rest).
+</Warning>
+
 | Flag | Description |
 |---|---|
 | `--l` / `--r` | Select the left or right arm (mutually exclusive, required) |
@@ -12,7 +16,7 @@ Sets the motor's zero-position reference to its current mechanical position (per
 | `--type {myactuator,damiao}` | Motor type (inferred from `--id` if omitted) |
 | `--guided` | Walk through every arm joint, zeroing each at its closer end stop |
 
-In `--guided` mode the CLI iterates through all 7 arm joints (the gripper is auto-calibrated at runtime). For each joint you place it somewhere inside its operating range, press Enter, then move it to the prompted end stop and press Enter again. If the motion direction doesn't match the expected sign the CLI loops back automatically and asks you to retry. Once the direction checks out, press Enter once more to commit the zero, or Ctrl-C to skip that joint.
+In `--guided` mode the CLI iterates through all 7 arm joints (the gripper is auto-calibrated at runtime). For each joint you place it somewhere inside its operating range, press Enter, then move it to the prompted end stop and press Enter again. If the motion is in the expected direction the zero is committed immediately. If you moved the wrong way, the CLI keeps your starting reference and asks you to travel to the *other* end stop instead; pressing Enter there sets the zero. Press Ctrl-C to skip a joint.
 
 ```bash
 axol motor.set-zero-pos --l --id 0x01      # single motor


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Wrong-direction recovery now zeros at the alternate end stop without re-validating motion sign, which could persist a bad zero if the operator confirms at the wrong pose; otherwise behavior is CLI/UX and documentation only.
> 
> **Overview**
> **Guided `motor.set-zero-pos`** no longer loops on wrong-direction motion or asks for a separate confirm step when motion matches the expected sign—it **zeros immediately** after a valid end-stop move (still warns on magnitude). If the user moved the **wrong way**, the CLI keeps the start reference, prompts them to go to the **other** end stop, and zeros on the next Enter instead of restarting the whole step.
> 
> **Docs and API docstrings** now state consistently that encoder zero is set at a **mechanical end stop**, not rest pose, and that **`AxolArm` offsets** keep the public API in joint frame (`0` = rest)—in the CLI module doc, `Motor.set_zero_position`, `AxolArm`/`Axol.set_zero_position`, and the motor/robot API plus CLI docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c00aa870b43fdc2ede0ed07becda1f448b29d75c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->