### PR TITLE
rotation multiplier

### DIFF
--- a/almond_axol/teleop/config.py
+++ b/almond_axol/teleop/config.py
@@ -79,6 +79,12 @@ class VRTeleopConfig:
             the robot's full reach when the arm is longer than the operator's.
             Applied to both the end-effector and elbow position deltas so the
             arm posture scales coherently.  Defaults to ``1.0``.
+        rotation_multiplier: Scale factor applied to the controller's
+            **orientation** displacement (not position) when mapping hand
+            motion to the end-effector target.  The relative rotation of the
+            controller since engage is converted to axis-angle and its angle
+            is scaled by this factor; ``1.0`` is 1:1 motion, ``2.0`` rotates
+            the end-effector twice as far as the wrist.  Defaults to ``1.0``.
     """
 
     rest_pose_left: np.ndarray = field(
@@ -125,3 +131,4 @@ class VRTeleopConfig:
     pose_min_cutoff: float = 1.5
     pose_beta: float = 5.0
     position_multiplier: float = 1.0
+    rotation_multiplier: float = 1.0

--- a/almond_axol/teleop/worker.py
+++ b/almond_axol/teleop/worker.py
@@ -8,6 +8,7 @@ All intermediate computations stay in NumPy; the single JAX boundary is the
 
 from __future__ import annotations
 
+import math
 import multiprocessing
 import multiprocessing.connection
 import os
@@ -63,6 +64,38 @@ def _vr_to_flu_np(
     return pos, rot
 
 
+def _scale_rotation_np(R: np.ndarray, scale: float) -> np.ndarray:
+    """Scale the angle of a rotation matrix by ``scale`` (a power in SO(3)).
+
+    Converts ``R`` to axis-angle, multiplies the angle by ``scale``, and maps
+    back via Rodrigues' formula.  ``scale == 1.0`` and near-identity rotations
+    are short-circuited.
+    """
+    if scale == 1.0:
+        return R
+    cos_theta = max(-1.0, min(1.0, (float(np.trace(R)) - 1.0) * 0.5))
+    theta = math.acos(cos_theta)
+    if theta < 1e-6:
+        return R
+    axis = np.array(
+        (R[2, 1] - R[1, 2], R[0, 2] - R[2, 0], R[1, 0] - R[0, 1]),
+        dtype=np.float64,
+    ) / (2.0 * math.sin(theta))
+    new_theta = theta * scale
+    k = np.array(
+        (
+            (0.0, -axis[2], axis[1]),
+            (axis[2], 0.0, -axis[0]),
+            (-axis[1], axis[0], 0.0),
+        ),
+        dtype=np.float64,
+    )
+    r_scaled = (
+        np.eye(3) + math.sin(new_theta) * k + (1.0 - math.cos(new_theta)) * (k @ k)
+    )
+    return r_scaled.astype(np.float32)
+
+
 def _relative_target_np(
     pos_curr: np.ndarray,
     rot_curr: np.ndarray,
@@ -71,11 +104,13 @@ def _relative_target_np(
     pos_snap_fk: np.ndarray,
     rot_snap_fk: np.ndarray,
     position_multiplier: float = 1.0,
+    rotation_multiplier: float = 1.0,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Compute absolute EE target from controller delta. Returns (pos_3, rot_3x3).
 
     ``position_multiplier`` scales only the translational displacement of the
-    controller relative to its engage snapshot; orientation is left untouched.
+    controller relative to its engage snapshot; ``rotation_multiplier`` scales
+    only the angle of its orientation displacement.
     """
     d = (rot_snap_ctrl.T @ (pos_curr - pos_snap_ctrl)) * position_multiplier
     new_t = (
@@ -89,6 +124,7 @@ def _relative_target_np(
     R_delta[0, :] = (A[2, 2], -A[2, 1], A[2, 0])
     R_delta[1, :] = (-A[1, 2], A[1, 1], -A[1, 0])
     R_delta[2, :] = (A[0, 2], -A[0, 1], A[0, 0])
+    R_delta = _scale_rotation_np(R_delta, rotation_multiplier)
     return new_t.astype(np.float32), (rot_snap_fk @ R_delta).astype(np.float32)
 
 
@@ -249,12 +285,14 @@ class IKWorker:
             return q_current
 
         pos_mult = self._config.position_multiplier
+        rot_mult = self._config.rotation_multiplier
         tl_pos, tl_rot = _relative_target_np(
             left_pos,
             left_rot,
             *self._snap_ctrl["left"],
             *self._snap_fk["left"],
             position_multiplier=pos_mult,
+            rotation_multiplier=rot_mult,
         )
         tr_pos, tr_rot = _relative_target_np(
             right_pos,
@@ -262,6 +300,7 @@ class IKWorker:
             *self._snap_ctrl["right"],
             *self._snap_fk["right"],
             position_multiplier=pos_mult,
+            rotation_multiplier=rot_mult,
         )
 
         elbow_l = self._snap_elbow_fk["left"] + pos_mult * (

--- a/docs/api/teleop.mdx
+++ b/docs/api/teleop.mdx
@@ -46,6 +46,7 @@ See the [`teleop`](/cli/teleop) CLI command for the equivalent command-line entr
 | `pose_min_cutoff` | `1.5` Hz | One Euro Filter tremor cutoff for raw VR poses |
 | `pose_beta` | `5.0` | One Euro Filter speed coefficient (raises cutoff during fast moves) |
 | `position_multiplier` | `1.0` | Scale on hand **position** (not orientation): the EE target moves this many times as far as the hand. `>1` extends reach when the arm is longer than the operator's |
+| `rotation_multiplier` | `1.0` | Scale on hand **orientation** (not position): the EE target rotates this many times as far as the hand. `>1` rotates the arm further than the wrist |
 | `reset_speed` | `0.1 rev/s` | Average joint velocity of the worst-case joint during return-to-rest (peak is `1.5×` this) |
 | `reset_min_duration` | `1.5` s | Floor on return-to-rest duration so near-rest starts don't snap home |
 | `rest_pose_left` / `rest_pose_right` | near-zero | Reset target for each arm, shape `(7,)` in `ARM_JOINTS` order |

--- a/docs/cli/collect-data.mdx
+++ b/docs/cli/collect-data.mdx
@@ -24,6 +24,7 @@ This command is configured via draccus. The robot and teleop subsystems are expo
 | `--robot_config.axol_config.<side>.gripper.torque_limit FLOAT` | Max torque (Nm) for a gripper in POSITION_FORCE mode (default: 0.5); `<side>` is `left`/`right` |
 | `--robot_config.axol_config.left_stiffness S` | Compliance↔stiffness blend for the left arm in `[0, 1]`. Scalar or 7-element list (one per arm joint, in `Joint` enum order). `0` = fully compliant; `1` = pre-tuning industrial gains; `0.5` (default) is the geometric mean. Use `right_stiffness` for the right arm. See [`AxolConfig.left_stiffness`](/api/robot). |
 | `--teleop_config.vr_teleop_config.position_multiplier FLOAT` | Scale factor on hand **position** (not orientation): the end-effector target moves this many times as far as your hand. `1.0` (default) is 1:1; `2.0` moves the arm twice as far, helping cover the robot's full reach when the arm is longer than the operator's. |
+| `--teleop_config.vr_teleop_config.rotation_multiplier FLOAT` | Scale factor on hand **orientation** (not position): the end-effector target rotates this many times as far as your wrist. `1.0` (default) is 1:1; `2.0` rotates the arm twice as far. |
 | `--rerun_ip IP` | IP of a Rerun viewer on your local machine for live visualization |
 | `--rerun_port INT` | Rerun viewer port (default: 9876); only used when `--rerun_ip` is set |
 | `--log_level {DEBUG,INFO,WARNING,ERROR}` | Default: `INFO` |

--- a/docs/cli/teleop.mdx
+++ b/docs/cli/teleop.mdx
@@ -34,6 +34,7 @@ Runs on the **real robot by default**; pass `--sim` for the browser visualizer. 
 | `--axol.left.gripper.torque_limit FLOAT` | Max torque (Nm) for the left gripper in POSITION_FORCE mode (default: 0.5). Use `right` for the right gripper. |
 | `--axol.<side>.<joint>.<gain> VALUE` | Override any per-joint gain, e.g. `--axol.left.elbow.kp 60`. `<side>` is `left`/`right`; `<joint>` is `shoulder_1…wrist_3`; `<gain>` is `kp`/`kd`/etc. |
 | `--teleop.position_multiplier FLOAT` | Scale factor on hand **position** (not orientation): the end-effector target moves this many times as far as your hand. `1.0` (default) is 1:1; `2.0` moves the arm twice as far, helping cover the robot's full reach when the arm is longer than the operator's. |
+| `--teleop.rotation_multiplier FLOAT` | Scale factor on hand **orientation** (not position): the end-effector rotates this many times as far as your wrist. `1.0` (default) is 1:1; `2.0` rotates the arm twice as far. |
 | `--log_level {DEBUG,INFO,WARNING,ERROR}` | Default: `INFO` |
 | `--config_path PATH` | Load a whole-config JSON/YAML file; CLI overrides layer on top. See [Command configuration](/cli/configuration). |
 
@@ -43,6 +44,7 @@ axol teleop --sim                                 # browser visualizer
 axol teleop --axol.left_stiffness 0.8
 axol teleop --axol.left.elbow.kp 60 --axol.right.gripper.torque_limit 0.7
 axol teleop --teleop.position_multiplier 2.0      # scale hand motion 2x
+axol teleop --teleop.rotation_multiplier 2.0      # scale hand rotation 2x
 axol teleop --left_channel null                   # disable the left arm
 axol teleop --config_path my_teleop.json          # whole-config file
 ```


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes live IK orientation targets during teleoperation; defaults preserve prior behavior, but non-1.0 values directly affect commanded wrist motion on hardware.
> 
> **Overview**
> Adds a **`rotation_multiplier`** teleop setting (default **`1.0`**) that scales how much controller **orientation** since engage maps to end-effector rotation, parallel to the existing **`position_multiplier`** for translation.
> 
> The IK worker computes the controller’s relative rotation delta, scales its angle in SO(3) via a new **`_scale_rotation_np`** helper (axis-angle × Rodrigues), then applies the result when building left/right EE targets. **`VRTeleopConfig`**, **`axol teleop`**, **`collect-data`**, and the teleop API docs expose the knob (e.g. **`--teleop.rotation_multiplier 2.0`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3770af674a362c5856cff208beb550fd7dd7fa2. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->