### PR TITLE
Stop ops faster and actually kill what's running (ALM-1171)

### DIFF
--- a/almond_axol/cli/collect_data.py
+++ b/almond_axol/cli/collect_data.py
@@ -405,6 +405,14 @@ def _run(cfg: CollectDataConfig, stop_event: "threading.Event | None" = None) ->
         else:
             _register_camera_video(robot, teleop)
     except BaseException:
+        # Tear down teleop too: if a stop interrupts teleop.connect() while the
+        # IK worker is still compiling JAX, its VR server thread is otherwise
+        # left running and keeps holding its WebSocket port, so the next run
+        # can't bind it. disconnect() is a no-op if connect() never ran.
+        try:
+            teleop.disconnect()
+        except Exception:
+            _logger.exception("teleop cleanup after failed setup failed")
         if relay is not None:
             relay.shutdown()
         raise

--- a/almond_axol/serve/runner.py
+++ b/almond_axol/serve/runner.py
@@ -315,12 +315,22 @@ class OperationRunner:
         return session
 
     def _begin_stop(self, session: Session) -> bool:
-        """Signal the op to unwind. Returns ``False`` if a stop is already underway."""
+        """Signal the op to unwind. Returns ``False`` if there's nothing to stop.
+
+        The status check + flip happen under the lock, and the terminal
+        transitions (:meth:`_mark_terminal`) take the same lock, so a Stop that
+        races the op's own exit can't resurrect a finished session as
+        ``stopping``: either we flip a still-running op to ``stopping`` (and a
+        later ``_finish`` moves it to ``exited``), or the op already reached a
+        terminal state and we bail.
+        """
         with self._lock:
             if self._stopping:
                 return False
+            if session.status not in ("starting", "running"):
+                return False
             self._stopping = True
-        session.status = "stopping"
+            session.status = "stopping"
         session.emit("[serve] stopping…")
         self._stop_event.set()
         loop, task = self._async_loop, self._async_task
@@ -524,8 +534,9 @@ class OperationRunner:
             except asyncio.CancelledError:
                 pass
             except Exception as exc:  # noqa: BLE001
-                session.error = f"{type(exc).__name__}: {exc}"
-                session.status = "error"
+                self._mark_terminal(
+                    session, "error", error=f"{type(exc).__name__}: {exc}"
+                )
                 session.emit(f"[serve] error: {session.error}")
             finally:
                 try:
@@ -561,8 +572,9 @@ class OperationRunner:
                     self._policy_control = control
                     core(cfg, stop_event=self._stop_event, control=control)
             except Exception as exc:  # noqa: BLE001
-                session.error = f"{type(exc).__name__}: {exc}"
-                session.status = "error"
+                self._mark_terminal(
+                    session, "error", error=f"{type(exc).__name__}: {exc}"
+                )
                 session.emit(f"[serve] error: {session.error}")
             finally:
                 self._policy_control = None
@@ -570,10 +582,26 @@ class OperationRunner:
 
     # -- shared teardown ----------------------------------------------------
 
+    def _mark_terminal(
+        self, session: Session, status: str, *, error: str | None = None
+    ) -> None:
+        """Move a session to a terminal state (``exited`` / ``error``).
+
+        Taken under the lock so it can't interleave with :meth:`_begin_stop`'s
+        running-check-then-flip. Never downgrades an existing ``error`` (the
+        first failure wins, and a stop arriving after an error stays ``error``).
+        """
+        with self._lock:
+            if session.status == "error":
+                return
+            if error is not None:
+                session.error = error
+            session.status = status
+            if status == "exited":
+                session.exit_code = 0
+
     def _finish(self, session: Session, needs_robot: bool) -> None:
-        if session.status not in ("error",):
-            session.status = "exited"
-            session.exit_code = 0
+        self._mark_terminal(session, "exited")
         session.emit(f"[serve] {session.command_id} finished")
         session.close_stream()
         if needs_robot and self._robot_link is not None:

--- a/almond_axol/serve/runner.py
+++ b/almond_axol/serve/runner.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import multiprocessing
 import re
 import sys
 import threading
@@ -35,6 +36,19 @@ from ..zed import stereo_serials
 from .manager import Session
 
 _logger = logging.getLogger(__name__)
+
+# How long a stop waits for the op to unwind cleanly before force-killing the
+# op's child subprocesses, and how long it then waits for the freed-up worker
+# thread to finish. Kept short so Stop feels immediate: the worker thread can be
+# stuck for *minutes* on a child subprocess with no stop check in between —
+# either tearing down (``recorder.close()`` waits up to 180s for an in-flight
+# save; the video relay / IK joins add more) or still starting up (it blocks in
+# ``teleop.connect()`` on the IK worker's "ready" message, which only arrives
+# after JAX finishes compiling the IK solver — a cold compile is minutes). The
+# only reliable way to stop fast in all those cases is to kill the children out
+# from under it, which makes the blocked join/recv return.
+_STOP_GRACE_S = 6.0
+_FORCE_GRACE_S = 5.0
 
 # Operations that need exclusive ownership of the CAN bus (everything except
 # sim teleop, which is decided per-run from the ``sim`` arg).
@@ -166,6 +180,13 @@ class OperationRunner:
         self._session: Session | None = None
         self._thread: threading.Thread | None = None
         self._stop_event = threading.Event()
+        # Set once a stop has been kicked off for the current op, so a second
+        # Stop click (or a stop racing the op's own exit) is a no-op.
+        self._stopping = False
+        # multiprocessing children that already existed when the op started, so
+        # the force-kill only targets subprocesses this op spawned (relay,
+        # recorder, IK worker) and never anything the serve process owns.
+        self._baseline_children: set[int] = set()
         # asyncio op plumbing (set while an async op runs).
         self._async_loop: asyncio.AbstractEventLoop | None = None
         self._async_task: asyncio.Task[Any] | None = None
@@ -190,8 +211,10 @@ class OperationRunner:
         session.subscribers.discard(q)
 
     def is_running(self) -> bool:
+        # "stopping" still counts as running: the op owns the CAN bus until its
+        # worker thread unwinds, so a new op must not start until it's gone.
         s = self._session
-        return s is not None and s.status in ("starting", "running")
+        return s is not None and s.status in ("starting", "running", "stopping")
 
     # -- lifecycle ----------------------------------------------------------
 
@@ -213,6 +236,10 @@ class OperationRunner:
             session.loop = loop
             self._session = session
             self._stop_event = threading.Event()
+            self._stopping = False
+            # Snapshot pre-existing children so a later force-kill only targets
+            # the subprocesses this op is about to spawn.
+            self._baseline_children = {c.pid for c in multiprocessing.active_children()}
 
         # Fold the camera spec into the argv-style args for collect-data /
         # run-policy (their camera serials are required draccus inputs).
@@ -260,9 +287,40 @@ class OperationRunner:
         return session
 
     def stop(self) -> Session | None:
+        """Begin stopping the current op and return immediately.
+
+        Signals the op to unwind and hands off to a background watchdog that
+        force-kills the op's child subprocesses if it doesn't exit within the
+        grace period — so the HTTP request never blocks on a slow teardown
+        (e.g. a 180s dataset save). The session goes to ``stopping`` now and to
+        ``exited`` once the worker thread finishes (or is abandoned).
+        """
         session = self._session
         if session is None:
             return None
+        if not self.is_running():
+            # Already finished (or finishing): nothing to stop, and we must not
+            # flip a terminal session back to "stopping".
+            return session
+        if not self._begin_stop(session):
+            return session
+        thread = self._thread
+        watchdog = threading.Thread(
+            target=self._await_stop,
+            args=(session, thread),
+            name="axol-op-stop",
+            daemon=True,
+        )
+        watchdog.start()
+        return session
+
+    def _begin_stop(self, session: Session) -> bool:
+        """Signal the op to unwind. Returns ``False`` if a stop is already underway."""
+        with self._lock:
+            if self._stopping:
+                return False
+            self._stopping = True
+        session.status = "stopping"
         session.emit("[serve] stopping…")
         self._stop_event.set()
         loop, task = self._async_loop, self._async_task
@@ -271,10 +329,49 @@ class OperationRunner:
                 loop.call_soon_threadsafe(task.cancel)
             except RuntimeError:
                 pass
-        thread = self._thread
-        if thread is not None:
-            thread.join(timeout=20.0)
-        return self._session
+        return True
+
+    def _await_stop(self, session: Session, thread: threading.Thread | None) -> None:
+        """Wait for the op to exit, force-killing its children if it stalls."""
+        if thread is None:
+            return
+        thread.join(timeout=_STOP_GRACE_S)
+        if thread.is_alive():
+            session.emit(
+                f"[serve] still stopping after {_STOP_GRACE_S:.0f}s — "
+                "force-killing the operation's child processes"
+            )
+            self._kill_op_children(session)
+            thread.join(timeout=_FORCE_GRACE_S)
+        if thread.is_alive():
+            # The thread is stuck on something we can't kill (an in-process
+            # native call); leave it abandoned rather than block forever. It
+            # still owns the CAN bus, so the session stays "running"/"stopping"
+            # and is_running() keeps a new op from clobbering it.
+            session.emit(
+                "[serve] operation did not exit after force-kill and is now "
+                "abandoned — restart axol serve if it persists"
+            )
+
+    def _kill_op_children(self, session: Session) -> None:
+        """SIGKILL every subprocess this op spawned (relay, recorder, IK worker).
+
+        The worker thread blocks on these children either while tearing down
+        (``recorder.close()`` / ``relay.shutdown()`` / ``teleop.disconnect()``
+        joins) or while starting up (waiting on the IK worker's "ready" message
+        across the pipe while it compiles JAX). Killing the children makes the
+        blocked join/recv return so the thread can finish.
+        """
+        for child in multiprocessing.active_children():
+            if child.pid in self._baseline_children:
+                continue
+            session.emit(
+                f"[serve] killing child process {child.name} (pid {child.pid})"
+            )
+            try:
+                child.kill()
+            except Exception as exc:  # noqa: BLE001 - best-effort
+                session.emit(f"[serve] failed to kill pid {child.pid}: {exc}")
 
     def episode_command(self, command: str) -> bool:
         """Forward a run-policy episode command (start/s/r/q) to its control."""
@@ -285,8 +382,18 @@ class OperationRunner:
         return True
 
     async def shutdown(self) -> None:
+        # Server shutdown: stop and block until the op is actually gone (unlike
+        # the API stop, which returns early and lets the watchdog finish).
         if self.is_running():
-            await asyncio.to_thread(self.stop)
+            await asyncio.to_thread(self._stop_blocking)
+
+    def _stop_blocking(self) -> None:
+        session = self._session
+        thread = self._thread
+        if session is None:
+            return
+        self._begin_stop(session)
+        self._await_stop(session, thread)
 
     # -- config building ----------------------------------------------------
 

--- a/almond_axol/serve/runner.py
+++ b/almond_axol/serve/runner.py
@@ -362,9 +362,21 @@ class OperationRunner:
         across the pipe while it compiles JAX). Killing the children makes the
         blocked join/recv return so the thread can finish.
         """
-        for child in multiprocessing.active_children():
-            if child.pid in self._baseline_children:
-                continue
+        # Snapshot the targets under the lock and only if this is still the
+        # op being stopped: a slow watchdog could otherwise wake after the
+        # stopped worker exited and a *new* op started, and SIGKILL the new
+        # op's subprocesses. ``start()`` swaps ``_session`` / ``_baseline_children``
+        # under the same lock, so either we see the old op (and its children) or
+        # we see the swap and bail — never a mix.
+        with self._lock:
+            if self._session is not session:
+                return
+            targets = [
+                c
+                for c in multiprocessing.active_children()
+                if c.pid not in self._baseline_children
+            ]
+        for child in targets:
             session.emit(
                 f"[serve] killing child process {child.name} (pid {child.pid})"
             )

--- a/almond_axol/teleop/teleop.py
+++ b/almond_axol/teleop/teleop.py
@@ -234,7 +234,21 @@ class VRTeleop:
         await self._robot.disable()
 
     async def __aenter__(self) -> VRTeleop:
-        await self.enable()
+        # If enable() is interrupted partway — e.g. the operation is stopped
+        # while the IK worker is still compiling JAX, cancelling enable()'s wait
+        # for its "ready" message — __aexit__ never runs (the context never
+        # finished entering). Without cleanup here the already-started VR server
+        # thread leaks and keeps holding its WebSocket port, so the next teleop
+        # fails to bind it ("address already in use"). Tear down what enable()
+        # started before propagating.
+        try:
+            await self.enable()
+        except BaseException:
+            try:
+                await self.disable()
+            except Exception:
+                _logger.exception("teleop startup cleanup failed")
+            raise
         return self
 
     async def __aexit__(self, *_: object) -> None:

--- a/web/app/src/components/operation-panel.tsx
+++ b/web/app/src/components/operation-panel.tsx
@@ -41,6 +41,7 @@ export function OperationPanel({
   cameras,
   robot,
   live,
+  stopping,
   busy,
   session,
   host,
@@ -60,6 +61,7 @@ export function OperationPanel({
   cameras: CameraSpec
   robot: RobotStatus | null
   live: boolean
+  stopping: boolean
   busy: boolean
   session: SessionInfo | null
   host: string
@@ -129,7 +131,12 @@ export function OperationPanel({
             <p className="mt-2 max-w-prose text-sm text-white/55">{meta.description}</p>
           </div>
           <div className="flex shrink-0 items-center gap-2">
-            {live ? (
+            {stopping ? (
+              <Button variant="destructive" disabled>
+                <Loader2 className="animate-spin" />
+                Stopping…
+              </Button>
+            ) : live ? (
               <Button variant="destructive" onClick={onStop} disabled={busy}>
                 {busy ? <Loader2 className="animate-spin" /> : <Square />}
                 Stop
@@ -354,6 +361,8 @@ function StatusBadge({ session }: { session: SessionInfo | null }) {
       return <Badge variant="warning">Starting</Badge>
     case "running":
       return <Badge variant="success">Running</Badge>
+    case "stopping":
+      return <Badge variant="warning">Stopping</Badge>
     case "error":
       return <Badge variant="destructive">Error</Badge>
     case "exited":

--- a/web/app/src/lib/supervisor.ts
+++ b/web/app/src/lib/supervisor.ts
@@ -44,7 +44,7 @@ export interface CommandSpec {
 /** Catalog category display order (matches serve/commands.py CATEGORY_ORDER). */
 export const CATEGORY_ORDER = ["Operate", "Cameras", "Calibrate", "Setup"]
 
-export type SessionStatus = "starting" | "running" | "exited" | "error"
+export type SessionStatus = "starting" | "running" | "stopping" | "exited" | "error"
 
 export interface SessionInfo {
   id: string

--- a/web/app/src/routes/ControlPanel.tsx
+++ b/web/app/src/routes/ControlPanel.tsx
@@ -371,12 +371,27 @@ export default function ControlPanel() {
     [commands, selectedOp]
   )
 
-  // Stop the running task (if any) and wait for it to actually exit. The
-  // server-side stop joins the task thread before responding, so awaiting this
-  // guarantees the op is gone before a disconnect tears its connection down.
+  // Stop the running task (if any) and wait for it to actually exit before
+  // returning, so a disconnect never tears the host/robot link down mid-cleanup.
+  // The server-side stop now returns immediately with "stopping" (it force-kills
+  // a stuck op in the background), so we poll op status until the op is truly
+  // gone rather than relying on the stop response to block.
   async function stopRunningOp() {
     if (!isLive) return
     setSession(await stopOperation())
+    // Bounded so an unkillable op (abandoned server-side) can't wedge the UI;
+    // we proceed best-effort after the deadline.
+    const deadline = Date.now() + 30_000
+    while (Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 500))
+      try {
+        const op = await fetchOpStatus()
+        if (op.session) setSession(op.session)
+        if (!op.running) return
+      } catch {
+        return // host unreachable — nothing left to wait on
+      }
+    }
   }
 
   async function handleStart() {

--- a/web/app/src/routes/ControlPanel.tsx
+++ b/web/app/src/routes/ControlPanel.tsx
@@ -333,10 +333,37 @@ export default function ControlPanel() {
   const effectiveStatus = status ?? session
   const sources = [status, session].filter((s): s is SessionInfo => s != null)
   const isLive =
-    sources.some((s) => s.status === "running" || s.status === "starting") &&
-    !sources.some((s) => s.status === "exited" || s.status === "error")
+    sources.some(
+      (s) => s.status === "running" || s.status === "starting" || s.status === "stopping"
+    ) && !sources.some((s) => s.status === "exited" || s.status === "error")
+  // The op has been asked to stop and is unwinding (its worker thread is still
+  // tearing down / its children are being killed). The Stop button shows a
+  // disabled "Stopping…" until a terminal status flips the op back to idle.
+  const isStopping = isLive && sources.some((s) => s.status === "stopping")
   const runningOp = isLive ? (effectiveStatus?.command as OperationId) : null
   const selectedLive = isLive && runningOp === selectedOp
+  const selectedStopping = isStopping && runningOp === selectedOp
+
+  // While an op is live (including the "stopping" window), poll the server's
+  // authoritative op status so the panel reliably catches the transition to
+  // exited even if the logs WebSocket drops its final status frame. The stop
+  // itself returns immediately server-side, so this is what flips the button
+  // back to Start once the op has actually torn down.
+  useEffect(() => {
+    if (conn.state !== "ok" || !isLive) return
+    let active = true
+    const t = setInterval(() => {
+      fetchOpStatus()
+        .then((op) => {
+          if (active && op.session) setSession(op.session)
+        })
+        .catch(() => {})
+    }, 1500)
+    return () => {
+      active = false
+      clearInterval(t)
+    }
+  }, [conn.state, isLive])
 
   const meta = operationMeta(selectedOp)
   const spec = useMemo(
@@ -429,6 +456,7 @@ export default function ControlPanel() {
           cameras={cameras}
           robot={robot}
           live={selectedLive}
+          stopping={selectedStopping}
           busy={busy}
           session={selectedLive ? effectiveStatus : null}
           host={viewerHost}

--- a/web/app/src/routes/ControlPanel.tsx
+++ b/web/app/src/routes/ControlPanel.tsx
@@ -330,8 +330,23 @@ export default function ControlPanel() {
   // serve host), leaving its last-seen status stuck at "running". So treat the
   // op as live only when a source reports it active AND neither source reports
   // it finished — a terminal state from either side flips the button to Start.
-  const effectiveStatus = status ?? session
   const sources = [status, session].filter((s): s is SessionInfo => s != null)
+  // Display the most-advanced status across the two sources. The logs
+  // WebSocket only ever reports "running" then "exited" — it never emits
+  // "stopping" — so during a stop the REST/poll session is ahead; ranking it
+  // higher makes the badge show "Stopping" instead of a stale "Running".
+  const STATUS_RANK: Record<string, number> = {
+    starting: 0,
+    running: 1,
+    stopping: 2,
+    exited: 3,
+    error: 3,
+  }
+  const rank = (s: SessionInfo) => STATUS_RANK[s.status] ?? 0
+  const effectiveStatus = sources.reduce<SessionInfo | null>(
+    (best, s) => (best && rank(best) >= rank(s) ? best : s),
+    null
+  )
   const isLive =
     sources.some(
       (s) => s.status === "running" || s.status === "starting" || s.status === "stopping"
@@ -413,6 +428,10 @@ export default function ControlPanel() {
 
   async function handleStop() {
     setBusy(true)
+    // Reflect "Stopping…" immediately — the server stop returns right away and
+    // teardown runs in the background, so don't wait for the response/next poll
+    // to flip the button.
+    setSession((s) => (s ? { ...s, status: "stopping" } : s))
     try {
       setSession(await stopOperation())
     } catch (e) {


### PR DESCRIPTION
Hitting Stop on an in-process op (teleop, collect-data, etc.) could hang for minutes and leave the op running, because the worker thread can't be killed and blocks on child subprocesses with no stop check in between — `recorder.close()` waits up to 180s for a save, and `teleop.connect()` waits on the IK worker's "ready" message while JAX compiles. Now `/api/op/stop` returns immediately (session → `stopping`) and a background watchdog SIGKILLs the op's child subprocesses (video relay, dataset recorder, IK worker) after a short grace, which makes the blocked join/recv return so the worker actually unwinds. The web control panel shows a disabled "Stopping…" button + badge and polls op status until the op is truly gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Force-killing op subprocesses can interrupt in-flight dataset saves or teleop startup, but scope is limited to children spawned after op start; abandoned worker threads could leave CAN ownership stuck until serve restart.
> 
> **Overview**
> **Stop no longer blocks the API or the UI for minutes** while an in-process op tears down. `/api/op/stop` returns right away with session status **`stopping`**, and a background watchdog waits briefly then **SIGKILLs only child processes spawned by that op** (video relay, dataset recorder, IK worker), using a baseline PID snapshot so serve-owned processes are untouched. Duplicate Stop clicks are ignored; **`stopping` still counts as running** so the CAN bus and a new start stay blocked until the worker thread finishes (or is abandoned with a log hint). Server **`shutdown`** uses a separate blocking path that runs the same watchdog to completion.
> 
> The control panel adds a **`stopping`** session state: disabled **Stopping…** button and badge, treats **`stopping`** as live, and **polls `/api/op/status` every 1.5s** while an op is active so the UI reaches **exited** even when the logs WebSocket drops the final frame.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45354427f92392ce71f85857d2e29a835c88ad76. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->