### PR TITLE
better zed handling

### DIFF
--- a/almond_axol/zed/devices.py
+++ b/almond_axol/zed/devices.py
@@ -156,7 +156,9 @@ def list_zed_devices(timeout_s: float = _ENUMERATE_TIMEOUT_S) -> list[ZedDevice]
     if status == "ok":
         return payload[0]
     error_type, message = payload
-    if error_type == "ImportError":
+    # ModuleNotFoundError (raised when pyzed is absent) is an ImportError
+    # subclass; preserve it so callers' ``except ImportError`` paths still fire.
+    if error_type in ("ImportError", "ModuleNotFoundError"):
         raise ImportError(message)
     raise RuntimeError(f"{error_type}: {message}")
 

--- a/almond_axol/zed/devices.py
+++ b/almond_axol/zed/devices.py
@@ -4,14 +4,38 @@ Mono ZED-X One cameras live in ``sl.CameraOne``'s device list and stereo
 ZED X cameras in ``sl.Camera``'s, so both are queried. The ZED X daemon only
 enumerates GMSL cameras when it starts — a camera plugged in after boot stays
 invisible until the daemon restarts (see :func:`..daemon.restart_zed_daemon`).
+
+The ZED SDK keeps a *process-global* RPC connection to ``zed_x_daemon`` with a
+background receive thread. That connection can wedge for the entire life of a
+long-lived process — when the daemon restarts under it, or when the SDK was
+first touched before the daemon was ready — after which every SDK call in that
+process fails with ``InvalidState`` ("Receive thread is not running cannot
+send") and ``get_device_list`` returns nothing. From Python that is
+indistinguishable from "no cameras": no exception is raised, the list is just
+empty, and a stereo camera silently downgrades to the mono pipeline. The
+connection cannot be revived in-process; only a *fresh* process gets a fresh
+client (which is why restarting the whole ``axol`` service clears it).
+
+So :func:`list_zed_devices` runs the enumeration in a short-lived ``spawn``
+subprocess, which always has a fresh RPC client and is therefore immune to a
+wedged client in the host (serve / teleop) process. :func:`list_zed_devices_inproc`
+is the in-process primitive that subprocess runs.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import TypedDict
+from typing import TYPE_CHECKING, TypedDict
+
+if TYPE_CHECKING:
+    import multiprocessing.connection
 
 _logger = logging.getLogger(__name__)
+
+# A fresh enumeration subprocess imports pyzed and round-trips to the daemon;
+# a few seconds is plenty. The cap also bounds a genuinely hung daemon so the
+# host process never blocks forever waiting on detection.
+_ENUMERATE_TIMEOUT_S = 15.0
 
 
 class ZedDevice(TypedDict):
@@ -22,8 +46,13 @@ class ZedDevice(TypedDict):
     kind: str  # "mono" (ZED-X One) | "stereo" (ZED X)
 
 
-def list_zed_devices() -> list[ZedDevice]:
-    """Return every locally connected ZED camera (mono + stereo).
+def list_zed_devices_inproc() -> list[ZedDevice]:
+    """Enumerate ZED cameras using *this* process's SDK client.
+
+    Prefer :func:`list_zed_devices`, which runs this in a fresh subprocess so a
+    wedged RPC client in a long-lived host process can't make every camera look
+    absent. This primitive is what that subprocess worker runs (and is safe to
+    call directly from an already short-lived process).
 
     Raises:
         ImportError: If pyzed is not installed (run ``axol zed.install``).
@@ -55,16 +84,105 @@ def list_zed_devices() -> list[ZedDevice]:
     return out
 
 
+def _enumerate_worker(conn: "multiprocessing.connection.Connection") -> None:
+    """Subprocess entry: enumerate with a fresh SDK client, send the result back.
+
+    Sends ``("ok", devices)`` on success or ``("err", error_type, message)`` so
+    the parent can re-raise the same exception class — notably ``ImportError``
+    for a missing pyzed, which the UI surfaces specially.
+    """
+    try:
+        devices = list_zed_devices_inproc()
+        conn.send(("ok", devices))
+    except Exception as exc:  # noqa: BLE001 - report every failure to the parent
+        conn.send(("err", type(exc).__name__, str(exc)))
+    finally:
+        conn.close()
+
+
+def list_zed_devices(timeout_s: float = _ENUMERATE_TIMEOUT_S) -> list[ZedDevice]:
+    """Return every locally connected ZED camera (mono + stereo).
+
+    Runs the enumeration in a short-lived ``spawn`` subprocess so it always uses
+    a *fresh* SDK RPC client (see the module docstring): the SDK's connection to
+    ``zed_x_daemon`` is process-global and can wedge for the life of a long-lived
+    process, after which in-process enumeration silently returns nothing. A fresh
+    subprocess sidesteps that entirely, so a single hiccup no longer pins every
+    camera to "absent" (and every stereo camera to the mono pipeline) until the
+    host process is restarted.
+
+    Raises:
+        ImportError: If pyzed is not installed in the subprocess.
+        TimeoutError: If the subprocess doesn't answer within ``timeout_s``
+            (e.g. a genuinely hung daemon).
+        RuntimeError: If enumeration failed in the subprocess for any other
+            reason (the original error type + message are preserved), or the
+            subprocess crashed without reporting a result.
+    """
+    import multiprocessing
+
+    ctx = multiprocessing.get_context("spawn")
+    parent_conn, child_conn = ctx.Pipe()
+    proc = ctx.Process(
+        target=_enumerate_worker,
+        args=(child_conn,),
+        daemon=True,
+        name="zed-enumerate",
+    )
+    proc.start()
+    # Only the child writes; closing our copy means poll() sees EOF promptly if
+    # the child dies (e.g. a native crash in pyzed) instead of blocking.
+    child_conn.close()
+    try:
+        if not parent_conn.poll(timeout_s):
+            raise TimeoutError(
+                f"ZED enumeration subprocess did not respond within "
+                f"{timeout_s:.0f}s (is zed_x_daemon hung?)."
+            )
+        try:
+            status, *payload = parent_conn.recv()
+        except EOFError:
+            raise RuntimeError(
+                "ZED enumeration subprocess exited without a result "
+                "(the SDK likely crashed while talking to zed_x_daemon)."
+            ) from None
+    finally:
+        parent_conn.close()
+        proc.join(timeout=2.0)
+        if proc.is_alive():
+            proc.terminate()
+            proc.join(timeout=2.0)
+
+    if status == "ok":
+        return payload[0]
+    error_type, message = payload
+    if error_type == "ImportError":
+        raise ImportError(message)
+    raise RuntimeError(f"{error_type}: {message}")
+
+
 def stereo_serials() -> set[int]:
     """Serials of locally connected stereo (ZED X) cameras.
 
     Best-effort companion to :func:`list_zed_devices` used to auto-detect
     whether a configured camera is stereo from its serial, so operators never
-    have to flag it manually. Any enumeration failure (pyzed missing, daemon
-    down) returns an empty set, in which case callers treat cameras as mono.
+    have to flag it manually. Enumeration runs in a fresh subprocess, so a
+    wedged in-process SDK client no longer silently downgrades a stereo camera
+    to mono. Any remaining failure (daemon down, subprocess crash) returns an
+    empty set — in which case callers treat cameras as mono — but it is logged
+    loudly so the cause is visible rather than masquerading as "no cameras".
     """
     try:
         return {d["serial"] for d in list_zed_devices() if d["kind"] == "stereo"}
-    except Exception:  # noqa: BLE001 - detection is best-effort
-        _logger.debug("stereo_serials: ZED enumeration failed", exc_info=True)
+    except ImportError:
+        # pyzed absent (sim / dev host): legitimately no local cameras, not a
+        # fault — keep it quiet so it doesn't spam the non-hardware paths.
+        _logger.debug("stereo_serials: pyzed not installed; cameras treated as mono")
+        return set()
+    except Exception:  # noqa: BLE001 - detection is best-effort, but surface it
+        _logger.warning(
+            "stereo_serials: ZED enumeration failed; treating all cameras as "
+            "mono (a stereo camera will open on the wrong pipeline)",
+            exc_info=True,
+        )
         return set()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes camera detection on hardware paths and adds subprocess IPC/timeouts; failures now surface as exceptions or warnings instead of quiet empty lists, which could affect serve UI and stereo auto-detection until daemon/SDK issues are fixed.
> 
> **Overview**
> **ZED device enumeration** no longer runs entirely in the long-lived serve/teleop process. The previous in-process `list_zed_devices` logic is renamed to **`list_zed_devices_inproc`**, and the public **`list_zed_devices`** now runs that work in a short-lived **`spawn`** subprocess over a pipe, with a **15s timeout**, cleanup/terminate on hang, and **`ImportError` / `TimeoutError` / `RuntimeError`** raised in the parent when enumeration fails or the child dies without a result.
> 
> **`stereo_serials`** still best-effort returns an empty set on failure, but **`ImportError`** (missing pyzed) stays at debug while other enumeration failures are **`warning`**-logged with stack traces so a silent “no stereo” downgrade is easier to diagnose.
> 
> Module docs explain the wedged process-global ZED SDK RPC client and why a fresh subprocess fixes false “no cameras” / wrong mono pipeline behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae4b7990b57011b54c7554b5d107386355cc3d19. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->