### PR TITLE
Quiet install false-alarms: GStreamer stack warning + CPU governor message

### DIFF
--- a/almond_axol/cli/gst/install.py
+++ b/almond_axol/cli/gst/install.py
@@ -41,11 +41,16 @@ _logger = logging.getLogger(__name__)
 # cannot build here. Pin to the last 3.5x that targets girepository-1.0.
 _PYGOBJECT_SPEC = "pygobject>=3.50,<3.52"
 
-# GStreamer elements the gst_zed pipeline relies on. zedxonesrc / zedsrc are
-# built + installed by ``axol gst.build-zed`` (patched for sensor-accurate
-# PTS); nvvidconv / nvv4l2h264enc ship with the Jetson L4T BSP (none of these
-# are apt-installable here — verified + warned).
+# GStreamer elements gst.install is itself responsible for verifying: the NVENC
+# encode path (nvvidconv / nvv4l2h264enc), which ships with the Jetson L4T BSP.
+# These gate gst.install's success alongside the gi/appsink import.
 _REQUIRED_ELEMENTS = ("nvvidconv", "nvv4l2h264enc")
+
+# The patched ZED source element ``axol gst.build-zed`` builds + installs
+# (sensor-accurate PTS). gst.install only *reports* whether it's present — its
+# absence is expected before build-zed runs, so it's a note, not a failure
+# (build-zed, which the installer/provision runs right after, installs it).
+_ZED_SOURCE_MARKER = "zedxonesrc"
 
 # System packages: GStreamer introspection typelibs (Gst + GstApp/appsink) and
 # the build deps PyGObject needs to compile against gobject-introspection.
@@ -86,8 +91,8 @@ def _run(cmd: list[str]) -> bool:
     return True
 
 
-def _gst_ok() -> bool:
-    """True when a clean subprocess can import gi and find the gst elements.
+def _gi_elements_ok(elements: tuple[str, ...]) -> bool:
+    """True when a clean subprocess can import gi and find every element given.
 
     Checked in a subprocess so the result reflects a PyGObject that was just
     installed (importing it in this process would hit a stale import state).
@@ -95,7 +100,7 @@ def _gst_ok() -> bool:
     from ...vr.gst_zed import _set_typelib_path
 
     _set_typelib_path()  # ensure the child inherits the typelib search path
-    elements = ",".join(repr(e) for e in (*_REQUIRED_ELEMENTS, "zedxonesrc"))
+    els = ",".join(repr(e) for e in elements)
     code = (
         "import gi;"
         "gi.require_version('Gst','1.0');"
@@ -103,7 +108,7 @@ def _gst_ok() -> bool:
         "from gi.repository import Gst, GstApp;"  # GstApp registers AppSink
         "Gst.init(None);"
         "import sys;"
-        f"els=({elements},);"
+        f"els=({els},);"
         "sys.exit(0 if all(Gst.ElementFactory.find(e) for e in els) else 1)"
     )
     try:
@@ -115,6 +120,35 @@ def _gst_ok() -> bool:
         )
     except Exception:  # noqa: BLE001 - interpreter/import failure
         return False
+
+
+def _gst_ok() -> bool:
+    """True when gst.install's own deliverables work: PyGObject can import gi +
+    GstApp (the appsink reader) and the Jetson NVENC elements are present.
+
+    Deliberately excludes the zedxonesrc / zedsrc source elements: those are
+    ``axol gst.build-zed``'s responsibility and aren't built until the step
+    *after* this one, so gating on them here would misreport a clean install as
+    failed. Their presence is reported separately by :func:`_note_zed_sources`.
+    """
+    return _gi_elements_ok(_REQUIRED_ELEMENTS)
+
+
+def _note_zed_sources() -> None:
+    """Report (note only) whether the patched ZED source elements are present.
+
+    ``axol gst.build-zed`` builds + installs zedxonesrc / zedsrc, and the
+    installer/provision runs it right after gst.install, so their absence here
+    is expected on a first install — informational, never a warning.
+    """
+    if _gi_elements_ok((_ZED_SOURCE_MARKER,)):
+        print("Patched ZED source elements (zedxonesrc / zedsrc) present.")
+    else:
+        print(
+            "Note: the ZED source elements (zedxonesrc / zedsrc) aren't built "
+            "yet — 'axol gst.build-zed' builds + installs them (the installer "
+            "runs it right after this step)."
+        )
 
 
 def _apt_install() -> bool:
@@ -158,7 +192,8 @@ def run(_args: object = None) -> None:
     ``axol gst.build-zed``; this command only verifies those are present.
     """
     if _gst_ok():
-        print("GStreamer ZED camera stack already available.")
+        print("GStreamer appsink + NVENC stack already available.")
+        _note_zed_sources()
         return
 
     print("Installing GStreamer system packages (apt)...")
@@ -167,13 +202,13 @@ def run(_args: object = None) -> None:
     _pip_install_pygobject()
 
     if _gst_ok():
-        print("GStreamer ZED camera stack installed.")
+        print("GStreamer appsink + NVENC stack installed.")
+        _note_zed_sources()
     else:
         print(
-            "WARNING: the GStreamer ZED camera stack is still unavailable. "
-            "Ensure PyGObject, the zed-gstreamer elements (zedxonesrc / zedsrc), "
-            "and the Jetson NVENC elements (nvvidconv / nvv4l2h264enc) are "
-            "installed. Camera video will fall back to the ZED SDK path "
-            "(higher latency) until then.",
+            "WARNING: the GStreamer appsink + NVENC stack is still unavailable. "
+            "Ensure PyGObject and the Jetson NVENC elements (nvvidconv / "
+            "nvv4l2h264enc) are installed. Camera video will fall back to the "
+            "ZED SDK path (higher latency) until then.",
             file=sys.stderr,
         )

--- a/almond_axol/utils/jetson.py
+++ b/almond_axol/utils/jetson.py
@@ -238,7 +238,8 @@ def _pin_cpu(writer: _RootEscalator) -> None:
         _logger.debug("not a Jetson; leaving the CPU cpufreq governor unchanged")
         return
     pinned = 0
-    failed: str | None = None
+    failed = 0
+    failed_detail: str | None = None
     for cpu in sorted(Path("/sys/devices/system/cpu").glob("cpu[0-9]*")):
         gov = cpu / "cpufreq" / "scaling_governor"
         try:
@@ -250,17 +251,26 @@ def _pin_cpu(writer: _RootEscalator) -> None:
         if ok:
             pinned += 1
         else:
-            failed = detail
+            failed += 1
+            failed_detail = detail
     if pinned:
         _logger.info("pinned %d CPU core(s) to the %s governor", pinned, _CPU_GOVERNOR)
-    if failed is not None:
+    if failed:
+        # Report the count (not just the last core's error): a single line that
+        # named only cpuN understated how many cores actually failed. EINVAL
+        # here is usually the clock-ceiling cap of a non-MAXN power mode, which
+        # clears once MAXN is active (it may be pending a reboot — the boot
+        # service re-pins then), so point there before the manual override.
         _logger.warning(
-            "cannot set CPU governor to %s (%s) — the schedutil default "
-            "underclocks bursty control loops (~30%% lower IK rate). Fix "
-            "manually with: echo %s | sudo tee "
+            "could not set %d CPU core(s) to the %s governor (last error: %s) — "
+            "the schedutil default underclocks bursty control loops (~30%% lower "
+            "IK rate). This usually clears once the MAXN power mode is active "
+            "(it may be pending a reboot; the boot service re-pins then). If it "
+            "persists, fix manually with: echo %s | sudo tee "
             "/sys/devices/system/cpu/cpu*/cpufreq/scaling_governor",
+            failed,
             _CPU_GOVERNOR,
-            failed or "write failed",
+            failed_detail or "write failed",
             _CPU_GOVERNOR,
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -159,7 +159,7 @@ wheels = [
 
 [[package]]
 name = "almond-axol"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiortc" },


### PR DESCRIPTION
The hosted installer printed a "GStreamer ZED camera stack is still unavailable" WARNING on every run because `gst.install` gated success on `zedxonesrc`, which `gst.build-zed` (the next provision step) is what actually installs. This splits the gate so `gst.install` verifies only its own deliverables (PyGObject/appsink + NVENC) and reports the `zedxonesrc`/`zedsrc` source elements as an informational note. It also fixes the Jetson CPU-governor warning to report how many cores failed (previously it named only the last core) and to point at the pending-MAXN/reboot path before the manual override. Finally, `uv.lock` is synced to the current `pyproject` version (0.1.1). These are messaging/UX fixes only — no install or runtime behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Messaging and success-gating scope only—no changes to apt/pip install steps or clock-pinning write behavior.
> 
> **Overview**
> Stops **`gst.install`** from treating missing **`zedxonesrc`/`zedsrc`** as a failed install. Success now checks only what this step owns—PyGObject/appsink plus Jetson NVENC elements—and prints an informational note (or “present”) for the ZED source plugins that **`gst.build-zed`** installs on the next provision step. User-facing text and the failure WARNING were renamed to **“appsink + NVENC stack”** so they no longer imply the whole ZED camera stack is broken mid-installer.
> 
> On Jetson, **`_pin_cpu`** warnings now report **how many cores** failed to switch to **`performance`**, not just the last core’s error, and steer operators toward **pending MAXN / reboot** before the manual **`echo performance | sudo tee …`** override.
> 
> **`uv.lock`** is bumped to match **`pyproject`** version **0.1.1**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40bdc50c9bb88c6143e026802d350f0e5c07cb63. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->