### PR TITLE
Add health check command

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Each operation can be driven from the web control panel or the CLI:
 - [`can.enable`](https://docs.almond.bot/cli/can-enable)
 - [`can.driver`](https://docs.almond.bot/cli/can-driver)
 - [`motor.info`](https://docs.almond.bot/cli/motor-info)
+- [`motor.health`](https://docs.almond.bot/cli/motor-health)
 - [`motor.set-can-id`](https://docs.almond.bot/cli/motor-set-can-id)
 - [`motor.set-zero-pos`](https://docs.almond.bot/cli/motor-set-zero-pos)
 - [`teleop`](https://docs.almond.bot/cli/teleop)

--- a/almond_axol/cli/__init__.py
+++ b/almond_axol/cli/__init__.py
@@ -12,6 +12,7 @@ from .can import setup as can_setup
 from .gst import build_zed as gst_build_zed
 from .gst import install as gst_install
 from .jetson import setup as jetson_setup
+from .motor import health as motor_health
 from .motor import info as motor_info
 from .motor import set_can_id, set_zero_pos
 from .tune import friction, pid, repeatability
@@ -57,6 +58,7 @@ def main() -> None:
     set_can_id.add_parser(subparsers)
     set_zero_pos.add_parser(subparsers)
     motor_info.add_parser(subparsers)
+    motor_health.add_parser(subparsers)
     zed_install.add_parser(subparsers)
     gst_install.add_parser(subparsers)
     gst_build_zed.add_parser(subparsers)

--- a/almond_axol/cli/motor/__init__.py
+++ b/almond_axol/cli/motor/__init__.py
@@ -1,1 +1,1 @@
-"""Per-motor CLI commands (info, CAN ID, zero-position calibration)."""
+"""Per-motor CLI commands (info, health, CAN ID, zero-position calibration)."""

--- a/almond_axol/cli/motor/health.py
+++ b/almond_axol/cli/motor/health.py
@@ -1,0 +1,87 @@
+"""
+axol motor.health
+
+Probe every motor on both arms and report which responded.
+Runs the same status reads as motor.info on all 16 motors.
+
+Examples:
+    axol motor.health
+"""
+
+import argparse
+import asyncio
+
+from ...motor.bus import CanBus
+from ...motor.motor import Motor
+from ...utils.shared import CAN_LEFT, CAN_RIGHT, Joint
+
+# CAN IDs 0x01–0x08 in Joint control order.
+_MOTOR_IDS: dict[Joint, int] = {
+    joint: motor_id for joint, motor_id in zip(Joint, range(0x01, 0x09), strict=True)
+}
+
+_OK = "\033[32mOK\033[0m"
+
+
+async def _probe_motor(motor: Motor) -> str | None:
+    """Run the same reads as motor.info; return an error string on failure."""
+    try:
+        await motor.get_position()
+        await motor.get_velocity()
+        await motor.get_torque()
+        await motor.get_temperature()
+        await motor.get_voltage()
+        await motor.get_error_code()
+        await motor.get_control_mode()
+        await motor.get_firmware_version()
+        await motor.get_model()
+    except Exception as e:
+        return str(e)
+    return None
+
+
+async def _check_arm(channel: str) -> list[tuple[Joint, str | None]]:
+    results: list[tuple[Joint, str | None]] = []
+    async with CanBus(channel) as bus:
+        for joint in Joint:
+            result = await _probe_motor(Motor(bus, joint))
+            results.append((joint, result))
+    return results
+
+
+def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    """Register the ``motor.health`` subcommand."""
+    p = subparsers.add_parser(
+        "motor.health",
+        help="Probe all motors and report which responded.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=__doc__,
+    )
+    p.set_defaults(func=run)
+
+
+def run(args: argparse.Namespace) -> None:
+    """Probe every motor on both arms."""
+    failed = asyncio.run(_run())
+    if failed:
+        raise SystemExit(1)
+
+
+async def _run() -> list[tuple[str, Joint]]:
+    """Return the list of motors that failed to respond."""
+    failed: list[tuple[str, Joint]] = []
+    arms = [("left", CAN_LEFT), ("right", CAN_RIGHT)]
+
+    for side, channel in arms:
+        print(f"{side.upper()} ({channel})")
+        for joint, error in await _check_arm(channel):
+            motor_id = _MOTOR_IDS[joint]
+            label = f"  {joint.name:<11} id={motor_id:#04x}"
+            if error is not None:
+                print(f"{label}  {error}")
+                failed.append((side, joint))
+            else:
+                print(f"{label}  {_OK}")
+        print()
+
+    return failed

--- a/almond_axol/serve/commands.py
+++ b/almond_axol/serve/commands.py
@@ -211,6 +211,16 @@ COMMANDS: dict[str, CommandDef] = {
         _argparse_loader("..cli.motor.info"),
         requires_hardware=True,
     ),
+    "motor.health": CommandDef(
+        "motor.health",
+        "motor.health",
+        "Motor health",
+        "Probe all 16 motors and report which responded.",
+        "Calibrate",
+        "argparse",
+        _argparse_loader("..cli.motor.health"),
+        requires_hardware=True,
+    ),
     # -- Setup --------------------------------------------------------------
     "can.setup": CommandDef(
         "can.setup",

--- a/docs/cli/motor-health.mdx
+++ b/docs/cli/motor-health.mdx
@@ -1,0 +1,12 @@
+---
+title: "motor.health"
+description: "Probe every motor on both arms and report which responded."
+---
+
+Probes all 16 motors (8 per arm) and reports which responded. For each motor it runs the same status reads as [`motor.info`](https://docs.almond.bot/cli/motor-info) — position, velocity, torque, temperature, voltage, error code, control mode, firmware version, and model — and prints `OK` if every read succeeds or the error string if any read fails.
+
+The command iterates the left arm (`CAN_LEFT`) then the right arm (`CAN_RIGHT`), printing one line per joint. It exits with status `1` if any motor failed to respond, making it suitable for scripts and provisioning checks.
+
+```bash
+axol motor.health
+```

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -58,6 +58,7 @@
               "cli/can-enable",
               "cli/can-driver",
               "cli/motor-info",
+              "cli/motor-health",
               "cli/motor-set-can-id",
               "cli/motor-set-zero-pos",
               "cli/teleop",


### PR DESCRIPTION
@shawnpatel let me know if you like this and if so what am i missing -- i assume docs aren't automatic 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only CAN reachability check with the same argparse/serve registration pattern as `motor.info`; no auth or motion-control changes.
> 
> **Overview**
> Adds **`axol motor.health`**, a Calibrate-style hardware command that **probes all 16 motors** and reports which ones respond (complementing single-ID **`motor.info`**).
> 
> Wiring only in this diff: the CLI registers **`motor.health`** via **`motor_health.add_parser`**, the motor package docstring mentions health, and the web control panel exposes **Motor health** under **Calibrate** with **`requires_hardware=True`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1d3fa593ad1de3e4917e756b0fc6f71bfd809f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->