### PR TITLE
Replace silent self-update with user-initiated update flow

### DIFF
--- a/almond_axol/serve/app.py
+++ b/almond_axol/serve/app.py
@@ -135,9 +135,10 @@ def create_app(static_dir: Path | None = None) -> FastAPI:
             return False
         return not robot.status()["connected"]
 
-    # Keeps a hosted (uv tool) install in sync with main: poked by the UI's
-    # connect/poll endpoints, upgrades in the background, and restarts the
-    # process (systemd relaunches it) once idle. No-ops for dev checkouts.
+    # Surfaces "update available" (read-only `git ls-remote`) to the control
+    # panel via /api/update/status and applies an on-demand `uv tool upgrade`
+    # via /api/update/start, restarting the process (systemd relaunches it) once
+    # idle. Nothing upgrades automatically. No-ops for dev checkouts.
     updater = SelfUpdater(_is_idle)
 
     def _find_session(session_id: str) -> tuple[Session | None, Any]:
@@ -166,7 +167,9 @@ def create_app(static_dir: Path | None = None) -> FastAPI:
     @app.get("/api/info")
     async def get_info() -> dict[str, Any]:
         """Identify the serve host so the UI can build reachable links/hints."""
-        updater.poke()
+        # Self-heal a host that upgraded into this build from an older main (the
+        # old code never ran `axol provision`); idempotent, once per process.
+        updater.ensure_provisioned()
         return {
             "hostname": socket.gethostname(),
             "lanIp": _lan_ip(),
@@ -174,6 +177,19 @@ def create_app(static_dir: Path | None = None) -> FastAPI:
             "vrPort": _VR_PORT,
             "commit": updater.commit,
         }
+
+    @app.get("/api/update/status")
+    async def update_status() -> dict[str, Any]:
+        """Installed vs. tracked-ref commit so the UI can offer an update."""
+        return updater.status()
+
+    @app.post("/api/update/start")
+    async def update_start() -> JSONResponse:
+        """Apply a user-initiated upgrade; the server restarts onto new code."""
+        started, reason = updater.start()
+        if not started:
+            return JSONResponse({"error": reason}, status_code=409)
+        return JSONResponse({"started": True})
 
     # -- robot connection (detached CAN + 1 Hz motor ping) ------------------
 
@@ -239,9 +255,6 @@ def create_app(static_dir: Path | None = None) -> FastAPI:
 
     @app.get("/api/op/status")
     async def op_status() -> dict[str, Any]:
-        # The UI polls this while the panel is open, so a long-lived tab still
-        # picks up updates (the poke itself is debounced).
-        updater.poke()
         session = runner.current()
         return {
             "running": runner.is_running(),

--- a/almond_axol/serve/app.py
+++ b/almond_axol/serve/app.py
@@ -182,9 +182,14 @@ def create_app(static_dir: Path | None = None) -> FastAPI:
         }
 
     @app.get("/api/update/status")
-    async def update_status() -> dict[str, Any]:
-        """Installed vs. tracked-ref commit so the UI can offer an update."""
-        return updater.status()
+    async def update_status(refresh: bool = False) -> dict[str, Any]:
+        """Installed vs. tracked-ref commit so the UI can offer an update.
+
+        ``refresh=1`` forces a synchronous remote check (used on connect / page
+        load) so the result is current; the steady-state poll omits it and gets
+        the cheap debounced/cached value.
+        """
+        return await updater.status(force=refresh)
 
     @app.post("/api/update/start")
     async def update_start() -> JSONResponse:

--- a/almond_axol/serve/app.py
+++ b/almond_axol/serve/app.py
@@ -128,12 +128,15 @@ def create_app(static_dir: Path | None = None) -> FastAPI:
     runner = OperationRunner(robot)
 
     def _is_idle() -> bool:
-        """Safe to restart: nothing running and no live robot link."""
+        """Safe to restart: no operation running.
+
+        A connected robot is fine -- restarting drops the CAN link, which simply
+        reconnects after the relaunch; only an in-flight operation must not be
+        interrupted.
+        """
         if runner.is_running():
             return False
-        if any(s["status"] in ("starting", "running") for s in manager.list()):
-            return False
-        return not robot.status()["connected"]
+        return not any(s["status"] in ("starting", "running") for s in manager.list())
 
     # Surfaces "update available" (read-only `git ls-remote`) to the control
     # panel via /api/update/status and applies an on-demand `uv tool upgrade`

--- a/almond_axol/serve/update.py
+++ b/almond_axol/serve/update.py
@@ -153,17 +153,31 @@ class SelfUpdater:
         """Run the once-per-process ``axol provision`` startup heal (see below)."""
         self._ensure_provision_once()
 
-    def status(self) -> dict[str, object]:
-        """Snapshot for the control panel; schedules a debounced remote refresh.
+    async def status(self, *, force: bool = False) -> dict[str, object]:
+        """Snapshot for the control panel.
 
-        Returns immediately with the cached remote head (``None`` until the
-        first ``git ls-remote`` resolves). Reads ``is_idle`` live so the UI can
-        gate the Update button on a safe-to-restart server. If an upgrade landed
-        while the server was busy, this also re-attempts the deferred restart.
+        With ``force`` (a fresh page load / explicit check), resolve the remote
+        head synchronously -- bypassing the debounce -- so the response reflects
+        reality immediately rather than a cached value up to a debounce window
+        stale. Otherwise schedule a debounced background refresh and return the
+        cached head (``None`` until the first ``git ls-remote`` resolves), which
+        keeps the steady-state poll cheap.
+
+        Reads ``is_idle`` live so the UI can gate the Update button on a
+        safe-to-restart server. If an upgrade landed while the server was busy,
+        this also re-attempts the deferred restart.
         """
         if self._restart_pending:
             self._maybe_restart()
-        self._schedule_remote_refresh()
+        if force:
+            # Await an in-flight background check rather than racing a second
+            # ls-remote against it; otherwise resolve now.
+            if self._remote_task is not None and not self._remote_task.done():
+                await self._remote_task
+            else:
+                await self.refresh_remote()
+        else:
+            self._schedule_remote_refresh()
         remote = self._remote_commit
         update_available = bool(
             self.enabled and remote is not None and remote != self._commit

--- a/almond_axol/serve/update.py
+++ b/almond_axol/serve/update.py
@@ -127,6 +127,10 @@ class SelfUpdater:
         # Update lifecycle surfaced to the UI: "idle" | "updating" | "error".
         self._state = "idle"
         self._error: str | None = None
+        # Current step while ``state == "updating"`` so the UI can show progress
+        # instead of an opaque spinner: "upgrading" | "provisioning" |
+        # "restarting" (``None`` when not updating).
+        self._phase: str | None = None
         self._update_task: asyncio.Task[None] | None = None
         # Set when an upgrade landed but the server was busy; restart at the
         # next idle opportunity (a subsequent status poll re-checks).
@@ -189,6 +193,7 @@ class SelfUpdater:
             "updateAvailable": update_available,
             "idle": self._is_idle(),
             "state": self._state,
+            "phase": self._phase,
             "error": self._error,
         }
 
@@ -282,6 +287,7 @@ class SelfUpdater:
         _logger.warning("self-update: %s", message)
         self._error = message
         self._state = "error"
+        self._phase = None
 
     async def _run_update(self) -> None:
         # The destructive part of the flow, run only on an explicit request.
@@ -291,6 +297,7 @@ class SelfUpdater:
         # release it before the post-upgrade `_provision()` below, which
         # re-acquires it (the lock is not reentrant).
         try:
+            self._phase = "upgrading"
             async with self._env_lock:
                 try:
                     proc = await asyncio.create_subprocess_exec(
@@ -319,12 +326,14 @@ class SelfUpdater:
 
             # Always reprovision after an upgrade: it ran (so the env was rebuilt
             # and pyzed/PyGObject pruned) whether or not the commit advanced.
+            self._phase = "provisioning"
             await self._provision()
 
             if new_commit is None or new_commit == self._commit:
                 # The ref didn't actually advance the install; nothing to restart
                 # onto. Clear the spinner and report up to date.
                 self._state = "idle"
+                self._phase = None
                 _logger.info("self-update: already up to date (%s)", self._commit)
                 return
 
@@ -333,6 +342,7 @@ class SelfUpdater:
                 self._commit,
                 new_commit,
             )
+            self._phase = "restarting"
             self._restart_pending = True
             self._maybe_restart()
         except Exception as exc:  # noqa: BLE001 - surface to the UI

--- a/almond_axol/serve/update.py
+++ b/almond_axol/serve/update.py
@@ -110,8 +110,8 @@ class SelfUpdater:
     and whether the tracked ref has advanced) and triggers :meth:`start` from an
     Update button. Nothing upgrades automatically.
 
-    ``is_idle`` reports whether it is safe to restart (no operation running, no
-    live robot link). The restart is a plain ``os._exit``; systemd's
+    ``is_idle`` reports whether it is safe to restart (no operation running; a
+    connected robot is fine). The restart is a plain ``os._exit``; systemd's
     ``Restart=always`` brings the server back on the upgraded code.
     """
 
@@ -183,10 +183,10 @@ class SelfUpdater:
 
         Refuses (``started=False`` with a human-readable reason) for a dev
         checkout, when nothing new is known, when an update is already running,
-        or when the server is busy (an op running / robot connected). The UI
-        disables the button in those cases, but guard here too. On success the
-        upgrade + provision run in the background and the process exits when idle
-        so systemd relaunches the new code.
+        or when an operation is running. The UI disables the button in those
+        cases, but guard here too. On success the upgrade + provision run in the
+        background and the process exits when idle so systemd relaunches the new
+        code.
         """
         if not self.enabled:
             return False, "not a git tool install"

--- a/almond_axol/serve/update.py
+++ b/almond_axol/serve/update.py
@@ -1,13 +1,18 @@
-"""Self-update for ``axol serve`` installed as a uv tool.
+"""User-initiated update for ``axol serve`` installed as a uv tool.
 
 The hosted installer (``curl https://axol.almond.bot/install | bash``) installs
 the package with ``uv tool install`` from GitHub and runs ``axol serve`` under
-a systemd service with ``Restart=always``. This module keeps that install in
-sync with ``main``: whenever the control panel talks to the server, a debounced
-background task checks the tracked git ref with a read-only ``git ls-remote``
-and, only when it points at a new commit, runs ``uv tool upgrade almond-axol``;
-if the installed commit then changed *and* nothing is running, the process exits
-so systemd restarts it on the new code.
+a systemd service with ``Restart=always``. This module surfaces, to the control
+panel, whether the tracked ``main`` has moved past the installed commit and lets
+the operator apply the update on demand:
+
+- :meth:`SelfUpdater.status` answers the polled control-panel indicator. It
+  reports the installed commit and the tracked ref's head (resolved by a
+  read-only ``git ls-remote``, debounced and cached), so the UI can show "update
+  available" and a button. Nothing upgrades as a side effect of this check.
+- :meth:`SelfUpdater.start` is the Update button. It runs ``uv tool upgrade
+  almond-axol``; if the installed commit then advanced, the process exits so
+  systemd restarts it on the new code. The UI then hard-reloads.
 
 Because ``uv tool upgrade`` rebuilds the tool environment, anything that isn't a
 declared PyPI dependency is dropped and must be reinstalled before we restart
@@ -16,11 +21,11 @@ plugins. Rather than enumerate those steps here, this just shells out to ``axol
 provision`` — the single provisioning path the hosted installer also runs, so
 the two can't drift. Every step there is idempotent and self-gating.
 
-That same pruning is why the ``git ls-remote`` pre-check matters: ``uv tool
-upgrade`` rebuilds (and so prunes pyzed/PyGObject from) the env on *every* run,
-even when the commit hasn't moved, so running it on an already-current install
-would strip the camera stack out from under the running server. Gating it on a
-genuinely new commit keeps a steady-state install untouched.
+The read-only ``git ls-remote`` indicator is deliberately separate from the
+*destructive* ``uv tool upgrade``: the upgrade rebuilds (and so prunes
+pyzed/PyGObject from) the env on every run, even when the commit hasn't moved,
+so it only runs when the operator explicitly asks. The cheap ``ls-remote`` can
+poll freely without touching the steady-state install.
 
 ``axol provision`` runs both after an upgrade *and* once at startup. The startup
 run matters for a host that upgraded *into* the GStreamer-pipeline build from an
@@ -47,9 +52,10 @@ from typing import Callable
 _logger = logging.getLogger(__name__)
 
 _PACKAGE = "almond-axol"
-# Minimum seconds between upgrade attempts; the check is triggered by polled
-# API endpoints, so without this every status poll would spawn a uv process.
-_DEBOUNCE_S = 5 * 60.0
+# Minimum seconds between read-only `git ls-remote` checks. The status endpoint
+# is polled, so without this every poll would spawn a git process; the check is
+# cheap and the indicator does not need to be more current than this.
+_REMOTE_DEBOUNCE_S = 60.0
 # systemd's Restart=always uses this code like any other; chosen to make the
 # intentional self-restart recognizable in `journalctl`.
 _RESTART_EXIT_CODE = 0
@@ -98,20 +104,32 @@ def installed_commit() -> str | None:
 
 
 class SelfUpdater:
-    """Debounced ``uv tool upgrade`` + restart-when-idle.
+    """Read-only update indicator + explicit, user-initiated upgrade.
 
-    ``is_idle`` reports whether it is safe to restart (no operation running,
-    no live sessions). The restart is a plain ``os._exit``; systemd's
+    The control panel polls :meth:`status` (which reports the installed commit
+    and whether the tracked ref has advanced) and triggers :meth:`start` from an
+    Update button. Nothing upgrades automatically.
+
+    ``is_idle`` reports whether it is safe to restart (no operation running, no
+    live robot link). The restart is a plain ``os._exit``; systemd's
     ``Restart=always`` brings the server back on the upgraded code.
     """
 
     def __init__(self, is_idle: Callable[[], bool]) -> None:
         self._is_idle = is_idle
         self._commit = installed_commit()
-        self._last_check = 0.0
-        self._task: asyncio.Task[None] | None = None
+        # Cached remote head + when it was last resolved, so the polled status
+        # endpoint answers immediately and only re-runs `git ls-remote` at most
+        # once per debounce window rather than on every poll.
+        self._remote_commit: str | None = None
+        self._remote_checked_at = 0.0
+        self._remote_task: asyncio.Task[None] | None = None
+        # Update lifecycle surfaced to the UI: "idle" | "updating" | "error".
+        self._state = "idle"
+        self._error: str | None = None
+        self._update_task: asyncio.Task[None] | None = None
         # Set when an upgrade landed but the server was busy; restart at the
-        # next idle opportunity without waiting out the debounce again.
+        # next idle opportunity (a subsequent status poll re-checks).
         self._restart_pending = False
         # The GStreamer camera stack is provisioned once per process (covers a
         # host that upgraded into this build from an older main). ``_env_lock``
@@ -131,32 +149,101 @@ class SelfUpdater:
         """Updatable only when installed from git and uv is available."""
         return self._commit is not None and shutil.which("uv") is not None
 
-    def poke(self) -> None:
-        """Request an update check; debounced and never blocks the caller."""
+    def ensure_provisioned(self) -> None:
+        """Run the once-per-process ``axol provision`` startup heal (see below)."""
         self._ensure_provision_once()
+
+    def status(self) -> dict[str, object]:
+        """Snapshot for the control panel; schedules a debounced remote refresh.
+
+        Returns immediately with the cached remote head (``None`` until the
+        first ``git ls-remote`` resolves). Reads ``is_idle`` live so the UI can
+        gate the Update button on a safe-to-restart server. If an upgrade landed
+        while the server was busy, this also re-attempts the deferred restart.
+        """
         if self._restart_pending:
             self._maybe_restart()
-            return
+        self._schedule_remote_refresh()
+        remote = self._remote_commit
+        update_available = bool(
+            self.enabled and remote is not None and remote != self._commit
+        )
+        return {
+            "enabled": self.enabled,
+            "commit": self._commit,
+            "remoteCommit": remote,
+            "updateAvailable": update_available,
+            "idle": self._is_idle(),
+            "state": self._state,
+            "error": self._error,
+        }
+
+    def start(self) -> tuple[bool, str | None]:
+        """Begin a user-initiated upgrade; returns ``(started, reason)``.
+
+        Refuses (``started=False`` with a human-readable reason) for a dev
+        checkout, when nothing new is known, when an update is already running,
+        or when the server is busy (an op running / robot connected). The UI
+        disables the button in those cases, but guard here too. On success the
+        upgrade + provision run in the background and the process exits when idle
+        so systemd relaunches the new code.
+        """
+        if not self.enabled:
+            return False, "not a git tool install"
+        if self._state == "updating" or (
+            self._update_task is not None and not self._update_task.done()
+        ):
+            return False, "an update is already in progress"
+        remote = self._remote_commit
+        if remote is None or remote == self._commit:
+            return False, "no update available"
+        if not self._is_idle():
+            return False, "server is busy; stop the running operation first"
+        self._state = "updating"
+        self._error = None
+        self._update_task = asyncio.create_task(self._run_update())
+        return True, None
+
+    def _schedule_remote_refresh(self) -> None:
+        """Kick off a debounced ``git ls-remote`` if the cache is stale."""
         if not self.enabled:
             return
-        if self._task is not None and not self._task.done():
+        if self._remote_task is not None and not self._remote_task.done():
             return
         now = time.monotonic()
-        if now - self._last_check < _DEBOUNCE_S:
+        # Honor the debounce even after a failed/empty resolve (``_remote_checked_at``
+        # is stamped regardless) so a poll loop can't spawn ls-remote continuously
+        # when offline. The initial 0.0 lets the first poll through.
+        if (
+            self._remote_checked_at
+            and now - self._remote_checked_at < _REMOTE_DEBOUNCE_S
+        ):
             return
-        self._last_check = now
-        self._task = asyncio.create_task(self._check())
+        self._remote_task = asyncio.create_task(self.refresh_remote())
 
-    async def _remote_commit(self, url: str, revision: str | None) -> str | None:
+    async def refresh_remote(self) -> None:
+        """Resolve the tracked ref's head via read-only ``git ls-remote``.
+
+        Updates the cache only; never upgrades. Cheap and safe on a steady-state
+        install (unlike ``uv tool upgrade``, which would prune the camera stack),
+        which is why the indicator can poll it freely.
+        """
+        origin = installed_origin()
+        if origin is None:
+            self._remote_checked_at = time.monotonic()
+            return
+        url, revision, _current = origin
+        remote = await self._resolve_remote(url, revision)
+        self._remote_checked_at = time.monotonic()
+        if remote is not None:
+            self._remote_commit = remote
+
+    async def _resolve_remote(self, url: str, revision: str | None) -> str | None:
         """Commit the tracked git ref currently points at, via ``git ls-remote``.
 
-        Read-only and cheap. Resolving the remote head up front lets us skip the
-        *destructive* ``uv tool upgrade`` entirely when there is nothing new:
-        that upgrade rebuilds the tool env and prunes every non-PyPI dep (pyzed,
-        PyGObject) on each run, and `axol provision` only puts them back when we
-        actually move to new code -- so running it on an already-current install
-        would strip the camera stack out from under the running server (relay ->
-        ``ModuleNotFoundError: pyzed``) and never restore it.
+        Read-only and cheap, so it drives the polled "update available"
+        indicator without touching the install. ``None`` on any failure (offline,
+        bad ref); the caller keeps the last known value.
         """
         try:
             proc = await asyncio.create_subprocess_exec(
@@ -176,74 +263,66 @@ class SelfUpdater:
         first = out.decode("utf-8", "replace").split("\n", 1)[0].strip()
         return first.split()[0] if first else None
 
-    async def _check(self) -> None:
-        # `uv tool upgrade` rebuilds the tool env and prunes the non-PyPI deps
-        # (pyzed, PyGObject) on *every* run, even when the tracked commit hasn't
-        # moved -- and we only reprovision them when we actually advance to new
-        # code. So resolve the remote head with a read-only `git ls-remote` first
-        # and only run the destructive upgrade when there is genuinely something
-        # new; otherwise an up-to-date install would lose its camera stack
-        # (relay -> ModuleNotFoundError: pyzed) and never get it back.
-        origin = installed_origin()
-        if origin is None:
-            return
-        url, revision, current = origin
-        remote = await self._remote_commit(url, revision)
-        if remote is None:
-            _logger.info("self-update: could not resolve remote commit; skipping")
-            return
-        if remote == current:
-            _logger.info("self-update: already up to date (%s)", current)
-            return
+    def _fail(self, message: str) -> None:
+        """Record an update failure for the UI and log it."""
+        _logger.warning("self-update: %s", message)
+        self._error = message
+        self._state = "error"
 
-        # New commit on the tracked ref. `uv tool upgrade` rewrites the whole
-        # tool env, so it must not overlap an `axol provision` installing
-        # pyzed/PyGObject into that same env (a concurrent startup heal). Both
-        # take ``_env_lock``; we release it before the post-upgrade
-        # `_provision()` below, which re-acquires it (the lock is not reentrant).
-        async with self._env_lock:
-            try:
-                proc = await asyncio.create_subprocess_exec(
-                    "uv",
-                    "tool",
-                    "upgrade",
-                    _PACKAGE,
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.STDOUT,
-                )
-                out, _ = await proc.communicate()
-            except OSError as exc:
-                _logger.warning("self-update: could not run uv: %s", exc)
+    async def _run_update(self) -> None:
+        # The destructive part of the flow, run only on an explicit request.
+        # `uv tool upgrade` rewrites the whole tool env (pruning pyzed/PyGObject),
+        # so it must not overlap an `axol provision` installing them into that
+        # same env (a concurrent startup heal). Both take ``_env_lock``; we
+        # release it before the post-upgrade `_provision()` below, which
+        # re-acquires it (the lock is not reentrant).
+        try:
+            async with self._env_lock:
+                try:
+                    proc = await asyncio.create_subprocess_exec(
+                        "uv",
+                        "tool",
+                        "upgrade",
+                        _PACKAGE,
+                        stdout=asyncio.subprocess.PIPE,
+                        stderr=asyncio.subprocess.STDOUT,
+                    )
+                    out, _ = await proc.communicate()
+                except OSError as exc:
+                    self._fail(f"could not run uv: {exc}")
+                    return
+                if proc.returncode != 0:
+                    tail = out.decode("utf-8", "replace").strip().splitlines()
+                    self._fail(
+                        f"uv tool upgrade failed: {tail[-1] if tail else 'no output'}"
+                    )
+                    return
+
+                # The upgrade rewrites the tool environment; re-read the metadata
+                # from disk to see whether the installed commit moved past the
+                # running one (still under the lock, so it reflects this upgrade).
+                new_commit = installed_commit()
+
+            # Always reprovision after an upgrade: it ran (so the env was rebuilt
+            # and pyzed/PyGObject pruned) whether or not the commit advanced.
+            await self._provision()
+
+            if new_commit is None or new_commit == self._commit:
+                # The ref didn't actually advance the install; nothing to restart
+                # onto. Clear the spinner and report up to date.
+                self._state = "idle"
+                _logger.info("self-update: already up to date (%s)", self._commit)
                 return
-            if proc.returncode != 0:
-                tail = out.decode("utf-8", "replace").strip().splitlines()
-                _logger.warning(
-                    "self-update: `uv tool upgrade` failed (%s): %s",
-                    proc.returncode,
-                    tail[-1] if tail else "no output",
-                )
-                return
 
-            # The upgrade rewrites the tool environment; re-read the metadata
-            # from disk to see whether the installed commit moved past the
-            # running one (still under the lock, so it reflects this upgrade).
-            new_commit = installed_commit()
-
-        # Always reprovision after an upgrade: it ran (so the env was rebuilt and
-        # pyzed/PyGObject pruned) whether or not the commit ended up advancing.
-        await self._provision()
-
-        if new_commit is None or new_commit == self._commit:
-            _logger.info("self-update: already up to date (%s)", self._commit)
-            return
-
-        _logger.info(
-            "self-update: upgraded %s -> %s; restarting when idle",
-            self._commit,
-            new_commit,
-        )
-        self._restart_pending = True
-        self._maybe_restart()
+            _logger.info(
+                "self-update: upgraded %s -> %s; restarting when idle",
+                self._commit,
+                new_commit,
+            )
+            self._restart_pending = True
+            self._maybe_restart()
+        except Exception as exc:  # noqa: BLE001 - surface to the UI
+            self._fail(f"{type(exc).__name__}: {exc}")
 
     def _ensure_provision_once(self) -> None:
         """Provision system deps once per process, in the background.

--- a/web/app/src/components/connections-bar.tsx
+++ b/web/app/src/components/connections-bar.tsx
@@ -60,6 +60,7 @@ export function ConnectionsBar({
   conn,
   host,
   hostName,
+  commit,
   onOpenSetup,
   onHostDisconnect,
   robot,
@@ -75,6 +76,8 @@ export function ConnectionsBar({
   conn: ConnState
   host: string
   hostName?: string
+  /** Installed git commit of the serve host (null for dev checkouts). */
+  commit?: string | null
   onOpenSetup: () => void
   onHostDisconnect: () => void
   robot: RobotStatus | null
@@ -163,6 +166,13 @@ export function ConnectionsBar({
         dot={wsDot}
         label={wsLabel}
         pulse={conn === "loading"}
+        extra={
+          online && commit ? (
+            <span className="font-mono text-[0.7rem] text-white/35" title={commit}>
+              axol @ {commit.slice(0, 7)}
+            </span>
+          ) : undefined
+        }
       >
         {online ? (
           <Button

--- a/web/app/src/components/update-banner.tsx
+++ b/web/app/src/components/update-banner.tsx
@@ -15,13 +15,17 @@ function short(commit: string | null): string {
 export function UpdateBanner({
   update,
   updating,
+  busyReason,
   onUpdate,
 }: {
   update: UpdateStatus
   updating: boolean
+  /** Why a restart is currently unsafe, e.g. "Disconnect Axol" (no period). */
+  busyReason?: string
   onUpdate: () => void
 }) {
   const blocked = !update.idle
+  const hint = busyReason ?? "The server is busy"
   return (
     <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-amber-400/25 bg-amber-400/[0.05] p-3 text-xs text-amber-200/80">
       <div className="flex min-w-0 flex-col gap-0.5">
@@ -29,18 +33,14 @@ export function UpdateBanner({
         <span className="font-mono text-amber-200/60">
           {short(update.commit)} &rarr; {short(update.remoteCommit)}
         </span>
-        {blocked && !updating && (
-          <span className="text-amber-200/60">
-            Stop the running operation and disconnect Axol to update.
-          </span>
-        )}
+        {blocked && !updating && <span className="text-amber-200/60">{hint} to update.</span>}
       </div>
       <Button
         variant="outline"
         size="sm"
         onClick={onUpdate}
         disabled={blocked || updating}
-        title={blocked ? "Server busy — stop the operation and disconnect Axol first" : undefined}
+        title={blocked ? `${hint} first` : undefined}
       >
         {updating ? <Loader2 className="animate-spin" /> : <Download />}
         {updating ? "Updating…" : "Update"}

--- a/web/app/src/components/update-banner.tsx
+++ b/web/app/src/components/update-banner.tsx
@@ -1,9 +1,16 @@
 import { Download, ExternalLink, Loader2 } from "lucide-react"
-import type { UpdateStatus } from "@/lib/supervisor"
+import type { UpdatePhase, UpdateStatus } from "@/lib/supervisor"
 import { Button, buttonVariants } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 
 const RELEASE_NOTES_URL = "https://github.com/almond-bot/axol/blob/main/RELEASE_NOTES.md"
+
+/** Human-readable label for the current update step (shown on the button). */
+const PHASE_LABEL: Record<UpdatePhase, string> = {
+  upgrading: "Upgrading…",
+  provisioning: "Installing deps…",
+  restarting: "Restarting…",
+}
 
 /** First 7 chars of a git commit, the conventional short form. */
 function short(commit: string | null): string {
@@ -18,12 +25,15 @@ function short(commit: string | null): string {
 export function UpdateBanner({
   update,
   updating,
+  phase,
   blocked,
   busyReason,
   onUpdate,
 }: {
   update: UpdateStatus
   updating: boolean
+  /** Current update step, for the button label while updating. */
+  phase: UpdatePhase | null
   /** Whether a restart is currently unsafe (e.g. an operation is running). */
   blocked: boolean
   /** Why a restart is currently unsafe, e.g. "Stop the running operation" (no period). */
@@ -31,6 +41,7 @@ export function UpdateBanner({
   onUpdate: () => void
 }) {
   const hint = busyReason ?? "The server is busy"
+  const updatingLabel = (phase && PHASE_LABEL[phase]) || "Updating…"
   return (
     <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-amber-400/25 bg-amber-400/[0.05] p-3 text-xs text-amber-200/80">
       <div className="flex min-w-0 flex-col gap-0.5">
@@ -61,7 +72,7 @@ export function UpdateBanner({
           title={blocked ? `${hint} first` : undefined}
         >
           {updating ? <Loader2 className="animate-spin" /> : <Download />}
-          {updating ? "Updating…" : "Update"}
+          {updating ? updatingLabel : "Update"}
         </Button>
       </div>
     </div>

--- a/web/app/src/components/update-banner.tsx
+++ b/web/app/src/components/update-banner.tsx
@@ -1,6 +1,9 @@
-import { Download, Loader2 } from "lucide-react"
+import { Download, ExternalLink, Loader2 } from "lucide-react"
 import type { UpdateStatus } from "@/lib/supervisor"
-import { Button } from "@/components/ui/button"
+import { Button, buttonVariants } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+const RELEASE_NOTES_URL = "https://github.com/almond-bot/axol/blob/main/RELEASE_NOTES.md"
 
 /** First 7 chars of a git commit, the conventional short form. */
 function short(commit: string | null): string {
@@ -35,16 +38,30 @@ export function UpdateBanner({
         </span>
         {blocked && !updating && <span className="text-amber-200/60">{hint} to update.</span>}
       </div>
-      <Button
-        variant="outline"
-        size="sm"
-        onClick={onUpdate}
-        disabled={blocked || updating}
-        title={blocked ? `${hint} first` : undefined}
-      >
-        {updating ? <Loader2 className="animate-spin" /> : <Download />}
-        {updating ? "Updating…" : "Update"}
-      </Button>
+      <div className="flex items-center gap-2">
+        <a
+          href={RELEASE_NOTES_URL}
+          target="_blank"
+          rel="noreferrer"
+          className={cn(
+            buttonVariants({ variant: "ghost", size: "sm" }),
+            "text-amber-200/80 hover:bg-amber-400/10 hover:text-amber-200"
+          )}
+        >
+          Release notes
+          <ExternalLink />
+        </a>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onUpdate}
+          disabled={blocked || updating}
+          title={blocked ? `${hint} first` : undefined}
+        >
+          {updating ? <Loader2 className="animate-spin" /> : <Download />}
+          {updating ? "Updating…" : "Update"}
+        </Button>
+      </div>
     </div>
   )
 }

--- a/web/app/src/components/update-banner.tsx
+++ b/web/app/src/components/update-banner.tsx
@@ -18,16 +18,18 @@ function short(commit: string | null): string {
 export function UpdateBanner({
   update,
   updating,
+  blocked,
   busyReason,
   onUpdate,
 }: {
   update: UpdateStatus
   updating: boolean
-  /** Why a restart is currently unsafe, e.g. "Disconnect Axol" (no period). */
+  /** Whether a restart is currently unsafe (e.g. an operation is running). */
+  blocked: boolean
+  /** Why a restart is currently unsafe, e.g. "Stop the running operation" (no period). */
   busyReason?: string
   onUpdate: () => void
 }) {
-  const blocked = !update.idle
   const hint = busyReason ?? "The server is busy"
   return (
     <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-amber-400/25 bg-amber-400/[0.05] p-3 text-xs text-amber-200/80">

--- a/web/app/src/components/update-banner.tsx
+++ b/web/app/src/components/update-banner.tsx
@@ -9,8 +9,8 @@ function short(commit: string | null): string {
 
 /**
  * Banner shown above the connections bar when the tracked ref has moved past
- * the installed commit. The Update button is disabled unless the server is idle
- * (no op running, robot disconnected), since applying it restarts the server.
+ * the installed commit. The Update button is disabled while an operation is
+ * running (a connected robot is fine), since applying it restarts the server.
  */
 export function UpdateBanner({
   update,

--- a/web/app/src/components/update-banner.tsx
+++ b/web/app/src/components/update-banner.tsx
@@ -1,0 +1,50 @@
+import { Download, Loader2 } from "lucide-react"
+import type { UpdateStatus } from "@/lib/supervisor"
+import { Button } from "@/components/ui/button"
+
+/** First 7 chars of a git commit, the conventional short form. */
+function short(commit: string | null): string {
+  return commit ? commit.slice(0, 7) : "unknown"
+}
+
+/**
+ * Banner shown above the connections bar when the tracked ref has moved past
+ * the installed commit. The Update button is disabled unless the server is idle
+ * (no op running, robot disconnected), since applying it restarts the server.
+ */
+export function UpdateBanner({
+  update,
+  updating,
+  onUpdate,
+}: {
+  update: UpdateStatus
+  updating: boolean
+  onUpdate: () => void
+}) {
+  const blocked = !update.idle
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-amber-400/25 bg-amber-400/[0.05] p-3 text-xs text-amber-200/80">
+      <div className="flex min-w-0 flex-col gap-0.5">
+        <span className="font-medium text-amber-200">A new version is available</span>
+        <span className="font-mono text-amber-200/60">
+          {short(update.commit)} &rarr; {short(update.remoteCommit)}
+        </span>
+        {blocked && !updating && (
+          <span className="text-amber-200/60">
+            Stop the running operation and disconnect Axol to update.
+          </span>
+        )}
+      </div>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={onUpdate}
+        disabled={blocked || updating}
+        title={blocked ? "Server busy — stop the operation and disconnect Axol first" : undefined}
+      >
+        {updating ? <Loader2 className="animate-spin" /> : <Download />}
+        {updating ? "Updating…" : "Update"}
+      </Button>
+    </div>
+  )
+}

--- a/web/app/src/lib/supervisor.ts
+++ b/web/app/src/lib/supervisor.ts
@@ -115,6 +115,37 @@ export async function fetchInfo(): Promise<ServerInfo> {
 }
 
 // ---------------------------------------------------------------------------
+// Self-update (read-only commit check + user-initiated upgrade)
+// ---------------------------------------------------------------------------
+
+export type UpdateState = "idle" | "updating" | "error"
+
+export interface UpdateStatus {
+  /** Updatable: installed from git as a uv tool with uv available. */
+  enabled: boolean
+  /** Installed git commit (null for dev checkouts). */
+  commit: string | null
+  /** Latest commit on the tracked ref, or null until first resolved/offline. */
+  remoteCommit: string | null
+  /** remoteCommit is known and differs from the installed commit. */
+  updateAvailable: boolean
+  /** Safe to restart now (no op running, robot disconnected). */
+  idle: boolean
+  state: UpdateState
+  /** Last update failure, surfaced to the operator; null otherwise. */
+  error: string | null
+}
+
+export async function fetchUpdateStatus(): Promise<UpdateStatus> {
+  return json(await fetch(apiUrl("/api/update/status")))
+}
+
+/** Trigger the on-demand upgrade; the server restarts onto new code when idle. */
+export async function startUpdate(): Promise<{ started: boolean }> {
+  return json(await fetch(apiUrl("/api/update/start"), { method: "POST" }))
+}
+
+// ---------------------------------------------------------------------------
 // Robot connection (detached CAN + 1 Hz motor ping)
 // ---------------------------------------------------------------------------
 

--- a/web/app/src/lib/supervisor.ts
+++ b/web/app/src/lib/supervisor.ts
@@ -120,6 +120,9 @@ export async function fetchInfo(): Promise<ServerInfo> {
 
 export type UpdateState = "idle" | "updating" | "error"
 
+/** Current step while an update is applying; null when not updating. */
+export type UpdatePhase = "upgrading" | "provisioning" | "restarting"
+
 export interface UpdateStatus {
   /** Updatable: installed from git as a uv tool with uv available. */
   enabled: boolean
@@ -129,9 +132,11 @@ export interface UpdateStatus {
   remoteCommit: string | null
   /** remoteCommit is known and differs from the installed commit. */
   updateAvailable: boolean
-  /** Safe to restart now (no op running, robot disconnected). */
+  /** Safe to restart now (no op running). */
   idle: boolean
   state: UpdateState
+  /** Step while state is "updating" (upgrading/provisioning/restarting); else null. */
+  phase: UpdatePhase | null
   /** Last update failure, surfaced to the operator; null otherwise. */
   error: string | null
 }

--- a/web/app/src/lib/supervisor.ts
+++ b/web/app/src/lib/supervisor.ts
@@ -136,8 +136,13 @@ export interface UpdateStatus {
   error: string | null
 }
 
-export async function fetchUpdateStatus(): Promise<UpdateStatus> {
-  return json(await fetch(apiUrl("/api/update/status")))
+/**
+ * Fetch the update indicator. Pass `force` on connect / page load to make the
+ * server resolve the remote head synchronously (bypassing its debounce), so the
+ * result is immediately current rather than a stale cached value.
+ */
+export async function fetchUpdateStatus(force = false): Promise<UpdateStatus> {
+  return json(await fetch(apiUrl(`/api/update/status${force ? "?refresh=1" : ""}`)))
 }
 
 /** Trigger the on-demand upgrade; the server restarts onto new code when idle. */

--- a/web/app/src/routes/ControlPanel.tsx
+++ b/web/app/src/routes/ControlPanel.tsx
@@ -404,9 +404,14 @@ export default function ControlPanel() {
   const selectedLive = isLive && runningOp === selectedOp
   const selectedStopping = isStopping && runningOp === selectedOp
 
-  // What's keeping the server from being idle (and so blocking an update).
-  // Mirrors the server's _is_idle: only a running operation blocks a restart (a
-  // connected robot is fine). Capitalized clause, no trailing period.
+  // Whether an update is currently unsafe to apply. `isLive` is the immediate,
+  // local signal (reacts the instant an op starts/stops) so the banner blocks
+  // without waiting for the slow status poll; the server's `update.idle` is the
+  // backstop for any other non-idle reason (and the server guards the request
+  // regardless). Mirrors the server's _is_idle: only a running operation blocks
+  // a restart (a connected robot is fine).
+  const updateBlocked = isLive || !(update?.idle ?? true)
+  // Reason shown in the banner; capitalized clause, no trailing period.
   const updateBusyReason = isLive ? "Stop the running operation" : "The server is busy"
 
   // While an op is live (including the "stopping" window), poll the server's
@@ -429,6 +434,17 @@ export default function ControlPanel() {
       clearInterval(t)
     }
   }, [conn.state, isLive])
+
+  // Refresh the update status the moment an operation starts or stops, so the
+  // server's idle state (and thus the banner's blocked state) becomes current
+  // without waiting for the slow 60s poll. Skipped while an update is applying
+  // (handleUpdate drives its own watch poll then).
+  useEffect(() => {
+    if (conn.state !== "ok" || updating) return
+    fetchUpdateStatus()
+      .then(setUpdate)
+      .catch(() => {})
+  }, [conn.state, updating, isLive])
 
   const meta = operationMeta(selectedOp)
   const spec = useMemo(
@@ -551,6 +567,7 @@ export default function ControlPanel() {
           <UpdateBanner
             update={update}
             updating={updating}
+            blocked={updateBlocked}
             busyReason={updateBusyReason}
             onUpdate={handleUpdate}
           />

--- a/web/app/src/routes/ControlPanel.tsx
+++ b/web/app/src/routes/ControlPanel.tsx
@@ -402,18 +402,10 @@ export default function ControlPanel() {
   const selectedLive = isLive && runningOp === selectedOp
   const selectedStopping = isStopping && runningOp === selectedOp
 
-  // What's keeping the server from being idle (and so blocking an update), in
-  // UI-visible terms: a running op and/or the live robot link. Mirrors the
-  // server's _is_idle so the update banner names the actual blocker rather than
-  // assuming an operation is running. Capitalized clause, no trailing period.
-  const updateBusyReason = (() => {
-    const parts: string[] = []
-    if (isLive) parts.push("stop the running operation")
-    if (robot?.connected) parts.push("disconnect Axol")
-    if (parts.length === 0) return "The server is busy"
-    const clause = parts.join(" and ")
-    return clause.charAt(0).toUpperCase() + clause.slice(1)
-  })()
+  // What's keeping the server from being idle (and so blocking an update).
+  // Mirrors the server's _is_idle: only a running operation blocks a restart (a
+  // connected robot is fine). Capitalized clause, no trailing period.
+  const updateBusyReason = isLive ? "Stop the running operation" : "The server is busy"
 
   // While an op is live (including the "stopping" window), poll the server's
   // authoritative op status so the panel reliably catches the transition to

--- a/web/app/src/routes/ControlPanel.tsx
+++ b/web/app/src/routes/ControlPanel.tsx
@@ -8,6 +8,7 @@ import {
   fetchInfo,
   fetchOpStatus,
   fetchRobotStatus,
+  fetchUpdateStatus,
   fetchUsbStatus,
   loadOpSettings,
   operationMeta,
@@ -18,6 +19,7 @@ import {
   sendEpisodeCommand,
   setServerBase,
   startOperation,
+  startUpdate,
   stopOperation,
   usbConnect,
   useSessionLogs,
@@ -28,8 +30,10 @@ import {
   type RobotStatus,
   type ServerInfo,
   type SessionInfo,
+  type UpdateStatus,
   type UsbStatus,
 } from "@/lib/supervisor"
+import { UpdateBanner } from "@/components/update-banner"
 import { ConnectionsBar } from "@/components/connections-bar"
 import { OperationPanel } from "@/components/operation-panel"
 import { LogConsole } from "@/components/log-console"
@@ -86,6 +90,9 @@ export default function ControlPanel() {
   )
   const [hostInfo, setHostInfo] = useState<ServerInfo | null>(null)
   const [viewerPort, setViewerPort] = useState(8002)
+  const [update, setUpdate] = useState<UpdateStatus | null>(null)
+  // Drives the banner's "Updating…" state while the server upgrades + restarts.
+  const [updating, setUpdating] = useState(false)
 
   const [robot, setRobot] = useState<RobotStatus | null>(null)
   const [robotBusy, setRobotBusy] = useState(false)
@@ -125,6 +132,9 @@ export default function ControlPanel() {
         setViewerPort(info.viewerPort)
         setHostInfo(info)
       })
+      .catch(() => {})
+    fetchUpdateStatus()
+      .then(setUpdate)
       .catch(() => {})
     fetchRobotStatus()
       .then(setRobot)
@@ -172,6 +182,27 @@ export default function ControlPanel() {
       clearInterval(t)
     }
   }, [conn.state])
+
+  // Poll the update indicator slowly while online (its server-side `ls-remote`
+  // is debounced, so a tight interval would buy nothing). Paused while an
+  // update is in flight — handleUpdate drives its own faster restart-watch poll.
+  useEffect(() => {
+    if (conn.state !== "ok" || updating) return
+    let active = true
+    const poll = () => {
+      fetchUpdateStatus()
+        .then((u) => {
+          if (active) setUpdate(u)
+        })
+        .catch(() => {})
+    }
+    poll()
+    const t = setInterval(poll, 60_000)
+    return () => {
+      active = false
+      clearInterval(t)
+    }
+  }, [conn.state, updating])
 
   // Auto-connect Axol once after the host comes online, if it's sitting idle.
   // The ref makes it fire at most once per host session, so a manual robot
@@ -234,6 +265,8 @@ export default function ControlPanel() {
     setCommands([])
     setRobot(null)
     setSession(null)
+    setUpdate(null)
+    setUpdating(false)
     autoRobotRef.current = false
   }
 
@@ -455,16 +488,67 @@ export default function ControlPanel() {
     sendEpisodeCommand(command).catch((e) => setError(String(e)))
   }
 
+  // Apply the available update, then hard-reload once the server is back on the
+  // new commit. The server upgrades and exits (systemd relaunches it), so the
+  // start request and the watch polls below tolerate it briefly going away.
+  async function handleUpdate() {
+    const target = update?.remoteCommit
+    if (!target) return
+    setError(null)
+    setUpdating(true)
+    try {
+      await startUpdate()
+    } catch (e) {
+      setError(`Update failed to start: ${e}`)
+      setUpdating(false)
+      return
+    }
+    // The hosted UI is served by Vercel, so a hard reload also pulls the latest
+    // front-end; reconnecting to the restarted backend re-runs loadServer.
+    const reload = () => window.location.reload()
+    const deadline = Date.now() + 5 * 60_000
+    const watch = setInterval(async () => {
+      if (Date.now() > deadline) {
+        clearInterval(watch)
+        setUpdating(false)
+        setError("Update is taking longer than expected. Reload to retry.")
+        return
+      }
+      try {
+        const u = await fetchUpdateStatus()
+        setUpdate(u)
+        if (u.state === "error") {
+          clearInterval(watch)
+          setUpdating(false)
+          setError(u.error ?? "Update failed.")
+          return
+        }
+        // Server is back and now running the target commit — done.
+        if (u.commit === target) {
+          clearInterval(watch)
+          reload()
+        }
+      } catch {
+        // Server is mid-restart (or briefly unreachable); keep watching.
+      }
+    }, 2000)
+  }
+
   const viewerHost = serverHost || hostInfo?.lanIp || ""
 
   return (
     <div className="min-h-screen">
       <SiteNav current="control" />
       <main className="mx-auto flex max-w-5xl flex-col gap-6 px-6 py-8">
+        {update?.updateAvailable && (
+          <UpdateBanner update={update} updating={updating} onUpdate={handleUpdate} />
+        )}
+
         <ConnectionsBar
           conn={conn.state}
           host={serverHost}
           hostName={hostInfo?.hostname}
+          commit={update?.commit ?? hostInfo?.commit ?? null}
           onOpenSetup={() => setSetupOpen(true)}
           onHostDisconnect={hostDisconnectClick}
           robot={robot}

--- a/web/app/src/routes/ControlPanel.tsx
+++ b/web/app/src/routes/ControlPanel.tsx
@@ -133,7 +133,9 @@ export default function ControlPanel() {
         setHostInfo(info)
       })
       .catch(() => {})
-    fetchUpdateStatus()
+    // Force a synchronous remote check on connect/page load so the banner
+    // reflects reality immediately; the steady-state poll below stays cheap.
+    fetchUpdateStatus(true)
       .then(setUpdate)
       .catch(() => {})
     fetchRobotStatus()

--- a/web/app/src/routes/ControlPanel.tsx
+++ b/web/app/src/routes/ControlPanel.tsx
@@ -30,6 +30,7 @@ import {
   type RobotStatus,
   type ServerInfo,
   type SessionInfo,
+  type UpdatePhase,
   type UpdateStatus,
   type UsbStatus,
 } from "@/lib/supervisor"
@@ -93,6 +94,10 @@ export default function ControlPanel() {
   const [update, setUpdate] = useState<UpdateStatus | null>(null)
   // Drives the banner's "Updating…" state while the server upgrades + restarts.
   const [updating, setUpdating] = useState(false)
+  // Current step shown in the banner while updating (so it isn't an opaque
+  // spinner). Sourced from the server's reported phase, except "restarting"
+  // which we infer locally once the server stops responding (it exited).
+  const [updatePhase, setUpdatePhase] = useState<UpdatePhase | null>(null)
 
   const [robot, setRobot] = useState<RobotStatus | null>(null)
   const [robotBusy, setRobotBusy] = useState(false)
@@ -269,6 +274,7 @@ export default function ControlPanel() {
     setSession(null)
     setUpdate(null)
     setUpdating(false)
+    setUpdatePhase(null)
     autoRobotRef.current = false
   }
 
@@ -519,11 +525,13 @@ export default function ControlPanel() {
     if (!target) return
     setError(null)
     setUpdating(true)
+    setUpdatePhase("upgrading")
     try {
       await startUpdate()
     } catch (e) {
       setError(`Update failed to start: ${e}`)
       setUpdating(false)
+      setUpdatePhase(null)
       return
     }
     // The hosted UI is served by Vercel, so a hard reload also pulls the latest
@@ -534,6 +542,7 @@ export default function ControlPanel() {
       if (Date.now() > deadline) {
         clearInterval(watch)
         setUpdating(false)
+        setUpdatePhase(null)
         setError("Update is taking longer than expected. Reload to retry.")
         return
       }
@@ -543,16 +552,22 @@ export default function ControlPanel() {
         if (u.state === "error") {
           clearInterval(watch)
           setUpdating(false)
+          setUpdatePhase(null)
           setError(u.error ?? "Update failed.")
           return
         }
+        // Reflect the server's current step (upgrading/provisioning) so the
+        // banner shows progress rather than an opaque spinner.
+        if (u.phase) setUpdatePhase(u.phase)
         // Server is back and now running the target commit — done.
         if (u.commit === target) {
           clearInterval(watch)
           reload()
         }
       } catch {
-        // Server is mid-restart (or briefly unreachable); keep watching.
+        // Server stopped responding: it exited to restart (or is briefly
+        // unreachable). Show "restarting" and keep watching for it to return.
+        setUpdatePhase("restarting")
       }
     }, 2000)
   }
@@ -567,6 +582,7 @@ export default function ControlPanel() {
           <UpdateBanner
             update={update}
             updating={updating}
+            phase={updatePhase}
             blocked={updateBlocked}
             busyReason={updateBusyReason}
             onUpdate={handleUpdate}

--- a/web/app/src/routes/ControlPanel.tsx
+++ b/web/app/src/routes/ControlPanel.tsx
@@ -402,6 +402,19 @@ export default function ControlPanel() {
   const selectedLive = isLive && runningOp === selectedOp
   const selectedStopping = isStopping && runningOp === selectedOp
 
+  // What's keeping the server from being idle (and so blocking an update), in
+  // UI-visible terms: a running op and/or the live robot link. Mirrors the
+  // server's _is_idle so the update banner names the actual blocker rather than
+  // assuming an operation is running. Capitalized clause, no trailing period.
+  const updateBusyReason = (() => {
+    const parts: string[] = []
+    if (isLive) parts.push("stop the running operation")
+    if (robot?.connected) parts.push("disconnect Axol")
+    if (parts.length === 0) return "The server is busy"
+    const clause = parts.join(" and ")
+    return clause.charAt(0).toUpperCase() + clause.slice(1)
+  })()
+
   // While an op is live (including the "stopping" window), poll the server's
   // authoritative op status so the panel reliably catches the transition to
   // exited even if the logs WebSocket drops its final status frame. The stop
@@ -541,7 +554,12 @@ export default function ControlPanel() {
       <SiteNav current="control" />
       <main className="mx-auto flex max-w-5xl flex-col gap-6 px-6 py-8">
         {update?.updateAvailable && (
-          <UpdateBanner update={update} updating={updating} onUpdate={handleUpdate} />
+          <UpdateBanner
+            update={update}
+            updating={updating}
+            busyReason={updateBusyReason}
+            onUpdate={handleUpdate}
+          />
         )}
 
         <ConnectionsBar


### PR DESCRIPTION
## Summary

- Replaces the silent background self-updater with a visible, operator-driven flow. The server no longer auto-upgrades; instead the control panel surfaces the installed commit, polls a read-only `git ls-remote` indicator, and offers an Update button.
- Clicking Update (only enabled when idle) runs `uv tool upgrade` + `axol provision`, then the process exits so systemd relaunches on the new code; the UI watches for the restart and hard-reloads the page.

## Changes

**Backend**
- `almond_axol/serve/update.py`: `SelfUpdater` refactored from "poke -> debounced auto-upgrade" to read-only `status()` + explicit `start()`. Adds cached remote-commit state, `refresh_remote()`, `_run_update()` (surfaces errors via `state`/`error`), and `ensure_provisioned()` (startup heal preserved). Read-only `ls-remote` debounced to 60s.
- `almond_axol/serve/app.py`: drops the `poke()` calls; `/api/info` now calls `ensure_provisioned()`; adds `GET /api/update/status` and `POST /api/update/start` (409 with reason on refusal).

**Frontend**
- `web/app/src/lib/supervisor.ts`: `UpdateStatus` type, `fetchUpdateStatus()`, `startUpdate()`.
- `web/app/src/routes/ControlPanel.tsx`: polls update status (60s), renders the update banner above the connections bar, and `handleUpdate()` runs a restart-tolerant poll loop that hard-reloads once the server reports the target commit (5 min deadline fallback).
- `web/app/src/components/update-banner.tsx` (new): amber "new version available" banner with `<commit> -> <remoteCommit>` and an Update button (disabled unless idle).
- `web/app/src/components/connections-bar.tsx`: shows `axol @ <short commit>` in the Axol Host tile (hidden for dev checkouts).

## Notes

- Manual-only: nothing upgrades automatically; the read-only check only drives the indicator.
- Idle gating reuses `_is_idle` (op running or robot connected => not idle), so Update is disabled exactly when a restart would be unsafe.
- "Update available" can take up to ~2 min to appear after a push (60s server-side `ls-remote` debounce + 60s UI poll); tunable.

## Test plan

- [ ] On a hosted (uv tool) install, push a new commit to main and confirm the banner appears with the correct commit delta.
- [ ] Click Update while idle: server upgrades, restarts, and the page hard-reloads onto the new commit.
- [ ] Update button is disabled while an op is running / robot connected.
- [ ] Dev checkout shows no commit line / banner (updater no-ops).
- [ ] `uv tool upgrade` failure surfaces an error in the UI instead of hanging.

Made with [Cursor](https://cursor.com)