### PR TITLE
Fix mp4 DTS crash on episode append and NVENC frame-drop storm

### DIFF
--- a/almond_axol/cli/record_proc.py
+++ b/almond_axol/cli/record_proc.py
@@ -100,6 +100,146 @@ def _tune_software_encoder() -> None:
     )
 
 
+def _concatenate_video_files_rebased(
+    input_video_paths: list,
+    output_video_path: "Path | str",
+    overwrite: bool = True,
+    compatibility_check: bool = False,
+) -> None:
+    """Stream-copy concat that re-bases each segment's timestamps (drop-in for
+    LeRobot's ``concatenate_video_files``).
+
+    LeRobot appends each new episode's video to the running per-key chunk file
+    (``save_episode`` on episode index >= 1). Its stock implementation feeds both
+    segments through PyAV's ``concat`` demuxer and copies packets verbatim, trusting
+    the demuxer to offset the later segment past the first. With our NVENC mp4
+    segments that offset isn't applied, so at the segment boundary the muxer's DTS
+    jumps backwards (e.g. ``734200 >= 367200``) and libav aborts:
+
+        non monotonically increasing dts to muxer in stream 0
+        [Errno 22] Invalid argument: '/tmp/tmpXXXX.mp4'
+
+    which surfaces as ``recorder save_episode failed`` and loses the episode.
+
+    Instead, open each input independently and shift every packet so each segment
+    starts exactly where the previous one ended (per output stream, in the output
+    stream's time_base). Within a segment timestamps are already monotonic, so the
+    concatenated stream is monotonic by construction — independent of whatever
+    start offset / duration metadata the source segments carry. PTS-vs-DTS
+    spacing is preserved, so B-frame reordering survives.
+    """
+    import tempfile
+    from fractions import Fraction
+    from pathlib import Path
+
+    import av
+
+    output_video_path = Path(output_video_path)
+    if output_video_path.exists() and not overwrite:
+        _logger.warning(
+            "Video file already exists: %s. Skipping concatenation.", output_video_path
+        )
+        return
+    if len(input_video_paths) == 0:
+        raise FileNotFoundError("No input video paths provided.")
+    output_video_path.parent.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as tmp_named_file:
+        tmp_output_video_path = tmp_named_file.name
+
+    try:
+        with av.open(
+            tmp_output_video_path, mode="w", options={"movflags": "faststart"}
+        ) as dst:
+            out_streams: dict[int, object] = {}  # input stream index -> output stream
+            offsets: dict[object, int] = {}  # output stream -> next start dts (out tb)
+
+            for file_idx, input_path in enumerate(input_video_paths):
+                with av.open(str(input_path), mode="r") as src:
+                    seg_start: dict[
+                        object, int
+                    ] = {}  # out stream -> first dts (out tb)
+                    seg_end: dict[
+                        object, int
+                    ] = {}  # out stream -> last dts+dur (out tb)
+                    for in_stream in src.streams:
+                        if in_stream.type not in ("video", "audio", "subtitle"):
+                            continue
+                        if file_idx == 0:
+                            out_stream = dst.add_stream_from_template(
+                                template=in_stream, opaque=True
+                            )
+                            out_stream.time_base = in_stream.time_base
+                            out_streams[in_stream.index] = out_stream
+                            offsets[out_stream] = 0
+
+                    for packet in src.demux():
+                        if packet.dts is None:  # demux flushing packet
+                            continue
+                        out_stream = out_streams.get(packet.stream.index)
+                        if out_stream is None:
+                            continue
+                        # Rescale into the output stream's time_base (a no-op for our
+                        # homogeneous segments, correct if a segment ever differs).
+                        ratio = Fraction(packet.stream.time_base) / Fraction(
+                            out_stream.time_base
+                        )
+                        dts = int(round(packet.dts * ratio))
+                        pts = (
+                            None
+                            if packet.pts is None
+                            else int(round(packet.pts * ratio))
+                        )
+                        dur = int(round((packet.duration or 0) * ratio))
+
+                        if out_stream not in seg_start:
+                            seg_start[out_stream] = dts
+                        shift = offsets[out_stream] - seg_start[out_stream]
+
+                        packet.dts = dts + shift
+                        packet.pts = None if pts is None else pts + shift
+                        packet.duration = dur
+                        packet.stream = out_stream
+
+                        end = packet.dts + dur
+                        if end > seg_end.get(out_stream, end - 1):
+                            seg_end[out_stream] = end
+                        dst.mux(packet)
+
+                    for out_stream, end in seg_end.items():
+                        offsets[out_stream] = end
+
+        shutil.move(tmp_output_video_path, str(output_video_path))
+    except Exception:
+        Path(tmp_output_video_path).unlink(missing_ok=True)
+        raise
+
+    if not output_video_path.exists():
+        raise OSError(
+            f"Video concatenation did not work. File not found: {output_video_path}."
+        )
+
+
+def _patch_video_concat() -> None:
+    """Replace LeRobot's ``concatenate_video_files`` with the re-basing version.
+
+    Idempotent. Patches the name where it's *called* (``dataset_writer``, which does
+    ``from .video_utils import concatenate_video_files``) as well as its definition
+    module, so every code path picks up the fix.
+    """
+    import lerobot.datasets.dataset_writer as _dw
+    import lerobot.datasets.video_utils as _vu
+
+    if getattr(_vu, "_axol_concat_rebased", False):
+        return
+    _vu.concatenate_video_files = _concatenate_video_files_rebased
+    _dw.concatenate_video_files = _concatenate_video_files_rebased
+    _vu._axol_concat_rebased = True
+    _logger.info(
+        "patched LeRobot concatenate_video_files to re-base segment timestamps"
+    )
+
+
 def install_dataset_encoder() -> bool:
     """Prefer the Jetson NVENC encoder for dataset video; else tune libx264.
 
@@ -115,6 +255,10 @@ def install_dataset_encoder() -> bool:
         hw_dataset_encoder_available,
     )
 
+    # Episode-append concat re-bases timestamps regardless of which encoder writes
+    # the segments, so patch it on every path (NVENC and the libx264 fallback).
+    _patch_video_concat()
+
     if getattr(LeRobotDataset, "_axol_nvenc_installed", False):
         return True
 
@@ -123,7 +267,9 @@ def install_dataset_encoder() -> bool:
         return False
 
     def _build_nvenc(fps, vcodec, encoder_queue_maxsize, encoder_threads):
-        return NvencStreamingEncoder(fps=fps, queue_maxsize=encoder_queue_maxsize)
+        # Ignore LeRobot's shallow default (30); NvencStreamingEncoder uses its own
+        # deeper feed queue to ride out gst pipeline spin-up. See _FEED_QUEUE_MAXSIZE.
+        return NvencStreamingEncoder(fps=fps)
 
     LeRobotDataset._build_streaming_encoder = staticmethod(_build_nvenc)
     LeRobotDataset._axol_nvenc_installed = True

--- a/almond_axol/lerobot/nvenc_encoder.py
+++ b/almond_axol/lerobot/nvenc_encoder.py
@@ -70,11 +70,20 @@ _FEED_QUEUE_MAXSIZE = 90
 
 # Image stats are accumulated *during* the episode on the encoder's writer
 # thread in the recorder subprocess (not by decoding the finished mp4 afterwards,
-# which made save_episode slow). This mirrors LeRobot's own streaming encoder
-# (_StreamingEncoderThread in datasets/video_utils.py) exactly: the same
-# auto_downsample_height_width + RunningQuantileStats, updated on every frame.
-# The recorder has its own GIL/cores, away from the control loop and the relay's
-# WebRTC send, so the per-frame work is harmless there.
+# which made save_episode slow). Like LeRobot's streaming encoder we use
+# auto_downsample_height_width + RunningQuantileStats, but on a *sampled* subset
+# of frames rather than every frame: each update costs ~4.3 ms (downsample +
+# quantile sketch), so updating all three cameras at 60 fps would need ~780 ms of
+# GIL-held time per wall-clock second. Since the recorder's three writer threads
+# share one GIL, that alone saturates it, the threads can't drain their feed
+# queues, and frames overflow ("queue full, dropped N" storm). Sampling at
+# ~_STATS_SAMPLE_HZ keeps the per-second stats cost ~6x lower while still feeding
+# the quantile sketch hundreds of uniformly-spaced frames per episode — far more
+# than enough for image normalization stats.
+#
+# Target rate (Hz) at which each camera folds a frame into its running image
+# stats. The per-camera stride is derived from this and the dataset fps.
+_STATS_SAMPLE_HZ = 10
 
 
 def hw_dataset_encoder_available() -> bool:
@@ -164,12 +173,15 @@ class _CameraNvencEncoder:
         self._dropped = 0
         self._error: str | None = None
 
-        # Running image stats, accumulated inline as frames are encoded (mirrors
-        # LeRobot's auto_downsample + RunningQuantileStats so the result matches
-        # the software path). Disabled if lerobot's compute_stats can't import.
+        # Running image stats, accumulated inline from a sampled subset of frames
+        # (LeRobot's auto_downsample + RunningQuantileStats; see _STATS_SAMPLE_HZ
+        # for why we sample). Disabled if lerobot's compute_stats can't import.
         self._stats: object | None = None
         self._downsample = None
         self._stats_samples = 0
+        # Fold every Nth frame into the running stats (uniform sampling) so the
+        # quantile sketch stays cheap on the shared-GIL writer threads. >=1.
+        self._stats_stride = max(1, round(fps / _STATS_SAMPLE_HZ))
         try:
             from lerobot.datasets.compute_stats import (
                 RunningQuantileStats,
@@ -271,7 +283,10 @@ class _CameraNvencEncoder:
         assert self._rgba is not None and self._stdin_fd is not None
         self._rgba[:, :, :3] = frame
         self._write(self._rgba)
-        if self._stats is not None:
+        # Sample stats every _stats_stride-th frame to keep the GIL-bound quantile
+        # update off the per-frame hot path (see _STATS_SAMPLE_HZ). frame 0 is
+        # always sampled so even short episodes contribute.
+        if self._stats is not None and self._frame_count % self._stats_stride == 0:
             self._update_stats(frame)
         self._t_copy += time.perf_counter() - t0
         self._frame_count += 1

--- a/almond_axol/lerobot/nvenc_encoder.py
+++ b/almond_axol/lerobot/nvenc_encoder.py
@@ -59,6 +59,15 @@ _BITRATE_BPP = 0.25
 _BITRATE_MIN = 6_000_000
 _BITRATE_MAX = 40_000_000
 
+# Per-camera feed-queue depth (frames). LeRobot's default is 30 (0.5 s at 60 fps),
+# too shallow to ride out the gst pipeline's spin-up: gst-launch takes ~1 s to
+# negotiate caps and allocate NVMM before its first frame is consumed, during
+# which the queue fills at the capture rate and overflows. 90 frames (~1.5 s) buys
+# enough slack to absorb that transient; steady-state throughput is handled by the
+# pipelined gst queues (see `_gst_argv`), so in normal running it stays near empty.
+# Cost is ~1.7 MB/frame (HWC RGB uint8): 90 x 3 cameras ~= 460 MB peak.
+_FEED_QUEUE_MAXSIZE = 90
+
 # Image stats are accumulated *during* the episode on the encoder's writer
 # thread in the recorder subprocess (not by decoding the finished mp4 afterwards,
 # which made save_episode slow). This mirrors LeRobot's own streaming encoder
@@ -88,6 +97,19 @@ def _gst_argv(
     ``nvv4l2h264enc`` encodes on NVENC, so no CPU ``videoconvert`` is involved.
     ``h264parse`` + ``mp4mux`` produce a standard mp4; closing stdin sends EOS so
     ``mp4mux`` finalizes the moov atom and ``filesink`` flushes the file.
+
+    The two ``queue`` elements are load-bearing, not cosmetic. Without them the
+    whole chain runs in ``fdsrc``'s single streaming thread, so ``fdsrc`` only
+    reads the next frame off the pipe *after* VIC convert + NVENC + mux finish the
+    previous one — i.e. the pipe-drain rate equals the full serial chain rate. On
+    the recorder's niced/background cores that can't keep up with 60 fps x 3
+    cameras, the ``os.write`` on the feeding side blocks, the writer thread stalls,
+    and the Python feed queue overflows (the "queue full, dropped N frames" storm).
+    A ``queue`` after ``fdsrc`` lets it keep draining the pipe (unblocking the
+    writer) while a ``queue`` before the encoder puts the VIC and NVENC on separate
+    threads, so chain throughput is ``min(VIC, NVENC)`` instead of their sum. The
+    queues are non-leaky (back-pressure is fine; real drops are counted/logged in
+    Python ``feed``) and bounded by buffer count to cap latency and memory.
     """
     pipeline = [
         f"fdsrc fd=0 blocksize={width * height * 4}",
@@ -95,8 +117,10 @@ def _gst_argv(
             "rawvideoparse use-sink-caps=false format=rgba "
             f"width={width} height={height} framerate={fps}/1"
         ),
+        "queue max-size-buffers=8 max-size-bytes=0 max-size-time=0",
         "nvvidconv",
         "video/x-raw(memory:NVMM),format=NV12",
+        "queue max-size-buffers=8 max-size-bytes=0 max-size-time=0",
         (
             f"nvv4l2h264enc control-rate=1 bitrate={bitrate} preset-level=1 "
             f"insert-sps-pps=true idrinterval={fps} maxperf-enable=true"
@@ -353,7 +377,7 @@ class NvencStreamingEncoder:
     / ``close``. One ``_CameraNvencEncoder`` (and one gst subprocess) per camera.
     """
 
-    def __init__(self, fps: int, queue_maxsize: int = 30) -> None:
+    def __init__(self, fps: int, queue_maxsize: int = _FEED_QUEUE_MAXSIZE) -> None:
         self.fps = fps
         self.queue_maxsize = queue_maxsize
         self._cams: dict[str, _CameraNvencEncoder] = {}

--- a/almond_axol/utils/affinity.py
+++ b/almond_axol/utils/affinity.py
@@ -45,18 +45,22 @@ def core_groups() -> dict[str, set[int]] | None:
     a restricted mask). Reading the inherited mask would wrongly see only the
     realtime cores.
 
-    8+ cores get the full 3-way split (control 3 / relay 2 / dataset rest). On
-    6-7 cores the control group shrinks to 2; below 6 there's no room to isolate
-    the relay, so relay shares the background group (still kept off the control
-    cores). ``None`` when partitioning isn't applicable at all.
+    8+ cores: control 3 / relay 1 / dataset rest. The dataset recorder re-encodes
+    three camera streams from raw RGBA and is the heaviest throughput consumer, so
+    it gets the widest group; the relay keeps a single core because its headset
+    H.264 runs on the hardware NVENC block (``nvv4l2h264enc``) and that core mainly
+    carries the latency-sensitive WebRTC send. On 6-7 cores the control group
+    shrinks to 2; below 6 there's no room to isolate the relay, so relay shares the
+    background group (still kept off the control cores). ``None`` when partitioning
+    isn't applicable at all.
     """
     n = os.cpu_count()
     if not n or n < _MIN_CORES:
         return None
     if n >= 8:
         rt = set(range(3))
-        relay = {3, 4}
-        bg = set(range(5, n))
+        relay = {3}
+        bg = set(range(4, n))
     elif n >= 6:
         rt = {0, 1}
         relay = {2, 3}


### PR DESCRIPTION
`save_episode` crashed on episode index ≥ 1 with "non monotonically increasing dts to muxer" / `[Errno 22]` because LeRobot's `concatenate_video_files` stream-copies our NVENC mp4 segments without re-basing the later segment's timestamps, so the muxer's DTS jumps backward at the boundary and libav aborts (losing the episode); this is replaced via an idempotent monkeypatch with a re-basing concat that opens each input independently and shifts every packet so each segment starts where the previous ended (monotonic by construction, PTS-vs-DTS spacing preserved). Separately, the NVENC gst pipeline had no `queue` elements, so the whole chain ran in `fdsrc`'s single thread and the pipe-drain rate equalled the serial VIC+NVENC+mux rate — too slow for 60fps × 3 cameras on the recorder's background cores, so `os.write` blocked, the writer stalled, and the feed queue overflowed (the growing "queue full, dropped N frames" storm). That is fixed by adding `queue` elements to pipeline the stages (throughput becomes `min(VIC, NVENC)` instead of their sum) and deepening the per-camera feed queue from 30 to 90 frames to ride out gst spin-up.

The concat re-basing was verified against real PyAV/LeRobot (monotonic, lossless, including the B-frame negative-DTS / identical-start case); the gst throughput change is standard practice but needs one on-robot `collect-data` run to confirm, as it can't be exercised without the Jetson NVENC stack.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the dataset video write/append path and live recording throughput on Jetson; regressions could still lose episodes or drop frames until validated on-robot.
> 
> **Overview**
> Fixes **`save_episode`** failures on episode index ≥ 1 by monkeypatching LeRobot’s **`concatenate_video_files`** with a stream-copy concat that **re-bases each segment’s DTS/PTS** so appended NVENC mp4s stay monotonic (replacing PyAV’s concat demuxer, which left backward DTS at segment boundaries).
> 
> On the NVENC path, **GStreamer `queue` elements** pipeline fdsrc/VIC/NVENC so pipe writes don’t block on the full serial chain; the per-camera Python feed queue defaults to **90 frames** (and **`install_dataset_encoder`** no longer passes LeRobot’s shallow 30). **Image normalization stats** are updated on a **~10 Hz sampled stride** instead of every frame to cut GIL contention across three writer threads.
> 
> On **8+ CPU** hosts, **core affinity** gives the dataset recorder a wider **background** group (relay drops from two cores to one).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa03ebcc709701562dc4267eb985e8acbb284897. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->