### PR TITLE
Encode dataset video at constant quality, not fixed bitrate (ALM-1164)

### DIFF
--- a/almond_axol/cli/record_proc.py
+++ b/almond_axol/cli/record_proc.py
@@ -247,6 +247,11 @@ def install_dataset_encoder() -> bool:
     be applied in whatever process creates the dataset (the recorder subprocess,
     or the control process for the in-process fallback). Returns True when NVENC
     is in use.
+
+    The NVENC encoder runs in **constant-quality** mode (a fixed quantizer, see
+    ``nvenc_encoder._QP``) to mirror LeRobot's libx264 ``crf=30`` — the bitrate is
+    content-adaptive, so a mostly-static teleop scene stays small instead of being
+    padded to a fixed bitrate budget.
     """
     from lerobot.datasets.lerobot_dataset import LeRobotDataset
 

--- a/almond_axol/lerobot/nvenc_encoder.py
+++ b/almond_axol/lerobot/nvenc_encoder.py
@@ -52,12 +52,14 @@ if TYPE_CHECKING:
 
 _logger = logging.getLogger(__name__)
 
-# Stored-video bitrate budget, in bits per pixel-second (width*height*fps*bpp),
-# clamped to a sane range. Higher than the headset relay's ~0.12 bpp since this
-# is the training data we keep, not a bandwidth-constrained LAN stream.
-_BITRATE_BPP = 0.25
-_BITRATE_MIN = 6_000_000
-_BITRATE_MAX = 40_000_000
+# Constant-quality quantizer for the stored video, mirroring LeRobot's libx264
+# default (``crf=30``). nvv4l2h264enc has no CRF, so we disable rate control and
+# pin a fixed QP: the bitrate is then content-adaptive (a mostly-static teleop
+# scene stays small) instead of being padded to a fixed bitrate budget, which is
+# what made on-Jetson datasets several times larger than the upper-computer ones.
+# H.264 QP and x264 CRF share the same 0-51 scale, so 30 matches the CRF value;
+# nudge down for higher quality / larger files, up for smaller. See ALM-1164.
+_QP = 30
 
 # Per-camera feed-queue depth (frames). LeRobot's default is 30 (0.5 s at 60 fps),
 # too shallow to ride out the gst pipeline's spin-up: gst-launch takes ~1 s to
@@ -91,15 +93,7 @@ def hw_dataset_encoder_available() -> bool:
     return hw_h264_available()
 
 
-def _bitrate_for(width: int, height: int, fps: int) -> int:
-    return max(
-        _BITRATE_MIN, min(_BITRATE_MAX, int(width * height * fps * _BITRATE_BPP))
-    )
-
-
-def _gst_argv(
-    width: int, height: int, fps: int, bitrate: int, out_path: Path
-) -> list[str]:
+def _gst_argv(width: int, height: int, fps: int, qp: int, out_path: Path) -> list[str]:
     """``gst-launch-1.0`` argv: packed RGBA on stdin -> H.264 mp4 file.
 
     ``nvvidconv`` does the RGBA->NV12 colorspace conversion on the VIC and
@@ -131,7 +125,12 @@ def _gst_argv(
         "video/x-raw(memory:NVMM),format=NV12",
         "queue max-size-buffers=8 max-size-bytes=0 max-size-time=0",
         (
-            f"nvv4l2h264enc control-rate=1 bitrate={bitrate} preset-level=1 "
+            # Constant-quality (fixed QP), not fixed-bitrate: ratecontrol-enable=false
+            # makes the quant-*-frames the encoder's constant quantizer, so bitrate
+            # tracks scene complexity like libx264's crf (see _QP). preset-level=1 is
+            # the fast NVENC preset; idrinterval keeps a ~1 s keyframe cadence.
+            f"nvv4l2h264enc ratecontrol-enable=false quant-i-frames={qp} "
+            f"quant-p-frames={qp} quant-b-frames={qp} preset-level=1 "
             f"insert-sps-pps=true idrinterval={fps} maxperf-enable=true"
         ),
         "h264parse",
@@ -328,9 +327,8 @@ class _CameraNvencEncoder:
 
     def _start(self, width: int, height: int) -> None:
         self.video_path.parent.mkdir(parents=True, exist_ok=True)
-        bitrate = _bitrate_for(width, height, self._fps)
         self._proc = subprocess.Popen(
-            _gst_argv(width, height, self._fps, bitrate, self.video_path),
+            _gst_argv(width, height, self._fps, _QP, self.video_path),
             stdin=subprocess.PIPE,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.PIPE,
@@ -342,12 +340,12 @@ class _CameraNvencEncoder:
         self._rgba = np.empty((height, width, 4), dtype=np.uint8)
         self._rgba[:, :, 3] = 255
         _logger.info(
-            "NVENC mp4 pipeline started: %s %dx%d@%dfps %.1f Mbps (pid %d)",
+            "NVENC mp4 pipeline started: %s %dx%d@%dfps qp=%d (pid %d)",
             self.video_path.name,
             width,
             height,
             self._fps,
-            bitrate / 1e6,
+            _QP,
             self._proc.pid,
         )
 

--- a/docs/cli/collect-data.mdx
+++ b/docs/cli/collect-data.mdx
@@ -17,7 +17,7 @@ This command is configured via draccus. The robot and teleop subsystems are expo
 | `--task TEXT` | Natural language task description (required) |
 | `--fps INT` | Dataset recording frame rate — camera frames captured at this rate (default: 60) |
 | `--dataset_resolution {SVGA,HD1080,HD1200}` | Resolution the **dataset** video is recorded at (default: `SVGA` = 960×600), downscaled from the camera capture on the GPU's VIC. SVGA is ~4× lighter to encode and store than `HD1200` while the **headset still gets the full-resolution stream**. Resuming an existing dataset keeps its original resolution regardless of this flag. |
-| `--vcodec STR` | Video codec recorded for the dataset (default: per-platform — `h264` on Jetson/aarch64, `auto` elsewhere). Accepts any LeRobot codec (e.g. `auto`, `h264`, `libsvtav1`). On the Jetson `h264` is encoded on the NVENC hardware via GStreamer. |
+| `--vcodec STR` | Video codec recorded for the dataset (default: per-platform — `h264` on Jetson/aarch64, `auto` elsewhere). Accepts any LeRobot codec (e.g. `auto`, `h264`, `libsvtav1`). On the Jetson `h264` is encoded on the NVENC hardware via GStreamer, in **constant-quality** mode (fixed QP 30, mirroring LeRobot's libx264 `crf=30`) so the bitrate tracks scene complexity and dataset sizes match a non-Jetson host's instead of a fixed bitrate budget. |
 | `--teleop_hz INT` | Motor command rate in Hz; decoupled from `--fps` for smooth control (default: 120) |
 | `--root PATH` | Local dataset root (default: `$HF_LEROBOT_HOME`) |
 | `--push_to_hub true` | Push to HuggingFace Hub when done |


### PR DESCRIPTION
On-Jetson `collect-data` recordings were several times larger than the old upper-computer ones (e.g. 500 MB → 4 GB for a comparable session) because the NVENC dataset encoder ran at a fixed ~0.25 bpp bitrate budget, spending the full bitrate every second regardless of scene motion. This switches `nvv4l2h264enc` to constant-quality mode (`ratecontrol-enable=false`, fixed QP 30) to mirror LeRobot's libx264 `crf=30`, so the bitrate now tracks scene complexity and a mostly-static teleop scene encodes small again. Hardware encoding is retained — only the rate-control changes — and the docs are updated to match.

Note: I couldn't test on a Jetson, so please verify the gst pipeline launches on your L4T/BSP (look for `NVENC mp4 pipeline started: … qp=30`) and that QP 30 lands at the desired quality/size (tune `_QP` if needed, since x264's CRF and NVENC's raw QP aren't perceptually identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes only Jetson hardware encode settings and stored dataset size/quality; pipeline must be validated on target L4T/BSP since QP 30 may not match x264 CRF perceptually.
> 
> **Overview**
> Jetson **collect-data** dataset video no longer uses a fixed NVENC bitrate budget (~0.25 bpp); **`nvv4l2h264enc`** now runs with **`ratecontrol-enable=false`** and fixed **QP 30** on I/P/B frames, aligned with LeRobot’s libx264 **`crf=30`**. Bitrate becomes scene-dependent so low-motion teleop sessions shrink instead of padding to a high Mbps floor.
> 
> **`install_dataset_encoder`** and **`collect-data`** docs describe constant-quality Jetson encoding; startup logs report **`qp=30`** instead of Mbps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42e5e6943e8df524c797c3b87946a6fa1773819c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->