### PR TITLE
Make axol available to all users + run full can.setup on web UI connect

### DIFF
--- a/almond_axol/serve/robot_link.py
+++ b/almond_axol/serve/robot_link.py
@@ -24,7 +24,6 @@ from typing import Any
 
 from ..motor import CanBus, Joint, Motor, MotorError
 from ..utils.shared import CAN_LEFT, CAN_RIGHT
-from ..utils.sudo import run_root
 
 _logger = logging.getLogger(__name__)
 
@@ -299,28 +298,27 @@ class RobotLink:
     def _enable_can(self) -> None:
         """Bring up the CAN interfaces.
 
-        Order of attempts:
-          1. If the interfaces are already up, do nothing (common case: cron
-             brought them up at boot).
-          2. If CAN was never configured on this machine, run the full
-             ``can.setup`` (udev rules, persistent names, @reboot bring-up)
-             non-interactively — it may not have been set up before.
-          3. Otherwise just run the persisted startup script.
+        1. If the interfaces are already up, do nothing (common case: cron
+           brought them up at boot).
+        2. Otherwise run the full ``can.setup`` (driver, udev rules, persistent
+           names, @reboot bring-up, then bring-up) non-interactively.
 
-        ``axol serve`` runs as root under the hosted install, so privileged
-        steps run directly through :func:`run_root`.
+        We always run the full setup rather than just the persisted startup
+        script (``can.enable``): on a fresh axol the script doesn't exist yet,
+        and on a partially-configured one the driver may be unloaded or the
+        interfaces unnamed, so the bare bring-up script can't connect. The
+        whole setup is idempotent (see :func:`ensure_setup`), so re-running it
+        on an already-configured machine is safe and cheap.
+
+        ``axol serve`` runs as root under the hosted install, so the privileged
+        steps inside :func:`ensure_setup` run without a sudo prompt.
         """
         if self._can_already_up():
             _logger.info("CAN interfaces already up; skipping bring-up.")
             return
 
-        from ..cli.can.setup import _CRON_SCRIPT, ensure_setup, is_configured
+        from ..cli.can.setup import ensure_setup
 
-        if not is_configured():
-            _logger.info("CAN not configured yet; running can.setup.")
-            ensure_setup()
-            _logger.info("CAN setup complete; interfaces brought up.")
-            return
-
-        run_root(["bash", str(_CRON_SCRIPT)], check=True)
-        _logger.info("CAN interfaces brought up.")
+        _logger.info("CAN interfaces down; running can.setup.")
+        ensure_setup()
+        _logger.info("CAN setup complete; interfaces brought up.")

--- a/web/app/public/install
+++ b/web/app/public/install
@@ -22,6 +22,16 @@ PYTHON_VERSION="3.13"
 BIN_DIR="/usr/local/bin"
 SERVICE_NAME="axol"
 SERVICE_FILE="/etc/systemd/system/${SERVICE_NAME}.service"
+# We install as root (the systemd service runs as root), but operators log in
+# as their own user and expect `axol` to work there too. uv's default tool +
+# managed-Python locations live under /root (mode 0700), which only root can
+# traverse, so the `axol` wrapper on PATH would fail for everyone else. Pin
+# both to shared, world-readable locations instead. The same vars are baked
+# into the systemd unit below so the self-updater's `uv tool upgrade` keeps
+# operating on this one shared install rather than spawning a /root copy.
+UV_TOOL_DIR="/opt/axol/uv/tools"
+UV_PYTHON_INSTALL_DIR="/opt/axol/uv/python"
+export UV_TOOL_DIR UV_PYTHON_INSTALL_DIR
 
 say() { printf "\033[1;36m[axol]\033[0m %s\n" "$*"; }
 die() { printf "\033[1;31m[axol]\033[0m %s\n" "$*" >&2; exit 1; }
@@ -51,10 +61,16 @@ UV="$(command -v uv || echo "${BIN_DIR}/uv")"
 # -- axol ---------------------------------------------------------------------
 
 say "Installing axol from GitHub (extras: ${EXTRAS}) — this can take a few minutes..."
+mkdir -p "${UV_TOOL_DIR}" "${UV_PYTHON_INSTALL_DIR}"
 UV_TOOL_BIN_DIR="${BIN_DIR}" "${UV}" tool install \
     --python "${PYTHON_VERSION}" \
     --force \
     "almond-axol[${EXTRAS}] @ ${REPO}"
+
+# uv creates the tool venv + managed Python with the root umask; make sure every
+# user can read/traverse them (dirs + already-executable files only, via 'X') so
+# the `axol` wrapper on PATH works for the operator's own login, not just root.
+chmod -R a+rX "${UV_TOOL_DIR}" "${UV_PYTHON_INSTALL_DIR}"
 
 command -v axol >/dev/null 2>&1 || die "axol did not end up on PATH (expected ${BIN_DIR}/axol)."
 say "axol installed at $(command -v axol)."
@@ -101,6 +117,10 @@ RestartSec=3
 # Include the sbin dirs: CAN bring-up shells out to modinfo/modprobe/ip/etc.
 Environment=PATH=${BIN_DIR}:/usr/sbin:/usr/bin:/sbin:/bin
 Environment=PYTHONUNBUFFERED=1
+# Keep the self-updater's \`uv tool upgrade\` on the same shared install the
+# installer wrote, rather than letting uv fall back to its /root defaults.
+Environment=UV_TOOL_DIR=${UV_TOOL_DIR}
+Environment=UV_PYTHON_INSTALL_DIR=${UV_PYTHON_INSTALL_DIR}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The installer now puts the uv tool venv and managed Python under shared, world-readable `/opt/axol/uv` instead of `/root` (mode 0700), so the `axol` CLI works for the operator's own login and not just root, and bakes the matching `UV_TOOL_DIR`/`UV_PYTHON_INSTALL_DIR` into the systemd unit so the self-updater keeps upgrading that one shared install. On the control-panel connect path, `_enable_can` now always runs the idempotent full `can.setup` whenever the CAN interfaces are down, instead of only running the persisted bring-up script (`can.enable`). This lets a fresh or partially-configured axol — driver unloaded or interfaces unnamed — actually connect, since the bare bring-up script can't recover that state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CAN connect now always runs full privileged setup when interfaces are down (heavier but idempotent), and the installer changes where uv stores tools/Python system-wide.
> 
> **Overview**
> **Installer** now pins `UV_TOOL_DIR` and `UV_PYTHON_INSTALL_DIR` to `/opt/axol/uv/*`, creates those dirs before `uv tool install`, and runs `chmod -R a+rX` so non-root operators can run the `axol` wrapper. The systemd unit sets the same env vars so in-service `uv tool upgrade` targets that shared install instead of `/root` defaults.
> 
> **Web panel connect** (`RobotLink._enable_can`): when CAN is not already up, it always calls idempotent `ensure_setup()` instead of branching on `is_configured()` and invoking the cron bring-up script via `run_root`. That covers fresh machines (no cron script yet) and partial configs (driver unloaded, unnamed interfaces). The `run_root` import is removed from `robot_link.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba250c889e2d106bb070ef21cf057af3e793c43c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->