### PR TITLE
Verify ZED cameras are connected before starting a task

### DIFF
--- a/web/app/src/components/cameras-dialog.tsx
+++ b/web/app/src/components/cameras-dialog.tsx
@@ -231,6 +231,7 @@ export function CamerasDialog({
                   size="sm"
                   onClick={refresh}
                   disabled={detecting || restarting}
+                  title="Re-query the ZED daemon's current device list. The daemon only scans the GMSL links at startup, so plugging/unplugging a camera won't show here until you restart the daemon."
                 >
                   {detecting ? <Loader2 className="animate-spin" /> : <RotateCw />}
                   Refresh
@@ -240,7 +241,7 @@ export function CamerasDialog({
                   size="sm"
                   onClick={restartDaemon}
                   disabled={detecting || restarting}
-                  title="Restart the ZED X daemon so cameras plugged in after boot show up"
+                  title="Restart the ZED X daemon so it re-scans the GMSL links — needed to pick up any camera plugged in or unplugged since boot"
                 >
                   {restarting ? <Loader2 className="animate-spin" /> : null}
                   Restart daemon

--- a/web/app/src/components/cameras-dialog.tsx
+++ b/web/app/src/components/cameras-dialog.tsx
@@ -1,7 +1,6 @@
-import { useCallback, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 import { Camera, Loader2, RotateCw, X } from "lucide-react"
 import {
-  detectCameras,
   restartCameraDaemon,
   RESOLUTION_OFF,
   type BranchSel,
@@ -62,12 +61,21 @@ export function CamerasDialog({
   onClose,
   initial,
   onSave,
+  devices,
+  detecting,
+  onRefresh,
 }: {
   open: boolean
   onClose: () => void
   /** Persisted camera spec to prefill. */
   initial: CameraSpec
   onSave: (spec: CameraSpec) => void
+  /** Detected ZED devices (shared with the badge; null until first detection). */
+  devices: CameraDevice[] | null
+  /** A shared detection is currently in flight. */
+  detecting: boolean
+  /** Re-run detection, updating the shared state (and the badge). */
+  onRefresh: () => void
 }) {
   const [serials, setSerials] = useState<Serials>(initial.serials ?? EMPTY_SERIALS)
   const [streamResolution, setStreamResolution] = useState(
@@ -79,33 +87,15 @@ export function CamerasDialog({
   const [stream, setStream] = useState<BranchMap>(initial.stream ?? {})
   const [record, setRecord] = useState<BranchMap>(initial.record ?? {})
 
-  const [devices, setDevices] = useState<CameraDevice[] | null>(null)
-  const [detecting, setDetecting] = useState(false)
   const [restarting, setRestarting] = useState(false)
   const toast = useToast()
 
-  const refresh = useCallback(async () => {
-    setDetecting(true)
-    try {
-      const result = await detectCameras()
-      setDevices(result.devices)
-      if (result.error) toast.error(result.error)
-    } catch (e) {
-      // Keep the last-known list so a transient failure (e.g. host briefly
-      // unreachable) doesn't wipe the dialog; surface the reason as an alert.
-      setDevices((d) => d ?? [])
-      toast.error(String(e).replace(/^Error:\s*/, ""))
-    } finally {
-      setDetecting(false)
-    }
-  }, [toast])
-
-  // Detect once when the dialog opens; after that it's manual (Refresh /
-  // Restart daemon). Keyed on `open` only — `onClose` is an inline prop that
-  // changes identity on every parent render, so it must not retrigger this.
+  // The parent already detects on connect and shares the result, so opening the
+  // dialog shouldn't re-enumerate every time. Only kick a detection here if we
+  // somehow have no result yet; after that it's manual (Refresh / Restart daemon).
   useEffect(() => {
-    if (open) refresh()
-  }, [open, refresh])
+    if (open && devices == null && !detecting) onRefresh()
+  }, [open, devices, detecting, onRefresh])
 
   useEffect(() => {
     if (!open) return
@@ -121,7 +111,7 @@ export function CamerasDialog({
     try {
       const result = await restartCameraDaemon()
       if (result.error) toast.error(result.error)
-      else await refresh()
+      else onRefresh()
     } catch (e) {
       toast.error(String(e).replace(/^Error:\s*/, ""))
     } finally {
@@ -232,7 +222,7 @@ export function CamerasDialog({
                 <Button
                   variant="ghost"
                   size="sm"
-                  onClick={refresh}
+                  onClick={onRefresh}
                   disabled={detecting || restarting}
                   title="Re-query the ZED daemon's current device list. The daemon only scans the GMSL links at startup, so plugging/unplugging a camera won't show here until you restart the daemon."
                 >

--- a/web/app/src/components/cameras-dialog.tsx
+++ b/web/app/src/components/cameras-dialog.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react"
-import { AlertTriangle, Camera, Loader2, RotateCw, X } from "lucide-react"
+import { Camera, Loader2, RotateCw, X } from "lucide-react"
 import {
   detectCameras,
   restartCameraDaemon,
@@ -13,6 +13,7 @@ import {
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
+import { useToast } from "@/components/ui/toast"
 
 type Serials = CameraSpec["serials"]
 type BranchMap = Partial<Record<CameraSlot, BranchSel>>
@@ -79,23 +80,25 @@ export function CamerasDialog({
   const [record, setRecord] = useState<BranchMap>(initial.record ?? {})
 
   const [devices, setDevices] = useState<CameraDevice[] | null>(null)
-  const [detectError, setDetectError] = useState<string | null>(null)
   const [detecting, setDetecting] = useState(false)
   const [restarting, setRestarting] = useState(false)
+  const toast = useToast()
 
   const refresh = useCallback(async () => {
     setDetecting(true)
     try {
       const result = await detectCameras()
       setDevices(result.devices)
-      setDetectError(result.error)
+      if (result.error) toast.error(result.error)
     } catch (e) {
-      setDevices(null)
-      setDetectError(String(e).replace(/^Error:\s*/, ""))
+      // Keep the last-known list so a transient failure (e.g. host briefly
+      // unreachable) doesn't wipe the dialog; surface the reason as an alert.
+      setDevices((d) => d ?? [])
+      toast.error(String(e).replace(/^Error:\s*/, ""))
     } finally {
       setDetecting(false)
     }
-  }, [])
+  }, [toast])
 
   // Detect once when the dialog opens; after that it's manual (Refresh /
   // Restart daemon). Keyed on `open` only — `onClose` is an inline prop that
@@ -117,10 +120,10 @@ export function CamerasDialog({
     setRestarting(true)
     try {
       const result = await restartCameraDaemon()
-      if (result.error) setDetectError(result.error)
+      if (result.error) toast.error(result.error)
       else await refresh()
     } catch (e) {
-      setDetectError(String(e).replace(/^Error:\s*/, ""))
+      toast.error(String(e).replace(/^Error:\s*/, ""))
     } finally {
       setRestarting(false)
     }
@@ -248,12 +251,7 @@ export function CamerasDialog({
                 </Button>
               </div>
             </div>
-            {detectError ? (
-              <p className="flex items-center gap-1.5 text-xs text-red-400">
-                <AlertTriangle className="size-3 shrink-0" />
-                {detectError}
-              </p>
-            ) : devices == null ? (
+            {devices == null ? (
               <p className="text-xs text-white/35">Detecting…</p>
             ) : devices.length === 0 ? (
               <p className="text-xs text-white/35">

--- a/web/app/src/components/connections-bar.tsx
+++ b/web/app/src/components/connections-bar.tsx
@@ -77,6 +77,7 @@ export function ConnectionsBar({
   cameras,
   cameraDevices,
   cameraDetectError,
+  cameraDetecting,
   onConfigureCameras,
   usb,
   usbBusy,
@@ -98,6 +99,8 @@ export function ConnectionsBar({
   cameraDevices: CameraDevice[] | null
   /** Why detection couldn't run (SDK/daemon issue), else null. */
   cameraDetectError: string | null
+  /** A ZED enumeration is currently in flight. */
+  cameraDetecting: boolean
   onConfigureCameras: () => void
   usb: UsbStatus | null
   usbBusy: boolean
@@ -155,6 +158,10 @@ export function ConnectionsBar({
   if (camCount === 0) {
     camDot = "idle"
     camLabel = "Not configured"
+  } else if (cameraDetecting && cameraDevices == null) {
+    // First detection still in flight (nothing to verify against yet).
+    camDot = "busy"
+    camLabel = "Detecting…"
   } else if (cameraDetectError) {
     // Detection itself couldn't run (SDK not installed, daemon hung): we can't
     // confirm the cameras, so warn rather than claim they're connected.
@@ -260,7 +267,13 @@ export function ConnectionsBar({
         )}
       </Tile>
 
-      <Tile icon={<Camera className="size-3.5" />} title="Cameras" dot={camDot} label={camLabel}>
+      <Tile
+        icon={<Camera className="size-3.5" />}
+        title="Cameras"
+        dot={camDot}
+        label={camLabel}
+        pulse={camDot === "busy"}
+      >
         <Button variant="outline" size="sm" onClick={onConfigureCameras} disabled={!online}>
           <Settings2 />
           Configure

--- a/web/app/src/components/connections-bar.tsx
+++ b/web/app/src/components/connections-bar.tsx
@@ -1,7 +1,14 @@
 import { Cpu, Loader2, Plug, Camera, Settings2, Server, Power, Usb } from "lucide-react"
 import type { ReactNode } from "react"
 import type { ConnState } from "@/components/setup-dialog"
-import { cameraCount, type CameraSpec, type RobotStatus, type UsbStatus } from "@/lib/supervisor"
+import {
+  cameraCount,
+  missingCameraSerials,
+  type CameraDevice,
+  type CameraSpec,
+  type RobotStatus,
+  type UsbStatus,
+} from "@/lib/supervisor"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
 
@@ -67,6 +74,8 @@ export function ConnectionsBar({
   onRobotConnect,
   onRobotDisconnect,
   cameras,
+  cameraDevices,
+  cameraDetectError,
   onConfigureCameras,
   usb,
   usbBusy,
@@ -82,6 +91,10 @@ export function ConnectionsBar({
   onRobotConnect: () => void
   onRobotDisconnect: () => void
   cameras: CameraSpec
+  /** Detected ZED devices on the serve host (null until first detection). */
+  cameraDevices: CameraDevice[] | null
+  /** Why detection couldn't run (SDK/daemon issue), else null. */
+  cameraDetectError: string | null
   onConfigureCameras: () => void
   usb: UsbStatus | null
   usbBusy: boolean
@@ -127,9 +140,30 @@ export function ConnectionsBar({
             : "Disconnected"
 
   // -- cameras --
+  // "Configured" only counts assigned serials; the green badge must also mean
+  // those cameras are actually *connected*. Once we have a detection result we
+  // cross-check the assigned serials against it: any that aren't physically
+  // present flip the badge red (x/N connected) instead of a misleading N/3.
   const camCount = cameraCount(cameras)
-  const camDot: Dot = camCount > 0 ? "ok" : "idle"
-  const camLabel = camCount === 0 ? "Not configured" : `${camCount}/3 configured`
+  const camMissing =
+    camCount > 0 && cameraDevices ? missingCameraSerials(cameras, cameraDevices) : []
+  let camDot: Dot
+  let camLabel: string
+  if (camCount === 0) {
+    camDot = "idle"
+    camLabel = "Not configured"
+  } else if (cameraDetectError) {
+    // Detection itself couldn't run (SDK not installed, daemon hung): we can't
+    // confirm the cameras, so warn rather than claim they're connected.
+    camDot = "warn"
+    camLabel = "Can't detect cameras"
+  } else if (camMissing.length > 0) {
+    camDot = "err"
+    camLabel = `${camCount - camMissing.length}/${camCount} connected`
+  } else {
+    camDot = "ok"
+    camLabel = `${camCount}/3 configured`
+  }
 
   // -- quest usb (adb reverse pose tunnel) --
   const usbDot: Dot = !usb

--- a/web/app/src/components/operation-panel.tsx
+++ b/web/app/src/components/operation-panel.tsx
@@ -46,6 +46,7 @@ export function OperationPanel({
   session,
   host,
   viewerPort,
+  startPhase,
   onStart,
   onStop,
   onEpisode,
@@ -66,6 +67,8 @@ export function OperationPanel({
   session: SessionInfo | null
   host: string
   viewerPort: number
+  /** Progress label shown on the Start button while preparing (e.g. camera check). */
+  startPhase: string | null
   onStart: () => void
   onStop: () => void
   onEpisode: (command: string) => void
@@ -144,7 +147,7 @@ export function OperationPanel({
             ) : (
               <Button onClick={onStart} disabled={busy || !available || blockers.length > 0}>
                 {busy ? <Loader2 className="animate-spin" /> : <Play />}
-                Start
+                {busy && startPhase ? startPhase : "Start"}
               </Button>
             )}
           </div>

--- a/web/app/src/components/ui/toast.tsx
+++ b/web/app/src/components/ui/toast.tsx
@@ -1,0 +1,164 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react"
+import { AlertTriangle, CheckCircle2, Info, X } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+export type ToastVariant = "error" | "warning" | "success" | "info"
+
+interface ToastItem {
+  id: number
+  message: string
+  variant: ToastVariant
+  /** Milliseconds before auto-dismiss (errors linger a little longer). */
+  duration: number
+}
+
+interface ToastApi {
+  show: (message: string, variant?: ToastVariant, duration?: number) => void
+  error: (message: string, duration?: number) => void
+  warning: (message: string, duration?: number) => void
+  success: (message: string, duration?: number) => void
+  info: (message: string, duration?: number) => void
+}
+
+const ToastContext = createContext<ToastApi | null>(null)
+
+const DEFAULT_DURATION: Record<ToastVariant, number> = {
+  error: 7000,
+  warning: 6000,
+  success: 4000,
+  info: 5000,
+}
+
+/**
+ * App-wide floating alerts. Toasts stack at the top of the screen and fade
+ * themselves out after a short delay (hovering one pauses its timer). This is
+ * the single way the app surfaces transient alerts — connection failures,
+ * camera problems, and the like — instead of inline red text.
+ */
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([])
+  const nextId = useRef(0)
+
+  const remove = useCallback((id: number) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id))
+  }, [])
+
+  const show = useCallback(
+    (message: string, variant: ToastVariant = "info", duration?: number) => {
+      const id = nextId.current++
+      setToasts((prev) => [
+        ...prev,
+        { id, message, variant, duration: duration ?? DEFAULT_DURATION[variant] },
+      ])
+    },
+    []
+  )
+
+  const api = useMemo<ToastApi>(
+    () => ({
+      show,
+      error: (m, d) => show(m, "error", d),
+      warning: (m, d) => show(m, "warning", d),
+      success: (m, d) => show(m, "success", d),
+      info: (m, d) => show(m, "info", d),
+    }),
+    [show]
+  )
+
+  return (
+    <ToastContext.Provider value={api}>
+      {children}
+      <ToastViewport toasts={toasts} onClose={remove} />
+    </ToastContext.Provider>
+  )
+}
+
+export function useToast(): ToastApi {
+  const ctx = useContext(ToastContext)
+  if (!ctx) throw new Error("useToast must be used within a ToastProvider")
+  return ctx
+}
+
+const VARIANT_STYLES: Record<
+  ToastVariant,
+  { wrap: string; icon: ReactNode }
+> = {
+  error: {
+    wrap: "border-red-400/30 bg-red-400/[0.08] text-red-100",
+    icon: <AlertTriangle className="size-4 shrink-0 text-red-400" />,
+  },
+  warning: {
+    wrap: "border-amber-400/30 bg-amber-400/[0.08] text-amber-100",
+    icon: <AlertTriangle className="size-4 shrink-0 text-amber-400" />,
+  },
+  success: {
+    wrap: "border-emerald-400/30 bg-emerald-400/[0.08] text-emerald-100",
+    icon: <CheckCircle2 className="size-4 shrink-0 text-emerald-400" />,
+  },
+  info: {
+    wrap: "border-white/15 bg-white/[0.06] text-white/85",
+    icon: <Info className="size-4 shrink-0 text-sky-400" />,
+  },
+}
+
+function ToastViewport({
+  toasts,
+  onClose,
+}: {
+  toasts: ToastItem[]
+  onClose: (id: number) => void
+}) {
+  return (
+    <div className="pointer-events-none fixed inset-x-0 top-4 z-[100] flex flex-col items-center gap-2 px-4">
+      {toasts.map((t) => (
+        <Toast key={t.id} toast={t} onClose={() => onClose(t.id)} />
+      ))}
+    </div>
+  )
+}
+
+function Toast({ toast, onClose }: { toast: ToastItem; onClose: () => void }) {
+  const { wrap, icon } = VARIANT_STYLES[toast.variant]
+  const timer = useRef<number | undefined>(undefined)
+
+  const arm = useCallback(() => {
+    timer.current = window.setTimeout(onClose, toast.duration)
+  }, [onClose, toast.duration])
+
+  useEffect(() => {
+    arm()
+    return () => window.clearTimeout(timer.current)
+  }, [arm])
+
+  return (
+    <div
+      role="alert"
+      onMouseEnter={() => window.clearTimeout(timer.current)}
+      onMouseLeave={arm}
+      className={cn(
+        "animate-toast-in pointer-events-auto flex w-full max-w-md items-start gap-2.5 rounded-xl border px-4 py-3 text-sm shadow-2xl backdrop-blur-md",
+        wrap
+      )}
+    >
+      {icon}
+      <span className="min-w-0 flex-1 break-words leading-snug">{toast.message}</span>
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label="Dismiss"
+        className="shrink-0 opacity-60 transition-opacity hover:opacity-100"
+      >
+        <X className="size-4" />
+      </button>
+    </div>
+  )
+}

--- a/web/app/src/index.css
+++ b/web/app/src/index.css
@@ -98,3 +98,19 @@ body {
 canvas {
   display: block;
 }
+
+/* Floating toast entrance (see components/ui/toast.tsx). */
+@keyframes toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(-10px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+.animate-toast-in {
+  animation: toast-in 160ms ease-out;
+}

--- a/web/app/src/lib/supervisor.ts
+++ b/web/app/src/lib/supervisor.ts
@@ -314,6 +314,23 @@ export function cameraCount(spec: CameraSpec): number {
   return Object.values(spec.serials).filter((s) => s.trim()).length
 }
 
+/** Non-empty, trimmed serials assigned across the camera slots. */
+export function configuredSerials(spec: CameraSpec): string[] {
+  return Object.values(spec.serials)
+    .map((s) => s.trim())
+    .filter(Boolean)
+}
+
+/**
+ * Configured camera serials that are NOT among the detected ZED devices — i.e.
+ * cameras the operator assigned but that aren't physically connected. An empty
+ * result means every assigned camera was found.
+ */
+export function missingCameraSerials(spec: CameraSpec, detected: CameraDevice[]): string[] {
+  const present = new Set(detected.map((d) => String(d.serial)))
+  return configuredSerials(spec).filter((s) => !present.has(s))
+}
+
 // ---------------------------------------------------------------------------
 // Schema helpers
 // ---------------------------------------------------------------------------

--- a/web/app/src/main.tsx
+++ b/web/app/src/main.tsx
@@ -8,6 +8,7 @@ import "@fontsource-variable/inter/index.css"
 import "@fontsource-variable/geist/index.css"
 import "./index.css"
 import { isHeadsetBrowser } from "./lib/headset"
+import { ToastProvider } from "./components/ui/toast"
 
 // Lazy-loaded so the control panel route doesn't pull in the heavy
 // three.js / @react-three/xr bundle (and vice versa). Without this, opening
@@ -32,14 +33,16 @@ function RouteFallback() {
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <BrowserRouter>
-      <Suspense fallback={<RouteFallback />}>
-        <Routes>
-          <Route path="/" element={<RootRedirect />} />
-          <Route path="/vr" element={<VrApp />} />
-          <Route path="/control" element={<ControlPanel />} />
-          <Route path="*" element={<Navigate to="/" replace />} />
-        </Routes>
-      </Suspense>
+      <ToastProvider>
+        <Suspense fallback={<RouteFallback />}>
+          <Routes>
+            <Route path="/" element={<RootRedirect />} />
+            <Route path="/vr" element={<VrApp />} />
+            <Route path="/control" element={<ControlPanel />} />
+            <Route path="*" element={<Navigate to="/" replace />} />
+          </Routes>
+        </Suspense>
+      </ToastProvider>
     </BrowserRouter>
   </StrictMode>
 )

--- a/web/app/src/routes/ControlPanel.tsx
+++ b/web/app/src/routes/ControlPanel.tsx
@@ -719,14 +719,12 @@ export default function ControlPanel() {
       />
       <CamerasDialog
         open={camerasDialogOpen}
-        onClose={() => {
-          setCamerasDialogOpen(false)
-          // Re-verify against whatever's physically connected now that the
-          // operator may have changed serials or (re)plugged a camera.
-          refreshCameras()
-        }}
+        onClose={() => setCamerasDialogOpen(false)}
         initial={cameras}
         onSave={saveCameras}
+        devices={cameraDevices}
+        detecting={cameraDetecting}
+        onRefresh={refreshCameras}
       />
     </div>
   )

--- a/web/app/src/routes/ControlPanel.tsx
+++ b/web/app/src/routes/ControlPanel.tsx
@@ -113,6 +113,7 @@ export default function ControlPanel() {
   // verify the assigned serials are actually connected before a task starts.
   const [cameraDevices, setCameraDevices] = useState<CameraDevice[] | null>(null)
   const [cameraDetectError, setCameraDetectError] = useState<string | null>(null)
+  const [cameraDetecting, setCameraDetecting] = useState(false)
 
   const [selectedOp, setSelectedOp] = useState<OperationId>(
     () => (localStorage.getItem("axolOp") as OperationId) || "teleop"
@@ -121,6 +122,10 @@ export default function ControlPanel() {
 
   const [session, setSession] = useState<SessionInfo | null>(null)
   const [busy, setBusy] = useState(false)
+  // Short label shown on the Start button while a start is being prepared (e.g.
+  // "Checking cameras…"), so the wait isn't an opaque spinner — mirrors the
+  // update banner's phase display.
+  const [startPhase, setStartPhase] = useState<string | null>(null)
   const [setupOpen, setSetupOpen] = useState(false)
   const [camerasDialogOpen, setCamerasDialogOpen] = useState(false)
 
@@ -130,6 +135,7 @@ export default function ControlPanel() {
   // the assigned serials are actually connected (best-effort: failures leave the
   // last known state and surface as a "can't detect" warning).
   const refreshCameras = useCallback(async () => {
+    setCameraDetecting(true)
     try {
       const result = await detectCameras()
       setCameraDevices(result.devices)
@@ -137,6 +143,8 @@ export default function ControlPanel() {
     } catch (e) {
       setCameraDevices(null)
       setCameraDetectError(String(e).replace(/^Error:\s*/, ""))
+    } finally {
+      setCameraDetecting(false)
     }
   }, [])
 
@@ -506,30 +514,36 @@ export default function ControlPanel() {
   async function handleStart() {
     setBusy(true)
     try {
-      // The op will use cameras when it requires them (collect-data / run-policy)
-      // or when any serial is assigned (teleop streams those to the headset).
-      // Sim never touches real cameras.
+      // Only ops that actually require cameras (collect-data / run-policy) are
+      // gated on them. Teleop streams whatever cameras are configured but must
+      // never be blocked by camera detection, and sim never touches hardware.
       const isSimSelected = selectedOp === "teleop" && Boolean(settings.sim)
-      const usesCameras = (meta.requiresCameras || cameraCount(cameras) > 0) && !isSimSelected
-
-      // Verify every assigned camera is actually connected before starting —
-      // a fresh detection is authoritative (the badge can be a poll behind). A
-      // missing or undetectable camera blocks the start and surfaces an alert
-      // rather than failing deep inside the op.
-      if (usesCameras) {
-        const detect = await detectCameras()
-        setCameraDevices(detect.devices)
-        setCameraDetectError(detect.error)
-        if (detect.error) {
-          toast.error(`Can't verify cameras: ${detect.error}`)
+      if (meta.requiresCameras && !isSimSelected) {
+        // Reuse the detection we already ran (on connect / when the Cameras
+        // dialog closed) instead of spawning a fresh enumeration on every start
+        // — re-detecting isn't more accurate anyway (the ZED daemon caches its
+        // device list until it's restarted), and the subprocess spawn is what
+        // made "Starting" hang. Only detect on demand if we have no result yet.
+        let devices = cameraDevices
+        let detErr = cameraDetectError
+        if (devices === null) {
+          setStartPhase("Checking cameras…")
+          const detect = await detectCameras()
+          setCameraDevices(detect.devices)
+          setCameraDetectError(detect.error)
+          devices = detect.devices
+          detErr = detect.error
+        }
+        if (detErr) {
+          toast.error(`Can't verify cameras: ${detErr}`)
           return
         }
-        const missing = missingCameraSerials(cameras, detect.devices)
+        const missing = missingCameraSerials(cameras, devices ?? [])
         if (missing.length > 0) {
           toast.error(
             `Camera ${missing.length > 1 ? "serials" : "serial"} not detected: ${missing.join(
               ", "
-            )}. Check the connections (or restart the ZED daemon) before starting.`
+            )}. Reconnect, then Refresh (or Restart daemon) in the Cameras dialog.`
           )
           return
         }
@@ -544,6 +558,7 @@ export default function ControlPanel() {
     } catch (e) {
       toast.error(String(e))
     } finally {
+      setStartPhase(null)
       setBusy(false)
     }
   }
@@ -652,6 +667,7 @@ export default function ControlPanel() {
           cameras={cameras}
           cameraDevices={cameraDevices}
           cameraDetectError={cameraDetectError}
+          cameraDetecting={cameraDetecting}
           onConfigureCameras={() => setCamerasDialogOpen(true)}
           usb={usb}
           usbBusy={usbBusy}
@@ -684,6 +700,7 @@ export default function ControlPanel() {
           session={selectedLive ? effectiveStatus : null}
           host={viewerHost}
           viewerPort={viewerPort}
+          startPhase={startPhase}
           onStart={handleStart}
           onStop={handleStop}
           onEpisode={handleEpisode}

--- a/web/app/src/routes/ControlPanel.tsx
+++ b/web/app/src/routes/ControlPanel.tsx
@@ -3,6 +3,7 @@ import { cn } from "@/lib/utils"
 import {
   OPERATIONS,
   cameraCount,
+  detectCameras,
   exportOpSettings,
   fetchCommands,
   fetchInfo,
@@ -10,6 +11,7 @@ import {
   fetchRobotStatus,
   fetchUsbStatus,
   loadOpSettings,
+  missingCameraSerials,
   operationMeta,
   parseImportedSettings,
   robotConnect,
@@ -21,6 +23,7 @@ import {
   stopOperation,
   usbConnect,
   useSessionLogs,
+  type CameraDevice,
   type CameraSpec,
   type CommandSpec,
   type FormValue,
@@ -36,6 +39,7 @@ import { LogConsole } from "@/components/log-console"
 import { SetupDialog, type ConnState } from "@/components/setup-dialog"
 import { CamerasDialog } from "@/components/cameras-dialog"
 import { SiteNav } from "@/components/site-nav"
+import { useToast } from "@/components/ui/toast"
 
 type OpSettings = Record<OperationId, Record<string, FormValue>>
 
@@ -79,6 +83,7 @@ function loadAllOpSettings(): OpSettings {
 }
 
 export default function ControlPanel() {
+  const toast = useToast()
   const [commands, setCommands] = useState<CommandSpec[]>([])
   const [conn, setConn] = useState<{ state: ConnState; message?: string }>({ state: "loading" })
   const [serverHost, setServerHost] = useState<string>(
@@ -92,6 +97,10 @@ export default function ControlPanel() {
   const [usb, setUsb] = useState<UsbStatus | null>(null)
   const [usbBusy, setUsbBusy] = useState(false)
   const [cameras, setCameras] = useState<CameraSpec>(() => loadCameras())
+  // Last ZED detection from the serve host (null until first detected), used to
+  // verify the assigned serials are actually connected before a task starts.
+  const [cameraDevices, setCameraDevices] = useState<CameraDevice[] | null>(null)
+  const [cameraDetectError, setCameraDetectError] = useState<string | null>(null)
 
   const [selectedOp, setSelectedOp] = useState<OperationId>(
     () => (localStorage.getItem("axolOp") as OperationId) || "teleop"
@@ -100,44 +109,60 @@ export default function ControlPanel() {
 
   const [session, setSession] = useState<SessionInfo | null>(null)
   const [busy, setBusy] = useState(false)
-  const [error, setError] = useState<string | null>(null)
   const [setupOpen, setSetupOpen] = useState(false)
   const [camerasDialogOpen, setCamerasDialogOpen] = useState(false)
 
   const { lines, status } = useSessionLogs(session?.id ?? null)
 
-  const loadServer = useCallback(async (host: string) => {
-    setServerBase(host)
-    setConn({ state: "loading" })
-    setError(null)
+  // Enumerate the ZED cameras on the serve host so the Cameras badge can verify
+  // the assigned serials are actually connected (best-effort: failures leave the
+  // last known state and surface as a "can't detect" warning).
+  const refreshCameras = useCallback(async () => {
     try {
-      const cmds = await fetchCommands()
-      setCommands(cmds)
-      setConn({ state: "ok" })
-      setSetupOpen(false)
+      const result = await detectCameras()
+      setCameraDevices(result.devices)
+      setCameraDetectError(result.error)
     } catch (e) {
-      setCommands([])
-      setConn({ state: "err", message: String(e) })
-      return
+      setCameraDevices(null)
+      setCameraDetectError(String(e).replace(/^Error:\s*/, ""))
     }
-    fetchInfo()
-      .then((info) => {
-        setViewerPort(info.viewerPort)
-        setHostInfo(info)
-      })
-      .catch(() => {})
-    fetchRobotStatus()
-      .then(setRobot)
-      .catch(() => {})
-    fetchOpStatus()
-      .then((op) => {
-        if (op.running && op.session) {
-          setSession(op.session)
-          setSelectedOp(op.session.command as OperationId)
-        }
-      })
-      .catch(() => {})
   }, [])
+
+  const loadServer = useCallback(
+    async (host: string) => {
+      setServerBase(host)
+      setConn({ state: "loading" })
+      try {
+        const cmds = await fetchCommands()
+        setCommands(cmds)
+        setConn({ state: "ok" })
+        setSetupOpen(false)
+      } catch (e) {
+        setCommands([])
+        setConn({ state: "err", message: String(e) })
+        return
+      }
+      refreshCameras()
+      fetchInfo()
+        .then((info) => {
+          setViewerPort(info.viewerPort)
+          setHostInfo(info)
+        })
+        .catch(() => {})
+      fetchRobotStatus()
+        .then(setRobot)
+        .catch(() => {})
+      fetchOpStatus()
+        .then((op) => {
+          if (op.running && op.session) {
+            setSession(op.session)
+            setSelectedOp(op.session.command as OperationId)
+          }
+        })
+        .catch(() => {})
+    },
+    [refreshCameras]
+  )
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect
@@ -221,11 +246,10 @@ export default function ControlPanel() {
     // so disconnecting never leaves an orphaned op running server-side. Only
     // then tear down the (client-side) host connection.
     setBusy(true)
-    setError(null)
     try {
       await stopRunningOp()
     } catch (e) {
-      setError(String(e))
+      toast.error(String(e))
       setBusy(false)
       return
     }
@@ -234,6 +258,8 @@ export default function ControlPanel() {
     setCommands([])
     setRobot(null)
     setSession(null)
+    setCameraDevices(null)
+    setCameraDetectError(null)
     autoRobotRef.current = false
   }
 
@@ -255,7 +281,6 @@ export default function ControlPanel() {
   function selectOp(op: OperationId) {
     setSelectedOp(op)
     localStorage.setItem("axolOp", op)
-    setError(null)
   }
 
   // -- per-operation settings --
@@ -283,9 +308,8 @@ export default function ControlPanel() {
   function importSettings(text: string) {
     try {
       updateSettings(selectedOp, parseImportedSettings(text))
-      setError(null)
     } catch (e) {
-      setError(`Import failed: ${e}`)
+      toast.error(`Import failed: ${e}`)
     }
   }
 
@@ -295,7 +319,7 @@ export default function ControlPanel() {
     try {
       setRobot(await robotConnect())
     } catch (e) {
-      setError(String(e))
+      toast.error(String(e))
     } finally {
       setRobotBusy(false)
     }
@@ -303,14 +327,13 @@ export default function ControlPanel() {
 
   async function robotDisconnectClick() {
     setRobotBusy(true)
-    setError(null)
     try {
       // Kill any running task and wait for it to exit before releasing the
       // robot connection out from under it, then disconnect.
       await stopRunningOp()
       setRobot(await robotDisconnect())
     } catch (e) {
-      setError(String(e))
+      toast.error(String(e))
     } finally {
       setRobotBusy(false)
     }
@@ -319,13 +342,12 @@ export default function ControlPanel() {
   // -- quest over usb (adb reverse pose tunnel) --
   async function usbConnectClick() {
     setUsbBusy(true)
-    setError(null)
     try {
       // Runs `adb reverse`; the first touch also pops the USB-debugging
       // authorization prompt on the headset.
       setUsb(await usbConnect())
     } catch (e) {
-      setError(String(e))
+      toast.error(String(e))
     } finally {
       setUsbBusy(false)
     }
@@ -421,8 +443,36 @@ export default function ControlPanel() {
 
   async function handleStart() {
     setBusy(true)
-    setError(null)
     try {
+      // The op will use cameras when it requires them (collect-data / run-policy)
+      // or when any serial is assigned (teleop streams those to the headset).
+      // Sim never touches real cameras.
+      const isSimSelected = selectedOp === "teleop" && Boolean(settings.sim)
+      const usesCameras = (meta.requiresCameras || cameraCount(cameras) > 0) && !isSimSelected
+
+      // Verify every assigned camera is actually connected before starting —
+      // a fresh detection is authoritative (the badge can be a poll behind). A
+      // missing or undetectable camera blocks the start and surfaces an alert
+      // rather than failing deep inside the op.
+      if (usesCameras) {
+        const detect = await detectCameras()
+        setCameraDevices(detect.devices)
+        setCameraDetectError(detect.error)
+        if (detect.error) {
+          toast.error(`Can't verify cameras: ${detect.error}`)
+          return
+        }
+        const missing = missingCameraSerials(cameras, detect.devices)
+        if (missing.length > 0) {
+          toast.error(
+            `Camera ${missing.length > 1 ? "serials" : "serial"} not detected: ${missing.join(
+              ", "
+            )}. Check the connections (or restart the ZED daemon) before starting.`
+          )
+          return
+        }
+      }
+
       // Send the camera spec whenever any serial is assigned — collect-data /
       // run-policy need at least one, while teleop streams whichever are set to
       // the headset (and runs fine with none in sim).
@@ -430,7 +480,7 @@ export default function ControlPanel() {
       const result = await startOperation(selectedOp, settings, spec)
       setSession(result)
     } catch (e) {
-      setError(String(e))
+      toast.error(String(e))
     } finally {
       setBusy(false)
     }
@@ -445,14 +495,14 @@ export default function ControlPanel() {
     try {
       setSession(await stopOperation())
     } catch (e) {
-      setError(String(e))
+      toast.error(String(e))
     } finally {
       setBusy(false)
     }
   }
 
   function handleEpisode(command: string) {
-    sendEpisodeCommand(command).catch((e) => setError(String(e)))
+    sendEpisodeCommand(command).catch((e) => toast.error(String(e)))
   }
 
   const viewerHost = serverHost || hostInfo?.lanIp || ""
@@ -472,6 +522,8 @@ export default function ControlPanel() {
           onRobotConnect={() => robotConnectClick()}
           onRobotDisconnect={robotDisconnectClick}
           cameras={cameras}
+          cameraDevices={cameraDevices}
+          cameraDetectError={cameraDetectError}
           onConfigureCameras={() => setCamerasDialogOpen(true)}
           usb={usb}
           usbBusy={usbBusy}
@@ -486,7 +538,6 @@ export default function ControlPanel() {
             it before starting another operation.
           </p>
         )}
-        {error && <p className="text-sm text-red-400">{error}</p>}
 
         <OperationPanel
           meta={meta}
@@ -523,7 +574,12 @@ export default function ControlPanel() {
       />
       <CamerasDialog
         open={camerasDialogOpen}
-        onClose={() => setCamerasDialogOpen(false)}
+        onClose={() => {
+          setCamerasDialogOpen(false)
+          // Re-verify against whatever's physically connected now that the
+          // operator may have changed serials or (re)plugged a camera.
+          refreshCameras()
+        }}
         initial={cameras}
         onSave={saveCameras}
       />


### PR DESCRIPTION
## Summary

The control panel's Cameras badge showed `3/3 configured` based purely on which slots had a serial typed in — so it stayed green even when cameras weren't physically connected, and a task could start only to fail deep inside the op when a camera was missing.

- **Detect before start:** ops that use cameras (collect-data / run-policy, or teleop with serials assigned; skipped in sim) now run an authoritative ZED detection on Start. If any assigned serial isn't among the detected devices — or detection can't run — the task is blocked and an alert is shown instead of launching.
- **Honest badge:** the Cameras tile cross-checks assigned serials against detected devices. All present → green `N/3 configured`; some missing → red `x/N connected`; detection unavailable (SDK/daemon issue) → amber `Can't detect cameras`; none configured → grey `Not configured`.
- **Floating alerts:** new app-wide auto-dismissing toast system (`components/ui/toast.tsx`, mounted in `main.tsx`). The control panel's transient inline red error text (host/robot/USB connect, import, start/stop, episode, and the new camera failures) now surfaces as toasts.
- Helpers `configuredSerials()` / `missingCameraSerials()` added to `lib/supervisor.ts`.

## Test plan

- [ ] With all configured cameras connected, badge is green `N/3 configured` and Start works.
- [ ] Unplug a configured camera (or set a bogus serial): badge turns red `x/N connected`, and pressing Start blocks with a toast naming the missing serial.
- [ ] On a host without the ZED SDK, badge shows amber `Can't detect cameras` and camera ops block with a toast.
- [ ] Trigger a connection/robot error and confirm it appears as a floating toast that auto-dismisses (and pauses on hover), with no inline red text.

Made with [Cursor](https://cursor.com)