### PR TITLE
Exit VR automatically when the server connection is lost

### DIFF
--- a/web/app/src/App.tsx
+++ b/web/app/src/App.tsx
@@ -1152,6 +1152,21 @@ export default function App() {
   // it over the main WebSocket, which stays as the fallback.
   const { poseChannelRef } = useAxolControlChannel(wsRef, status === AxolConnectionStatus.Open)
 
+  // If the server connection is lost while the headset is presenting (the
+  // socket closes and every reconnect attempt fails → Failed), end the XR
+  // session — the same exit the Y button performs. Without this the operator
+  // is stuck in-headset on a frozen feed or an eternal "Connecting cameras…"
+  // spinner with no way to know the server is gone; ending the session drops
+  // them back to the app, which shows the connection-failed card. Transient
+  // blips are unaffected: the retry loop keeps the session alive unless all
+  // retries are exhausted. (Y itself is no help here — its exit path still
+  // works, but the user doesn't know they need to press it.)
+  useEffect(() => {
+    if (status === AxolConnectionStatus.Failed) {
+      void store.getState().session?.end()
+    }
+  }, [status])
+
   const handleConnect = () => {
     localStorage.setItem("wsHostname", hostname)
     connect()


### PR DESCRIPTION
## Summary
- When the teleop server connection is lost while the headset is presenting, the XR session now ends automatically (same effect as pressing Y), dropping the operator back to the app instead of leaving them stuck on a frozen feed or an eternal "Connecting cameras…" spinner.
- Implemented as an effect in `App.tsx` that ends the session once the connection status reaches the terminal `Failed` state, so transient blips covered by the existing reconnect/retry loop never kick the user out.
- Back in the app, the existing connection-failed card explains that the server is unreachable and offers reconnect.

## Test plan
- [ ] Start `axol teleop`, connect the headset, enter VR, then kill the server: the headset should exit VR within a few seconds and show the "Could not connect" card.
- [ ] Briefly interrupt the network so the socket reconnects within the retry budget: the VR session should stay alive.
- [ ] Verify the Y-button exit still works as before.

Made with [Cursor](https://cursor.com)