### PR TITLE
Expose full camera config in UI; decouple stream/record eyes (ALM-1177)

### DIFF
--- a/almond_axol/cli/collect_data.py
+++ b/almond_axol/cli/collect_data.py
@@ -178,19 +178,31 @@ def _start_video_relay(cfg: "CollectDataConfig", dataset_resolution: str) -> Any
         # Downscale target for the dataset (raw) branch only; the encoded headset
         # branch keeps the full capture resolution. Clamped to capture in the relay.
         spec["dataset_resolution"] = dataset_resolution
-        # Eye policy must match observation_cameras() so the relay exports exactly
-        # the keys the recorder expects. Physically-stereo cameras are already
-        # flagged stereo on the config (see AxolRobotConfig.apply_detected_stereo,
-        # applied in _run before this), so here we just honour the flag: a
-        # ``eyes="both"`` camera (the head) records both eyes, suffixed
-        # (overhead_left / overhead_right); a single-eye stereo camera (a wrist)
-        # crops/encodes just that eye and exports it under the plain name, so it
-        # records one image like a mono camera.
+        # The recorded eyes (``eyes``) must match observation_cameras() so the
+        # relay's raw branch exports exactly the keys the recorder expects; the
+        # streamed eyes (``stream_eyes``) drive the headset feed independently, so
+        # the operator can e.g. stream both eyes for depth while recording only
+        # one. Physically-stereo cameras are already flagged stereo on the config
+        # (see AxolRobotConfig.apply_detected_stereo, applied in _run before this).
+        # For each branch: ``"both"`` records/streams both eyes suffixed
+        # (overhead_left / overhead_right); a single eye is cropped and exported
+        # under the plain name, so it costs and reads like a mono camera.
         if bool(getattr(camcfg, "stereo", False)):
-            eyes_cfg = getattr(camcfg, "eyes", "both")
+            record_eyes = getattr(camcfg, "eyes", "both")
+            stream_eyes = (
+                camcfg.streaming_eyes()
+                if hasattr(camcfg, "streaming_eyes")
+                else getattr(camcfg, "stream_eyes", None) or record_eyes
+            )
             spec["stereo"] = True
-            spec["eyes"] = ["left", "right"] if eyes_cfg == "both" else [eyes_cfg]
-            spec["eye_suffix"] = eyes_cfg == "both"
+            spec["record_eyes"] = (
+                ["left", "right"] if record_eyes == "both" else [record_eyes]
+            )
+            spec["record_suffix"] = record_eyes == "both"
+            spec["stream_eyes"] = (
+                ["left", "right"] if stream_eyes == "both" else [stream_eyes]
+            )
+            spec["stream_suffix"] = stream_eyes == "both"
         else:
             spec["stereo"] = False
         specs[name] = spec

--- a/almond_axol/cli/collect_data.py
+++ b/almond_axol/cli/collect_data.py
@@ -219,7 +219,13 @@ def _start_video_relay(cfg: "CollectDataConfig", dataset_resolution: str) -> Any
         specs[name] = spec
 
     relay = VideoRelayProcess(specs, want_raw=True)
-    if not relay.has_sources:
+    # Keep the relay if it can serve *either* branch: raw frames for the dataset
+    # (the primary purpose for collect-data) or encoded streams for the headset.
+    # A record-only setup (streaming disabled for every camera) has no encoded
+    # sources but still needs the relay's raw export, so don't discard it just
+    # because nothing streams — otherwise we fall back to the in-process path and
+    # open every camera a second time.
+    if not (relay.has_sources or relay.raw_cameras):
         relay.shutdown()
         return None
     return relay

--- a/almond_axol/cli/collect_data.py
+++ b/almond_axol/cli/collect_data.py
@@ -170,8 +170,19 @@ def _start_video_relay(cfg: "CollectDataConfig", dataset_resolution: str) -> Any
 
     specs: dict[str, dict[str, Any]] = {}
     for name, camcfg in cameras.items():
+        # Each camera opts into either branch: ``stream`` (headset) and ``record``
+        # (dataset). A camera in neither is dropped — never opened by the relay.
+        wants_record = bool(getattr(camcfg, "record", True))
+        wants_stream = bool(getattr(camcfg, "stream", True))
+        if not (wants_record or wants_stream):
+            continue
         serial = int(camcfg.serial)
-        spec: dict[str, Any] = {"serial": serial, "fps": camcfg.fps or 60}
+        spec: dict[str, Any] = {
+            "serial": serial,
+            "fps": camcfg.fps or 60,
+            "record": wants_record,
+            "stream": wants_stream,
+        }
         res = camcfg.resolution_name() if hasattr(camcfg, "resolution_name") else None
         if res:
             spec["resolution"] = res
@@ -308,6 +319,13 @@ def _run(cfg: CollectDataConfig, stop_event: "threading.Event | None" = None) ->
         from ..zed import stereo_serials
 
         cfg.robot_config.prepare_capture_cameras(stereo_serials(), minimum=1)
+        if not cfg.robot_config.observation_cameras():
+            raise ValueError(
+                "collect-data has no camera with recording enabled — every "
+                "assigned camera is set to stream-only (or recording is turned "
+                "off). Enable recording for at least one camera in the Cameras "
+                "dialog (or set its record_resolution / eyes)."
+            )
 
     robot = AxolRobot(cfg.robot_config)
     teleop = AxolVRTeleop(cfg.teleop_config)

--- a/almond_axol/cli/config.py
+++ b/almond_axol/cli/config.py
@@ -469,6 +469,12 @@ class TeleopCmdConfig:
     the capture resolution for all cameras (``SVGA`` / ``HD1080`` /
     ``HD1200``); ``null`` (the default) keeps each camera's SDK default.
 
+    ``--camera_eyes`` overrides which eye(s) of a stereo slot are streamed to
+    the headset, keyed by slot (``both`` / ``left`` / ``right``) — e.g.
+    ``--camera_eyes "{overhead: both, left_arm: left}"``. Unset slots fall
+    back to the default policy (overhead streams both eyes per-lens, wrists
+    stream their left eye).
+
     The VR WebSocket server (port, TLS certs) lives on the nested
     ``vr_server`` config — e.g. ``--vr_server.port 9000``.
     """
@@ -481,6 +487,7 @@ class TeleopCmdConfig:
     left_channel: str | None = CAN_LEFT
     right_channel: str | None = CAN_RIGHT
     cameras: dict[str, int] = field(default_factory=dict)
+    camera_eyes: dict[str, str] = field(default_factory=dict)
     resolution: str | None = None
     log_level: LogLevel = "INFO"
 

--- a/almond_axol/cli/run_policy.py
+++ b/almond_axol/cli/run_policy.py
@@ -843,6 +843,13 @@ def _run(
         from ..zed import stereo_serials
 
         robot_config.prepare_capture_cameras(stereo_serials(), minimum=1)
+        if not robot_config.observation_cameras():
+            raise ValueError(
+                "run-policy has no camera with recording enabled — every assigned "
+                "camera is set to stream-only (or recording is turned off). The "
+                "policy needs the cameras it was trained on; enable recording for "
+                "them in the Cameras dialog."
+            )
 
     robot = AxolRobot(robot_config)
     _, robot_action_proc, robot_obs_proc = make_default_processors()

--- a/almond_axol/cli/teleop.py
+++ b/almond_axol/cli/teleop.py
@@ -108,6 +108,22 @@ def _stereo_eyes_for(name: str) -> tuple[list[str], bool]:
     return ["left"], False
 
 
+def _stream_eyes_for(cfg: TeleopCmdConfig, name: str) -> tuple[list[str], bool]:
+    """``(eyes, suffix)`` for a stereo slot's headset stream.
+
+    Honours an explicit per-slot ``--camera_eyes`` override (``both`` streams
+    both eyes per-lens, suffixed; ``left`` / ``right`` streams that single eye
+    under the plain name), falling back to the default head/wrist policy
+    (:func:`_stereo_eyes_for`) for slots the operator left unset.
+    """
+    eyes = (cfg.camera_eyes or {}).get(name)
+    if eyes == "both":
+        return ["left", "right"], True
+    if eyes in ("left", "right"):
+        return [eyes], False
+    return _stereo_eyes_for(name)
+
+
 def _start_video_relay(cfg: TeleopCmdConfig, stereo_set: set[int]) -> Any | None:
     """Start the out-of-process video relay for the configured cameras.
 
@@ -137,7 +153,7 @@ def _start_video_relay(cfg: TeleopCmdConfig, stereo_set: set[int]) -> Any | None
         spec: dict[str, Any] = {"serial": serial, "resolution": resolution, "fps": 60}
         if int(serial) in stereo_set:
             spec["stereo"] = True
-            spec["eyes"], spec["eye_suffix"] = _stereo_eyes_for(name)
+            spec["eyes"], spec["eye_suffix"] = _stream_eyes_for(cfg, name)
         specs[name] = spec
 
     relay = VideoRelayProcess(specs)
@@ -231,7 +247,7 @@ def _connect_zed_cameras(
             stereo = _connect(name, serial, stereo=True)
             if stereo is None:
                 continue
-            eyes, suffix = _stereo_eyes_for(name)
+            eyes, suffix = _stream_eyes_for(cfg, name)
             for side in eyes:
                 view = stereo.left_view if side == "left" else stereo.right_view
                 cameras.append((f"{name}_{side}" if suffix else name, view))

--- a/almond_axol/lerobot/camera/configuration_zed.py
+++ b/almond_axol/lerobot/camera/configuration_zed.py
@@ -76,6 +76,13 @@ class ZedCameraConfig(CameraConfig):
                     only ``"left"`` (or vice versa). Only the collect-data /
                     teleop relay honours this; run-policy streams no video.
                     Ignored when ``stereo`` is False.
+        record:     Whether this camera is recorded to the dataset at all.
+                    ``False`` drops it from the recorded observations
+                    (``observation_cameras``) while still allowing it to stream.
+                    Default True.
+        stream:     Whether this camera is streamed to the headset at all.
+                    ``False`` drops it from the relay's encoded feed while still
+                    allowing it to be recorded. Default True.
     """
 
     # 0 is the "unassigned" sentinel. collect-data / run-policy seed all three
@@ -93,6 +100,8 @@ class ZedCameraConfig(CameraConfig):
     stereo: bool = False
     eyes: StereoEyes = "both"
     stream_eyes: StereoEyes | None = None
+    record: bool = True
+    stream: bool = True
 
     def __post_init__(self) -> None:
         self.color_mode = ColorMode(self.color_mode)

--- a/almond_axol/lerobot/camera/configuration_zed.py
+++ b/almond_axol/lerobot/camera/configuration_zed.py
@@ -63,10 +63,19 @@ class ZedCameraConfig(CameraConfig):
         stereo:     Open the camera as a stereo ZED X. The robot expands a
                     stereo camera ``X`` into observation keys backed by a
                     single grab (see ``eyes``). Default False (mono ZED-X One).
-        eyes:       Which eye(s) of a stereo camera to expose as observations.
+        eyes:       Which eye(s) of a stereo camera to expose as **recorded**
+                    observations (the dataset / what a policy is trained on).
                     ``"both"`` (default) yields ``X_left`` and ``X_right``;
                     ``"left"`` yields only ``X_left``; ``"right"`` yields only
                     ``X_right``. Ignored when ``stereo`` is False.
+        stream_eyes: Which eye(s) of a stereo camera to **stream** to the VR
+                    headset, independently of ``eyes``. ``None`` (default) means
+                    follow ``eyes`` (the legacy coupled behaviour). Setting it
+                    decouples the headset feed from the recording — e.g. stream
+                    ``"both"`` for depth perception in teleop while recording
+                    only ``"left"`` (or vice versa). Only the collect-data /
+                    teleop relay honours this; run-policy streams no video.
+                    Ignored when ``stereo`` is False.
     """
 
     # 0 is the "unassigned" sentinel. collect-data / run-policy seed all three
@@ -83,6 +92,7 @@ class ZedCameraConfig(CameraConfig):
     warmup_s: int = 1
     stereo: bool = False
     eyes: StereoEyes = "both"
+    stream_eyes: StereoEyes | None = None
 
     def __post_init__(self) -> None:
         self.color_mode = ColorMode(self.color_mode)
@@ -90,6 +100,19 @@ class ZedCameraConfig(CameraConfig):
             raise ValueError(
                 f"eyes must be one of 'both', 'left', 'right'; got {self.eyes!r}."
             )
+        if self.stream_eyes is not None and self.stream_eyes not in (
+            "both",
+            "left",
+            "right",
+        ):
+            raise ValueError(
+                "stream_eyes must be None or one of 'both', 'left', 'right'; "
+                f"got {self.stream_eyes!r}."
+            )
+
+    def streaming_eyes(self) -> StereoEyes:
+        """Eye selection for the headset stream (falls back to ``eyes``)."""
+        return self.stream_eyes or self.eyes
 
     def resolution_name(self) -> str | None:
         """Resolution name for the configured dims (``None`` = auto-detect)."""

--- a/almond_axol/lerobot/robot/config_axol.py
+++ b/almond_axol/lerobot/robot/config_axol.py
@@ -136,6 +136,10 @@ class AxolRobotConfig(RobotConfig):
         """
         out: dict[str, tuple[CameraConfig, str | None]] = {}
         for name, cfg in self.cameras.items():
+            # A camera set to stream-only (record=False) is opened to feed the
+            # headset but kept out of the recorded dataset entirely.
+            if not getattr(cfg, "record", True):
+                continue
             if getattr(cfg, "stereo", False):
                 eyes = getattr(cfg, "eyes", "both")
                 if eyes != "both":

--- a/almond_axol/serve/app.py
+++ b/almond_axol/serve/app.py
@@ -38,10 +38,20 @@ class OpStartRequest(BaseModel):
     """Start one of the four in-process core operations.
 
     ``cameras`` (optional) carries the local ZED camera setup for teleop /
-    collect-data / run-policy: ``{"serials": {"overhead": 41234567, ...},
-    "resolution": "SVGA" | None}``. The runner folds it into the operation's
-    config (per-camera serials, capture resolution); whether the overhead is
-    stereo is auto-detected from its serial, not passed in.
+    collect-data / run-policy, e.g.::
+
+        {
+          "serials": {"overhead": 41234567, "left_arm": ..., "right_arm": ...},
+          "stream_resolution": "HD1200",   # capture res → headset feed
+          "record_resolution": "SVGA",     # dataset downscale (collect-data)
+          "stream_eyes": {"overhead": "both"},   # per stereo slot, headset
+          "record_eyes": {"overhead": "left"}    # per stereo slot, dataset
+        }
+
+    The runner folds it into the operation's config (per-camera serials,
+    capture/record resolution, per-eye stream/record selection). Whether a
+    slot is stereo is auto-detected from its serial, not passed in. The legacy
+    ``"resolution"`` key is still accepted as the streaming resolution.
     """
 
     op: str

--- a/almond_axol/serve/app.py
+++ b/almond_axol/serve/app.py
@@ -42,16 +42,20 @@ class OpStartRequest(BaseModel):
 
         {
           "serials": {"overhead": 41234567, "left_arm": ..., "right_arm": ...},
-          "stream_resolution": "HD1200",   # capture res → headset feed
-          "record_resolution": "SVGA",     # dataset downscale (collect-data)
-          "stream_eyes": {"overhead": "both"},   # per stereo slot, headset
-          "record_eyes": {"overhead": "left"}    # per stereo slot, dataset
+          "stream_resolution": "HD1200",   # capture res → headset; "off" disables
+          "record_resolution": "SVGA",     # dataset downscale; "off" disables
+          "stream": {"overhead": "both", "left_arm": true},   # per-slot headset
+          "record": {"overhead": "left", "left_arm": false}   # per-slot dataset
         }
 
-    The runner folds it into the operation's config (per-camera serials,
-    capture/record resolution, per-eye stream/record selection). Whether a
-    slot is stereo is auto-detected from its serial, not passed in. The legacy
-    ``"resolution"`` key is still accepted as the streaming resolution.
+    The ``stream`` / ``record`` maps decide per camera whether it takes part in
+    each branch: ``false`` opts a camera out, ``true`` opts a mono camera in, and
+    an eye name (``"both"`` / ``"left"`` / ``"right"``) opts a stereo camera in
+    with that eye selection. The runner folds all of this into the operation's
+    config (serials, capture/record resolution, per-camera stream/record enable,
+    per-eye selection). Whether a slot is stereo is auto-detected from its
+    serial, not passed in. The legacy ``"resolution"`` key is still accepted as
+    the streaming resolution.
     """
 
     op: str

--- a/almond_axol/serve/introspect.py
+++ b/almond_axol/serve/introspect.py
@@ -267,6 +267,42 @@ def _make_node(
     }
 
 
+# Config fields the control panel's Cameras dialog owns end-to-end (serials,
+# stream/record resolution, per-eye stream/record selection). They are hidden
+# from the generated "optional config" form so there is a single source of
+# truth — but they must stay in the Schema's ``emit`` map (the runner still
+# folds the camera spec into these dotted overrides), so the hiding is a
+# display-only prune applied after ``emit`` is built. Matched as a full key or
+# a dotted prefix, covering teleop (``cameras`` / ``camera_eyes`` /
+# ``resolution``), collect-data (``dataset_resolution``), and collect-data /
+# run-policy (``robot_config.cameras`` and its per-camera leaves).
+_HIDDEN_FORM_KEYS: frozenset[str] = frozenset(
+    {
+        "cameras",
+        "camera_eyes",
+        "resolution",
+        "dataset_resolution",
+        "robot_config.cameras",
+    }
+)
+
+
+def _is_hidden_form_key(key: str) -> bool:
+    return any(key == k or key.startswith(k + ".") for k in _HIDDEN_FORM_KEYS)
+
+
+def _prune_hidden(nodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Drop camera-owned nodes from a form node tree (display only)."""
+    out: list[dict[str, Any]] = []
+    for node in nodes:
+        if _is_hidden_form_key(node["key"]):
+            continue
+        if node["kind"] == "group":
+            node = {**node, "children": _prune_hidden(node["children"])}
+        out.append(node)
+    return out
+
+
 def _collect_leaf_keys(nodes: list[dict[str, Any]], out: set[str]) -> None:
     for node in nodes:
         if node["kind"] == "group":
@@ -312,6 +348,11 @@ def build_schema(config_class: type) -> Schema:
             }
         else:
             emit[key] = {"t": "opt", "flag": f"--{key}"}
+    # Hide camera-owned fields from the displayed form, but keep every leaf in
+    # ``emit`` above so the runner can still translate the camera spec into the
+    # corresponding ``--robot_config.cameras.*`` / ``--dataset_resolution``
+    # overrides. None of the hidden fields are required.
+    nodes = _prune_hidden(nodes)
     return Schema(nodes=nodes, required=sorted(required), emit=emit)
 
 

--- a/almond_axol/serve/runner.py
+++ b/almond_axol/serve/runner.py
@@ -305,34 +305,79 @@ class OperationRunner:
                 serials[slot] = serial
         return serials
 
+    @staticmethod
+    def _slot_eyes(cameras: dict[str, Any] | None, key: str) -> dict[str, str]:
+        """Valid ``slot -> eyes`` pairs from a camera spec's eye map."""
+        out: dict[str, str] = {}
+        for slot, raw in ((cameras or {}).get(key) or {}).items():
+            if slot in _CAMERA_SLOTS and raw in ("both", "left", "right"):
+                out[slot] = raw
+        return out
+
     def _merge_camera_args(
         self, args: dict[str, Any], cameras: dict[str, Any]
     ) -> dict[str, Any]:
         """Fold a camera spec into collect-data / run-policy form args.
 
-        Serials and the capture resolution map to dotted
-        ``robot_config.cameras.*`` keys that the command schema already emits,
-        so the resulting argv is parsed like any CLI override. Whether the
-        overhead is stereo is auto-detected from its serial (see
+        Serials, capture resolution, stereo flag, and per-eye selection map to
+        dotted ``robot_config.cameras.*`` keys the command schema emits, so the
+        result is parsed like any CLI override (those fields are hidden from the
+        UI's generated form — the Cameras dialog owns them). Whether a slot is
+        stereo is auto-detected from its serial (see
         :func:`almond_axol.zed.stereo_serials`) rather than flagged by hand.
+
+        Eyes are split into the **recorded** eyes (``record_eyes`` ->
+        ``cameras.<slot>.eyes``, the dataset) and the **streamed** eyes
+        (``stream_eyes`` -> ``cameras.<slot>.stream_eyes``, the headset feed),
+        so the operator can stream both eyes for depth while recording one (or
+        vice versa). Resolution is likewise split: ``stream_resolution`` is the
+        capture resolution (per-camera ``width``/``height``, what the headset
+        sees) and ``record_resolution`` is the dataset downscale target
+        (collect-data's top-level ``dataset_resolution``; run-policy has no such
+        field, and ``build_argv`` drops the unknown key there).
         """
+        from ..lerobot.camera.configuration_zed import ZED_RESOLUTION_DIMS
+
         merged = dict(args)
         serials = self._camera_serials(cameras)
         for slot, serial in serials.items():
             merged[f"robot_config.cameras.{slot}.serial"] = serial
-        overhead = serials.get("overhead")
-        if overhead is not None and overhead in stereo_serials():
-            merged["robot_config.cameras.overhead.stereo"] = True
-        resolution = str(cameras.get("resolution") or "").strip()
-        if resolution:
-            from ..lerobot.camera.configuration_zed import ZED_RESOLUTION_DIMS
 
-            dims = ZED_RESOLUTION_DIMS.get(resolution)
+        detected = stereo_serials()
+        record_eyes = self._slot_eyes(cameras, "record_eyes")
+        stream_eyes = self._slot_eyes(cameras, "stream_eyes")
+        for slot, serial in serials.items():
+            if serial not in detected:
+                continue
+            # Flag stereo explicitly so AxolRobotConfig.apply_detected_stereo
+            # leaves our eye selection untouched (it only defaults eyes when it
+            # flips a slot to stereo itself). Eye fields apply to stereo only.
+            merged[f"robot_config.cameras.{slot}.stereo"] = True
+            # Recorded eyes default to the head/wrist policy when the UI omits
+            # them (both for overhead, left for a wrist) — matching
+            # apply_detected_stereo — so a CLI/legacy spec still behaves.
+            rec = record_eyes.get(slot, "both" if slot == "overhead" else "left")
+            merged[f"robot_config.cameras.{slot}.eyes"] = rec
+            strm = stream_eyes.get(slot)
+            if strm is not None:
+                merged[f"robot_config.cameras.{slot}.stream_eyes"] = strm
+
+        stream_res = str(
+            cameras.get("stream_resolution") or cameras.get("resolution") or ""
+        ).strip()
+        if stream_res:
+            dims = ZED_RESOLUTION_DIMS.get(stream_res)
             if dims is None:
-                raise ValueError(f"unknown ZED resolution {resolution!r}")
+                raise ValueError(f"unknown ZED resolution {stream_res!r}")
             for slot in serials or _CAMERA_SLOTS:
                 merged[f"robot_config.cameras.{slot}.width"] = dims[0]
                 merged[f"robot_config.cameras.{slot}.height"] = dims[1]
+
+        record_res = str(cameras.get("record_resolution") or "").strip()
+        if record_res:
+            if record_res not in ZED_RESOLUTION_DIMS:
+                raise ValueError(f"unknown ZED resolution {record_res!r}")
+            merged["dataset_resolution"] = record_res
         return merged
 
     def _attach_cameras_to_teleop(
@@ -347,14 +392,22 @@ class OperationRunner:
         if not serials:
             return
         cfg.cameras = serials
-        # A stereo ZED X at the head streams both eyes per-lens; a stereo ZED X
-        # at a wrist streams only its left eye (one feed, like a mono camera) so
-        # wrist cost stays flat regardless of camera type. teleop auto-detects
-        # stereo per serial, so this is just the operator-facing note. See
-        # ``cli.teleop._stereo_serials_for`` / ``_stereo_eyes_for``.
+        # Teleop only streams (no recording), so just the streaming eye selection
+        # applies. A stereo slot the operator left unset falls back to the default
+        # head/wrist policy (overhead streams both eyes per-lens; a wrist streams
+        # its left eye, one feed). teleop auto-detects stereo per serial. See
+        # ``cli.teleop._stream_eyes_for`` / ``_stereo_eyes_for``.
         detected = stereo_serials()
         stereo_slots = sorted(s for s, serial in serials.items() if serial in detected)
-        resolution = str((cameras or {}).get("resolution") or "").strip()
+        stream_eyes = self._slot_eyes(cameras, "stream_eyes")
+        camera_eyes = {s: stream_eyes[s] for s in stereo_slots if s in stream_eyes}
+        if camera_eyes:
+            cfg.camera_eyes = camera_eyes
+        resolution = str(
+            (cameras or {}).get("stream_resolution")
+            or (cameras or {}).get("resolution")
+            or ""
+        ).strip()
         if resolution:
             cfg.resolution = resolution
         stereo_note = f" (stereo: {', '.join(stereo_slots)})" if stereo_slots else ""

--- a/almond_axol/serve/runner.py
+++ b/almond_axol/serve/runner.py
@@ -306,77 +306,112 @@ class OperationRunner:
         return serials
 
     @staticmethod
-    def _slot_eyes(cameras: dict[str, Any] | None, key: str) -> dict[str, str]:
-        """Valid ``slot -> eyes`` pairs from a camera spec's eye map."""
-        out: dict[str, str] = {}
-        for slot, raw in ((cameras or {}).get(key) or {}).items():
-            if slot in _CAMERA_SLOTS and raw in ("both", "left", "right"):
-                out[slot] = raw
-        return out
+    def _resolution(
+        cameras: dict[str, Any] | None, key: str, legacy: str | None = None
+    ) -> str | None:
+        """Resolution name for a branch, or ``None`` when off/unset.
+
+        A value of ``"off"`` (or empty) disables the whole branch (streaming or
+        recording). ``legacy`` reads the old single ``resolution`` key as the
+        streaming resolution for back-compat.
+        """
+        from ..lerobot.camera.configuration_zed import ZED_RESOLUTION_DIMS
+
+        val = (cameras or {}).get(key)
+        if val is None and legacy:
+            val = (cameras or {}).get(legacy)
+        val = str(val or "").strip()
+        if not val or val.lower() == "off":
+            return None
+        if val not in ZED_RESOLUTION_DIMS:
+            raise ValueError(f"unknown ZED resolution {val!r}")
+        return val
+
+    @staticmethod
+    def _branch(
+        cameras: dict[str, Any] | None, key: str, slot: str, global_on: bool
+    ) -> tuple[bool, str | None]:
+        """``(enabled, eyes)`` for one camera in one branch (stream / record).
+
+        ``cameras[key][slot]`` is per-camera participation: ``False`` / ``"off"``
+        opts the camera out; an eye name (``"both"`` / ``"left"`` / ``"right"``)
+        opts a stereo camera in with that eye selection; ``True`` (or absent,
+        the default) opts a mono camera in. The branch is only enabled when its
+        global resolution is set (``global_on``).
+        """
+        raw = ((cameras or {}).get(key) or {}).get(slot, True)
+        enabled = raw not in (False, None, "off", "")
+        eyes = raw if raw in ("both", "left", "right") else None
+        return (global_on and enabled), eyes
 
     def _merge_camera_args(
         self, args: dict[str, Any], cameras: dict[str, Any]
     ) -> dict[str, Any]:
         """Fold a camera spec into collect-data / run-policy form args.
 
-        Serials, capture resolution, stereo flag, and per-eye selection map to
-        dotted ``robot_config.cameras.*`` keys the command schema emits, so the
-        result is parsed like any CLI override (those fields are hidden from the
-        UI's generated form — the Cameras dialog owns them). Whether a slot is
-        stereo is auto-detected from its serial (see
-        :func:`almond_axol.zed.stereo_serials`) rather than flagged by hand.
+        Serials, capture resolution, stereo flag, per-branch enable, and per-eye
+        selection map to dotted ``robot_config.cameras.*`` keys the command
+        schema emits, so the result is parsed like any CLI override (those fields
+        are hidden from the UI's generated form — the Cameras dialog owns them).
+        Whether a slot is stereo is auto-detected from its serial (see
+        :func:`almond_axol.zed.stereo_serials`).
 
-        Eyes are split into the **recorded** eyes (``record_eyes`` ->
-        ``cameras.<slot>.eyes``, the dataset) and the **streamed** eyes
-        (``stream_eyes`` -> ``cameras.<slot>.stream_eyes``, the headset feed),
-        so the operator can stream both eyes for depth while recording one (or
-        vice versa). Resolution is likewise split: ``stream_resolution`` is the
-        capture resolution (per-camera ``width``/``height``, what the headset
-        sees) and ``record_resolution`` is the dataset downscale target
-        (collect-data's top-level ``dataset_resolution``; run-policy has no such
-        field, and ``build_argv`` drops the unknown key there).
+        Streaming (the headset) and recording (the dataset) are configured
+        independently, globally and per camera:
+
+        - ``stream_resolution`` / ``record_resolution`` set the capture and
+          dataset-downscale resolutions; ``"off"`` (or unset) disables that whole
+          branch. ``record_resolution`` maps to collect-data's top-level
+          ``dataset_resolution`` (run-policy has no such field; ``build_argv``
+          drops the unknown key there).
+        - ``stream`` / ``record`` are per-slot maps deciding which cameras (and,
+          for stereo, which eyes) take part — mapping to ``cameras.<slot>.stream``
+          / ``.record`` plus ``.stream_eyes`` (headset) and ``.eyes`` (dataset).
+
+        A camera that takes part in neither branch is omitted entirely. Capture
+        resolution per camera is the streaming resolution when it streams, else
+        the recording resolution (no point grabbing larger than it records).
         """
         from ..lerobot.camera.configuration_zed import ZED_RESOLUTION_DIMS
 
         merged = dict(args)
         serials = self._camera_serials(cameras)
-        for slot, serial in serials.items():
-            merged[f"robot_config.cameras.{slot}.serial"] = serial
-
+        stream_res = self._resolution(cameras, "stream_resolution", legacy="resolution")
+        record_res = self._resolution(cameras, "record_resolution")
         detected = stereo_serials()
-        record_eyes = self._slot_eyes(cameras, "record_eyes")
-        stream_eyes = self._slot_eyes(cameras, "stream_eyes")
+
         for slot, serial in serials.items():
-            if serial not in detected:
-                continue
-            # Flag stereo explicitly so AxolRobotConfig.apply_detected_stereo
-            # leaves our eye selection untouched (it only defaults eyes when it
-            # flips a slot to stereo itself). Eye fields apply to stereo only.
-            merged[f"robot_config.cameras.{slot}.stereo"] = True
-            # Recorded eyes default to the head/wrist policy when the UI omits
-            # them (both for overhead, left for a wrist) — matching
-            # apply_detected_stereo — so a CLI/legacy spec still behaves.
-            rec = record_eyes.get(slot, "both" if slot == "overhead" else "left")
-            merged[f"robot_config.cameras.{slot}.eyes"] = rec
-            strm = stream_eyes.get(slot)
-            if strm is not None:
-                merged[f"robot_config.cameras.{slot}.stream_eyes"] = strm
+            streams, s_eyes = self._branch(
+                cameras, "stream", slot, stream_res is not None
+            )
+            records, r_eyes = self._branch(
+                cameras, "record", slot, record_res is not None
+            )
+            if not (streams or records):
+                continue  # disabled in both branches → don't open this camera
+            prefix = f"robot_config.cameras.{slot}"
+            merged[f"{prefix}.serial"] = serial
+            merged[f"{prefix}.stream"] = streams
+            merged[f"{prefix}.record"] = records
+            if serial in detected:
+                # Flag stereo explicitly so apply_detected_stereo leaves our eye
+                # selection untouched. Recorded eyes default to the head/wrist
+                # policy when omitted; stream eyes default to follow them.
+                merged[f"{prefix}.stereo"] = True
+                merged[f"{prefix}.eyes"] = r_eyes or (
+                    "both" if slot == "overhead" else "left"
+                )
+                if s_eyes is not None:
+                    merged[f"{prefix}.stream_eyes"] = s_eyes
+            # Capture at the streaming resolution when the camera streams,
+            # otherwise at the (smaller) recording resolution.
+            cap = stream_res if streams else record_res
+            if cap:
+                dims = ZED_RESOLUTION_DIMS[cap]
+                merged[f"{prefix}.width"] = dims[0]
+                merged[f"{prefix}.height"] = dims[1]
 
-        stream_res = str(
-            cameras.get("stream_resolution") or cameras.get("resolution") or ""
-        ).strip()
-        if stream_res:
-            dims = ZED_RESOLUTION_DIMS.get(stream_res)
-            if dims is None:
-                raise ValueError(f"unknown ZED resolution {stream_res!r}")
-            for slot in serials or _CAMERA_SLOTS:
-                merged[f"robot_config.cameras.{slot}.width"] = dims[0]
-                merged[f"robot_config.cameras.{slot}.height"] = dims[1]
-
-        record_res = str(cameras.get("record_resolution") or "").strip()
-        if record_res:
-            if record_res not in ZED_RESOLUTION_DIMS:
-                raise ValueError(f"unknown ZED resolution {record_res!r}")
+        if record_res is not None:
             merged["dataset_resolution"] = record_res
         return merged
 
@@ -385,36 +420,42 @@ class OperationRunner:
     ) -> None:
         """Point teleop's headset video at the configured local ZED cameras.
 
-        Teleop's ``cameras`` field is a dict (not reachable via flat argv), so
-        the configured serials are written onto the built config directly.
+        Teleop only streams (no recording), so only the streaming branch applies:
+        cameras opted out of streaming (or all, when streaming is globally off)
+        are left off the headset feed. Teleop's ``cameras`` / ``camera_eyes``
+        fields are dicts (not reachable via flat argv), so they're written onto
+        the built config directly.
         """
         serials = self._camera_serials(cameras)
         if not serials:
             return
-        cfg.cameras = serials
-        # Teleop only streams (no recording), so just the streaming eye selection
-        # applies. A stereo slot the operator left unset falls back to the default
-        # head/wrist policy (overhead streams both eyes per-lens; a wrist streams
-        # its left eye, one feed). teleop auto-detects stereo per serial. See
-        # ``cli.teleop._stream_eyes_for`` / ``_stereo_eyes_for``.
+        stream_res = self._resolution(cameras, "stream_resolution", legacy="resolution")
         detected = stereo_serials()
-        stereo_slots = sorted(s for s, serial in serials.items() if serial in detected)
-        stream_eyes = self._slot_eyes(cameras, "stream_eyes")
-        camera_eyes = {s: stream_eyes[s] for s in stereo_slots if s in stream_eyes}
+        cam_map: dict[str, int] = {}
+        camera_eyes: dict[str, str] = {}
+        for slot, serial in serials.items():
+            streams, s_eyes = self._branch(
+                cameras, "stream", slot, stream_res is not None
+            )
+            if not streams:
+                continue
+            cam_map[slot] = serial
+            if serial in detected and s_eyes is not None:
+                camera_eyes[slot] = s_eyes
+        if not cam_map:
+            session.emit("[serve] teleop: streaming disabled (no cameras)")
+            return
+        cfg.cameras = cam_map
         if camera_eyes:
             cfg.camera_eyes = camera_eyes
-        resolution = str(
-            (cameras or {}).get("stream_resolution")
-            or (cameras or {}).get("resolution")
-            or ""
-        ).strip()
-        if resolution:
-            cfg.resolution = resolution
+        if stream_res:
+            cfg.resolution = stream_res
+        stereo_slots = sorted(s for s in cam_map if cam_map[s] in detected)
         stereo_note = f" (stereo: {', '.join(stereo_slots)})" if stereo_slots else ""
-        resolution_note = f" @ {resolution}" if resolution else ""
+        resolution_note = f" @ {stream_res}" if stream_res else ""
         session.emit(
             "[serve] teleop: streaming cameras to the headset "
-            f"({', '.join(sorted(serials))}){stereo_note}{resolution_note}"
+            f"({', '.join(sorted(cam_map))}){stereo_note}{resolution_note}"
         )
 
     def _build_config(self, op_id: str, args: dict[str, Any]) -> Any:

--- a/almond_axol/utils/ports.py
+++ b/almond_axol/utils/ports.py
@@ -38,6 +38,14 @@ VR_PORT = 8000
 _BIND_RETRIES = 12
 _BIND_RETRY_DELAY = 0.25  # seconds between attempts
 
+# Listening sockets we bound on a fixed port, kept so a later bind can reclaim a
+# port our *own* process leaked. The in-process servers (the VR server lives on
+# a worker thread inside ``axol serve``) are torn down between operations, but a
+# stopped/timed-out op can leave its uvicorn server still holding the socket —
+# and ``reclaim_port`` deliberately never SIGKILLs our own PID, so it can't
+# evict it. Closing the leaked socket fd here frees the bind for the next op.
+_owned_listen_sockets: dict[int, socket.socket] = {}
+
 
 def listening_pids(port: int) -> set[int]:
     """PIDs (other than our own) with a LISTEN socket on ``port``.
@@ -106,8 +114,9 @@ def open_listen_socket(host: str, port: int) -> socket.socket:
     yet; uvicorn/asyncio call ``listen()`` when they adopt it.
 
     The retry/reclaim sequence: bind immediately (the normal case), then retry
-    briefly to let a previous server finish releasing the socket, then evict any
-    process still holding it, then keep retrying until it's ours.
+    briefly to let a previous server finish releasing the socket, closing any
+    socket *we* still hold on the port (a leaked in-process server), then evict
+    any other process still holding it, then keep retrying until it's ours.
     """
     last_exc: OSError | None = None
     for attempt in range(_BIND_RETRIES):
@@ -122,12 +131,27 @@ def open_listen_socket(host: str, port: int) -> socket.socket:
             if exc.errno != errno.EADDRINUSE:
                 raise
             last_exc = exc
+            # First free a socket our own process leaked on this port — a
+            # previous op's server that didn't fully tear down (reclaim_port
+            # can't evict our own PID). Closing the fd releases the bind.
+            stale = _owned_listen_sockets.pop(port, None)
+            if stale is not None:
+                _logger.warning(
+                    "port %d still held by a previous in-process server; "
+                    "closing the leaked socket to reclaim it",
+                    port,
+                )
+                try:
+                    stale.close()
+                except OSError:
+                    pass
             # Attempt 0: just wait for a mid-shutdown server to let go.
-            # From attempt 1 on, actively evict the squatter.
+            # From attempt 1 on, actively evict any *other* process squatting.
             if attempt >= 1:
                 reclaim_port(port)
             time.sleep(_BIND_RETRY_DELAY)
             continue
+        _owned_listen_sockets[port] = sock
         return sock
     raise OSError(
         errno.EADDRINUSE,

--- a/almond_axol/vr/gst_zed.py
+++ b/almond_axol/vr/gst_zed.py
@@ -792,6 +792,8 @@ class ZedGstStereoCamera(_GstPipelineBase):
         right_raw_socket_path: str | None = None,
         raw_dims: tuple[int, int] | None = None,
         eyes: str = "both",
+        encoded_eyes: "list[str] | tuple[str, ...] | None" = None,
+        raw_eyes: "list[str] | tuple[str, ...] | None" = None,
     ) -> None:
         _GstPipelineBase.__init__(self)
         if resolution not in _STEREO_RESOLUTION_ENUM:
@@ -806,8 +808,6 @@ class ZedGstStereoCamera(_GstPipelineBase):
         # builds the full per-eye pair.
         if eyes not in ("both", "left", "right"):
             raise ValueError(f"eyes must be 'both', 'left', or 'right'; got {eyes!r}.")
-        self.eyes = eyes
-        self._sides: tuple[str, ...] = ("left", "right") if eyes == "both" else (eyes,)
         # A per-eye raw sink (the relay's shared-memory writer) or a shmsink socket
         # path implies that eye's raw branch and replaces its in-process _RawBuffer.
         want_raw = (
@@ -817,6 +817,35 @@ class ZedGstStereoCamera(_GstPipelineBase):
             or left_raw_socket_path is not None
             or right_raw_socket_path is not None
         )
+        # The encoded (headset stream) and raw (dataset recording) branches can
+        # select different eyes — e.g. stream both eyes for depth while recording
+        # only the left. ``encoded_eyes`` / ``raw_eyes`` override per branch; when
+        # unset each falls back to ``eyes`` (the legacy coupled behaviour, gated by
+        # the corresponding ``want_*``). Each eye is cropped once and tee'd into
+        # whichever branch(es) want it, so a side present in neither is never built.
+        base_sides = ("left", "right") if eyes == "both" else (eyes,)
+
+        def _order(sides: "list[str] | tuple[str, ...]") -> tuple[str, ...]:
+            for s in sides:
+                if s not in ("left", "right"):
+                    raise ValueError(f"eye must be 'left' or 'right'; got {s!r}.")
+            return tuple(s for s in ("left", "right") if s in sides)
+
+        self._encoded_sides = _order(
+            encoded_eyes
+            if encoded_eyes is not None
+            else (base_sides if want_encoded else ())
+        )
+        self._raw_sides = _order(
+            raw_eyes if raw_eyes is not None else (base_sides if want_raw else ())
+        )
+        want_encoded = bool(self._encoded_sides)
+        want_raw = bool(self._raw_sides)
+        # Build (crop) every eye either branch needs, ordered left-then-right.
+        self._sides: tuple[str, ...] = _order(
+            tuple(self._encoded_sides) + tuple(self._raw_sides)
+        )
+        self.eyes = eyes
         if not (want_encoded or want_raw):
             raise ValueError("ZedGstStereoCamera needs at least one of encoded/raw")
         self.serial = serial
@@ -836,12 +865,14 @@ class ZedGstStereoCamera(_GstPipelineBase):
         self.raw_latency_s = 0.0
 
         def eye(
-            raw_sink: Any, socket_path: str | None
+            side: str, raw_sink: Any, socket_path: str | None
         ) -> tuple[_AUChannel | None, _RawBuffer | None, _GstEye]:
-            enc = _AUChannel(lambda: self.alive) if want_encoded else None
+            enc = (
+                _AUChannel(lambda: self.alive) if side in self._encoded_sides else None
+            )
             raw = (
                 _RawBuffer(self.raw_width, self.raw_height)
-                if want_raw and raw_sink is None and socket_path is None
+                if side in self._raw_sides and raw_sink is None and socket_path is None
                 else None
             )
             view = _GstEye(self, enc, raw, self.width, self.height, self.fps)
@@ -855,18 +886,26 @@ class ZedGstStereoCamera(_GstPipelineBase):
         self.right_view: _GstEye | None = None
         if "left" in self._sides:
             self._left_enc, self._left_raw, self.left_view = eye(
-                left_raw_sink, left_raw_socket_path
+                "left", left_raw_sink, left_raw_socket_path
             )
         if "right" in self._sides:
             self._right_enc, self._right_raw, self.right_view = eye(
-                right_raw_sink, right_raw_socket_path
+                "right", right_raw_sink, right_raw_socket_path
             )
 
     def __repr__(self) -> str:
         return f"ZedGstStereoCamera(serial={self.serial})"
 
     def _eye_branch(self, side: str, sink_suffix: str) -> str:
-        """One eye: crop its half on the VIC, then encode and/or raw appsink."""
+        """One eye: crop its half on the VIC, then encode and/or raw appsink.
+
+        Encode and raw are gated per eye (``self._encoded_sides`` /
+        ``self._raw_sides``), so this eye may be encode-only (headset),
+        raw-only (dataset), or both (tee'd) depending on which branch asked
+        for it.
+        """
+        want_encoded = side in self._encoded_sides
+        want_raw = side in self._raw_sides
         eye_w, eye_h = self.width, self.height
         left = 0 if side == "left" else eye_w
         right = eye_w if side == "left" else eye_w * 2
@@ -876,7 +915,7 @@ class ZedGstStereoCamera(_GstPipelineBase):
             "pixel-aspect-ratio=1/1"
         )
         crop = f"{_QUEUE} ! nvvidconv left={left} right={right} top=0 bottom={eye_h} ! {caps}"
-        if self._want_encoded and self._want_raw:
+        if want_encoded and want_raw:
             enc = (
                 f"{_QUEUE} ! {_enc_branch(bitrate, self.fps)} ! "
                 f"{_enc_appsink('enc_' + sink_suffix)}"
@@ -895,7 +934,7 @@ class ZedGstStereoCamera(_GstPipelineBase):
                 f"width={self.raw_width},height={self.raw_height} ! {raw_tail}"
             )
             return f"{crop} ! tee name=t{sink_suffix}  t{sink_suffix}. ! {enc}  t{sink_suffix}. ! {raw}"
-        if self._want_encoded:
+        if want_encoded:
             return f"{crop} ! {_enc_branch(bitrate, self.fps)} ! {_enc_appsink('enc_' + sink_suffix)}"
         return (
             f"{crop} ! nvvidconv ! video/x-raw,format=RGBA,"
@@ -911,7 +950,7 @@ class ZedGstStereoCamera(_GstPipelineBase):
         """
         if not self._want_raw or self._pipeline is None:
             return
-        for side in self._sides:
+        for side in self._raw_sides:
             valve = self._pipeline.get_by_name(f"rawvalve_{side[0]}")
             if valve is not None:
                 valve.set_property("drop", not enabled)
@@ -959,7 +998,7 @@ class ZedGstStereoCamera(_GstPipelineBase):
                 )
             # shmsink writes the frame in C; only the appsink path needs a Python
             # pull thread (which would contend with the relay's send — the bug).
-            if self._want_raw and sock is None:
+            if side in self._raw_sides and sock is None:
                 sink = raw_sink or self._buffer_sink(raw)
                 self._start_pull(
                     f"zedgst-{self.serial}-raw{suffix}",

--- a/almond_axol/vr/video_proc.py
+++ b/almond_axol/vr/video_proc.py
@@ -119,18 +119,40 @@ def _pyshm_meta(shm_name: str, width: int, height: int, fps: int) -> dict:
     }
 
 
-def _eye_plan(name: str, spec: dict) -> list[tuple[str, str]]:
-    """``[(eye_side, source_name)]`` for a stereo camera spec.
+def _plan(name: str, eyes: list[str], suffix: bool) -> list[tuple[str, str]]:
+    """``[(eye_side, source_name)]`` from an eye list + naming flag.
 
-    ``spec["eyes"]`` lists the eyes to build (default both); ``spec["eye_suffix"]``
-    (default True) decides naming. The head camera streams/records both eyes as
-    ``{name}_left`` / ``{name}_right``; a wrist stereo camera builds only its left
-    eye and exposes it under the plain ``{name}`` (``eye_suffix=False``), so it is
-    indistinguishable from a mono wrist downstream — one encode, one source.
+    With ``suffix`` the eyes are exposed as ``{name}_left`` / ``{name}_right``
+    (the head camera, rendered per-lens); without it a single eye is exposed
+    under the plain ``{name}`` so it is indistinguishable from a mono camera
+    downstream — one encode/record, one source.
     """
-    eyes = spec.get("eyes") or ["left", "right"]
-    suffix = spec.get("eye_suffix", True)
     return [(side, f"{name}_{side}" if suffix else name) for side in eyes]
+
+
+def _eye_plan(name: str, spec: dict) -> list[tuple[str, str]]:
+    """Encoded (headset stream) ``[(eye_side, source_name)]`` for a stereo spec.
+
+    Prefers the stream-specific keys (``stream_eyes`` / ``stream_suffix``) and
+    falls back to the legacy coupled keys (``eyes`` / ``eye_suffix``) so an
+    encoded-only spec (teleop) keeps working unchanged.
+    """
+    eyes = spec.get("stream_eyes") or spec.get("eyes") or ["left", "right"]
+    suffix = spec.get("stream_suffix", spec.get("eye_suffix", True))
+    return _plan(name, eyes, suffix)
+
+
+def _raw_plan(name: str, spec: dict) -> list[tuple[str, str]]:
+    """Raw (dataset recording) ``[(eye_side, source_name)]`` for a stereo spec.
+
+    Independent of :func:`_eye_plan`: the recorded eyes (``record_eyes`` /
+    ``record_suffix``) can differ from the streamed eyes — e.g. stream both
+    eyes for depth while recording only the left. Falls back to the legacy
+    coupled keys so a spec that only sets ``eyes`` records what it streams.
+    """
+    eyes = spec.get("record_eyes") or spec.get("eyes") or ["left", "right"]
+    suffix = spec.get("record_suffix", spec.get("eye_suffix", True))
+    return _plan(name, eyes, suffix)
 
 
 def _open_gst_camera_raw(
@@ -191,10 +213,16 @@ def _open_gst_camera_raw(
         writers: list = []
         try:
             if stereo and use_shm:
-                plan = _eye_plan(name, spec)
-                gst_eyes = "both" if len(plan) == 2 else plan[0][0]
+                # Encoded eyes feed the headset; raw eyes feed the dataset — they
+                # may differ (stream both, record one). Build the union; each eye
+                # is cropped once and tee'd into whichever branch wants it.
+                enc_plan = _eye_plan(name, spec)
+                raw_plan = _raw_plan(name, spec)
+                enc_sides = [side for side, _ in enc_plan]
+                raw_sides = [side for side, _ in raw_plan]
                 socks = {
-                    side: os.path.join(socket_dir, f"{src}.sock") for side, src in plan
+                    side: os.path.join(socket_dir, f"{src}.sock")
+                    for side, src in raw_plan
                 }
                 eye_kwargs: dict = {}
                 if "left" in socks:
@@ -205,27 +233,31 @@ def _open_gst_camera_raw(
                     serial,
                     resolution,
                     fps,
-                    want_encoded=True,
                     raw_dims=raw_dims,
-                    eyes=gst_eyes,
+                    encoded_eyes=enc_sides,
+                    raw_eyes=raw_sides,
                     **eye_kwargs,
                 )
                 cam.connect()
                 caps = _raw_caps(raw_w, raw_h, fps)
                 lat = cam.raw_latency_s
-                sources = {}
-                raw_meta = {}
-                for side, src in plan:
-                    sources[src] = cam.left_view if side == "left" else cam.right_view
-                    raw_meta[src] = _gstshm_meta(
-                        socks[side], caps, raw_w, raw_h, fps, lat
-                    )
+                sources = {
+                    src: (cam.left_view if side == "left" else cam.right_view)
+                    for side, src in enc_plan
+                }
+                raw_meta = {
+                    src: _gstshm_meta(socks[side], caps, raw_w, raw_h, fps, lat)
+                    for side, src in raw_plan
+                }
                 return cam, sources, [], raw_meta
             if stereo:
-                plan = _eye_plan(name, spec)
-                gst_eyes = "both" if len(plan) == 2 else plan[0][0]
+                enc_plan = _eye_plan(name, spec)
+                raw_plan = _raw_plan(name, spec)
+                enc_sides = [side for side, _ in enc_plan]
+                raw_sides = [side for side, _ in raw_plan]
                 eye_writers = {
-                    side: RawFrameWriter.create(raw_w, raw_h, cond) for side, _ in plan
+                    side: RawFrameWriter.create(raw_w, raw_h, cond)
+                    for side, _ in raw_plan
                 }
                 writers = list(eye_writers.values())
                 eye_kwargs = {}
@@ -237,19 +269,20 @@ def _open_gst_camera_raw(
                     serial,
                     resolution,
                     fps,
-                    want_encoded=True,
                     raw_dims=raw_dims,
-                    eyes=gst_eyes,
+                    encoded_eyes=enc_sides,
+                    raw_eyes=raw_sides,
                     **eye_kwargs,
                 )
                 cam.connect()
-                sources = {}
-                raw_meta = {}
-                for side, src in plan:
-                    sources[src] = cam.left_view if side == "left" else cam.right_view
-                    raw_meta[src] = _pyshm_meta(
-                        eye_writers[side].name, raw_w, raw_h, fps
-                    )
+                sources = {
+                    src: (cam.left_view if side == "left" else cam.right_view)
+                    for side, src in enc_plan
+                }
+                raw_meta = {
+                    src: _pyshm_meta(eye_writers[side].name, raw_w, raw_h, fps)
+                    for side, src in raw_plan
+                }
                 return cam, sources, writers, raw_meta
             if use_shm:
                 sock = os.path.join(socket_dir, f"{name}.sock")

--- a/almond_axol/vr/video_proc.py
+++ b/almond_axol/vr/video_proc.py
@@ -498,7 +498,18 @@ def _relay_main(
     manager = WebRTCManager(sources) if sources else None
     conn.send(("ready", sorted(sources), raw_meta))
     if manager is None:
-        _logger.warning("video relay opened no cameras; nothing to stream")
+        if raw_meta:
+            # Record-only: every camera has streaming disabled, so there's no
+            # headset feed — but the raw branch still exports frames for the
+            # dataset. Not an error.
+            _logger.info(
+                "video relay: recording only (%d raw source(s), no headset streams)",
+                len(raw_meta),
+            )
+        else:
+            _logger.warning(
+                "video relay opened no cameras; nothing to stream or record"
+            )
 
     async def _loop_lag_monitor() -> None:
         """Log the relay event-loop's worst scheduling lag each second.
@@ -695,8 +706,13 @@ class VideoRelayProcess:
                 raw_meta = msg[2] if len(msg) > 2 else {}
                 self.raw_meta = dict(raw_meta)
                 self._attach_raw_readers(raw_meta)
-        if not self.sources:
-            _logger.warning("video relay started no camera streams")
+        if not self.sources and not self.raw_cameras:
+            _logger.warning("video relay started no camera streams or raw sources")
+        elif not self.sources:
+            _logger.info(
+                "video relay: recording only (%d raw source(s), no headset streams)",
+                len(self.raw_cameras),
+            )
 
     @property
     def raw_cond(self) -> object:

--- a/almond_axol/vr/video_proc.py
+++ b/almond_axol/vr/video_proc.py
@@ -208,6 +208,11 @@ def _open_gst_camera_raw(
             raw_w, raw_h = dw, dh
     raw_dims = (raw_w, raw_h)
     use_shm = socket_dir is not None
+    # A camera can opt out of either branch: stream-only (no raw / dataset) or
+    # record-only (no encoded / headset). This path is only entered when the
+    # camera records (see _relay_main), so the raw branch is always built; the
+    # encoded branch is gated on ``stream``.
+    wants_stream = bool(spec.get("stream", True))
 
     for fps in (int(spec.get("fps", 60)), 30):
         writers: list = []
@@ -216,7 +221,7 @@ def _open_gst_camera_raw(
                 # Encoded eyes feed the headset; raw eyes feed the dataset — they
                 # may differ (stream both, record one). Build the union; each eye
                 # is cropped once and tee'd into whichever branch wants it.
-                enc_plan = _eye_plan(name, spec)
+                enc_plan = _eye_plan(name, spec) if wants_stream else []
                 raw_plan = _raw_plan(name, spec)
                 enc_sides = [side for side, _ in enc_plan]
                 raw_sides = [side for side, _ in raw_plan]
@@ -251,7 +256,7 @@ def _open_gst_camera_raw(
                 }
                 return cam, sources, [], raw_meta
             if stereo:
-                enc_plan = _eye_plan(name, spec)
+                enc_plan = _eye_plan(name, spec) if wants_stream else []
                 raw_plan = _raw_plan(name, spec)
                 enc_sides = [side for side, _ in enc_plan]
                 raw_sides = [side for side, _ in raw_plan]
@@ -284,13 +289,16 @@ def _open_gst_camera_raw(
                     for side, src in raw_plan
                 }
                 return cam, sources, writers, raw_meta
+            # Mono: the camera streams only when ``stream`` is set; a record-only
+            # mono camera builds the raw branch alone (no encoded source, so it is
+            # not exposed to the headset).
             if use_shm:
                 sock = os.path.join(socket_dir, f"{name}.sock")
                 cam = ZedGstCamera(
                     serial,
                     resolution,
                     fps,
-                    want_encoded=True,
+                    want_encoded=wants_stream,
                     raw_socket_path=sock,
                     raw_dims=raw_dims,
                 )
@@ -299,21 +307,21 @@ def _open_gst_camera_raw(
                 meta = {
                     name: _gstshm_meta(sock, caps, raw_w, raw_h, fps, cam.raw_latency_s)
                 }
-                return cam, {name: cam}, [], meta
+                return cam, ({name: cam} if wants_stream else {}), [], meta
             writer = RawFrameWriter.create(raw_w, raw_h, cond)
             writers = [writer]
             cam = ZedGstCamera(
                 serial,
                 resolution,
                 fps,
-                want_encoded=True,
+                want_encoded=wants_stream,
                 raw_sink=writer.publish,
                 raw_dims=raw_dims,
             )
             cam.connect()
             return (
                 cam,
-                {name: cam},
+                {name: cam} if wants_stream else {},
                 writers,
                 {name: _pyshm_meta(writer.name, raw_w, raw_h, fps)},
             )
@@ -446,7 +454,14 @@ def _relay_main(
 
             socket_dir = tempfile.mkdtemp(prefix="axol-raw-")
     for name, spec in cameras.items():
-        if want_raw:
+        # A camera participates per its spec: ``stream`` adds it to the headset
+        # feed, ``record`` (only meaningful when the relay wants raw) adds it to
+        # the dataset. A camera in neither is skipped — never opened.
+        wants_stream = bool(spec.get("stream", True))
+        wants_record = want_raw and bool(spec.get("record", True))
+        if not (wants_stream or wants_record):
+            continue
+        if wants_record:
             raw = _open_gst_camera_raw(name, spec, raw_cond, socket_dir)
             if raw is not None:
                 cam, gst_sources, cam_writers, cam_meta = raw
@@ -455,7 +470,12 @@ def _relay_main(
                 writers.extend(cam_writers)
                 raw_meta.update(cam_meta)
                 continue
-            # No gst raw path for this camera; still stream it (encoded only).
+            # No gst raw path for this camera. If it also streams, fall through to
+            # the encoded-only path below; if it's record-only, there's nothing
+            # the relay can supply (SDK has no raw export), so skip it and let
+            # collect-data fall back to the in-process camera path.
+            if not wants_stream:
+                continue
         gst = _open_gst_camera(name, spec)
         if gst is not None:
             cam, gst_sources = gst

--- a/web/app/src/App.tsx
+++ b/web/app/src/App.tsx
@@ -437,6 +437,21 @@ function ImmersiveCameraFeed({ wsRef }: { wsRef: RefObject<WebSocket | null> }) 
     const cam = gl.xr.getCamera()
     const textures = texturesRef.current
 
+    // A camera is "available" once the relay has offered a track for it (its
+    // texture exists). The relay only offers the cameras actually being streamed,
+    // so we use this to (a) refuse to switch to a view whose camera isn't
+    // streamed and (b) only show the connecting spinner for cameras we're
+    // genuinely waiting on — never ones that will never arrive (e.g. wrist views
+    // when only the overhead is streamed).
+    const has = (name: string) => !!textures[name]
+    const modeAvailable = (m: ViewMode): boolean => {
+      if (m === "overhead") return has("overhead_left") || has("overhead_right") || has("overhead")
+      if (m === "left") return has("left_arm")
+      if (m === "right") return has("right_arm")
+      if (m === "split") return has("left_arm") || has("right_arm")
+      return true // "default" passthrough needs no camera
+    }
+
     // World-anchor the screen group once per session: place it at the head
     // with a yaw-only orientation. After that the screens stay put like TVs —
     // the operator can look around freely. The loading spinner stays
@@ -471,8 +486,13 @@ function ImmersiveCameraFeed({ wsRef }: { wsRef: RefObject<WebSocket | null> }) 
       let target: ViewMode
       if (Math.abs(sy) > Math.abs(sx)) target = sy < 0 ? "overhead" : "split"
       else target = sx < 0 ? "left" : "right"
-      viewModeRef.current = viewModeRef.current === target ? "default" : target
-      grabRef.current = null
+      // Ignore a flick toward a camera that isn't being streamed, so the operator
+      // can't land on a view that would just sit on "Connecting camera…".
+      // "default" (passthrough) is always reachable.
+      if (modeAvailable(target)) {
+        viewModeRef.current = viewModeRef.current === target ? "default" : target
+        grabRef.current = null
+      }
     }
     rightStickActiveRef.current = stickActive
 
@@ -503,9 +523,13 @@ function ImmersiveCameraFeed({ wsRef }: { wsRef: RefObject<WebSocket | null> }) 
     else live = !!(liveTex("left_arm") ?? liveTex("right_arm")) // default, split
 
     group.visible = presenting && live
-    // Spinner: presenting, frames not yet flowing, and the server hasn't said
-    // there's no video to expect.
-    spinner.visible = presenting && !live && available !== false
+    // Spinner only while genuinely waiting on a camera that IS being streamed
+    // (its track exists but hasn't decoded its first frame yet). Never for the
+    // default passthrough view, and never for a camera that isn't streamed at
+    // all — so streaming just the overhead no longer leaves the wrist views
+    // stuck on "Connecting camera…".
+    const expecting = mode !== "default" && modeAvailable(mode)
+    spinner.visible = presenting && expecting && !live && available !== false
     if (spinner.visible && spinnerMeshRef.current) {
       spinnerMeshRef.current.rotation.z -= 0.12
     }

--- a/web/app/src/App.tsx
+++ b/web/app/src/App.tsx
@@ -515,7 +515,8 @@ function ImmersiveCameraFeed({ wsRef }: { wsRef: RefObject<WebSocket | null> }) 
       return t && v && v.videoWidth ? t : undefined
     }
 
-    // Which cams a mode needs to be considered "live" (vs showing the spinner).
+    // Which cams the current mode needs decoded before it draws (otherwise the
+    // view is just passthrough). "default" shows the wrist PiPs when present.
     let live: boolean
     if (mode === "overhead") live = !!(liveTex("overhead_left") ?? liveTex("overhead"))
     else if (mode === "left") live = !!liveTex("left_arm")
@@ -523,13 +524,18 @@ function ImmersiveCameraFeed({ wsRef }: { wsRef: RefObject<WebSocket | null> }) 
     else live = !!(liveTex("left_arm") ?? liveTex("right_arm")) // default, split
 
     group.visible = presenting && live
-    // Spinner only while genuinely waiting on a camera that IS being streamed
-    // (its track exists but hasn't decoded its first frame yet). Never for the
-    // default passthrough view, and never for a camera that isn't streamed at
-    // all — so streaming just the overhead no longer leaves the wrist views
-    // stuck on "Connecting camera…".
-    const expecting = mode !== "default" && modeAvailable(mode)
-    spinner.visible = presenting && expecting && !live && available !== false
+
+    // "Connecting cameras…" is a global indicator, independent of the current
+    // view: show it while video is still being negotiated (available === null),
+    // or while any camera that IS being streamed hasn't produced its first frame
+    // yet. So streaming only the overhead still shows the spinner in the default
+    // view until the overhead appears, then it goes away. It's hidden once every
+    // streamed camera is live, and entirely when the server reports no video
+    // (available === false — nothing is streaming).
+    const streamed = Object.keys(textures)
+    const allLive = streamed.length > 0 && streamed.every((n) => !!liveTex(n))
+    const connecting = available === null || (available === true && !allLive)
+    spinner.visible = presenting && connecting
     if (spinner.visible && spinnerMeshRef.current) {
       spinnerMeshRef.current.rotation.z -= 0.12
     }
@@ -766,7 +772,7 @@ function ImmersiveCameraFeed({ wsRef }: { wsRef: RefObject<WebSocket | null> }) 
           material-depthTest={false}
           {...hudBg}
         >
-          Connecting camera…
+          Connecting cameras…
         </HudText>
       </group>
     </>

--- a/web/app/src/components/cameras-dialog.tsx
+++ b/web/app/src/components/cameras-dialog.tsx
@@ -159,6 +159,23 @@ export function CamerasDialog({
   }
 
   function save() {
+    // Persist exactly what each control displays. A slot the operator never
+    // touched still shows a default (e.g. overhead streams "both"); writing that
+    // default explicitly keeps the saved spec matching the dialog, so the
+    // backend never falls back to a different value (streaming would otherwise
+    // default to the recorded eyes). Materialized only for slots whose kind is
+    // known, so mono saves a boolean and stereo an eye selection.
+    const materialize = (map: BranchMap, slot: CameraSlot, stereo: boolean): BranchSel =>
+      !selEnabled(map[slot]) ? false : stereo ? selEyes(map[slot], slot) : true
+    const outStream: BranchMap = { ...stream }
+    const outRecord: BranchMap = { ...record }
+    for (const { key } of CAMERA_SLOTS) {
+      const kind = kindBySerial.get(serials[key].trim())
+      if (!kind) continue // unknown kind / unassigned: leave backend defaults
+      const stereo = kind === "stereo"
+      outStream[key] = materialize(stream, key, stereo)
+      outRecord[key] = materialize(record, key, stereo)
+    }
     onSave({
       serials: {
         overhead: serials.overhead.trim(),
@@ -167,8 +184,8 @@ export function CamerasDialog({
       },
       stream_resolution: streamResolution,
       record_resolution: recordResolution,
-      stream,
-      record,
+      stream: outStream,
+      record: outRecord,
     })
     onClose()
   }

--- a/web/app/src/components/cameras-dialog.tsx
+++ b/web/app/src/components/cameras-dialog.tsx
@@ -3,6 +3,8 @@ import { AlertTriangle, Camera, Loader2, RotateCw, X } from "lucide-react"
 import {
   detectCameras,
   restartCameraDaemon,
+  RESOLUTION_OFF,
+  type BranchSel,
   type CameraDevice,
   type CameraSlot,
   type CameraSpec,
@@ -13,7 +15,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 
 type Serials = CameraSpec["serials"]
-type EyeMap = Partial<Record<CameraSlot, StereoEyes>>
+type BranchMap = Partial<Record<CameraSlot, BranchSel>>
 
 const EMPTY_SERIALS: Serials = { overhead: "", left_arm: "", right_arm: "" }
 
@@ -27,29 +29,32 @@ const RESOLUTIONS: { value: string; label: string }[] = [
   { value: "SVGA", label: "SVGA (960×600)" },
   { value: "HD1080", label: "HD1080 (1920×1080)" },
   { value: "HD1200", label: "HD1200 (1920×1200)" },
+  { value: RESOLUTION_OFF, label: "Off" },
 ]
 
 const DEFAULT_RESOLUTION = "SVGA"
 
-// Default eye selection for a freshly-detected stereo slot, matching the
-// backend's head/wrist policy: the overhead streams/records both eyes (true
-// stereo / depth), a wrist a single (left) eye so it costs like a mono camera.
+// Default eye selection for a stereo slot, matching the backend's head/wrist
+// policy: the overhead uses both eyes (true stereo / depth), a wrist a single
+// (left) eye so it costs like a mono camera.
 const defaultEyes = (slot: CameraSlot): StereoEyes => (slot === "overhead" ? "both" : "left")
 
 const eyesLeft = (e: StereoEyes) => e !== "right"
 const eyesRight = (e: StereoEyes) => e !== "left"
-const eyesFromBools = (left: boolean, right: boolean): StereoEyes =>
-  left && right ? "both" : right ? "right" : "left"
+
+// A per-branch value is "enabled" unless explicitly false; its eye selection
+// (stereo only) is the stored eye name, else the slot default.
+const selEnabled = (v: BranchSel | undefined) => v === undefined || v !== false
+const selEyes = (v: BranchSel | undefined, slot: CameraSlot): StereoEyes =>
+  v === "both" || v === "left" || v === "right" ? v : defaultEyes(slot)
 
 /**
  * Local ZED camera setup dialog. The cameras are attached to the machine
- * running `axol serve`, so this assigns each camera slot a serial number (with
- * a detector to list what's plugged in) and configures capture/record settings
- * — no network link to manage. Streaming (the headset feed) and recording (the
- * dataset) are configured separately: each gets its own resolution, and for a
- * stereo camera its own eye selection (e.g. stream both eyes for depth while
- * recording only one). The spec is stored client-side and sent with each op
- * start.
+ * running `axol serve`. Streaming (the headset feed) and recording (the
+ * dataset) are configured independently: each has its own resolution (or Off to
+ * disable the whole branch), and each camera can be individually included in or
+ * excluded from streaming and recording — for a stereo camera, down to which
+ * eye(s). The spec is stored client-side and sent with each op start.
  */
 export function CamerasDialog({
   open,
@@ -70,8 +75,8 @@ export function CamerasDialog({
   const [recordResolution, setRecordResolution] = useState(
     initial.record_resolution || DEFAULT_RESOLUTION
   )
-  const [streamEyes, setStreamEyes] = useState<EyeMap>(initial.stream_eyes ?? {})
-  const [recordEyes, setRecordEyes] = useState<EyeMap>(initial.record_eyes ?? {})
+  const [stream, setStream] = useState<BranchMap>(initial.stream ?? {})
+  const [record, setRecord] = useState<BranchMap>(initial.record ?? {})
 
   const [devices, setDevices] = useState<CameraDevice[] | null>(null)
   const [detectError, setDetectError] = useState<string | null>(null)
@@ -123,37 +128,37 @@ export function CamerasDialog({
 
   // Stereo vs mono is determined from the detected device, so the operator
   // never flags it: surface the detected kind next to each assigned slot and
-  // gate the per-eye controls on it.
+  // shape the per-camera controls (mono = a single toggle; stereo = L/R).
   const kindBySerial = new Map((devices ?? []).map((d) => [String(d.serial), d.kind]))
-  const isStereo = (slot: CameraSlot) => kindBySerial.get(serials[slot].trim()) === "stereo"
 
-  function toggleEye(
-    map: EyeMap,
-    set: (m: EyeMap) => void,
+  const streamingOn = streamResolution !== RESOLUTION_OFF
+  const recordingOn = recordResolution !== RESOLUTION_OFF
+
+  // Toggle one camera's participation in a branch. Mono flips on/off; stereo
+  // flips the given eye, dropping to "off" when neither eye is left selected.
+  function toggle(
+    map: BranchMap,
+    set: (m: BranchMap) => void,
     slot: CameraSlot,
-    side: "left" | "right"
+    stereo: boolean,
+    side?: "left" | "right"
   ) {
-    const cur = map[slot] ?? defaultEyes(slot)
-    let left = eyesLeft(cur)
-    let right = eyesRight(cur)
+    const cur = map[slot]
+    if (!stereo) {
+      set({ ...map, [slot]: !selEnabled(cur) })
+      return
+    }
+    const enabled = selEnabled(cur)
+    const eyes = selEyes(cur, slot)
+    let left = enabled && eyesLeft(eyes)
+    let right = enabled && eyesRight(eyes)
     if (side === "left") left = !left
     else right = !right
-    // A stereo camera must expose at least one eye; ignore a toggle that would
-    // leave neither selected.
-    if (!left && !right) return
-    set({ ...map, [slot]: eyesFromBools(left, right) })
+    const next: BranchSel = left && right ? "both" : left ? "left" : right ? "right" : false
+    set({ ...map, [slot]: next })
   }
 
   function save() {
-    // Only persist eye selections for slots currently detected as stereo, so a
-    // stale per-eye choice can't linger on a slot that's now mono / unassigned.
-    const pickEyes = (map: EyeMap): EyeMap => {
-      const out: EyeMap = {}
-      for (const { key } of CAMERA_SLOTS) {
-        if (isStereo(key) && map[key]) out[key] = map[key]
-      }
-      return out
-    }
     onSave({
       serials: {
         overhead: serials.overhead.trim(),
@@ -162,8 +167,8 @@ export function CamerasDialog({
       },
       stream_resolution: streamResolution,
       record_resolution: recordResolution,
-      stream_eyes: pickEyes(streamEyes),
-      record_eyes: pickEyes(recordEyes),
+      stream,
+      record,
     })
     onClose()
   }
@@ -195,8 +200,9 @@ export function CamerasDialog({
 
         <div className="flex flex-col gap-5 p-5">
           <p className="text-xs text-white/45">
-            Assign the ZED cameras connected to this machine to their slots. Collect data and run
-            policy need at least one; teleop streams whichever are set to the headset.
+            Assign the ZED cameras connected to this machine to their slots, then choose what each
+            one is used for. Collect data and run policy need at least one camera recording; teleop
+            streams whichever are set to the headset.
           </p>
 
           <div className="flex flex-col gap-2">
@@ -260,24 +266,25 @@ export function CamerasDialog({
             <ResolutionSelect
               id="camera-stream-resolution"
               label="Streaming resolution"
-              hint="Capture resolution sent to the headset"
+              hint="Capture resolution sent to the headset (Off disables streaming)"
               value={streamResolution}
               onChange={setStreamResolution}
             />
             <ResolutionSelect
               id="camera-record-resolution"
               label="Recording resolution"
-              hint="Dataset video is downscaled to this"
+              hint="Dataset video is downscaled to this (Off disables recording)"
               value={recordResolution}
               onChange={setRecordResolution}
             />
           </div>
 
           <div className="flex flex-col gap-3 border-t border-white/10 pt-4">
-            <Label>Camera serials</Label>
+            <Label>Cameras</Label>
             {CAMERA_SLOTS.map((slot) => {
               const kind = kindBySerial.get(serials[slot.key].trim())
               const stereo = kind === "stereo"
+              const assignedSlot = serials[slot.key].trim() !== ""
               return (
                 <div key={slot.key} className="flex flex-col gap-2">
                   <div className="flex items-center justify-between gap-4">
@@ -307,17 +314,23 @@ export function CamerasDialog({
                       className="max-w-[180px]"
                     />
                   </div>
-                  {stereo && (
+                  {assignedSlot && kind && (
                     <div className="ml-1 flex flex-wrap items-center gap-x-5 gap-y-1.5 rounded-md border border-white/10 bg-white/[0.02] px-3 py-2">
-                      <EyeChoice
+                      <BranchControl
                         label="Stream"
-                        eyes={streamEyes[slot.key] ?? defaultEyes(slot.key)}
-                        onToggle={(side) => toggleEye(streamEyes, setStreamEyes, slot.key, side)}
+                        stereo={stereo}
+                        value={stream[slot.key]}
+                        slot={slot.key}
+                        disabled={!streamingOn}
+                        onToggle={(side) => toggle(stream, setStream, slot.key, stereo, side)}
                       />
-                      <EyeChoice
+                      <BranchControl
                         label="Record"
-                        eyes={recordEyes[slot.key] ?? defaultEyes(slot.key)}
-                        onToggle={(side) => toggleEye(recordEyes, setRecordEyes, slot.key, side)}
+                        stereo={stereo}
+                        value={record[slot.key]}
+                        slot={slot.key}
+                        disabled={!recordingOn}
+                        onToggle={(side) => toggle(record, setRecord, slot.key, stereo, side)}
                       />
                     </div>
                   )}
@@ -369,21 +382,46 @@ function ResolutionSelect({
   )
 }
 
-/** Left/right eye checkboxes for one branch (stream or record) of a stereo slot. */
-function EyeChoice({
+/** One branch (Stream/Record) toggle for a camera: mono = a single checkbox;
+ * stereo = L/R checkboxes (none checked = the camera is off for this branch). */
+function BranchControl({
   label,
-  eyes,
+  stereo,
+  value,
+  slot,
+  disabled,
   onToggle,
 }: {
   label: string
-  eyes: StereoEyes
-  onToggle: (side: "left" | "right") => void
+  stereo: boolean
+  value: BranchSel | undefined
+  slot: CameraSlot
+  disabled: boolean
+  onToggle: (side?: "left" | "right") => void
 }) {
+  const enabled = !disabled && selEnabled(value)
+  const eyes = selEyes(value, slot)
   return (
     <div className="flex items-center gap-2">
       <span className="text-[11px] font-medium uppercase tracking-wide text-white/45">{label}</span>
-      <EyeBox label="L" checked={eyesLeft(eyes)} onChange={() => onToggle("left")} />
-      <EyeBox label="R" checked={eyesRight(eyes)} onChange={() => onToggle("right")} />
+      {stereo ? (
+        <>
+          <EyeBox
+            label="L"
+            checked={enabled && eyesLeft(eyes)}
+            disabled={disabled}
+            onChange={() => onToggle("left")}
+          />
+          <EyeBox
+            label="R"
+            checked={enabled && eyesRight(eyes)}
+            disabled={disabled}
+            onChange={() => onToggle("right")}
+          />
+        </>
+      ) : (
+        <EyeBox label="On" checked={enabled} disabled={disabled} onChange={() => onToggle()} />
+      )}
     </div>
   )
 }
@@ -391,17 +429,25 @@ function EyeChoice({
 function EyeBox({
   label,
   checked,
+  disabled,
   onChange,
 }: {
   label: string
   checked: boolean
+  disabled?: boolean
   onChange: () => void
 }) {
   return (
-    <label className="flex cursor-pointer items-center gap-1 text-xs text-white/70 select-none">
+    <label
+      className={
+        "flex items-center gap-1 text-xs select-none " +
+        (disabled ? "cursor-not-allowed text-white/25" : "cursor-pointer text-white/70")
+      }
+    >
       <input
         type="checkbox"
         checked={checked}
+        disabled={disabled}
         onChange={onChange}
         className="size-3.5 accent-[#eff483]"
       />

--- a/web/app/src/components/cameras-dialog.tsx
+++ b/web/app/src/components/cameras-dialog.tsx
@@ -4,17 +4,20 @@ import {
   detectCameras,
   restartCameraDaemon,
   type CameraDevice,
+  type CameraSlot,
   type CameraSpec,
+  type StereoEyes,
 } from "@/lib/supervisor"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 
 type Serials = CameraSpec["serials"]
+type EyeMap = Partial<Record<CameraSlot, StereoEyes>>
 
 const EMPTY_SERIALS: Serials = { overhead: "", left_arm: "", right_arm: "" }
 
-const CAMERA_SLOTS: { key: keyof Serials; label: string }[] = [
+const CAMERA_SLOTS: { key: CameraSlot; label: string }[] = [
   { key: "overhead", label: "Overhead" },
   { key: "left_arm", label: "Left arm" },
   { key: "right_arm", label: "Right arm" },
@@ -28,11 +31,25 @@ const RESOLUTIONS: { value: string; label: string }[] = [
 
 const DEFAULT_RESOLUTION = "SVGA"
 
+// Default eye selection for a freshly-detected stereo slot, matching the
+// backend's head/wrist policy: the overhead streams/records both eyes (true
+// stereo / depth), a wrist a single (left) eye so it costs like a mono camera.
+const defaultEyes = (slot: CameraSlot): StereoEyes => (slot === "overhead" ? "both" : "left")
+
+const eyesLeft = (e: StereoEyes) => e !== "right"
+const eyesRight = (e: StereoEyes) => e !== "left"
+const eyesFromBools = (left: boolean, right: boolean): StereoEyes =>
+  left && right ? "both" : right ? "right" : "left"
+
 /**
  * Local ZED camera setup dialog. The cameras are attached to the machine
- * running `axol serve`, so this only assigns each camera slot a serial number
- * (with a detector to list what's plugged in) — no network link to manage.
- * The spec is stored client-side and sent along with each op start.
+ * running `axol serve`, so this assigns each camera slot a serial number (with
+ * a detector to list what's plugged in) and configures capture/record settings
+ * — no network link to manage. Streaming (the headset feed) and recording (the
+ * dataset) are configured separately: each gets its own resolution, and for a
+ * stereo camera its own eye selection (e.g. stream both eyes for depth while
+ * recording only one). The spec is stored client-side and sent with each op
+ * start.
  */
 export function CamerasDialog({
   open,
@@ -47,7 +64,14 @@ export function CamerasDialog({
   onSave: (spec: CameraSpec) => void
 }) {
   const [serials, setSerials] = useState<Serials>(initial.serials ?? EMPTY_SERIALS)
-  const [resolution, setResolution] = useState(initial.resolution || DEFAULT_RESOLUTION)
+  const [streamResolution, setStreamResolution] = useState(
+    initial.stream_resolution || initial.resolution || DEFAULT_RESOLUTION
+  )
+  const [recordResolution, setRecordResolution] = useState(
+    initial.record_resolution || DEFAULT_RESOLUTION
+  )
+  const [streamEyes, setStreamEyes] = useState<EyeMap>(initial.stream_eyes ?? {})
+  const [recordEyes, setRecordEyes] = useState<EyeMap>(initial.record_eyes ?? {})
 
   const [devices, setDevices] = useState<CameraDevice[] | null>(null)
   const [detectError, setDetectError] = useState<string | null>(null)
@@ -97,14 +121,49 @@ export function CamerasDialog({
     }
   }
 
+  // Stereo vs mono is determined from the detected device, so the operator
+  // never flags it: surface the detected kind next to each assigned slot and
+  // gate the per-eye controls on it.
+  const kindBySerial = new Map((devices ?? []).map((d) => [String(d.serial), d.kind]))
+  const isStereo = (slot: CameraSlot) => kindBySerial.get(serials[slot].trim()) === "stereo"
+
+  function toggleEye(
+    map: EyeMap,
+    set: (m: EyeMap) => void,
+    slot: CameraSlot,
+    side: "left" | "right"
+  ) {
+    const cur = map[slot] ?? defaultEyes(slot)
+    let left = eyesLeft(cur)
+    let right = eyesRight(cur)
+    if (side === "left") left = !left
+    else right = !right
+    // A stereo camera must expose at least one eye; ignore a toggle that would
+    // leave neither selected.
+    if (!left && !right) return
+    set({ ...map, [slot]: eyesFromBools(left, right) })
+  }
+
   function save() {
+    // Only persist eye selections for slots currently detected as stereo, so a
+    // stale per-eye choice can't linger on a slot that's now mono / unassigned.
+    const pickEyes = (map: EyeMap): EyeMap => {
+      const out: EyeMap = {}
+      for (const { key } of CAMERA_SLOTS) {
+        if (isStereo(key) && map[key]) out[key] = map[key]
+      }
+      return out
+    }
     onSave({
       serials: {
         overhead: serials.overhead.trim(),
         left_arm: serials.left_arm.trim(),
         right_arm: serials.right_arm.trim(),
       },
-      resolution,
+      stream_resolution: streamResolution,
+      record_resolution: recordResolution,
+      stream_eyes: pickEyes(streamEyes),
+      record_eyes: pickEyes(recordEyes),
     })
     onClose()
   }
@@ -114,10 +173,6 @@ export function CamerasDialog({
       .map((s) => s.trim())
       .filter(Boolean)
   )
-
-  // Stereo vs mono is determined from the detected device, so the operator
-  // never flags it: surface the detected kind next to each assigned slot.
-  const kindBySerial = new Map((devices ?? []).map((d) => [String(d.serial), d.kind]))
 
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/60 p-4 backdrop-blur-sm sm:p-8">
@@ -201,52 +256,71 @@ export function CamerasDialog({
             )}
           </div>
 
+          <div className="grid grid-cols-2 gap-3 border-t border-white/10 pt-4">
+            <ResolutionSelect
+              id="camera-stream-resolution"
+              label="Streaming resolution"
+              hint="Capture resolution sent to the headset"
+              value={streamResolution}
+              onChange={setStreamResolution}
+            />
+            <ResolutionSelect
+              id="camera-record-resolution"
+              label="Recording resolution"
+              hint="Dataset video is downscaled to this"
+              value={recordResolution}
+              onChange={setRecordResolution}
+            />
+          </div>
+
           <div className="flex flex-col gap-3 border-t border-white/10 pt-4">
-            <div className="flex items-center justify-between gap-4">
-              <Label>Camera Serials</Label>
-              <select
-                id="camera-resolution"
-                value={resolution}
-                onChange={(e) => setResolution(e.target.value)}
-                title="Capture resolution for all cameras"
-                className="h-9 w-full max-w-[180px] shrink-0 rounded-md border border-input bg-white/[0.02] px-3 text-sm text-foreground outline-none focus-visible:border-ring/70"
-              >
-                {RESOLUTIONS.map((r) => (
-                  <option key={r.value} value={r.value} className="bg-[#1a1a1a]">
-                    {r.label}
-                  </option>
-                ))}
-              </select>
-            </div>
+            <Label>Camera serials</Label>
             {CAMERA_SLOTS.map((slot) => {
               const kind = kindBySerial.get(serials[slot.key].trim())
+              const stereo = kind === "stereo"
               return (
-                <div key={slot.key} className="flex items-center justify-between gap-4">
-                  <div className="flex items-center gap-2">
-                    <Label className="text-white/70">{slot.label}</Label>
-                    {kind && (
-                      <span
-                        className="rounded border border-white/15 bg-white/[0.03] px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-white/45"
-                        title={
-                          kind === "stereo"
-                            ? "Stereo ZED X (both eyes from one grab) — detected automatically"
-                            : "Mono ZED-X One — detected automatically"
-                        }
-                      >
-                        {kind}
-                      </span>
-                    )}
+                <div key={slot.key} className="flex flex-col gap-2">
+                  <div className="flex items-center justify-between gap-4">
+                    <div className="flex items-center gap-2">
+                      <Label className="text-white/70">{slot.label}</Label>
+                      {kind && (
+                        <span
+                          className="rounded border border-white/15 bg-white/[0.03] px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-white/45"
+                          title={
+                            stereo
+                              ? "Stereo ZED X (both eyes from one grab) — detected automatically"
+                              : "Mono ZED-X One — detected automatically"
+                          }
+                        >
+                          {kind}
+                        </span>
+                      )}
+                    </div>
+                    <Input
+                      value={serials[slot.key]}
+                      inputMode="numeric"
+                      spellCheck={false}
+                      autoCapitalize="off"
+                      autoCorrect="off"
+                      onChange={(e) => setSerials((c) => ({ ...c, [slot.key]: e.target.value }))}
+                      placeholder="serial"
+                      className="max-w-[180px]"
+                    />
                   </div>
-                  <Input
-                    value={serials[slot.key]}
-                    inputMode="numeric"
-                    spellCheck={false}
-                    autoCapitalize="off"
-                    autoCorrect="off"
-                    onChange={(e) => setSerials((c) => ({ ...c, [slot.key]: e.target.value }))}
-                    placeholder="serial"
-                    className="max-w-[180px]"
-                  />
+                  {stereo && (
+                    <div className="ml-1 flex flex-wrap items-center gap-x-5 gap-y-1.5 rounded-md border border-white/10 bg-white/[0.02] px-3 py-2">
+                      <EyeChoice
+                        label="Stream"
+                        eyes={streamEyes[slot.key] ?? defaultEyes(slot.key)}
+                        onToggle={(side) => toggleEye(streamEyes, setStreamEyes, slot.key, side)}
+                      />
+                      <EyeChoice
+                        label="Record"
+                        eyes={recordEyes[slot.key] ?? defaultEyes(slot.key)}
+                        onToggle={(side) => toggleEye(recordEyes, setRecordEyes, slot.key, side)}
+                      />
+                    </div>
+                  )}
                 </div>
               )
             })}
@@ -258,5 +332,80 @@ export function CamerasDialog({
         </div>
       </div>
     </div>
+  )
+}
+
+function ResolutionSelect({
+  id,
+  label,
+  hint,
+  value,
+  onChange,
+}: {
+  id: string
+  label: string
+  hint: string
+  value: string
+  onChange: (value: string) => void
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <Label htmlFor={id}>{label}</Label>
+      <select
+        id={id}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        title={hint}
+        className="h-9 w-full rounded-md border border-input bg-white/[0.02] px-3 text-sm text-foreground outline-none focus-visible:border-ring/70"
+      >
+        {RESOLUTIONS.map((r) => (
+          <option key={r.value} value={r.value} className="bg-[#1a1a1a]">
+            {r.label}
+          </option>
+        ))}
+      </select>
+      <span className="text-[10px] text-white/35">{hint}</span>
+    </div>
+  )
+}
+
+/** Left/right eye checkboxes for one branch (stream or record) of a stereo slot. */
+function EyeChoice({
+  label,
+  eyes,
+  onToggle,
+}: {
+  label: string
+  eyes: StereoEyes
+  onToggle: (side: "left" | "right") => void
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-[11px] font-medium uppercase tracking-wide text-white/45">{label}</span>
+      <EyeBox label="L" checked={eyesLeft(eyes)} onChange={() => onToggle("left")} />
+      <EyeBox label="R" checked={eyesRight(eyes)} onChange={() => onToggle("right")} />
+    </div>
+  )
+}
+
+function EyeBox({
+  label,
+  checked,
+  onChange,
+}: {
+  label: string
+  checked: boolean
+  onChange: () => void
+}) {
+  return (
+    <label className="flex cursor-pointer items-center gap-1 text-xs text-white/70 select-none">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={onChange}
+        className="size-3.5 accent-[#eff483]"
+      />
+      {label}
+    </label>
   )
 }

--- a/web/app/src/lib/supervisor.ts
+++ b/web/app/src/lib/supervisor.ts
@@ -238,15 +238,37 @@ export async function sendEpisodeCommand(command: string): Promise<{ ok: boolean
   )
 }
 
+/** Which eye(s) of a stereo ZED X to use, per branch. */
+export type StereoEyes = "both" | "left" | "right"
+
+export type CameraSlot = "overhead" | "left_arm" | "right_arm"
+
 /** Local camera setup forwarded with op starts (see serve/runner.py).
  *
  * The serials map camera slots to the ZED cameras attached to the serve
  * machine; the runner folds them into the operation's config (collect-data /
  * run-policy record whichever slots are assigned and need at least one, teleop
  * streams whichever are set to the headset).
+ *
+ * Streaming (the headset feed) and recording (the dataset) are configured
+ * separately: ``stream_resolution`` is the capture resolution shown in the
+ * headset at full quality, while ``record_resolution`` is the downscale target
+ * for the recorded dataset (collect-data only). For a stereo camera the eyes
+ * are likewise independent — ``stream_eyes`` vs ``record_eyes`` per slot — so
+ * the operator can e.g. stream both eyes for depth perception while recording
+ * only one (or vice versa). Eye maps only apply to slots detected as stereo.
  */
 export interface CameraSpec {
-  serials: { overhead: string; left_arm: string; right_arm: string }
+  serials: Record<CameraSlot, string>
+  /** Capture resolution → headset stream (full quality). */
+  stream_resolution?: string
+  /** Dataset downscale target (collect-data recording). */
+  record_resolution?: string
+  /** Per-stereo-slot eye selection for the headset stream. */
+  stream_eyes?: Partial<Record<CameraSlot, StereoEyes>>
+  /** Per-stereo-slot eye selection for the recorded dataset. */
+  record_eyes?: Partial<Record<CameraSlot, StereoEyes>>
+  /** @deprecated legacy single resolution; read as ``stream_resolution``. */
   resolution?: string
 }
 

--- a/web/app/src/lib/supervisor.ts
+++ b/web/app/src/lib/supervisor.ts
@@ -243,32 +243,40 @@ export type StereoEyes = "both" | "left" | "right"
 
 export type CameraSlot = "overhead" | "left_arm" | "right_arm"
 
+/** Per-camera participation in a branch (streaming or recording):
+ * - `false` — camera opted out of this branch.
+ * - `true` — mono camera opted in.
+ * - an eye name — stereo camera opted in with that eye selection.
+ */
+export type BranchSel = boolean | StereoEyes
+
+/** "off" disables a whole branch (streaming or recording) globally. */
+export const RESOLUTION_OFF = "off"
+
 /** Local camera setup forwarded with op starts (see serve/runner.py).
  *
  * The serials map camera slots to the ZED cameras attached to the serve
- * machine; the runner folds them into the operation's config (collect-data /
- * run-policy record whichever slots are assigned and need at least one, teleop
- * streams whichever are set to the headset).
+ * machine. Streaming (the headset feed) and recording (the dataset) are
+ * configured independently — globally and per camera:
  *
- * Streaming (the headset feed) and recording (the dataset) are configured
- * separately: ``stream_resolution`` is the capture resolution shown in the
- * headset at full quality, while ``record_resolution`` is the downscale target
- * for the recorded dataset (collect-data only). For a stereo camera the eyes
- * are likewise independent — ``stream_eyes`` vs ``record_eyes`` per slot — so
- * the operator can e.g. stream both eyes for depth perception while recording
- * only one (or vice versa). Eye maps only apply to slots detected as stereo.
+ * - `stream_resolution` / `record_resolution` set the capture and dataset
+ *   resolutions; `"off"` disables that whole branch.
+ * - `stream` / `record` decide, per slot, whether the camera takes part (and,
+ *   for stereo, which eyes) — so an operator can stream both eyes for depth
+ *   while recording one, stream a camera without recording it (or vice versa),
+ *   or turn either branch off entirely.
  */
 export interface CameraSpec {
   serials: Record<CameraSlot, string>
-  /** Capture resolution → headset stream (full quality). */
+  /** Capture resolution → headset stream (full quality), or `"off"`. */
   stream_resolution?: string
-  /** Dataset downscale target (collect-data recording). */
+  /** Dataset downscale target (collect-data recording), or `"off"`. */
   record_resolution?: string
-  /** Per-stereo-slot eye selection for the headset stream. */
-  stream_eyes?: Partial<Record<CameraSlot, StereoEyes>>
-  /** Per-stereo-slot eye selection for the recorded dataset. */
-  record_eyes?: Partial<Record<CameraSlot, StereoEyes>>
-  /** @deprecated legacy single resolution; read as ``stream_resolution``. */
+  /** Per-slot streaming participation (headset feed). */
+  stream?: Partial<Record<CameraSlot, BranchSel>>
+  /** Per-slot recording participation (dataset). */
+  record?: Partial<Record<CameraSlot, BranchSel>>
+  /** @deprecated legacy single resolution; read as `stream_resolution`. */
   resolution?: string
 }
 

--- a/web/app/src/routes/ControlPanel.tsx
+++ b/web/app/src/routes/ControlPanel.tsx
@@ -43,8 +43,8 @@ const DEFAULT_CAMERAS: CameraSpec = {
   serials: { overhead: "", left_arm: "", right_arm: "" },
   stream_resolution: "SVGA",
   record_resolution: "SVGA",
-  stream_eyes: {},
-  record_eyes: {},
+  stream: {},
+  record: {},
 }
 
 function loadCameras(): CameraSpec {
@@ -60,8 +60,9 @@ function loadCameras(): CameraSpec {
         stream_resolution:
           parsed.stream_resolution ?? parsed.resolution ?? DEFAULT_CAMERAS.stream_resolution,
         record_resolution: parsed.record_resolution ?? DEFAULT_CAMERAS.record_resolution,
-        stream_eyes: { ...(parsed.stream_eyes ?? {}) },
-        record_eyes: { ...(parsed.record_eyes ?? {}) },
+        // Migrate the earlier per-eye maps to the per-branch participation maps.
+        stream: { ...(parsed.stream ?? parsed.stream_eyes ?? {}) },
+        record: { ...(parsed.record ?? parsed.record_eyes ?? {}) },
       }
     }
   } catch {

--- a/web/app/src/routes/ControlPanel.tsx
+++ b/web/app/src/routes/ControlPanel.tsx
@@ -41,7 +41,10 @@ type OpSettings = Record<OperationId, Record<string, FormValue>>
 
 const DEFAULT_CAMERAS: CameraSpec = {
   serials: { overhead: "", left_arm: "", right_arm: "" },
-  resolution: "SVGA",
+  stream_resolution: "SVGA",
+  record_resolution: "SVGA",
+  stream_eyes: {},
+  record_eyes: {},
 }
 
 function loadCameras(): CameraSpec {
@@ -53,6 +56,12 @@ function loadCameras(): CameraSpec {
         ...DEFAULT_CAMERAS,
         ...parsed,
         serials: { ...DEFAULT_CAMERAS.serials, ...(parsed.serials ?? {}) },
+        // Migrate the legacy single `resolution` to the streaming resolution.
+        stream_resolution:
+          parsed.stream_resolution ?? parsed.resolution ?? DEFAULT_CAMERAS.stream_resolution,
+        record_resolution: parsed.record_resolution ?? DEFAULT_CAMERAS.record_resolution,
+        stream_eyes: { ...(parsed.stream_eyes ?? {}) },
+        record_eyes: { ...(parsed.record_eyes ?? {}) },
       }
     }
   } catch {


### PR DESCRIPTION
The control panel's Cameras dialog now owns all camera configuration end-to-end: separate **streaming** (capture → headset) and **recording** (dataset downscale) resolution, plus per-stereo-slot **eye selection for streaming and recording independently** — so an operator can stream both eyes for depth while recording only one (or vice versa). To do this, `ZedGstStereoCamera` now builds per-side encoded/raw branches so the relay can emit different eyes to the headset vs the dataset, `ZedCameraConfig` gains a `stream_eyes` field (`eyes` stays the recorded eyes), and the runner routes the new fields into config overrides. All camera-owned fields are stripped from the per-op "optional config" form (kept in `emit` so overrides still translate) so there's a single source of truth. The dialog adds two resolution dropdowns and L/R stream/record checkboxes that appear only for slots detected as stereo, with legacy `resolution` migrated to the streaming resolution.

Verified with ruff/eslint clean, `tsc`/`vite build` passing, and end-to-end logic tests (merge → argv → parse → `observation_cameras()` → relay spec); the gst pipeline and ZED hardware could not be exercised in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live teleop/collect-data video pipelines and observation key alignment; wrong eye maps could mismatch recorder expectations, but legacy coupled behavior is preserved when stream settings are omitted.
> 
> **Overview**
> **Decouples VR headset streaming from dataset recording** for stereo ZED cameras: `ZedCameraConfig` adds optional `stream_eyes` (recorded observations stay on `eyes`), and the GStreamer stereo pipeline builds **per-branch** encode vs raw eye sets via `encoded_eyes` / `raw_eyes` so one eye can be cropped once and tee’d to headset, dataset, or both.
> 
> The **Cameras dialog** becomes the single source of truth: separate **streaming** and **recording** resolutions, L/R checkboxes per stereo slot for stream vs record, and legacy `resolution` migrated to `stream_resolution`. The serve **runner** maps `stream_resolution` / `record_resolution` and `stream_eyes` / `record_eyes` into teleop (`camera_eyes`) and collect-data/run-policy (`robot_config.cameras.*`, `dataset_resolution`); **introspect** hides those fields from the generic op form while keeping `emit` for argv folding. Teleop gains **`--camera_eyes`**; collect-data relay specs use `record_*` vs `stream_*` keys; `video_proc` plans encoded and raw sources independently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2acded14f62bebaf308cee893a258c059e5aa363. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->