### PR TITLE
Use public APIs in high-level integrations; isolate unavoidable private deps

### DIFF
--- a/almond_axol/cli/config.py
+++ b/almond_axol/cli/config.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 
 import argparse
 import dataclasses
+import logging
 import re
 from dataclasses import MISSING, dataclass, field
 from typing import Any, Literal, TypeVar, get_args
@@ -56,6 +57,8 @@ from ..utils.shared import CAN_LEFT, CAN_RIGHT
 from ..vr.config import VRServerConfig
 
 T = TypeVar("T")
+
+_logger = logging.getLogger(__name__)
 
 
 # ----------------------------------------------------------------------
@@ -331,43 +334,24 @@ def _condense_help(ap: argparse.ArgumentParser) -> None:
     Purely cosmetic: every suppressed field is still fully overridable on
     the CLI. A no-op for configs without nested dataclasses (e.g.
     ``gravity-comp``), whose help is already short.
+
+    Private-API note: this is the one place we intentionally read argparse's
+    internal ``_actions`` / ``_action_groups`` / ``_group_actions``. There is
+    no public way to condense help here — the truly public seam is
+    ``add_argument(help=SUPPRESS)`` at construction time, but *draccus* builds
+    the parser, not us, so we can only adjust it after the fact; argparse
+    exposes no public post-hoc help API and ``HelpFormatter`` subclassing is
+    equally undocumented. These attributes have been stable since Python 2,
+    but the whole introspection is wrapped defensively so a future CPython
+    change degrades to the full (un-condensed) help instead of breaking
+    ``--help`` and argument parsing for every command.
     """
-    actions: dict[int, argparse.Action] = {id(a): a for a in ap._actions}
-    for group in ap._action_groups:
-        for a in group._group_actions:
-            actions[id(a)] = a
-
-    suppressed = 0
-    for a in actions.values():
-        if _is_help_noise(a):
-            a.help = argparse.SUPPRESS
-            suppressed += 1
-    if not suppressed:
-        return
-
-    # Clean up the help shown for the fields that remain visible.
-    for a in actions.values():
-        if a.help == argparse.SUPPRESS:
-            continue
-        opt = next((o for o in a.option_strings if o.startswith("--")), "")
-        leaf = opt.lstrip("-").split(".")[-1]
-        if leaf in _FIELD_HELP:
-            a.help = _FIELD_HELP[leaf]
-        elif any(marker in (a.help or "") for marker in _GARBLED_HELP_MARKERS):
-            a.help = None
-
-    for group in ap._action_groups:
-        # Nested-dataclass groups are titled like ``AxolConfig ['axol']`` /
-        # ``JointConfig ['axol.left.elbow']``; their docstrings are the bulk
-        # of the noise. The top command-config group (no ``[`` in the title)
-        # keeps its docstring as the command summary.
-        if "[" in (group.title or ""):
-            group.description = None
-        if not any(a.help != argparse.SUPPRESS for a in group._group_actions):
-            group.title = None
-            group.description = None
-
-    ap.epilog = (
+    # The epilog narrates the condensing ("only common fields are shown"), so
+    # it's only set once we know condensing happened — either it ran (below) or
+    # it was skipped by a future argparse layout change (the except block). A
+    # config with nothing to condense (no nested dataclasses, e.g.
+    # ``gravity-comp``) shows its full, short help with no epilog.
+    epilog = (
         "Only common fields are shown above. Every nested config field is "
         "still overridable from the CLI — e.g. per-joint gains like "
         "--axol.left.elbow.kp 60 (or --robot_config.axol_config.* for "
@@ -375,6 +359,54 @@ def _condense_help(ap: argparse.ArgumentParser) -> None:
         "--config_path. Full reference: "
         "https://docs.almond.bot/cli/configuration"
     )
+
+    try:
+        # draccus registers the include options on the argument *groups* but
+        # not on ``parser._actions``, so both are scanned.
+        actions: dict[int, argparse.Action] = {id(a): a for a in ap._actions}
+        for group in ap._action_groups:
+            for a in group._group_actions:
+                actions[id(a)] = a
+
+        suppressed = 0
+        for a in actions.values():
+            if _is_help_noise(a):
+                a.help = argparse.SUPPRESS
+                suppressed += 1
+        if not suppressed:
+            return
+        ap.epilog = epilog
+
+        # Clean up the help shown for the fields that remain visible.
+        for a in actions.values():
+            if a.help == argparse.SUPPRESS:
+                continue
+            opt = next((o for o in a.option_strings if o.startswith("--")), "")
+            leaf = opt.lstrip("-").split(".")[-1]
+            if leaf in _FIELD_HELP:
+                a.help = _FIELD_HELP[leaf]
+            elif any(marker in (a.help or "") for marker in _GARBLED_HELP_MARKERS):
+                a.help = None
+
+        for group in ap._action_groups:
+            # Nested-dataclass groups are titled like ``AxolConfig ['axol']`` /
+            # ``JointConfig ['axol.left.elbow']``; their docstrings are the bulk
+            # of the noise. The top command-config group (no ``[`` in the title)
+            # keeps its docstring as the command summary.
+            if "[" in (group.title or ""):
+                group.description = None
+            if not any(a.help != argparse.SUPPRESS for a in group._group_actions):
+                group.title = None
+                group.description = None
+    except AttributeError:
+        # argparse changed its internal layout; show the full help rather than
+        # crash. Parsing is unaffected (these attrs only drive --help). Still
+        # attach the epilog so the "everything is overridable" pointer survives.
+        ap.epilog = epilog
+        _logger.debug(
+            "Skipping --help condensing: argparse internals not as expected.",
+            exc_info=True,
+        )
 
 
 def parse(config_class: type[T], argv: list[str]) -> T:

--- a/almond_axol/cli/inference_server.py
+++ b/almond_axol/cli/inference_server.py
@@ -51,13 +51,9 @@ def main(argv: list[str]) -> None:
     cfg = parse(InferenceServerConfig, argv)
     logging.basicConfig(level=getattr(logging, cfg.log_level), force=True)
 
-    from lerobot.async_inference import policy_server as _ps
+    from ..lerobot.inference_patch import disable_observation_similarity_filter
 
-    # Upstream's 1-rad L2 similarity filter drops nearly every observation
-    # on Axol's 16-DOF arms at 60 Hz, starving the action queue. There is
-    # no config knob, so patch the module symbol before ``serve`` (mirrors
-    # run-policy's local-server spawn).
-    _ps.observations_similar = lambda *args, **kwargs: False
+    disable_observation_similarity_filter()
 
     from lerobot.async_inference.configs import PolicyServerConfig
     from lerobot.async_inference.policy_server import serve

--- a/almond_axol/cli/run_policy.py
+++ b/almond_axol/cli/run_policy.py
@@ -312,12 +312,9 @@ def _serve_policy_server(server_cfg_dict: dict[str, Any]) -> None:
 
     signal.signal(signal.SIGINT, signal.SIG_IGN)
 
-    from lerobot.async_inference import policy_server as _ps
+    from ..lerobot.inference_patch import disable_observation_similarity_filter
 
-    # Upstream's 1-rad L2 similarity filter drops nearly every observation
-    # on Axol's 16-DOF arms at 60 Hz, starving the action queue. There is
-    # no config knob, so patch the module symbol before ``serve``.
-    _ps.observations_similar = lambda *args, **kwargs: False
+    disable_observation_similarity_filter()
 
     from lerobot.async_inference.configs import PolicyServerConfig
     from lerobot.async_inference.policy_server import serve
@@ -373,11 +370,26 @@ def _build_axol_robot_client(
           through ``_install_future_queue`` to avoid re-popping a
           just-executed timestep.
         - ``control_loop`` only pops actions; observation capture + send
-          moves to ``_observation_loop`` so the ~60-70 ms ZED read + gRPC
+          moves to ``observation_loop`` so the ~60-70 ms ZED read + gRPC
           send can't stall the 60 Hz action stream.
         - ``control_loop_action`` updates ``latest_action`` atomically
           with the queue pop (upstream updates it after ``send_action``,
           which leaves a re-pop race for the aggregator).
+
+        Everything here is built on public ``RobotClient`` API (public
+        instance attributes + public ``control_loop_observation`` /
+        ``send_action`` / ``actions_available``) with one unavoidable
+        exception: overriding ``_aggregate_action_queues``. LeRobot calls
+        the aggregator by that private name inside the public
+        ``receive_actions`` (robot_client.py), and its only public
+        aggregation hook (``RobotClientConfig.aggregate_fn_name``) selects
+        one of four *stateless, pairwise* blend functions — which cannot
+        express our stateful, multi-chunk, recency-weighted
+        ``temporal_ensemble``. Overriding the private method is therefore
+        the minimal seam. ``__init__`` asserts the symbol still exists so a
+        LeRobot bump that renames it fails loudly instead of silently
+        disabling ensembling. (Upstreaming a public aggregator hook would
+        remove this last dependency.)
 
         The constructor also skips ``make_robot_from_config`` / connect so
         re-recording doesn't pay the camera reconnect cost, publishes
@@ -400,6 +412,19 @@ def _build_axol_robot_client(
             aggregate_strategy,
             temporal_ensemble_coeff,
         ):
+            # We override the private RobotClient._aggregate_action_queues to
+            # inject temporal_ensemble (no public hook can express it — see the
+            # class docstring). If a LeRobot upgrade renames it, receive_actions
+            # would call the new name and our override would silently never run,
+            # disabling ensembling. Fail loudly at construction instead.
+            if not hasattr(RobotClient, "_aggregate_action_queues"):
+                raise RuntimeError(
+                    "lerobot RobotClient no longer defines "
+                    "'_aggregate_action_queues'; AxolRobotClient's "
+                    "temporal_ensemble override needs review against the new "
+                    "LeRobot version."
+                )
+
             self.config = config
             self.robot = robot
             self._publisher = publisher
@@ -439,7 +464,6 @@ def _build_axol_robot_client(
             self.latest_action_lock = _threading.Lock()
             self.latest_action = -1
             self.action_chunk_size = -1
-            self._chunk_size_threshold = config.chunk_size_threshold
             self.action_queue = Queue()
             self.action_queue_lock = _threading.Lock()
             self.action_queue_size = []
@@ -646,9 +670,16 @@ def _build_axol_robot_client(
                     self.latest_action = timed_action.get_timestep()
                 qs_after = self.action_queue.qsize()
 
-            performed = self.robot.send_action(
-                self._action_tensor_to_action_dict(timed_action.get_action())
-            )
+            # Inlined from upstream RobotClient._action_tensor_to_action_dict
+            # so we depend only on the public ``robot.action_features`` rather
+            # than a private LeRobot method. Maps the flat action tensor to a
+            # {motor_name: float} dict by position.
+            action_tensor = timed_action.get_action()
+            action = {
+                key: action_tensor[i].item()
+                for i, key in enumerate(self.robot.action_features)
+            }
+            performed = self.robot.send_action(action)
 
             if verbose:
                 self.logger.debug(
@@ -662,7 +693,7 @@ def _build_axol_robot_client(
             return performed
 
         def control_loop(self, task, verbose: bool = False):  # type: ignore[no-untyped-def,override]
-            """Action-only control loop; obs send is on ``_observation_loop``.
+            """Action-only control loop; obs send is on ``observation_loop``.
 
             Upstream interleaves microsecond action pops with the 60-70 ms
             obs send on one thread, collapsing 60 Hz down to ~27 Hz on
@@ -687,7 +718,7 @@ def _build_axol_robot_client(
                 self.fatal_error = exc
                 self.shutdown_event.set()
 
-        def _observation_loop(self, task, verbose: bool = False):  # type: ignore[no-untyped-def]
+        def observation_loop(self, task, verbose: bool = False):  # type: ignore[no-untyped-def]
             """Dedicated thread: capture and send observations.
 
             Fires ``control_loop_observation`` once the action queue
@@ -697,7 +728,16 @@ def _build_axol_robot_client(
             self.logger.info("Observation loop thread starting")
             while self.running:
                 try:
-                    if self._ready_to_send_observation():
+                    # Inlined from upstream RobotClient._ready_to_send_observation
+                    # so we read only public state (``action_queue``,
+                    # ``action_chunk_size``) and the public
+                    # ``config.chunk_size_threshold`` instead of the private
+                    # method/attribute. Send once the queue drains to threshold.
+                    with self.action_queue_lock:
+                        queue_fraction = (
+                            self.action_queue.qsize() / self.action_chunk_size
+                        )
+                    if queue_fraction <= self.config.chunk_size_threshold:
                         self.control_loop_observation(task, verbose)
                     else:
                         time.sleep(self.config.environment_dt)
@@ -958,7 +998,7 @@ def _run(
             )
             # Decoupled from the control thread — see AxolRobotClient.control_loop.
             obs_thread = threading.Thread(
-                target=client._observation_loop,
+                target=client.observation_loop,
                 args=(task,),
                 name="axol-obs-loop",
                 daemon=True,

--- a/almond_axol/lerobot/inference_patch.py
+++ b/almond_axol/lerobot/inference_patch.py
@@ -1,0 +1,47 @@
+"""LeRobot async-inference compatibility shims.
+
+Isolated so both the auto-launched policy-server child process
+(``run-policy``) and the standalone ``inference-server`` apply the exact
+same patch through one guarded code path.
+"""
+
+from __future__ import annotations
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def disable_observation_similarity_filter() -> None:
+    """Stop ``PolicyServer`` from dropping observations as "too similar".
+
+    Upstream's ``observations_similar`` filter skips any observation whose
+    joint-space L2 distance from the previous one is under a **hardcoded**
+    1-rad tolerance (``lerobot.async_inference.helpers``). On Axol's 16-DOF
+    arms at 60 Hz consecutive observations are almost always within that
+    bound, so the filter drops nearly every observation and starves the
+    action queue.
+
+    LeRobot exposes no public knob for this — the tolerance is a function
+    default that ``PolicyServer`` never threads through ``PolicyServerConfig``
+    — so the only fix without an upstream change is to neutralize the module
+    symbol before ``serve`` runs. This is a deliberate private-API
+    dependency; it is guarded so a LeRobot upgrade that renames or removes
+    the symbol fails loudly here instead of silently re-enabling the filter.
+
+    (The clean long-term fix is to upstream a ``similarity_atol`` /
+    ``skip_similar_observations`` field on ``PolicyServerConfig``.)
+    """
+    from lerobot.async_inference import policy_server as ps
+
+    if not hasattr(ps, "observations_similar"):
+        raise RuntimeError(
+            "lerobot.async_inference.policy_server no longer defines "
+            "'observations_similar'; the Axol observation-filter workaround "
+            "needs review against the new LeRobot version (otherwise the "
+            "policy server may silently drop observations and starve the "
+            "action queue)."
+        )
+
+    ps.observations_similar = lambda *args, **kwargs: False
+    _logger.debug("Disabled PolicyServer observation-similarity filter.")

--- a/almond_axol/motor/driver.py
+++ b/almond_axol/motor/driver.py
@@ -18,6 +18,29 @@ class MotorDriver(ABC):
     carry the authoritative docstrings inherited by both implementations.
     """
 
+    # Push-based feedback callback, installed via ``set_feedback_callback``.
+    # Subclasses initialize this to ``None`` in ``__init__`` and invoke it
+    # from their CAN message handler when a feedback frame arrives.
+    _on_feedback: Callable[[float, float], None] | None = None
+
+    def set_feedback_callback(
+        self, callback: Callable[[float, float], None] | None
+    ) -> None:
+        """Register a callback fired with ``(position, torque)`` on each feedback frame.
+
+        This is the push-based counterpart to :meth:`get_telemetry`'s
+        pull-based ``on_position`` / ``on_torque`` callbacks: drivers invoke
+        it whenever an unsolicited or command-response feedback frame arrives
+        (for example the response to :meth:`set_impedance`), letting callers
+        cache the latest position/torque without an explicit telemetry
+        round-trip. Pass ``None`` to clear the callback.
+
+        Args:
+            callback: Receives ``(position_rad, torque_nm)``, or ``None`` to
+                disable feedback callbacks.
+        """
+        self._on_feedback = callback
+
     @abstractmethod
     async def enable(self) -> None:
         """Enable the motor and release the brake."""

--- a/almond_axol/motor/motor.py
+++ b/almond_axol/motor/motor.py
@@ -116,8 +116,10 @@ class Motor:
         self._position: float | None = None
         self._torque: float | None = None
         self._telemetry_task: asyncio.Task | None = None
-        self._driver._on_feedback = lambda pos, torq: (
-            setattr(self, "_position", pos) or setattr(self, "_torque", torq)
+        self._driver.set_feedback_callback(
+            lambda pos, torq: (
+                setattr(self, "_position", pos) or setattr(self, "_torque", torq)
+            )
         )
 
     async def enable(self) -> None:


### PR DESCRIPTION
Audits the high-level features (teleop, gravity-comp, data-collection, run-policy) for private-API usage and rewrites everything that can be expressed against public APIs: run-policy's `AxolRobotClient` now inlines `_action_tensor_to_action_dict` and `_ready_to_send_observation` against public `RobotClient` attributes (dropping `_chunk_size_threshold`) and renames its own `_observation_loop` to `observation_loop`, and `motor` gets a public `MotorDriver.set_feedback_callback` hook instead of poking the driver's private `_on_feedback`. Three dependencies have no public path and are kept but isolated, guarded, and documented so a LeRobot/CPython change fails loudly rather than silently: the `_aggregate_action_queues` override (temporal ensemble — no public hook can express a stateful multi-chunk aggregator) now asserts the symbol exists, the `observations_similar` monkeypatch (hardcoded tolerance, no config knob) is consolidated into one guarded helper at `almond_axol/lerobot/inference_patch.py`, and the argparse internals in `_condense_help` (draccus builds the parser, so the public `add_argument(help=SUPPRESS)` seam is unavailable) are wrapped in a defensive `try/except` that degrades to full help. Teleop and data-collection were already public-only and are unchanged. CLI help output is verified byte-identical for teleop and gravity-comp.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the 60 Hz run-policy control/observation path and LeRobot private hooks; behavior is intended to match prior logic but LeRobot or argparse upgrades could surface the new guards or change help formatting on fallback.
> 
> **Overview**
> This PR **audits high-level integrations** (CLI help, run-policy/inference-server, motors) and **replaces private LeRobot/argparse usage with public seams** wherever one exists, while **isolating and hardening** the few dependencies that cannot.
> 
> **`AxolRobotClient`** inlines action dict mapping and observation-send gating using **`robot.action_features`**, public queue state, and **`config.chunk_size_threshold`** (drops a private **`_chunk_size_threshold`** mirror). The decoupled obs thread is renamed **`observation_loop`** (public name). Construction **asserts** **`RobotClient._aggregate_action_queues`** still exists so a LeRobot rename fails loudly instead of silently disabling temporal ensembling.
> 
> **Policy server observation filtering** is no longer duplicated inline: **`almond_axol/lerobot/inference_patch.disable_observation_similarity_filter()`** is called from both **`inference-server`** and the run-policy child process, with a **RuntimeError** if **`observations_similar`** disappears upstream.
> 
> **Motors** gain **`MotorDriver.set_feedback_callback`**; **`Motor`** registers position/torque caching through that API instead of assigning **`_on_feedback`** on the driver.
> 
> **CLI `--help` condensing** (`_condense_help`) wraps argparse’s internal **`_actions` / `_action_groups`** introspection in **`try/except AttributeError`**, sets the docs epilog only when condensing runs (or on fallback), and logs at debug if CPython layout changes—parsing behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c9dad829b1581f1a5d08ec3ec02d26a19d3a40f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->