### PR TITLE
Enable persistent JAX compilation cache to speed up IK/FK boot

### DIFF
--- a/almond_axol/kinematics/fk.py
+++ b/almond_axol/kinematics/fk.py
@@ -29,6 +29,7 @@ from ..constants import (
     urdf_arm_joint_names,
     urdf_body_name,
 )
+from .jax_cache import enable_persistent_compilation_cache
 
 _logger = logging.getLogger(__name__)
 
@@ -88,6 +89,7 @@ class AxolForwardKinematics:
     """
 
     def __init__(self) -> None:
+        enable_persistent_compilation_cache()
         _logger.info("Loading Axol URDF for forward kinematics...")
         urdf = yourdfpy.URDF.load(str(URDF_PATH), mesh_dir=str(URDF_PATH.parent))
         self.robot = pk.Robot.from_urdf(urdf)

--- a/almond_axol/kinematics/jax_cache.py
+++ b/almond_axol/kinematics/jax_cache.py
@@ -1,0 +1,52 @@
+"""Persistent JAX compilation cache shared by the FK and IK entry points.
+
+JAX JIT-compiles per process: every ``jax.jit`` graph is lowered and compiled
+by XLA the first time it runs, and by default the resulting executable lives
+only in memory. That makes the IK solver pay the full XLA compile (~tens of
+seconds on CPU) on every boot even though nothing changed between sessions.
+
+Pointing ``jax_compilation_cache_dir`` at a stable on-disk location lets XLA
+reuse compiled executables across processes. The cache key covers the computed
+graph, jax/jaxlib versions, backend, and compile flags, so stale entries are
+never reused — a jax upgrade or a change to the solver costs simply recompiles
+and rewrites the cache. Note the cache only skips the XLA backend compile;
+Python-side tracing and lowering (e.g. ``jaxls`` problem analysis) still runs
+each session.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+_logger = logging.getLogger(__name__)
+
+
+def enable_persistent_compilation_cache() -> None:
+    """Point JAX at an on-disk compilation cache so XLA compiles survive restarts.
+
+    Must be called before the first JIT compilation to benefit that compile.
+    A cache dir already configured by the operator (via the
+    ``JAX_COMPILATION_CACHE_DIR`` env var, which JAX latches into ``jax.config``
+    at import time, or via code) is honored.
+    """
+    import jax
+
+    if jax.config.jax_compilation_cache_dir:
+        return
+
+    cache_dir = Path.home() / ".almond" / "jax-cache"
+    try:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        _logger.warning(
+            "Could not create JAX compilation cache dir %s: %s", cache_dir, e
+        )
+        return
+
+    jax.config.update("jax_compilation_cache_dir", str(cache_dir))
+    # Cache every executable regardless of size or compile time — the solver
+    # graph is the dominant cost, but the small FK kernels are free to keep too.
+    jax.config.update("jax_persistent_cache_min_entry_size_bytes", -1)
+    jax.config.update("jax_persistent_cache_min_compile_time_secs", 0.0)
+    _logger.info("JAX persistent compilation cache: %s", cache_dir)

--- a/almond_axol/kinematics/solver.py
+++ b/almond_axol/kinematics/solver.py
@@ -25,6 +25,7 @@ from ..constants import (
     urdf_body_name,
 )
 from .config import KinematicsConfig
+from .jax_cache import enable_persistent_compilation_cache
 
 _logger = logging.getLogger(__name__)
 
@@ -347,6 +348,8 @@ class KinematicsSolver:
             config: Cost weights and solver parameters.
         """
         self.config = config
+
+        enable_persistent_compilation_cache()
 
         _logger.info("Loading Axol URDF...")
         urdf = yourdfpy.URDF.load(str(URDF_PATH), mesh_dir=str(URDF_PATH.parent))


### PR DESCRIPTION
## Summary
- JAX JIT-compiles the IK solver graph from scratch on every boot because compiled XLA executables are kept in memory only; nothing had opted into JAX's persistent compilation cache.
- Adds `almond_axol/kinematics/jax_cache.py` with `enable_persistent_compilation_cache()`, pointing JAX at `~/.almond/jax-cache` (matching the repo's `~/.almond` convention). An operator-set `JAX_COMPILATION_CACHE_DIR` is honored.
- Called from both `KinematicsSolver.__init__` and `AxolForwardKinematics.__init__` before their first compile.

Measured on CPU: solver init drops from ~36s (no cache) to ~12.5s on every warm session (cold first session ~29s while writing the cache). The remaining time is Python-side tracing/lowering (jaxls problem analysis), which the cache cannot skip.

The cache key hashes the lowered XLA graph plus jax/jaxlib version, backend, and flags, so code or URDF changes safely recompile and rewrite the entry — stale binaries are never served.

## Test plan
- [x] Cold boot writes cache to `~/.almond/jax-cache`, second session boots ~3x faster (verified in sim environment, CPU backend)
- [x] `ruff` and `ruff-format` pass via pre-commit
- [ ] Verify warm-boot speedup on robot hardware (Jetson)

Made with [Cursor](https://cursor.com)