### PR TITLE
Keep last camera frame in VR feed during brief WebRTC dropouts

### DIFF
--- a/web/app/src/App.tsx
+++ b/web/app/src/App.tsx
@@ -339,6 +339,10 @@ function ImmersiveCameraFeed({ wsRef }: { wsRef: RefObject<WebSocket | null> }) 
   const spinnerMeshRef = useRef<THREE.Mesh>(null)
   const videosRef = useRef<Record<string, HTMLVideoElement>>({})
   const texturesRef = useRef<Record<string, THREE.VideoTexture>>({})
+  // Cameras that have decoded at least one real frame. Used to keep the last
+  // good frame on screen through brief dropouts instead of cutting to
+  // passthrough (see `liveTex`).
+  const shownRef = useRef<Record<string, boolean>>({})
   // The current view mode; only changes on a thumbstick flick (edge), so the
   // operator doesn't have to hold the stick.
   const viewModeRef = useRef<ViewMode>("default")
@@ -365,8 +369,17 @@ function ImmersiveCameraFeed({ wsRef }: { wsRef: RefObject<WebSocket | null> }) 
   // Right-thumbstick click last frame, for rising-edge re-anchor detection.
   const stickClickPrevRef = useRef(false)
 
-  // Wrap each incoming MediaStream in a <video> + VideoTexture, and tear down
-  // textures whose stream has gone away.
+  // Wrap each incoming MediaStream in a <video> + VideoTexture.
+  //
+  // We deliberately do NOT tear down a camera's <video>/texture when its stream
+  // momentarily disappears from `streams`. A `THREE.VideoTexture` keeps the last
+  // decoded frame uploaded on the GPU, so as long as we keep the texture alive
+  // and the plane visible, a brief WebRTC blip (a transient `failed`/`closed`,
+  // a socket swap, or a re-offer — all of which clear `streams` upstream) shows
+  // the frozen last frame instead of cutting to passthrough. When the stream
+  // returns we just re-point the existing <video> at the new MediaStream, so the
+  // texture keeps streaming into the same object with no flash. Textures are
+  // only released on unmount (below).
   useEffect(() => {
     const videos = videosRef.current
     const textures = texturesRef.current
@@ -389,16 +402,6 @@ function ImmersiveCameraFeed({ wsRef }: { wsRef: RefObject<WebSocket | null> }) 
         textures[name] = tex
       }
     }
-    for (const name of Object.keys(textures)) {
-      if (streams[name]) continue
-      textures[name].dispose()
-      delete textures[name]
-      const video = videos[name]
-      if (video) {
-        video.srcObject = null
-        delete videos[name]
-      }
-    }
   }, [streams])
 
   // Release GPU textures / video elements when the feed unmounts.
@@ -408,6 +411,7 @@ function ImmersiveCameraFeed({ wsRef }: { wsRef: RefObject<WebSocket | null> }) 
     return () => {
       for (const tex of Object.values(textures)) tex.dispose()
       for (const video of Object.values(videos)) video.srcObject = null
+      shownRef.current = {}
     }
   }, [])
 
@@ -510,11 +514,21 @@ function ImmersiveCameraFeed({ wsRef }: { wsRef: RefObject<WebSocket | null> }) 
 
     const mode = viewModeRef.current
 
-    // A texture is usable only once its <video> has decoded real frames.
+    // A texture is usable once its <video> has decoded at least one real frame.
+    // Once that's happened we keep returning it (the texture still holds that
+    // last frame on the GPU) even if `videoWidth` momentarily reads 0 during a
+    // stall or stream reconnect — that's what stops the feed from flickering to
+    // passthrough and back. It only becomes unusable again if the texture itself
+    // is gone (i.e. on unmount).
     const liveTex = (name: string) => {
       const t = textures[name]
-      const v = t?.image as HTMLVideoElement | undefined
-      return t && v && v.videoWidth ? t : undefined
+      if (!t) return undefined
+      const v = t.image as HTMLVideoElement | undefined
+      if (v && v.videoWidth) {
+        shownRef.current[name] = true
+        return t
+      }
+      return shownRef.current[name] ? t : undefined
     }
 
     // Which cams the current mode needs decoded before it draws (otherwise the

--- a/web/app/src/App.tsx
+++ b/web/app/src/App.tsx
@@ -415,6 +415,27 @@ function ImmersiveCameraFeed({ wsRef }: { wsRef: RefObject<WebSocket | null> }) 
     }
   }, [])
 
+  // Fully release the cameras when the XR session ends. This component stays
+  // mounted across sessions, and we intentionally keep the last frame through
+  // *in-session* dropouts (see the `[streams]` effect), but a session end is a
+  // clean teardown: without this, the sticky textures/videos/shownRef would
+  // survive and a later re-entry would treat last session's frozen GPU frames
+  // as live (hiding the connecting spinner) until fresh tracks arrive.
+  useEffect(() => {
+    if (session) return
+    const videos = videosRef.current
+    const textures = texturesRef.current
+    for (const name of Object.keys(textures)) {
+      textures[name].dispose()
+      delete textures[name]
+    }
+    for (const name of Object.keys(videos)) {
+      videos[name].srcObject = null
+      delete videos[name]
+    }
+    shownRef.current = {}
+  }, [session])
+
   // Confine the stereo eye planes to their lens via three.js layers: an object
   // on layer 1 renders to the left eye only, layer 2 to the right eye only.
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Fixes the VR camera "jitter" where the feed briefly cuts to passthrough and back. The cause is client-side, not the network: a transient WebRTC `failed`/`closed`, a socket swap, or a re-offer clears the `streams` map upstream, which tore down the `VideoTexture` and flipped the feed group invisible until the stream re-attached (with an extra blank gap while the fresh `<video>` reported `videoWidth === 0`).
- Stop destroying a camera's `<video>`/`VideoTexture` when its stream momentarily disappears. The texture keeps its last decoded frame on the GPU, so the headset shows the frozen frame instead of flashing to passthrough. When the stream returns, the existing `<video>` is re-pointed at the new `MediaStream` (no flash). Textures are still released on unmount.
- Make `liveTex` sticky: once a camera has decoded at least one real frame, keep returning its texture even if `videoWidth` momentarily reads 0 during a stall/reconnect, so visibility (and the "Connecting cameras…" spinner) no longer flips.

## Trade-off
If a camera is genuinely removed mid-session (not just a blip), its last frame stays frozen rather than disappearing. For this teleop app the camera set is fixed per session, so freezing-on-last-frame is the desired behavior. A grace timer to eventually clear after a real outage could be added if needed.

## Test plan
- `tsc -b app` passes; `eslint src/App.tsx` is clean.
- In a VR session, induce a brief WebRTC blip / re-offer and confirm the feed holds the last frame instead of flashing to passthrough, then resumes live frames on recovery.

Made with [Cursor](https://cursor.com)