### PR TITLE
teleop pos multiplier

### DIFF
--- a/almond_axol/cli/config.py
+++ b/almond_axol/cli/config.py
@@ -48,6 +48,7 @@ import numpy as np
 
 from ..robot.config import AxolConfig
 from ..shared import CAN_LEFT, CAN_RIGHT
+from ..teleop.config import VRTeleopConfig
 
 T = TypeVar("T")
 
@@ -369,10 +370,13 @@ class TeleopCmdConfig:
     blend live on the nested ``axol`` config — override them via
     ``--axol.left.gripper.torque_limit`` and ``--axol.left_stiffness``.
     Disable an arm with ``--left_channel null`` / ``--right_channel null``.
+    Teleop session parameters (e.g. the position multiplier) live on the
+    nested ``teleop`` config — e.g. ``--teleop.position_multiplier 2.0``.
     """
 
     sim: bool = False
     axol: AxolConfig = field(default_factory=AxolConfig)
+    teleop: VRTeleopConfig = field(default_factory=VRTeleopConfig)
     left_channel: str | None = CAN_LEFT
     right_channel: str | None = CAN_RIGHT
     log_level: LogLevel = "INFO"

--- a/almond_axol/cli/teleop.py
+++ b/almond_axol/cli/teleop.py
@@ -9,6 +9,7 @@ field is reachable from the CLI (draccus-style) or from a JSON/YAML file:
     axol teleop --sim                                 # browser visualizer
     axol teleop --axol.left_stiffness 0.8
     axol teleop --axol.left.elbow.kp 60 --axol.right.gripper.torque_limit 0.7
+    axol teleop --teleop.position_multiplier 2.0      # scale hand motion 2x
     axol teleop --left_channel null                   # disable the left arm
     axol teleop --config_path my_teleop.json          # whole-config file
 """
@@ -78,5 +79,5 @@ async def _run(cfg: TeleopCmdConfig) -> None:
             left_channel=cfg.left_channel,
             right_channel=cfg.right_channel,
         )
-    async with VRTeleop(robot) as teleop:
+    async with VRTeleop(robot, config=cfg.teleop) as teleop:
         await teleop.run()

--- a/almond_axol/teleop/config.py
+++ b/almond_axol/teleop/config.py
@@ -72,6 +72,13 @@ class VRTeleopConfig:
             keeping the filter transparent during fast intentional moves.  For
             meter-space positions at 120 Hz a value of ~20 works well; increase
             if fast moves feel sticky.  Defaults to ``20.0``.
+        position_multiplier: Scale factor applied to the controller's
+            **position** displacement (not orientation) when mapping hand
+            motion to the end-effector target.  ``1.0`` is 1:1 motion;
+            ``2.0`` moves the arm twice as far as the hand, which helps cover
+            the robot's full reach when the arm is longer than the operator's.
+            Applied to both the end-effector and elbow position deltas so the
+            arm posture scales coherently.  Defaults to ``1.0``.
     """
 
     rest_pose_left: np.ndarray = field(
@@ -117,3 +124,4 @@ class VRTeleopConfig:
     ik_alpha: float = 0.5
     pose_min_cutoff: float = 1.5
     pose_beta: float = 5.0
+    position_multiplier: float = 1.0

--- a/almond_axol/teleop/worker.py
+++ b/almond_axol/teleop/worker.py
@@ -70,9 +70,14 @@ def _relative_target_np(
     rot_snap_ctrl: np.ndarray,
     pos_snap_fk: np.ndarray,
     rot_snap_fk: np.ndarray,
+    position_multiplier: float = 1.0,
 ) -> tuple[np.ndarray, np.ndarray]:
-    """Compute absolute EE target from controller delta. Returns (pos_3, rot_3x3)."""
-    d = rot_snap_ctrl.T @ (pos_curr - pos_snap_ctrl)
+    """Compute absolute EE target from controller delta. Returns (pos_3, rot_3x3).
+
+    ``position_multiplier`` scales only the translational displacement of the
+    controller relative to its engage snapshot; orientation is left untouched.
+    """
+    d = (rot_snap_ctrl.T @ (pos_curr - pos_snap_ctrl)) * position_multiplier
     new_t = (
         pos_snap_fk
         + rot_snap_fk[:, 0] * d[2]
@@ -243,21 +248,26 @@ class IKWorker:
             )
             return q_current
 
+        pos_mult = self._config.position_multiplier
         tl_pos, tl_rot = _relative_target_np(
             left_pos,
             left_rot,
             *self._snap_ctrl["left"],
             *self._snap_fk["left"],
+            position_multiplier=pos_mult,
         )
         tr_pos, tr_rot = _relative_target_np(
             right_pos,
             right_rot,
             *self._snap_ctrl["right"],
             *self._snap_fk["right"],
+            position_multiplier=pos_mult,
         )
 
-        elbow_l = self._snap_elbow_fk["left"] + (left_e - self._snap_elbow_ctrl["left"])
-        elbow_r = self._snap_elbow_fk["right"] + (
+        elbow_l = self._snap_elbow_fk["left"] + pos_mult * (
+            left_e - self._snap_elbow_ctrl["left"]
+        )
+        elbow_r = self._snap_elbow_fk["right"] + pos_mult * (
             right_e - self._snap_elbow_ctrl["right"]
         )
 

--- a/docs/api/teleop.mdx
+++ b/docs/api/teleop.mdx
@@ -45,6 +45,7 @@ See the [`teleop`](/cli/teleop) CLI command for the equivalent command-line entr
 | `ik_alpha` | `0.5` | EMA blend factor on IK output; `1.0` disables smoothing |
 | `pose_min_cutoff` | `1.5` Hz | One Euro Filter tremor cutoff for raw VR poses |
 | `pose_beta` | `5.0` | One Euro Filter speed coefficient (raises cutoff during fast moves) |
+| `position_multiplier` | `1.0` | Scale on hand **position** (not orientation): the EE target moves this many times as far as the hand. `>1` extends reach when the arm is longer than the operator's |
 | `reset_speed` | `0.1 rev/s` | Average joint velocity of the worst-case joint during return-to-rest (peak is `1.5×` this) |
 | `reset_min_duration` | `1.5` s | Floor on return-to-rest duration so near-rest starts don't snap home |
 | `rest_pose_left` / `rest_pose_right` | near-zero | Reset target for each arm, shape `(7,)` in `ARM_JOINTS` order |

--- a/docs/cli/collect-data.mdx
+++ b/docs/cli/collect-data.mdx
@@ -23,6 +23,7 @@ This command is configured via draccus. The robot and teleop subsystems are expo
 | `--robot_config.zed_host IP` | Shared IP of the ZED streamer for all three cameras (default `192.168.10.1`; cameras use ports 30000/30002/30004). Override a single camera with `--robot_config.cameras.<name>.host IP` (`<name>` ∈ `overhead`/`left_arm`/`right_arm`). |
 | `--robot_config.axol_config.<side>.gripper.torque_limit FLOAT` | Max torque (Nm) for a gripper in POSITION_FORCE mode (default: 0.5); `<side>` is `left`/`right` |
 | `--robot_config.axol_config.left_stiffness S` | Compliance↔stiffness blend for the left arm in `[0, 1]`. Scalar or 7-element list (one per arm joint, in `Joint` enum order). `0` = fully compliant; `1` = pre-tuning industrial gains; `0.5` (default) is the geometric mean. Use `right_stiffness` for the right arm. See [`AxolConfig.left_stiffness`](/api/robot). |
+| `--teleop_config.vr_teleop_config.position_multiplier FLOAT` | Scale factor on hand **position** (not orientation): the end-effector target moves this many times as far as your hand. `1.0` (default) is 1:1; `2.0` moves the arm twice as far, helping cover the robot's full reach when the arm is longer than the operator's. |
 | `--rerun_ip IP` | IP of a Rerun viewer on your local machine for live visualization |
 | `--rerun_port INT` | Rerun viewer port (default: 9876); only used when `--rerun_ip` is set |
 | `--log_level {DEBUG,INFO,WARNING,ERROR}` | Default: `INFO` |

--- a/docs/cli/teleop.mdx
+++ b/docs/cli/teleop.mdx
@@ -33,6 +33,7 @@ Runs on the **real robot by default**; pass `--sim` for the browser visualizer. 
 | `--axol.right_stiffness S` | Same, for the right arm. |
 | `--axol.left.gripper.torque_limit FLOAT` | Max torque (Nm) for the left gripper in POSITION_FORCE mode (default: 0.5). Use `right` for the right gripper. |
 | `--axol.<side>.<joint>.<gain> VALUE` | Override any per-joint gain, e.g. `--axol.left.elbow.kp 60`. `<side>` is `left`/`right`; `<joint>` is `shoulder_1…wrist_3`; `<gain>` is `kp`/`kd`/etc. |
+| `--teleop.position_multiplier FLOAT` | Scale factor on hand **position** (not orientation): the end-effector target moves this many times as far as your hand. `1.0` (default) is 1:1; `2.0` moves the arm twice as far, helping cover the robot's full reach when the arm is longer than the operator's. |
 | `--log_level {DEBUG,INFO,WARNING,ERROR}` | Default: `INFO` |
 | `--config_path PATH` | Load a whole-config JSON/YAML file; CLI overrides layer on top. See [Command configuration](/cli/configuration). |
 
@@ -41,6 +42,7 @@ axol teleop                                       # real robot
 axol teleop --sim                                 # browser visualizer
 axol teleop --axol.left_stiffness 0.8
 axol teleop --axol.left.elbow.kp 60 --axol.right.gripper.torque_limit 0.7
+axol teleop --teleop.position_multiplier 2.0      # scale hand motion 2x
 axol teleop --left_channel null                   # disable the left arm
 axol teleop --config_path my_teleop.json          # whole-config file
 ```


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes live teleop IK target mapping on hardware; non-default multipliers can demand larger workspace motion and affect reach/collision behavior, though defaults preserve prior behavior.
> 
> **Overview**
> Adds **`position_multiplier`** to VR teleop so operators can scale **translational** hand motion without changing orientation mapping. Default **`1.0`** keeps existing 1:1 behavior; values like **`2.0`** amplify how far the end-effector and elbow targets move relative to the controller snapshot.
> 
> The IK worker applies the factor in `_relative_target_np` (controller displacement only) and to left/right elbow deltas so posture stays consistent. **`axol teleop`** now nests **`VRTeleopConfig`** under **`--teleop.*`** (e.g. **`--teleop.position_multiplier 2.0`**) and passes that config into **`VRTeleop`**. Docs cover the teleop CLI, API table, and **`collect-data`** flag **`--teleop_config.vr_teleop_config.position_multiplier`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f3dc78be8a6d0deb85e9c4c9254cb5ec19e4a5f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->