### PR TITLE
durable ports

### DIFF
--- a/almond_axol/cli/inference_server.py
+++ b/almond_axol/cli/inference_server.py
@@ -58,6 +58,13 @@ def main(argv: list[str]) -> None:
     from lerobot.async_inference.configs import PolicyServerConfig
     from lerobot.async_inference.policy_server import serve
 
+    from ..utils.ports import reclaim_port
+
+    # The gRPC port is fixed (it must match run-policy's ``--server_port``), so
+    # evict a leftover server from a crashed/previous run rather than failing to
+    # bind. lerobot owns the socket once ``serve`` takes over.
+    reclaim_port(cfg.port)
+
     _logger.info(
         "Serving policy inference on %s:%d (Ctrl+C to stop).", cfg.host, cfg.port
     )

--- a/almond_axol/cli/run_policy.py
+++ b/almond_axol/cli/run_policy.py
@@ -933,6 +933,12 @@ def _run(
             "port": server_port,
             "fps": fps,
         }
+        # Evict a leftover PolicyServer from a crashed/previous run before
+        # spawning ours, otherwise it would bind-fail and ``_wait_for_port``
+        # would silently attach to the stale (wrong-policy) server.
+        from ..utils.ports import reclaim_port
+
+        reclaim_port(server_port)
         ctx = mp.get_context("spawn")
         server_proc = ctx.Process(
             target=_serve_policy_server,

--- a/almond_axol/cli/serve.py
+++ b/almond_axol/cli/serve.py
@@ -117,7 +117,22 @@ def run(args: argparse.Namespace) -> None:
     if args.open:
         _open_browser_when_ready(local)
 
-    uvicorn.run(app, host=args.host, port=args.port, log_level="info", **ssl_kwargs)
+    # Bind the port ourselves — reclaiming it from a stale/leftover listener —
+    # before handing the socket to uvicorn, so a restart (or a crashed previous
+    # instance that didn't release the socket) doesn't fail with "address
+    # already in use". uvicorn still installs its own SIGINT/SIGTERM handlers
+    # and closes the adopted socket on exit.
+    from ..utils.ports import open_listen_socket
+
+    sock = open_listen_socket(args.host, args.port)
+    config = uvicorn.Config(
+        app, host=args.host, port=args.port, log_level="info", **ssl_kwargs
+    )
+    server = uvicorn.Server(config)
+    try:
+        server.run(sockets=[sock])
+    finally:
+        sock.close()
 
 
 def _ensure_cert() -> None:

--- a/almond_axol/robot/sim.py
+++ b/almond_axol/robot/sim.py
@@ -7,6 +7,7 @@ import threading
 
 import numpy as np
 
+from ..utils.ports import reclaim_port
 from ..utils.shared import ARM_JOINTS, URDF_PATH, urdf_arm_joint_names
 from .base import RobotBase
 
@@ -65,21 +66,52 @@ class Sim(RobotBase):
         self._latest_q: np.ndarray | None = None
         self._condition = threading.Condition()
         self._thread: threading.Thread | None = None
+        self._server: viser.ViserServer | None = None
+        self._stop = threading.Event()
         # Shape (8,): 7 arm joints then gripper, in Joint enum order
         self._last_left: np.ndarray = np.zeros(len(ARM_JOINTS) + 1, dtype=np.float32)
         self._last_right: np.ndarray = np.zeros(len(ARM_JOINTS) + 1, dtype=np.float32)
 
     async def enable(self) -> None:
-        """Start the viser server thread. No-op after the first call."""
+        """Start the viser server thread. No-op after the first call.
+
+        Reclaims the viewer port first so a leftover viser server from a
+        crashed/previous run (the URL is bookmarked, so the port is fixed)
+        doesn't make the new one fail to bind.
+        """
         if self._thread is not None:
             return
+        import asyncio
+
+        await asyncio.to_thread(reclaim_port, self._port)
+        self._stop = threading.Event()
         self._thread = threading.Thread(target=self._run, daemon=True)
         self._thread.start()
         _logger.info("Simulation server started at http://localhost:%d", self._port)
 
     async def disable(self) -> None:
-        """No-op — the daemon thread exits when the process ends."""
-        pass
+        """Stop the viser server and join its thread, freeing the viewer port.
+
+        A daemon thread would free the port when the *process* exits, but the
+        control panel runs sim teleop in-process and restarts it, so the server
+        has to be torn down on stop too — otherwise the next run can't bind 8002.
+        """
+        if self._thread is None:
+            return
+        import asyncio
+
+        self._stop.set()
+        with self._condition:
+            self._condition.notify_all()
+        server = self._server
+        if server is not None:
+            try:
+                await asyncio.to_thread(server.stop)
+            except Exception as exc:  # noqa: BLE001 - teardown is best-effort
+                _logger.debug("viser stop failed: %s", exc)
+        await asyncio.to_thread(self._thread.join, 5.0)
+        self._server = None
+        self._thread = None
 
     async def get_positions(self) -> tuple[np.ndarray | None, np.ndarray | None]:
         """Return the last commanded joint positions for both arms.
@@ -123,6 +155,7 @@ class Sim(RobotBase):
 
     def _run(self) -> None:
         server = viser.ViserServer(port=self._port)
+        self._server = server
 
         urdf = yourdfpy.URDF.load(str(URDF_PATH), mesh_dir=str(URDF_PATH.parent))
         viser_urdf = ViserUrdf(
@@ -165,9 +198,12 @@ class Sim(RobotBase):
 
         server.scene.add_grid("/grid", width=2.0, height=2.0, position=(0.0, 0.0, 0.0))
 
-        while True:
+        while not self._stop.is_set():
             with self._condition:
-                self._condition.wait()
+                # Time out so a stop set between notifications is still observed.
+                self._condition.wait(timeout=0.5)
                 q = self._latest_q
+            if self._stop.is_set():
+                break
             if q is not None and q.size > 0:
                 viser_urdf.update_cfg(_to_viser(np.asarray(q, dtype=float)))

--- a/almond_axol/robot/sim.py
+++ b/almond_axol/robot/sim.py
@@ -103,14 +103,19 @@ class Sim(RobotBase):
         self._stop.set()
         with self._condition:
             self._condition.notify_all()
-        server = self._server
-        if server is not None:
-            try:
-                await asyncio.to_thread(server.stop)
-            except Exception as exc:  # noqa: BLE001 - teardown is best-effort
-                _logger.debug("viser stop failed: %s", exc)
+        # The worker stops its own server in _run's finally block, so we only
+        # need to wait for it to exit. Don't clear _thread if the join times
+        # out: the worker (and its in-process server on self._port) is still
+        # alive, and reclaim_port can't kill the current PID, so letting enable
+        # start a second server would collide on the port.
         await asyncio.to_thread(self._thread.join, 5.0)
-        self._server = None
+        if self._thread.is_alive():
+            _logger.warning(
+                "viser worker did not exit within timeout; leaving it running "
+                "so a restart doesn't collide on port %d",
+                self._port,
+            )
+            return
         self._thread = None
 
     async def get_positions(self) -> tuple[np.ndarray | None, np.ndarray | None]:
@@ -156,54 +161,67 @@ class Sim(RobotBase):
     def _run(self) -> None:
         server = viser.ViserServer(port=self._port)
         self._server = server
+        # Always tear the server down from the worker itself. disable() can't
+        # reliably do it: a fast disable() may snapshot self._server before it's
+        # assigned above, and a timed-out join would skip its stop() entirely.
+        # Stopping here guarantees the in-process port is freed whenever the
+        # loop exits, which is what makes the in-process restart reliable.
+        try:
+            urdf = yourdfpy.URDF.load(str(URDF_PATH), mesh_dir=str(URDF_PATH.parent))
+            viser_urdf = ViserUrdf(
+                server,
+                urdf_or_path=urdf,
+                root_node_name="/robot",
+                load_meshes=True,
+                load_collision_meshes=False,
+            )
 
-        urdf = yourdfpy.URDF.load(str(URDF_PATH), mesh_dir=str(URDF_PATH.parent))
-        viser_urdf = ViserUrdf(
-            server,
-            urdf_or_path=urdf,
-            root_node_name="/robot",
-            load_meshes=True,
-            load_collision_meshes=False,
-        )
+            # Build the robot-side joint ordering to match _build_q's output:
+            # left arm joint1-N, then right arm joint1-N.
+            robot_order = (
+                self._joint_names or urdf_arm_joint_names(is_left=True)
+            ) + urdf_arm_joint_names(is_left=False)
 
-        # Build the robot-side joint ordering to match _build_q's output:
-        # left arm joint1-N, then right arm joint1-N.
-        robot_order = (
-            self._joint_names or urdf_arm_joint_names(is_left=True)
-        ) + urdf_arm_joint_names(is_left=False)
+            # Map each viser joint to its index in robot_order (-1 for joints not
+            # in robot_order, e.g. finger joints, which stay at 0).
+            viser_order = viser_urdf.get_actuated_joint_names()
+            viser_to_robot: list[int] = []
+            for name in viser_order:
+                try:
+                    viser_to_robot.append(robot_order.index(name))
+                except ValueError:
+                    viser_to_robot.append(-1)
 
-        # Map each viser joint to its index in robot_order (-1 for joints not
-        # in robot_order, e.g. finger joints, which stay at 0).
-        viser_order = viser_urdf.get_actuated_joint_names()
-        viser_to_robot: list[int] = []
-        for name in viser_order:
+            def _to_viser(q_robot: np.ndarray) -> np.ndarray:
+                q_out = np.zeros(len(viser_order), dtype=float)
+                for vi, ri in enumerate(viser_to_robot):
+                    if ri >= 0:
+                        q_out[vi] = q_robot[ri]
+                return q_out
+
+            q0 = (
+                np.asarray(self._default_q, dtype=float)
+                if self._default_q is not None
+                else np.zeros(len(robot_order))
+            )
+            viser_urdf.update_cfg(_to_viser(q0))
+
+            server.scene.add_grid(
+                "/grid", width=2.0, height=2.0, position=(0.0, 0.0, 0.0)
+            )
+
+            while not self._stop.is_set():
+                with self._condition:
+                    # Time out so a stop set between notifications is still observed.
+                    self._condition.wait(timeout=0.5)
+                    q = self._latest_q
+                if self._stop.is_set():
+                    break
+                if q is not None and q.size > 0:
+                    viser_urdf.update_cfg(_to_viser(np.asarray(q, dtype=float)))
+        finally:
             try:
-                viser_to_robot.append(robot_order.index(name))
-            except ValueError:
-                viser_to_robot.append(-1)
-
-        def _to_viser(q_robot: np.ndarray) -> np.ndarray:
-            q_out = np.zeros(len(viser_order), dtype=float)
-            for vi, ri in enumerate(viser_to_robot):
-                if ri >= 0:
-                    q_out[vi] = q_robot[ri]
-            return q_out
-
-        q0 = (
-            np.asarray(self._default_q, dtype=float)
-            if self._default_q is not None
-            else np.zeros(len(robot_order))
-        )
-        viser_urdf.update_cfg(_to_viser(q0))
-
-        server.scene.add_grid("/grid", width=2.0, height=2.0, position=(0.0, 0.0, 0.0))
-
-        while not self._stop.is_set():
-            with self._condition:
-                # Time out so a stop set between notifications is still observed.
-                self._condition.wait(timeout=0.5)
-                q = self._latest_q
-            if self._stop.is_set():
-                break
-            if q is not None and q.size > 0:
-                viser_urdf.update_cfg(_to_viser(np.asarray(q, dtype=float)))
+                server.stop()
+            except Exception as exc:  # noqa: BLE001 - teardown is best-effort
+                _logger.debug("viser stop failed: %s", exc)
+            self._server = None

--- a/almond_axol/serve/app.py
+++ b/almond_axol/serve/app.py
@@ -17,7 +17,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse
 from pydantic import BaseModel
 
-from ..utils import adb
+from ..utils import adb, ports
 from ..utils.certs import ACCEPT_PAGE_HTML
 from .commands import command_specs
 from .manager import Session, SessionManager
@@ -57,7 +57,7 @@ class EpisodeRequest(BaseModel):
 
 # Ports the launched commands expose on the serve host.
 _VIEWER_PORT = 8002  # viser sim 3D viewer
-_VR_PORT = 8000  # VR teleop WebSocket server
+_VR_PORT = ports.VR_PORT  # VR teleop WebSocket server (shared with the adb tunnel)
 
 
 def _lan_ip() -> str:

--- a/almond_axol/utils/adb.py
+++ b/almond_axol/utils/adb.py
@@ -23,12 +23,14 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
+from .ports import VR_PORT
 from .sudo import prime_sudo, run_root
 
 _logger = logging.getLogger(__name__)
 
-# The VR WebSocket server port; we forward the headset's loopback copy of it.
-VR_PORT = 8000
+# ``VR_PORT`` (the port we forward the headset's loopback copy of) is owned by
+# ``utils.ports`` so the tunnel target and the VR server's bind can't drift.
+__all__ = ["VR_PORT", "AdbStatus", "install", "status", "connect"]
 
 # Meta/Oculus USB vendor id. The udev rule lets a non-root user open the
 # headset for interactive ``adb`` (the root ``axol serve`` process opens it
@@ -230,6 +232,16 @@ def connect(port: int = VR_PORT) -> AdbStatus:
     The first adb command against a freshly connected headset also triggers the
     USB-debugging authorization popup on the device. Returns the resulting
     status so the caller can surface "authorize on headset" vs "ready".
+
+    Self-healing: any existing reverse for this port is removed first, then a
+    fresh one is added. ``adb reverse`` keys on the device-side spec, so a plain
+    re-add already replaces a prior mapping, but removing first also clears a
+    *wedged* tunnel (e.g. one left pointing at a server we since reclaimed/killed
+    on a different run) so reconnect reliably yields a working forward rather
+    than trusting whatever stale state the device held.
     """
+    # ``--remove`` of a non-existent reverse exits non-zero; that's expected and
+    # harmless (``_run`` only warns on spawn/timeout errors, not exit codes).
+    _run(["reverse", "--remove", f"tcp:{port}"])
     _run(["reverse", f"tcp:{port}", f"tcp:{port}"])
     return status(port)

--- a/almond_axol/utils/ports.py
+++ b/almond_axol/utils/ports.py
@@ -1,0 +1,136 @@
+"""Durable binding for the fixed TCP ports Axol servers use.
+
+Several servers bind a *fixed* port and can be started/stopped repeatedly within
+one long-running ``axol serve`` process — the VR WebSocket server (8000), the
+viser sim viewer (8002), and the control panel itself (8001). A previous run (or
+a crashed/force-killed one) can leave a listener squatting on the port, so a
+plain bind fails with ``[Errno 98] address already in use`` and the server comes
+up dead. This module centralizes "bind, reclaiming the port if necessary" so
+every fixed port behaves identically.
+
+The reclaim never targets our own PID, so it can't take down the control-panel
+process that hosts several of these servers at once.
+"""
+
+from __future__ import annotations
+
+import errno
+import logging
+import os
+import re
+import shutil
+import signal
+import socket
+import subprocess
+import time
+
+_logger = logging.getLogger(__name__)
+
+# Well-known fixed port. The VR WebSocket server binds it and the Quest-over-USB
+# ``adb reverse`` tunnel forwards the headset's loopback copy to it, so the two
+# must agree — this is the single source of truth for both (``vr.config`` and
+# ``utils.adb`` import it) so they can't drift and silently break USB teleop.
+VR_PORT = 8000
+
+# How hard ``open_listen_socket`` tries before giving up. A couple of plain
+# retries absorb a previous server still releasing the socket; after that we
+# evict whatever is squatting on the port.
+_BIND_RETRIES = 12
+_BIND_RETRY_DELAY = 0.25  # seconds between attempts
+
+
+def listening_pids(port: int) -> set[int]:
+    """PIDs (other than our own) with a LISTEN socket on ``port``.
+
+    Uses ``ss`` (iproute2, always present on the Jetson — CAN bring-up already
+    relies on it). Returns an empty set if ``ss`` is missing or unparseable, in
+    which case the caller simply can't reclaim and surfaces the bind error.
+    """
+    ss = shutil.which("ss")
+    if ss is None:
+        return set()
+    try:
+        proc = subprocess.run(
+            [ss, "-ltnpH", f"sport = :{port}"],
+            capture_output=True,
+            text=True,
+            timeout=5.0,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return set()
+    me = os.getpid()
+    return {
+        pid
+        for pid in (int(m.group(1)) for m in re.finditer(r"pid=(\d+)", proc.stdout))
+        if pid != me
+    }
+
+
+def _signal_pid(pid: int, sig: signal.Signals) -> None:
+    try:
+        os.kill(pid, sig)
+    except (ProcessLookupError, PermissionError) as exc:
+        _logger.debug("could not signal pid %d: %s", pid, exc)
+
+
+def reclaim_port(port: int) -> None:
+    """Best-effort: terminate any *other* process listening on ``port``.
+
+    Used for ports whose value is fixed (a headset tunnel, a bookmarked viewer
+    URL, a client's ``--server_port``), where a leftover listener from a crashed
+    or not-fully-stopped previous run has to be evicted rather than worked
+    around. Never targets our own PID, so it can't suicide a process that hosts
+    several of these servers at once.
+    """
+    pids = listening_pids(port)
+    if not pids:
+        return
+    _logger.warning(
+        "port %d held by pid(s) %s; terminating to reclaim it",
+        port,
+        ", ".join(map(str, sorted(pids))),
+    )
+    for pid in pids:
+        _signal_pid(pid, signal.SIGTERM)
+    time.sleep(_BIND_RETRY_DELAY)
+    for pid in listening_pids(port):
+        _signal_pid(pid, signal.SIGKILL)
+
+
+def open_listen_socket(host: str, port: int) -> socket.socket:
+    """Bind a listening socket on ``(host, port)``, reclaiming it if necessary.
+
+    Binding eagerly here — rather than letting an async server bind inside a
+    background task — means a real conflict raises to the caller instead of
+    being logged and swallowed. The returned socket is bound but *not* listening
+    yet; uvicorn/asyncio call ``listen()`` when they adopt it.
+
+    The retry/reclaim sequence: bind immediately (the normal case), then retry
+    briefly to let a previous server finish releasing the socket, then evict any
+    process still holding it, then keep retrying until it's ours.
+    """
+    last_exc: OSError | None = None
+    for attempt in range(_BIND_RETRIES):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        # SO_REUSEADDR lets us bind over a socket left in TIME_WAIT by a server
+        # that just exited (e.g. one we reclaimed a moment ago).
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.bind((host, port))
+        except OSError as exc:
+            sock.close()
+            if exc.errno != errno.EADDRINUSE:
+                raise
+            last_exc = exc
+            # Attempt 0: just wait for a mid-shutdown server to let go.
+            # From attempt 1 on, actively evict the squatter.
+            if attempt >= 1:
+                reclaim_port(port)
+            time.sleep(_BIND_RETRY_DELAY)
+            continue
+        return sock
+    raise OSError(
+        errno.EADDRINUSE,
+        f"port {port} is still in use after {_BIND_RETRIES} attempts; "
+        "another process is holding it and could not be reclaimed",
+    ) from last_exc

--- a/almond_axol/vr/config.py
+++ b/almond_axol/vr/config.py
@@ -4,17 +4,21 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from ..utils.ports import VR_PORT
+
 
 @dataclass
 class VRServerConfig:
     """Configuration for the VR WebSocket server.
 
     Attributes:
-        port:     Port to listen on.
+        port:     Port to listen on. Defaults to the shared ``VR_PORT`` so the
+                  Quest-over-USB ``adb reverse`` tunnel always targets the same
+                  port the server binds.
         certfile: Path to TLS certificate. None uses the auto-generated cert in ~/.almond/vr/certs/.
         keyfile:  Path to TLS private key. None uses the auto-generated key in ~/.almond/vr/certs/.
     """
 
-    port: int = 8000
+    port: int = VR_PORT
     certfile: str | None = None
     keyfile: str | None = None

--- a/almond_axol/vr/server.py
+++ b/almond_axol/vr/server.py
@@ -33,6 +33,7 @@ import asyncio
 import json
 import logging
 import os
+import socket
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
@@ -41,6 +42,7 @@ from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse
 
 from ..utils.certs import ACCEPT_PAGE_HTML, CERTFILE, KEYFILE, create_self_signed_cert
+from ..utils.ports import open_listen_socket
 from .config import VRServerConfig
 from .models import VRFrame
 
@@ -77,6 +79,7 @@ class VRServer:
         self._active_clients: set[WebSocket] = set()
         self._server_task: asyncio.Task[None] | None = None
         self._uvicorn_server: uvicorn.Server | None = None
+        self._listen_socket: socket.socket | None = None
         self._webrtc: WebRTCManager | Any | None = None
 
     # ------------------------------------------------------------------
@@ -158,13 +161,22 @@ class VRServer:
                 _logger.warning("Failed to send feedback to client: %s", exc)
 
     async def enable(self) -> None:
-        """Start the WSS server in the background."""
+        """Start the WSS server in the background.
+
+        The listening socket is bound *here* (reclaiming the port from a stale
+        listener if needed) so a bind failure raises synchronously instead of
+        being swallowed inside uvicorn's background task. uvicorn then adopts
+        the already-bound socket via ``serve(sockets=...)``.
+        """
         if self._server_task is not None:
             return
 
         if not os.path.isfile(self._certfile) or not os.path.isfile(self._keyfile):
             _logger.info("creating self-signed certificate")
             create_self_signed_cert(self._certfile, self._keyfile)
+
+        sock = await asyncio.to_thread(open_listen_socket, "0.0.0.0", self._port)
+        self._listen_socket = sock
 
         app = self._build_app()
         config = uvicorn.Config(
@@ -176,7 +188,9 @@ class VRServer:
             ssl_keyfile=self._keyfile,
         )
         self._uvicorn_server = uvicorn.Server(config)
-        self._server_task = asyncio.create_task(self._uvicorn_server.serve())
+        self._server_task = asyncio.create_task(
+            self._uvicorn_server.serve(sockets=[sock])
+        )
         _logger.info("listening on wss://0.0.0.0:%d/ws", self._port)
 
     async def disable(self) -> None:
@@ -201,6 +215,16 @@ class VRServer:
                 except asyncio.CancelledError:
                     pass
             self._server_task = None
+
+        # uvicorn closes the adopted socket on a clean shutdown, but close it
+        # ourselves too so a cancelled/timed-out shutdown still frees the port
+        # for the next ``enable()`` instead of leaking the bind.
+        if self._listen_socket is not None:
+            try:
+                self._listen_socket.close()
+            except OSError:
+                pass
+            self._listen_socket = None
 
         self._client_count = 0
         self._active_clients.clear()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> reclaim_port terminates other processes listening on fixed ports, which could affect unrelated services on the same host if they collide on 8000/8001/8002/8765; own PID is excluded.
> 
> **Overview**
> Adds **`utils.ports`** so Axol can bind fixed ports (control panel, VR WSS, viser viewer, policy gRPC) after crashes or in-process restarts without **address already in use**. **`reclaim_port`** finds other listeners via **`ss`** and sends **SIGTERM/SIGKILL** (never the current PID); **`open_listen_socket`** retries with **`SO_REUSEADDR`** and escalates to reclaim.
> 
> **`axol serve`** and **`VRServer`** bind the socket up front and pass it to uvicorn via **`serve(sockets=...)`**, so bind failures surface synchronously and the socket is closed on shutdown. **`inference-server`**, local **`run-policy`**, and **sim `enable()`** call **`reclaim_port`** before their fixed ports; **sim `disable()`** now stops viser and joins the thread so port **8002** is freed when the control panel restarts sim teleop.
> 
> **`VR_PORT` (8000)** is the single source of truth for the VR server, **`adb reverse`**, and the serve API. **`adb.connect`** removes an existing reverse on that port before re-adding it to clear wedged USB tunnels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a3104b3450dd85f21ea5c4bdee058ac1f7cc0d5. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->