### PR TITLE
Document Fly.io TURN config and add Replay Dataset as a core operation

### DIFF
--- a/docs/cli/serve.mdx
+++ b/docs/cli/serve.mdx
@@ -3,7 +3,7 @@ title: "serve"
 description: "Run the Axol web control panel — drive the robot from a browser instead of the terminal."
 ---
 
-Runs the **Axol web control panel**: a small local server that lets you drive the robot from a browser instead of a terminal. It serves the built web UI and a JSON/WebSocket API that starts, streams, and stops the core operations — teleoperation, gravity compensation, data collection, and policy inference — in-process.
+Runs the **Axol web control panel**: a small local server that lets you drive the robot from a browser instead of a terminal. It serves the built web UI and a JSON/WebSocket API that starts, streams, and stops the core operations — teleoperation, gravity compensation, data collection, dataset replay, and policy inference — in-process.
 
 With the [one-command install](/installation), this command already runs as a root systemd service (`axol.service`) that starts at boot, restarts automatically, and keeps itself in sync with the latest release — you don't run it by hand. Manual invocation is for development installs:
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -28,6 +28,7 @@
           "operations/teleop",
           "operations/gravity-comp",
           "operations/data-collection",
+          "operations/replay-dataset",
           "operations/run-policy"
         ]
       },

--- a/docs/guides/remote-teleop.mdx
+++ b/docs/guides/remote-teleop.mdx
@@ -109,7 +109,9 @@ This serves the control connection at `https://<your-machine>.tailXXXX.ts.net/` 
 
 ### 2. Add a TURN server for camera video
 
-Camera video is WebRTC, whose media is a separate peer-to-peer UDP stream — it does **not** travel through the Funnel. With both peers off each other's network, they need a publicly reachable **TURN** relay to bridge the media. Self-host [coturn](https://github.com/coturn/coturn) on a box with a public IP, or use a hosted TURN provider.
+Camera video is WebRTC, whose media is a separate peer-to-peer UDP stream — it does **not** travel through the Funnel. With both peers off each other's network, they need a publicly reachable **TURN** relay to bridge the media. Use a hosted TURN provider, or self-host [coturn](https://github.com/coturn/coturn) on a box with a public IP.
+
+The repo ships a ready-to-deploy coturn config for [Fly.io](https://fly.io) under [`deploy/turn/`](https://github.com/almond-bot/axol/tree/main/deploy/turn) — Fly supports the raw UDP that TURN needs (unlike most PaaS hosts), and the config handles the dedicated-IPv4 and `external-ip` gotchas for you. Follow [`deploy/turn/README.md`](https://github.com/almond-bot/axol/blob/main/deploy/turn/README.md) to launch your own relay in a few `flyctl` commands, then point Axol at it with the env vars below.
 
 Set these env vars on the machine running teleop **before** starting it (the VR server and its video relay read them at connect time):
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -5,7 +5,7 @@ description: "Command-line interface and Python SDK for the Almond Axol dual-arm
 
 <img src="/assets/axol.png" width="400" alt="Axol dual-arm robot" />
 
-The Axol SDK runs the Almond Axol dual-arm robot. Every core operation — **teleoperation**, **gravity compensation**, **data collection**, and **policy inference** — can be driven two ways: from the **web control panel** in a browser, or from the **`axol` CLI** in a terminal. Each operation page below shows both.
+The Axol SDK runs the Almond Axol dual-arm robot. Every core operation — **teleoperation**, **gravity compensation**, **data collection**, **dataset replay**, and **policy inference** — can be driven two ways: from the **web control panel** in a browser, or from the **`axol` CLI** in a terminal. Each operation page below shows both.
 
 <Note>
   **New here?** [Install in one command](/installation), then head to [Teleoperation](/operations/teleop) to drive the robot from a VR headset.
@@ -24,6 +24,9 @@ Each page covers the same task from the **Control Panel** and the **CLI** — pi
   </Card>
   <Card title="Data Collection" icon="record-vinyl" href="/operations/data-collection">
     Record teleoperation episodes to a LeRobot dataset.
+  </Card>
+  <Card title="Replay Dataset" icon="play" href="/operations/replay-dataset">
+    Play a recorded dataset episode back onto the arms.
   </Card>
   <Card title="Run Policy" icon="robot" href="/operations/run-policy">
     Run a trained policy autonomously — locally or on a remote server.

--- a/docs/operations/replay-dataset.mdx
+++ b/docs/operations/replay-dataset.mdx
@@ -1,0 +1,59 @@
+---
+title: "Replay Dataset"
+description: "Replay a recorded LeRobot dataset episode on the arms — from the web control panel or the CLI."
+---
+
+Replay plays one episode of an existing [LeRobot](/api/lerobot) dataset straight back onto the arms: the episode's recorded `action` column is streamed to the motors frame by frame, then the robot returns to its rest pose. It's the inverse of [data collection](/operations/data-collection) — instead of recording teleop actions it reproduces an already-recorded take on the hardware. You can launch it from the **web control panel** or the **CLI** (`axol replay-dataset`).
+
+No VR, cameras, or policy server are involved — replay only drives the arms, so the robot config carries no cameras. The arm is first moved to the rest pose (the same collision-aware return-to-rest [run-policy](/operations/run-policy) uses) so it starts where every recorded episode does: episodes are recorded from rest, so the first replayed action is ~rest and there's no jump.
+
+<Warning>
+  Replay drives the arms **open-loop** from the recorded actions — it does not watch the scene. Make sure the workspace is clear and roughly matches what the episode was recorded in before starting, and keep **Stop** (or `Ctrl+C`) within reach. Match the stiffness used at collection time so the arm tracks the same way it did when recorded.
+</Warning>
+
+## Before you start
+
+- **Axol installed** ([one-command install](/installation)), CAN up, and motors verified.
+- **A recorded dataset** to replay — either local under `--root` (`$HF_LEROBOT_HOME` by default) or pullable from the HuggingFace Hub by its `repo_id`. See [Data Collection](/operations/data-collection) to record one.
+
+## Run it
+
+<Tabs>
+  <Tab title="Control Panel">
+    <Steps>
+      <Step title="Connect the robot">
+        Connect the **Axol Host** and **Axol**. No cameras are needed for replay.
+      </Step>
+
+      <Step title="Select Replay Dataset and fill the fields">
+        Pick **Replay Dataset**. Set the dataset **repo&nbsp;id** (e.g. `myorg/pick-place`) and the **episode** index (0-indexed). Playback fps, stiffness, and **loop** live under the **Optional** dropdown.
+      </Step>
+
+      <Step title="Start">
+        Clear the workspace, then press **Start**. The arm moves to rest, replays the episode at the recorded timing, and returns to rest. With **loop** on it repeats (returning to rest between takes) until you press **Stop**.
+      </Step>
+    </Steps>
+  </Tab>
+
+  <Tab title="CLI">
+    On the robot machine:
+
+    ```bash
+    axol replay-dataset --repo_id myorg/pick-place --episode 0
+    axol replay-dataset --repo_id myorg/pick-place --episode 0 --loop true   # loop until Ctrl+C
+    ```
+
+    `--fps 0` (default) replays at the dataset's recorded fps, reproducing the original timing; set a positive value to override it. Match the stiffness used at collection time with `--robot_config.axol_config.left_stiffness` / `right_stiffness` so the arm tracks the recorded actions the same way. Press `Ctrl+C` to stop — the arm returns to rest before exiting. See [`replay-dataset`](/cli/replay-dataset) for the full field list and [Command configuration](/cli/configuration) for the override syntax.
+  </Tab>
+</Tabs>
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Data Collection" icon="record-vinyl" href="/operations/data-collection">
+    Record the episodes you replay here.
+  </Card>
+  <Card title="replay-dataset reference" icon="terminal" href="/cli/replay-dataset">
+    Every flag and the replay internals.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
Fills two gaps in the teleop docs. **Remote teleop** now documents the ready-to-deploy coturn config we ship under `deploy/turn/` for launching your own Fly.io TURN relay, linking its README from the camera-video TURN section. **Replay Dataset** is promoted from a CLI-only command to a first-class core operation: a new `operations/replay-dataset` page (Control Panel + CLI tabs, mirroring its siblings), added to the Operations nav group, and included in the core-operations lists on the index and `serve` pages plus a card on the landing page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or API behavior modifications.
> 
> **Overview**
> **Replay Dataset** is documented as a core operation alongside teleop, gravity comp, data collection, and policy inference. A new **`operations/replay-dataset`** page mirrors sibling ops (Control Panel steps + CLI examples, safety warning, links to data collection and CLI reference). The Operations nav, landing **index** card list, and **`serve`** core-operations blurb now include dataset replay.
> 
> **Remote teleop**’s Funnel + TURN section now points operators at the repo’s **`deploy/turn/`** Fly.io coturn bundle and its README for self-hosting a UDP-capable relay, with a small reorder (hosted TURN vs self-host) in the intro sentence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe47e58a587e79a4d42a9b0b7288d0d20a3aa0f4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->