### PR TITLE
Add public reset_command_state / gravity_compensate APIs

### DIFF
--- a/almond_axol/lerobot/robot/robot_axol.py
+++ b/almond_axol/lerobot/robot/robot_axol.py
@@ -414,3 +414,34 @@ class AxolRobot(Robot):
         ).result(timeout=1.0)
 
         return action
+
+    def gravity_compensate(
+        self, kd: float = 0.5, free_joints: set[Joint] | None = None
+    ) -> None:
+        """Apply one cycle of gravity compensation on both arms.
+
+        Submits onto the robot's background event loop (mirroring
+        :meth:`send_action`) and blocks until the cycle is sent. Telemetry must
+        be active, so call this only while connected; drive it in a loop at the
+        desired rate to keep the arms free to be hand-guided. See
+        :meth:`almond_axol.robot.axol.Axol.gravity_compensate` for the
+        ``kd``/``free_joints`` semantics.
+        """
+        assert self._axol is not None and self._loop is not None
+        asyncio.run_coroutine_threadsafe(
+            self._axol.gravity_compensate(kd=kd, free_joints=free_joints), self._loop
+        ).result(timeout=1.0)
+
+    def reset_command_state(self) -> None:
+        """Clear cached command history after an out-of-band move.
+
+        Call after hand-guiding the arms (e.g. under
+        :meth:`gravity_compensate`) and before resuming :meth:`send_action`, so
+        the return-to-pose command is not rejected by the max-step safety
+        check. See :meth:`almond_axol.robot.axol.Axol.reset_command_state`.
+
+        Mutates plain Python state on the arm wrappers, so it runs directly
+        without the event loop.
+        """
+        assert self._axol is not None
+        self._axol.reset_command_state()

--- a/almond_axol/robot/axol.py
+++ b/almond_axol/robot/axol.py
@@ -690,6 +690,29 @@ class AxolArm:
         self._gc_hold_q = None
         self._gc_hold_free = None
 
+    def reset_command_state(self) -> None:
+        """Forget cached command history after an out-of-band move.
+
+        When the arm is moved without going through :meth:`motion_control`
+        (e.g. hand-guided while under :meth:`gravity_compensate`), the cached
+        ``_last_q_commanded`` and the velocity/accel differentiators no longer
+        reflect the real pose. Left stale, the next ``motion_control`` command
+        would be measured against the old setpoint: the max-step safety check
+        could reject the first waypoint, and the velocity/accel feedforward
+        would spike on a phantom jump.
+
+        Calling this clears that history so the next ``motion_control`` is
+        treated like the first command after :meth:`connect` — the max-step
+        check is skipped and the differentiators restart from zero. Pair it
+        with :meth:`reset_gravity_hold` when handing control back after a
+        manual reposition.
+        """
+        self._last_q_commanded = None
+        n = len(list(Joint))
+        self._vel_diff = Differentiator(n=n)
+        self._accel_diff = Differentiator(n=n)
+        self._meas_vel_diff = Differentiator(n=n)
+
 
 class Axol(RobotBase):
     """Dual-arm Axol robot interface.
@@ -1120,3 +1143,16 @@ class Axol(RobotBase):
             self.left.reset_gravity_hold()
         if self.right is not None:
             self.right.reset_gravity_hold()
+
+    def reset_command_state(self) -> None:
+        """Clear cached command history on both arms after an out-of-band move.
+
+        See :meth:`AxolArm.reset_command_state`. Call this after hand-guiding
+        the arms (e.g. under :meth:`gravity_compensate`) and before resuming
+        :meth:`motion_control`, so the return-to-pose command is not rejected
+        by the max-step safety check.
+        """
+        if self.left is not None:
+            self.left.reset_command_state()
+        if self.right is not None:
+            self.right.reset_command_state()


### PR DESCRIPTION
Exposes gravity compensation and command-history reset as public methods so callers no longer reach into private SDK internals (`_axol`, `_last_q_commanded`, the differentiators) after an out-of-band, hand-guided arm move. Adds `AxolArm.reset_command_state()` (clears `_last_q_commanded` and re-news the velocity/accel differentiators so the next `motion_control` is treated like the first after connect — max-step check skipped, feedforward from zero) and a dual-arm `Axol.reset_command_state()` delegator mirroring `reset_gravity_hold()`. On the lerobot wrapper, adds public sync `AxolRobot.gravity_compensate()` and `AxolRobot.reset_command_state()` modeled on `send_action()`. This is the SDK half of a coordinated change; axol-pi can drop its private reach-ins once it bumps to this rev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches motion-control safety and feedforward state on the real-time arm path; misuse (skipping reset after hand-guiding) could still cause dropped commands or torque spikes, but the change only adds explicit reset APIs without altering `motion_control` logic.
> 
> **Overview**
> Adds **public** hooks for hand-guiding workflows so callers no longer touch private motion-control state (`_last_q_commanded`, differentiators, or raw `_axol`).
> 
> **SDK:** `AxolArm.reset_command_state()` clears the last commanded pose and re-instantiates velocity/accel differentiators so the next `motion_control` behaves like the first command after connect (max-step check skipped, feedforward from zero). `Axol.reset_command_state()` applies that on both arms, parallel to existing `reset_gravity_hold()`.
> 
> **LeRobot:** `AxolRobot.gravity_compensate()` runs one gravity-comp cycle on the background asyncio loop (same pattern as `send_action()`). `AxolRobot.reset_command_state()` forwards to the dual-arm SDK method synchronously.
> 
> Intended use: run gravity comp in a loop for manual posing, then call `reset_command_state()` (and optionally `reset_gravity_hold()`) before resuming `send_action` / `motion_control` so the return pose is not dropped by `max_step_rad` and feedforward does not spike on a phantom jump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 035592e67eaf47961cc21a125e306630cd74b7fb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->