### PR TITLE
Fix jetson.setup never actually reaching MAXN

### DIFF
--- a/almond_axol/diagnostics/rom/disable.py
+++ b/almond_axol/diagnostics/rom/disable.py
@@ -13,8 +13,15 @@ grippers (forcing them open and dropping the item) and reset the arm motors.
 Instead it only starts the CAN reader loops and talks to the gripper motors
 directly in raw motor radians, leaving the arms holding their last command.
 
+If ``rom.enable`` was run on a subset of joints (via ``--joints``), pass the
+same ``--joints`` here so only those motors are talked to and disabled. When
+the gripper is not among them there is nothing to release, so this just powers
+the selected motors down.
+
 Run (right after rom.enable, while the motors are still enabled):
     uv run -m almond_axol.diagnostics.rom.disable
+    uv run -m almond_axol.diagnostics.rom.disable --no-left
+    uv run -m almond_axol.diagnostics.rom.disable --joints wrist_1,wrist_2,wrist_3
 """
 
 import argparse
@@ -30,6 +37,27 @@ RATE_HZ = 100.0  # Hz
 OPEN_SPEED = 0.2 * 2 * math.pi  # rad/s — gradual, so the operator can catch the item
 OPEN_MAX_SPEED = 10.0  # rad/s — POSITION_FORCE velocity cap (smoothstep paces it)
 OPEN_TORQUE = 2.0  # Nm — POSITION_FORCE output cap while opening
+
+
+def parse_joints(spec: str | None) -> set[Joint]:
+    """Parse a comma-separated joint spec into a set of present :class:`Joint`.
+
+    ``None`` or empty selects every joint. Names match the joint enum values
+    (e.g. ``shoulder_1``, ``elbow``, ``gripper``).
+    """
+    if not spec:
+        return set(Joint)
+    by_value = {j.value: j for j in Joint}
+    selected: set[Joint] = set()
+    for raw in spec.split(","):
+        name = raw.strip().lower()
+        if not name:
+            continue
+        if name not in by_value:
+            valid = ", ".join(by_value)
+            raise SystemExit(f"Unknown joint '{name}'. Valid joints: {valid}")
+        selected.add(by_value[name])
+    return selected or set(Joint)
 
 
 async def open_gripper(arm: AxolArm, side: str) -> None:
@@ -66,8 +94,35 @@ async def open_gripper(arm: AxolArm, side: str) -> None:
     print(f"  {side} gripper open.")
 
 
-async def run(no_left: bool, no_right: bool) -> None:
-    """Open each gripper sequentially, then disable all motors."""
+async def _disable(axol: Axol, present: set[Joint]) -> None:
+    """Disable the motors and close the buses, limited to the present joints.
+
+    A full set delegates to ``Axol.disable`` (its usual all-motor shutdown);
+    a subset only disables the motors that are actually on the bus so absent
+    ones are not waited on, then closes the buses.
+    """
+    if present == set(Joint):
+        await axol.disable()
+        return
+    tasks = []
+    for arm in (axol.left, axol.right):
+        if arm is not None:
+            tasks.extend(arm.motors[j].disable() for j in present)
+    try:
+        await asyncio.gather(*tasks)
+    except Exception:
+        pass
+    finally:
+        close_tasks = []
+        if axol.left is not None:
+            close_tasks.append(axol._left_bus.close())
+        if axol.right is not None:
+            close_tasks.append(axol._right_bus.close())
+        await asyncio.gather(*close_tasks)
+
+
+async def run(no_left: bool, no_right: bool, present: set[Joint]) -> None:
+    """Open each present gripper sequentially, then disable the present motors."""
     kwargs = {}
     if no_left:
         kwargs["left_channel"] = None
@@ -75,6 +130,7 @@ async def run(no_left: bool, no_right: bool) -> None:
         kwargs["right_channel"] = None
 
     axol = Axol(**kwargs)
+    has_gripper = Joint.GRIPPER in present
 
     # The motors are already enabled and holding (rom.enable left them up); only
     # start the CAN reader loops so we can command them. Do NOT call enable().
@@ -86,38 +142,50 @@ async def run(no_left: bool, no_right: bool) -> None:
     await asyncio.gather(*bus_tasks)
 
     try:
-        targets: list[tuple[str, AxolArm]] = []
-        if axol.right is not None:
-            targets.append(("RIGHT", axol.right))
-        if axol.left is not None:
-            targets.append(("LEFT", axol.left))
+        if has_gripper:
+            targets: list[tuple[str, AxolArm]] = []
+            if axol.right is not None:
+                targets.append(("RIGHT", axol.right))
+            if axol.left is not None:
+                targets.append(("LEFT", axol.left))
 
-        for side, arm in targets:
-            await asyncio.to_thread(
-                input, f"Press Enter to open the {side} gripper ..."
-            )
-            await open_gripper(arm, side)
+            for side, arm in targets:
+                await asyncio.to_thread(
+                    input, f"Press Enter to open the {side} gripper ..."
+                )
+                await open_gripper(arm, side)
 
-        print("\nBoth grippers open — item released.")
+            print("\nGrippers open — item released.")
+        else:
+            print("\nNo gripper in this run — nothing to release.")
     finally:
         print("Disabling motors ...")
-        await axol.disable()
+        await _disable(axol, present)
         print("Motors disabled.")
 
 
 def main() -> None:
     """Parse CLI arguments and run the gripper release routine."""
+    valid_joints = [j.value for j in Joint]
     parser = argparse.ArgumentParser(
         description="Open the grippers from rom.enable and disable the robot."
     )
     parser.add_argument("--no-left", action="store_true", help="Skip the left arm.")
     parser.add_argument("--no-right", action="store_true", help="Skip the right arm.")
+    parser.add_argument(
+        "--joints",
+        default=None,
+        help="Comma-separated joints present on the bus (must match the rom.enable run). "
+        f"Only these are talked to and disabled. Default: all. One of: {', '.join(valid_joints)}.",
+    )
     args = parser.parse_args()
 
     if args.no_left and args.no_right:
         parser.error("Cannot disable both arms.")
 
-    asyncio.run(run(no_left=args.no_left, no_right=args.no_right))
+    present = parse_joints(args.joints)
+
+    asyncio.run(run(no_left=args.no_left, no_right=args.no_right, present=present))
 
 
 if __name__ == "__main__":

--- a/almond_axol/diagnostics/rom/enable.py
+++ b/almond_axol/diagnostics/rom/enable.py
@@ -19,9 +19,11 @@ Select a subset of joints and/or a single arm:
               Skip an arm entirely. Only the remaining arm is opened, enabled,
               and swept. Cannot skip both.
 
-When the gripper is not among the selected joints (or its arm is skipped) the
-run drops the grasp-an-item step and simply loops the range-of-motion sweeps
-for the selected joints.
+The grasp-an-item clamp (hold with force, then soak while holding) only runs on
+the full robot. Any subset run drops the grasp step and simply loops the
+range-of-motion sweeps for the selected joints; if the gripper is one of them it
+is cycled through its full open↔close range like any other joint (holding
+nothing, at the default gentle torque).
 
 Run:
     uv run -m almond_axol.diagnostics.rom.enable
@@ -494,6 +496,7 @@ async def run_rom_cycle(
     present: set[Joint] = FULL_JOINT_SET,
     run_left: bool = True,
     run_right: bool = True,
+    sweep_gripper: bool = False,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Sweep the selected joints through their ranges on the selected arms.
 
@@ -501,6 +504,10 @@ async def run_rom_cycle(
     current value. ``run_left`` / ``run_right`` gate which arm each mirrored
     sweep drives. Pre-poses that reposition a helper joint (shoulder_1 before
     shoulder_3, elbow before the wrists) are skipped when that joint is absent.
+
+    When ``sweep_gripper`` is set the gripper is cycled through its full
+    open↔close range at the end (holding nothing). This is left off for a
+    full-robot grasp run, where the gripper is instead clamped on the item.
     """
     arm_sel = "both" if run_left and run_right else ("left" if run_left else "right")
 
@@ -612,6 +619,14 @@ async def run_rom_cycle(
     if elbow_prepose:
         await step(Joint.ELBOW, 0.0, 0.0)
 
+    # Gripper full range of motion (normalized 1 = open, 0 = closed). Only when
+    # not grasping an item; the position-force controller caps speed and torque,
+    # so closing on nothing simply drives gently to the closed stop.
+    if sweep_gripper and Joint.GRIPPER in present:
+        print(f"  GRIPPER     ({arm_sel})  open ↔ close")
+        await step(Joint.GRIPPER, 0.0, 0.0)
+        await step(Joint.GRIPPER, 1.0, 1.0)
+
     return left_q, right_q
 
 
@@ -660,6 +675,11 @@ async def run_axol(
     run_left = not no_left
     run_right = not no_right
     has_gripper = Joint.GRIPPER in present
+    # The grasp-an-item clamp (hold with force, soak while holding) only runs on
+    # the full robot. Any subset that includes the gripper instead sweeps it
+    # through its full open↔close range like any other joint (holding nothing).
+    grasp = present == set(Joint)
+    sweep_gripper = has_gripper and not grasp
 
     print("=== ROM TEST — PHYSICAL ROBOT ===")
     print("Make sure the area is clear.")
@@ -676,7 +696,9 @@ async def run_axol(
     print(f"Running {arms_desc}  |  joints: {joints_desc}\n")
 
     config = AxolConfig(left_stiffness=1.0, right_stiffness=1.0)
-    if has_gripper:
+    if grasp:
+        # Raised grasp force is only needed to hold the item; a bare gripper
+        # ROM sweep keeps the default (gentle) torque cap.
         config.left.gripper.torque_limit = GRIPPER_TORQUE_LIMIT
         config.right.gripper.torque_limit = GRIPPER_TORQUE_LIMIT
     axol = Axol(
@@ -696,10 +718,10 @@ async def run_axol(
         assert closed_left_q is not None and closed_right_q is not None
         return closed_left_q.copy(), closed_right_q.copy()
 
-    # Only meaningful when a gripper is holding an item: on a normal soak
-    # completion or Ctrl-C the motors are left enabled so the grasp is kept and
-    # ``rom.disable`` can release it later. Without a gripper in the run there is
-    # nothing to hold, so the motors are always disabled in the finally block.
+    # Only meaningful on a full-robot grasp run, where the gripper is holding an
+    # item: on a normal soak completion or Ctrl-C the motors are left enabled so
+    # the grasp is kept and ``rom.disable`` can release it later. Any subset run
+    # holds nothing, so the motors are always disabled in the finally block.
     keep_enabled = False
 
     try:
@@ -725,9 +747,10 @@ async def run_axol(
         )
         left_q, right_q = ready_left, ready_right
 
-        # Grasp the item only when the gripper is part of the run; a partial run
-        # without it just sweeps the selected joints (see module docstring).
-        if has_gripper:
+        # Grasp the item only on a full-robot run; any subset (including one
+        # that contains the gripper) skips the grasp and sweeps the selected
+        # joints instead (see module docstring).
+        if grasp:
             if run_right:
                 await asyncio.to_thread(
                     input, "Press Enter to close the RIGHT gripper ..."
@@ -773,6 +796,7 @@ async def run_axol(
                 present=present,
                 run_left=run_left,
                 run_right=run_right,
+                sweep_gripper=sweep_gripper,
             )
 
             print(f"\nCycle {cycle} complete.")
@@ -796,10 +820,10 @@ async def run_axol(
             abort_on_collision=True,
         )
 
-        # With a gripper grasping the item, leave the robot holding it with the
+        # On a full-robot grasp run, leave the robot holding the item with the
         # motors enabled; the operator runs rom.disable to open the grippers and
         # retrieve it. Otherwise there is nothing to hold and we disable.
-        keep_enabled = has_gripper
+        keep_enabled = grasp
 
     except CollisionAbort as e:
         print(f"\n⚠  COLLISION ABORT: {e}")
@@ -811,12 +835,12 @@ async def run_axol(
         print("Home reached.")
 
     except (KeyboardInterrupt, asyncio.CancelledError):
-        if has_gripper:
+        if grasp:
             print("\nInterrupted — returning home, keeping the item gripped ...")
         else:
             print("\nInterrupted — returning home ...")
         await return_home(robot)
-        keep_enabled = has_gripper
+        keep_enabled = grasp
 
     finally:
         if keep_enabled:

--- a/almond_axol/diagnostics/rom/enable.py
+++ b/almond_axol/diagnostics/rom/enable.py
@@ -4,20 +4,29 @@ rom.enable
 Range of motion test for the Axol robot. Sweeps every joint through its full
 range while checking each waypoint for self-collision via pyroki.
 
-Pass --robot to select the backend:
-  - sim: launches a viser visualizer at http://localhost:8002 and runs the
-         sweep once. Collisions are skipped with a warning.
-  - axol: enables the motors, eases to home, then prompts to close each
-          gripper onto the item and loops the sweep for two hours. When the
-          soak finishes (or on Ctrl-C) the robot returns home but keeps
-          holding the item with the motors left enabled — run
-          ``almond_axol.diagnostics.rom.disable`` afterwards to open the grippers
-          and retrieve the item. A predicted collision aborts the run, returns
-          the robot home, and disables the motors.
+Enables the motors, eases to home, then prompts to close each gripper onto the
+item and loops the sweep for two hours. When the soak finishes (or on Ctrl-C)
+the robot returns home but keeps holding the item with the motors left enabled
+— run ``almond_axol.diagnostics.rom.disable`` afterwards to open the grippers
+and retrieve the item. A predicted collision aborts the run, returns the robot
+home, and disables the motors.
+
+Select a subset of joints and/or a single arm:
+  --joints    Comma-separated joints present on the CAN bus (e.g.
+              wrist_1,wrist_2,wrist_3). Only these motors are enabled and
+              swept; every other joint is left untouched at home. Default: all.
+  --no-left / --no-right
+              Skip an arm entirely. Only the remaining arm is opened, enabled,
+              and swept. Cannot skip both.
+
+When the gripper is not among the selected joints (or its arm is skipped) the
+run drops the grasp-an-item step and simply loops the range-of-motion sweeps
+for the selected joints.
 
 Run:
-    uv run -m almond_axol.diagnostics.rom.enable --robot sim
-    uv run -m almond_axol.diagnostics.rom.enable --robot axol
+    uv run -m almond_axol.diagnostics.rom.enable
+    uv run -m almond_axol.diagnostics.rom.enable --no-right
+    uv run -m almond_axol.diagnostics.rom.enable --joints wrist_1,wrist_2,wrist_3
 """
 
 import argparse
@@ -31,8 +40,9 @@ import numpy as np
 import pyroki as pk
 import yourdfpy
 
-from ...constants import URDF_PATH, Joint
+from ...constants import ARM_JOINTS, CAN_LEFT, CAN_RIGHT, URDF_PATH, Joint
 from ...kinematics.solver import _LEFT_JOINT_NAMES, _RIGHT_JOINT_NAMES
+from ...motor import ControlMode
 from ...robot.axol import (
     ELBOW_LEFT_LIMITS,
     ELBOW_RIGHT_LIMITS,
@@ -41,15 +51,11 @@ from ...robot.axol import (
     SHOULDER_2_LEFT_LIMITS,
     SHOULDER_2_RIGHT_LIMITS,
     Axol,
+    AxolArm,
 )
 from ...robot.config import AxolConfig
-from ...robot.sim import Sim
 
 CONTROL_RATE_HZ = 100.0  # Hz
-
-SIM_SPEED = 3.0  # rad/s
-SIM_PRE_POSE_SPEED = 0.8  # rad/s
-SIM_WAYPOINT_PAUSE = 0.5  # seconds
 
 AXOL_SPEED = 1.0  # rad/s
 AXOL_PRE_POSE_SPEED = 0.3  # rad/s
@@ -74,6 +80,37 @@ GRIPPER_SPEED = 1.0  # normalized [0, 1] per second — open/close speed
 
 JOINT_INDEX: dict[Joint, int] = {j: i for i, j in enumerate(Joint)}
 NUM_JOINTS = len(list(Joint))
+
+FULL_JOINT_SET: frozenset[Joint] = frozenset(Joint)
+
+
+def parse_joints(spec: str | None) -> set[Joint]:
+    """Parse a comma-separated joint spec into a set of present :class:`Joint`.
+
+    ``None`` or empty selects every joint. Names match the joint enum values
+    (e.g. ``shoulder_1``, ``elbow``, ``gripper``).
+    """
+    if not spec:
+        return set(Joint)
+    by_value = {j.value: j for j in Joint}
+    selected: set[Joint] = set()
+    for raw in spec.split(","):
+        name = raw.strip().lower()
+        if not name:
+            continue
+        if name not in by_value:
+            valid = ", ".join(by_value)
+            raise SystemExit(f"Unknown joint '{name}'. Valid joints: {valid}")
+        selected.add(by_value[name])
+    return selected or set(Joint)
+
+
+def _joint_frame(arm: AxolArm, idx: int, joint: Joint, raw: float) -> float:
+    """Convert a raw motor-frame reading to the public joint-frame value."""
+    if joint == Joint.GRIPPER:
+        gi = arm._gripper_i
+        return (raw - arm._limits_hi[gi]) / (arm._limits_lo[gi] - arm._limits_hi[gi])
+    return raw + float(arm._joint_offsets[idx])
 
 
 class CollisionChecker:
@@ -130,8 +167,139 @@ def home_pose() -> np.ndarray:
     return np.zeros(NUM_JOINTS, dtype=np.float32)
 
 
+class HardwareController:
+    """Motion facade over :class:`Axol` that restricts commands to a joint subset.
+
+    Presents the same ``enable`` / ``disable`` / ``get_positions`` /
+    ``motion_control`` surface the ROM cycle drives on both backends, but only
+    ever touches the joints in ``present`` on hardware. When ``present`` is the
+    full joint set this delegates straight to :class:`Axol` so a normal run
+    keeps its full feedforward stack and max-step safety check; otherwise absent
+    motors are never enabled, commanded, or read (so they may be off the bus).
+    """
+
+    def __init__(self, axol: Axol, present: set[Joint]) -> None:
+        self._axol = axol
+        self._present = set(present)
+        self._full = self._present == set(Joint)
+
+    def _arms(self) -> list[AxolArm]:
+        return [a for a in (self._axol.left, self._axol.right) if a is not None]
+
+    async def enable(self) -> None:
+        if self._full:
+            await self._axol.enable()
+            return
+        bus_tasks = []
+        if self._axol.left is not None:
+            bus_tasks.append(self._axol._left_bus.start())
+        if self._axol.right is not None:
+            bus_tasks.append(self._axol._right_bus.start())
+        await asyncio.gather(*bus_tasks)
+        await asyncio.gather(*[self._enable_arm(a) for a in self._arms()])
+
+    async def _enable_arm(self, arm: AxolArm) -> None:
+        motors = [arm.motors[j] for j in self._present]
+        await asyncio.gather(*[m.enable() for m in motors])
+        await asyncio.gather(
+            *[m.set_control_mode(ControlMode.IMPEDANCE) for m in motors]
+        )
+        if Joint.GRIPPER in self._present:
+            await arm._calibrate_gripper()
+            await arm.motors[Joint.GRIPPER].set_control_mode(ControlMode.POSITION_FORCE)
+
+    async def disable(self) -> None:
+        if self._full:
+            await self._axol.disable()
+            return
+        tasks = []
+        for arm in self._arms():
+            tasks.extend(arm.motors[j].disable() for j in self._present)
+        try:
+            await asyncio.gather(*tasks)
+        except Exception:
+            pass
+        finally:
+            close_tasks = []
+            if self._axol.left is not None:
+                close_tasks.append(self._axol._left_bus.close())
+            if self._axol.right is not None:
+                close_tasks.append(self._axol._right_bus.close())
+            await asyncio.gather(*close_tasks)
+
+    async def get_positions(self) -> tuple[np.ndarray, np.ndarray]:
+        """Current positions as (left, right); an absent arm reports home."""
+        left = (
+            await self._read_arm(self._axol.left)
+            if self._axol.left is not None
+            else home_pose()
+        )
+        right = (
+            await self._read_arm(self._axol.right)
+            if self._axol.right is not None
+            else home_pose()
+        )
+        return left, right
+
+    async def _read_arm(self, arm: AxolArm) -> np.ndarray:
+        if self._full:
+            return await arm.get_positions()
+        q = home_pose()
+        for i, j in enumerate(Joint):
+            if j in self._present:
+                q[i] = _joint_frame(arm, i, j, await arm.motors[j].get_position())
+        return q
+
+    async def motion_control(
+        self,
+        left: np.ndarray | None = None,
+        right: np.ndarray | None = None,
+    ) -> None:
+        if self._full:
+            await self._axol.motion_control(left=left, right=right)
+            return
+        tasks = []
+        if left is not None and self._axol.left is not None:
+            tasks.append(self._command_arm(self._axol.left, left))
+        if right is not None and self._axol.right is not None:
+            tasks.append(self._command_arm(self._axol.right, right))
+        if tasks:
+            await asyncio.gather(*tasks)
+
+    async def _command_arm(self, arm: AxolArm, q: np.ndarray) -> None:
+        """Gravity-compensated impedance hold for the present arm joints, plus a
+        position-force command to the gripper when it is present."""
+        q = q.copy()
+        arm_q = q[: len(ARM_JOINTS)].astype(np.float32)
+        gravity = arm._gravity_comp.gravity_arm(arm_q, is_left=arm._is_left)
+        offsets = arm._joint_offsets
+        tasks = []
+        for i, j in enumerate(ARM_JOINTS):
+            if j not in self._present:
+                continue
+            gains = getattr(arm._arm_config, j.value)
+            tasks.append(
+                arm.motors[j].set_impedance(
+                    float(q[i] - offsets[i]), 0.0, gains.kp, gains.kd, float(gravity[i])
+                )
+            )
+        if Joint.GRIPPER in self._present:
+            gi = arm._gripper_i
+            gripper_pos = arm._limits_hi[gi] + float(q[gi]) * (
+                arm._limits_lo[gi] - arm._limits_hi[gi]
+            )
+            tasks.append(
+                arm.motors[Joint.GRIPPER].set_position_force(
+                    gripper_pos,
+                    arm._arm_config.gripper.max_speed,
+                    arm._arm_config.gripper.torque_limit,
+                )
+            )
+        await asyncio.gather(*tasks)
+
+
 async def move_grippers(
-    robot: Axol | Sim,
+    robot: Axol | HardwareController,
     left_q: np.ndarray,  # rad
     right_q: np.ndarray,  # rad
     left_grip: float,  # normalized [0, 1] — 0 closed, 1 open
@@ -169,7 +337,7 @@ async def move_grippers(
 
 
 async def sweep_to_target(
-    robot: Axol | Sim,
+    robot: Axol | HardwareController,
     checker: CollisionChecker,
     left_q: np.ndarray,  # rad
     right_q: np.ndarray,  # rad
@@ -215,7 +383,7 @@ async def sweep_to_target(
 
 
 async def sweep_unchecked(
-    robot: Axol | Sim,
+    robot: Axol | HardwareController,
     left_q: np.ndarray,  # rad
     right_q: np.ndarray,  # rad
     left_target: np.ndarray,  # rad
@@ -253,7 +421,7 @@ def with_joint(
 
 
 async def sweep_joint_range(
-    robot: Axol | Sim,
+    robot: Axol | HardwareController,
     checker: CollisionChecker,
     left_q: np.ndarray,  # rad
     right_q: np.ndarray,  # rad
@@ -314,7 +482,7 @@ async def sweep_joint_range(
 
 
 async def run_rom_cycle(
-    robot: Axol | Sim,
+    robot: Axol | HardwareController,
     checker: CollisionChecker,
     left_q: np.ndarray,  # rad
     right_q: np.ndarray,  # rad
@@ -323,255 +491,131 @@ async def run_rom_cycle(
     pause: float,  # seconds
     abort_on_collision: bool,
     shoulder3_mirror: bool,
+    present: set[Joint] = FULL_JOINT_SET,
+    run_left: bool = True,
+    run_right: bool = True,
 ) -> tuple[np.ndarray, np.ndarray]:
-    # Shoulder_1 limits are mirrored across arms: the right arm's range is the
-    # negation of the left's, so sweep both arms simultaneously in mirror.
-    s1_left_low, s1_left_high = SHOULDER_1_LEFT_LIMITS
-    print(
-        f"  SHOULDER_1  (both, mirrored)  "
-        f"[{round(s1_left_high, 3)}, {round(s1_left_low, 3)}] → 0"
-    )
-    for value in (s1_left_high, s1_left_low, 0.0):
+    """Sweep the selected joints through their ranges on the selected arms.
+
+    Only joints in ``present`` are moved; every other joint stays at its
+    current value. ``run_left`` / ``run_right`` gate which arm each mirrored
+    sweep drives. Pre-poses that reposition a helper joint (shoulder_1 before
+    shoulder_3, elbow before the wrists) are skipped when that joint is absent.
+    """
+    arm_sel = "both" if run_left and run_right else ("left" if run_left else "right")
+
+    async def step(
+        joint: Joint,
+        left_val: float,  # rad
+        right_val: float,  # rad
+        spd: float = speed,  # rad/s
+    ) -> None:
+        nonlocal left_q, right_q
+        left_target = with_joint(left_q, joint, left_val) if run_left else left_q.copy()
+        right_target = (
+            with_joint(right_q, joint, right_val) if run_right else right_q.copy()
+        )
         left_q, right_q = await sweep_to_target(
             robot,
             checker,
             left_q,
             right_q,
-            with_joint(left_q, Joint.SHOULDER_1, value),
-            with_joint(right_q, Joint.SHOULDER_1, -value),
+            left_target,
+            right_target,
+            spd,
+            pause,
+            abort_on_collision,
+        )
+
+    # Shoulder_1 limits are mirrored across arms: the right arm's range is the
+    # negation of the left's, so sweep both arms simultaneously in mirror.
+    if Joint.SHOULDER_1 in present:
+        s1_left_low, s1_left_high = SHOULDER_1_LEFT_LIMITS
+        print(
+            f"  SHOULDER_1  ({arm_sel}, mirrored)  "
+            f"[{round(s1_left_high, 3)}, {round(s1_left_low, 3)}] → 0"
+        )
+        for value in (s1_left_high, s1_left_low, 0.0):
+            await step(Joint.SHOULDER_1, value, -value)
+
+    if Joint.SHOULDER_2 in present:
+        _, right_high = SHOULDER_2_RIGHT_LIMITS
+        left_low, _ = SHOULDER_2_LEFT_LIMITS
+        print(
+            f"  SHOULDER_2  ({arm_sel})  → [{round(left_low, 3)}, {round(right_high, 3)}] → 0"
+        )
+        await step(Joint.SHOULDER_2, left_low, right_high)
+        await step(Joint.SHOULDER_2, 0.0, 0.0)
+
+    if Joint.SHOULDER_3 in present:
+        # The forward pre-pose uses shoulder_1; skip it when shoulder_1 is
+        # absent and sweep shoulder_3 in place instead.
+        s3_prepose = Joint.SHOULDER_1 in present
+        if s3_prepose:
+            print(
+                f"  SHOULDER_3 pre-pose: arms forward "
+                f"{round(math.degrees(SHOULDER_PRE_POSE_ANGLE), 1)}°"
+            )
+            await step(
+                Joint.SHOULDER_1,
+                -SHOULDER_PRE_POSE_ANGLE,
+                SHOULDER_PRE_POSE_ANGLE,
+                pre_pose_speed,
+            )
+        low, high = LIMITS[Joint.SHOULDER_3]
+        print(f"  SHOULDER_3  ({arm_sel} fwd)  [{round(low, 3)}, {round(high, 3)}] → 0")
+        shoulder3_left_low = low if shoulder3_mirror else -low
+        shoulder3_left_high = high if shoulder3_mirror else -high
+        await step(Joint.SHOULDER_3, shoulder3_left_low, -low)
+        await step(Joint.SHOULDER_3, shoulder3_left_high, -high)
+        await step(Joint.SHOULDER_3, 0.0, 0.0)
+        if s3_prepose:
+            await step(Joint.SHOULDER_1, 0.0, 0.0, pre_pose_speed)
+
+    if Joint.ELBOW in present:
+        _, elbow_left_high = ELBOW_LEFT_LIMITS
+        elbow_right_low, _ = ELBOW_RIGHT_LIMITS
+        print(
+            f"  ELBOW       ({arm_sel})  "
+            f"[{round(elbow_right_low, 3)}, {round(elbow_left_high, 3)}] → 0"
+        )
+        await step(Joint.ELBOW, elbow_left_high, elbow_right_low)
+        await step(Joint.ELBOW, 0.0, 0.0)
+
+    # The wrists are swept with the elbows bent to 90° so they clear the body;
+    # skip that pre-pose (and its return) when the elbow is off the bus.
+    wrist_joints = [
+        j for j in (Joint.WRIST_1, Joint.WRIST_2, Joint.WRIST_3) if j in present
+    ]
+    elbow_prepose = Joint.ELBOW in present and bool(wrist_joints)
+    if elbow_prepose:
+        print("  Pre-pose: elbows at 90°")
+        await step(Joint.ELBOW, +WRIST_TEST_ELBOW_ANGLE, -WRIST_TEST_ELBOW_ANGLE)
+
+    for wrist in wrist_joints:
+        low, high = LIMITS[wrist]
+        label = f"{wrist.value.replace('_', ' ').upper():<11} ({arm_sel})"
+        left_q, right_q = await sweep_joint_range(
+            robot,
+            checker,
+            left_q,
+            right_q,
+            wrist,
+            arm_sel,
+            [high, low],
+            label,
             speed,
             pause,
             abort_on_collision,
         )
 
-    _, right_high = SHOULDER_2_RIGHT_LIMITS
-    left_low, _ = SHOULDER_2_LEFT_LIMITS
-    print(f"  SHOULDER_2  (both)  → [{round(left_low, 3)}, {round(right_high, 3)}] → 0")
-    left_q, right_q = await sweep_to_target(
-        robot,
-        checker,
-        left_q,
-        right_q,
-        with_joint(left_q, Joint.SHOULDER_2, left_low),
-        with_joint(right_q, Joint.SHOULDER_2, right_high),
-        speed,
-        pause,
-        abort_on_collision,
-    )
-    left_q, right_q = await sweep_to_target(
-        robot,
-        checker,
-        left_q,
-        right_q,
-        with_joint(left_q, Joint.SHOULDER_2, 0.0),
-        with_joint(right_q, Joint.SHOULDER_2, 0.0),
-        speed,
-        pause,
-        abort_on_collision,
-    )
-
-    print(
-        f"  SHOULDER_3 pre-pose: arms forward {round(math.degrees(SHOULDER_PRE_POSE_ANGLE), 1)}°"
-    )
-    left_q, right_q = await sweep_to_target(
-        robot,
-        checker,
-        left_q,
-        right_q,
-        with_joint(left_q, Joint.SHOULDER_1, -SHOULDER_PRE_POSE_ANGLE),
-        with_joint(right_q, Joint.SHOULDER_1, SHOULDER_PRE_POSE_ANGLE),
-        pre_pose_speed,
-        pause,
-        abort_on_collision,
-    )
-    low, high = LIMITS[Joint.SHOULDER_3]
-    print(f"  SHOULDER_3  (both fwd)  [{round(low, 3)}, {round(high, 3)}] → 0")
-    shoulder3_left_low = low if shoulder3_mirror else -low
-    shoulder3_left_high = high if shoulder3_mirror else -high
-    left_q, right_q = await sweep_to_target(
-        robot,
-        checker,
-        left_q,
-        right_q,
-        with_joint(left_q, Joint.SHOULDER_3, shoulder3_left_low),
-        with_joint(right_q, Joint.SHOULDER_3, -low),
-        speed,
-        pause,
-        abort_on_collision,
-    )
-    left_q, right_q = await sweep_to_target(
-        robot,
-        checker,
-        left_q,
-        right_q,
-        with_joint(left_q, Joint.SHOULDER_3, shoulder3_left_high),
-        with_joint(right_q, Joint.SHOULDER_3, -high),
-        speed,
-        pause,
-        abort_on_collision,
-    )
-    left_q, right_q = await sweep_to_target(
-        robot,
-        checker,
-        left_q,
-        right_q,
-        with_joint(left_q, Joint.SHOULDER_3, 0.0),
-        with_joint(right_q, Joint.SHOULDER_3, 0.0),
-        speed,
-        pause,
-        abort_on_collision,
-    )
-    left_q, right_q = await sweep_to_target(
-        robot,
-        checker,
-        left_q,
-        right_q,
-        with_joint(left_q, Joint.SHOULDER_1, 0.0),
-        with_joint(right_q, Joint.SHOULDER_1, 0.0),
-        pre_pose_speed,
-        pause,
-        abort_on_collision,
-    )
-
-    _, elbow_left_high = ELBOW_LEFT_LIMITS
-    elbow_right_low, _ = ELBOW_RIGHT_LIMITS
-    print(
-        f"  ELBOW       (both)  [{round(elbow_right_low, 3)}, {round(elbow_left_high, 3)}] → 0"
-    )
-    left_q, right_q = await sweep_to_target(
-        robot,
-        checker,
-        left_q,
-        right_q,
-        with_joint(left_q, Joint.ELBOW, elbow_left_high),
-        with_joint(right_q, Joint.ELBOW, elbow_right_low),
-        speed,
-        pause,
-        abort_on_collision,
-    )
-    left_q, right_q = await sweep_to_target(
-        robot,
-        checker,
-        left_q,
-        right_q,
-        with_joint(left_q, Joint.ELBOW, 0.0),
-        with_joint(right_q, Joint.ELBOW, 0.0),
-        speed,
-        pause,
-        abort_on_collision,
-    )
-
-    print("  Pre-pose: elbows at 90°")
-    left_q, right_q = await sweep_to_target(
-        robot,
-        checker,
-        left_q,
-        right_q,
-        with_joint(left_q, Joint.ELBOW, +WRIST_TEST_ELBOW_ANGLE),
-        with_joint(right_q, Joint.ELBOW, -WRIST_TEST_ELBOW_ANGLE),
-        speed,
-        pause,
-        abort_on_collision,
-    )
-
-    low, high = LIMITS[Joint.WRIST_1]
-    left_q, right_q = await sweep_joint_range(
-        robot,
-        checker,
-        left_q,
-        right_q,
-        Joint.WRIST_1,
-        "both",
-        [high, low],
-        "WRIST 1     (both)",
-        speed,
-        pause,
-        abort_on_collision,
-    )
-
-    low, high = LIMITS[Joint.WRIST_2]
-    left_q, right_q = await sweep_joint_range(
-        robot,
-        checker,
-        left_q,
-        right_q,
-        Joint.WRIST_2,
-        "both",
-        [high, low],
-        "WRIST 2     (both)",
-        speed,
-        pause,
-        abort_on_collision,
-    )
-
-    low, high = LIMITS[Joint.WRIST_3]
-    left_q, right_q = await sweep_joint_range(
-        robot,
-        checker,
-        left_q,
-        right_q,
-        Joint.WRIST_3,
-        "both",
-        [high, low],
-        "WRIST 3     (both)",
-        speed,
-        pause,
-        abort_on_collision,
-    )
-
-    left_q, right_q = await sweep_to_target(
-        robot,
-        checker,
-        left_q,
-        right_q,
-        with_joint(left_q, Joint.ELBOW, 0.0),
-        with_joint(right_q, Joint.ELBOW, 0.0),
-        speed,
-        pause,
-        abort_on_collision,
-    )
+    if elbow_prepose:
+        await step(Joint.ELBOW, 0.0, 0.0)
 
     return left_q, right_q
 
 
-async def run_sim() -> None:
-    checker = CollisionChecker()
-
-    sim = Sim()
-    await sim.enable()
-    try:
-        print("=== ROM TEST — simulation ===")
-        print("Viser server running at  http://localhost:8002")
-        print("Open that URL in a browser, then come back here.\n")
-        await asyncio.to_thread(input, "Press Enter to start the ROM sweep ...")
-
-        left_q = home_pose()
-        right_q = home_pose()
-
-        await sim.motion_control(left=left_q, right=right_q)
-        await asyncio.sleep(0.5)
-        print("\nStarting ROM sweep ...\n")
-
-        await run_rom_cycle(
-            sim,
-            checker,
-            left_q,
-            right_q,
-            speed=SIM_SPEED,
-            pre_pose_speed=SIM_PRE_POSE_SPEED,
-            pause=SIM_WAYPOINT_PAUSE,
-            abort_on_collision=False,
-            shoulder3_mirror=True,
-        )
-
-        print("\nROM sweep complete. Robot is at home position.")
-        print("Viser server still running — press Ctrl+C to exit.\n")
-        await asyncio.Event().wait()
-    finally:
-        await sim.disable()
-
-
-async def return_home(robot: Axol) -> None:
+async def return_home(robot: Axol | HardwareController) -> None:
     """Ease the arms back to home from their current pose, keeping the grippers shut.
 
     Used to bring the robot to a safe home position while it stays clamped on
@@ -606,17 +650,42 @@ async def close_buses(robot: Axol) -> None:
     await asyncio.gather(*(bus.close() for bus in buses))
 
 
-async def run_axol() -> None:
+async def run_axol(
+    present: set[Joint] = FULL_JOINT_SET,
+    no_left: bool = False,
+    no_right: bool = False,
+) -> None:
     checker = CollisionChecker()
 
+    run_left = not no_left
+    run_right = not no_right
+    has_gripper = Joint.GRIPPER in present
+
     print("=== ROM TEST — PHYSICAL ROBOT ===")
-    print("Make sure the area is clear.\n")
+    print("Make sure the area is clear.")
+    arms_desc = (
+        "both arms"
+        if run_left and run_right
+        else ("left arm" if run_left else "right arm")
+    )
+    joints_desc = (
+        "all joints"
+        if present == set(Joint)
+        else ", ".join(j.value for j in Joint if j in present)
+    )
+    print(f"Running {arms_desc}  |  joints: {joints_desc}\n")
 
     config = AxolConfig(left_stiffness=1.0, right_stiffness=1.0)
-    config.left.gripper.torque_limit = GRIPPER_TORQUE_LIMIT
-    config.right.gripper.torque_limit = GRIPPER_TORQUE_LIMIT
-    axol = Axol(config=config)
-    await axol.enable()
+    if has_gripper:
+        config.left.gripper.torque_limit = GRIPPER_TORQUE_LIMIT
+        config.right.gripper.torque_limit = GRIPPER_TORQUE_LIMIT
+    axol = Axol(
+        config=config,
+        left_channel=None if no_left else CAN_LEFT,
+        right_channel=None if no_right else CAN_RIGHT,
+    )
+    robot = HardwareController(axol, present)
+    await robot.enable()
     print("Motors enabled.")
     await asyncio.sleep(2.0)
 
@@ -627,9 +696,10 @@ async def run_axol() -> None:
         assert closed_left_q is not None and closed_right_q is not None
         return closed_left_q.copy(), closed_right_q.copy()
 
-    # When True (normal soak completion or Ctrl-C) the motors are left enabled
-    # and the item stays gripped; otherwise (collision / unexpected error) the
-    # motors are disabled in the finally block.
+    # Only meaningful when a gripper is holding an item: on a normal soak
+    # completion or Ctrl-C the motors are left enabled so the grasp is kept and
+    # ``rom.disable`` can release it later. Without a gripper in the run there is
+    # nothing to hold, so the motors are always disabled in the finally block.
     keep_enabled = False
 
     try:
@@ -641,27 +711,38 @@ async def run_axol() -> None:
         # otherwise command home as a single stiff (s=1) impedance setpoint and
         # snap the arms there; sweep_unchecked ramps them in with a smoothstep
         # trajectory instead.
-        cur_left, cur_right = await axol.get_positions()
+        cur_left, cur_right = await robot.get_positions()
         ready_left = home.copy()
         ready_right = home.copy()
-        ready_left[gripper_i] = 1.0
-        ready_right[gripper_i] = 1.0
-        print("Easing to home position (grippers open) ...")
+        if has_gripper:
+            ready_left[gripper_i] = 1.0
+            ready_right[gripper_i] = 1.0
+            print("Easing to home position (grippers open) ...")
+        else:
+            print("Easing to home position ...")
         await sweep_unchecked(
-            axol, cur_left, cur_right, ready_left, ready_right, speed=AXOL_HOME_SPEED
+            robot, cur_left, cur_right, ready_left, ready_right, speed=AXOL_HOME_SPEED
         )
         left_q, right_q = ready_left, ready_right
 
-        await asyncio.to_thread(input, "Press Enter to close the RIGHT gripper ...")
-        left_q, right_q = await move_grippers(
-            axol, left_q, right_q, left_q[gripper_i], 0.0, GRIPPER_SPEED
-        )
-
-        await asyncio.to_thread(input, "Press Enter to close the LEFT gripper ...")
-        left_q, right_q = await move_grippers(
-            axol, left_q, right_q, 0.0, right_q[gripper_i], GRIPPER_SPEED
-        )
-        print("Both grippers closed.")
+        # Grasp the item only when the gripper is part of the run; a partial run
+        # without it just sweeps the selected joints (see module docstring).
+        if has_gripper:
+            if run_right:
+                await asyncio.to_thread(
+                    input, "Press Enter to close the RIGHT gripper ..."
+                )
+                left_q, right_q = await move_grippers(
+                    robot, left_q, right_q, left_q[gripper_i], 0.0, GRIPPER_SPEED
+                )
+            if run_left:
+                await asyncio.to_thread(
+                    input, "Press Enter to close the LEFT gripper ..."
+                )
+                left_q, right_q = await move_grippers(
+                    robot, left_q, right_q, 0.0, right_q[gripper_i], GRIPPER_SPEED
+                )
+            print("Grippers closed.")
 
         closed_left_q = left_q.copy()
         closed_right_q = right_q.copy()
@@ -680,7 +761,7 @@ async def run_axol() -> None:
             left_q, right_q = home_with_grippers_closed()
 
             left_q, right_q = await run_rom_cycle(
-                axol,
+                robot,
                 checker,
                 left_q,
                 right_q,
@@ -689,6 +770,9 @@ async def run_axol() -> None:
                 pause=AXOL_WAYPOINT_PAUSE,
                 abort_on_collision=True,
                 shoulder3_mirror=False,
+                present=present,
+                run_left=run_left,
+                run_right=run_right,
             )
 
             print(f"\nCycle {cycle} complete.")
@@ -701,7 +785,7 @@ async def run_axol() -> None:
         print("Returning to home position ...")
         home_left, home_right = home_with_grippers_closed()
         left_q, right_q = await sweep_to_target(
-            axol,
+            robot,
             checker,
             left_q,
             right_q,
@@ -712,23 +796,27 @@ async def run_axol() -> None:
             abort_on_collision=True,
         )
 
-        # Leave the robot holding the item with the motors enabled. The operator
-        # runs rom.disable to open the grippers and retrieve the item.
-        keep_enabled = True
+        # With a gripper grasping the item, leave the robot holding it with the
+        # motors enabled; the operator runs rom.disable to open the grippers and
+        # retrieve it. Otherwise there is nothing to hold and we disable.
+        keep_enabled = has_gripper
 
     except CollisionAbort as e:
         print(f"\n⚠  COLLISION ABORT: {e}")
         print("Returning to home position ...")
         safe_left, safe_right = home_with_grippers_closed()
         await sweep_unchecked(
-            axol, e.left_q, e.right_q, safe_left, safe_right, speed=AXOL_SPEED
+            robot, e.left_q, e.right_q, safe_left, safe_right, speed=AXOL_SPEED
         )
         print("Home reached.")
 
     except (KeyboardInterrupt, asyncio.CancelledError):
-        print("\nInterrupted — returning home, keeping the item gripped ...")
-        await return_home(axol)
-        keep_enabled = True
+        if has_gripper:
+            print("\nInterrupted — returning home, keeping the item gripped ...")
+        else:
+            print("\nInterrupted — returning home ...")
+        await return_home(robot)
+        keep_enabled = has_gripper
 
     finally:
         if keep_enabled:
@@ -739,26 +827,31 @@ async def run_axol() -> None:
                 "grippers and retrieve it."
             )
         else:
-            await axol.disable()
+            await robot.disable()
             print("Motors disabled.")
 
 
 def main() -> None:
+    valid_joints = [j.value for j in Joint]
     parser = argparse.ArgumentParser(
         description="Range of motion test for the Axol robot."
     )
     parser.add_argument(
-        "--robot",
-        choices=["axol", "sim"],
-        required=True,
-        help="Robot backend: 'axol' for hardware, 'sim' for visualizer.",
+        "--joints",
+        default=None,
+        help="Comma-separated joints present on the bus (e.g. wrist_1,wrist_2,wrist_3). "
+        f"Only these are enabled and swept. Default: all. One of: {', '.join(valid_joints)}.",
     )
+    parser.add_argument("--no-left", action="store_true", help="Skip the left arm.")
+    parser.add_argument("--no-right", action="store_true", help="Skip the right arm.")
     args = parser.parse_args()
 
-    if args.robot == "sim":
-        asyncio.run(run_sim())
-    else:
-        asyncio.run(run_axol())
+    if args.no_left and args.no_right:
+        parser.error("Cannot skip both arms.")
+
+    present = parse_joints(args.joints)
+
+    asyncio.run(run_axol(present=present, no_left=args.no_left, no_right=args.no_right))
 
 
 if __name__ == "__main__":

--- a/almond_axol/diagnostics/rom/enable.py
+++ b/almond_axol/diagnostics/rom/enable.py
@@ -2,14 +2,13 @@
 rom.enable
 
 Range of motion test for the Axol robot. Sweeps every joint through its full
-range while checking each waypoint for self-collision via pyroki.
+range.
 
 Enables the motors, eases to home, then prompts to close each gripper onto the
 item and loops the sweep for two hours. When the soak finishes (or on Ctrl-C)
 the robot returns home but keeps holding the item with the motors left enabled
 — run ``almond_axol.diagnostics.rom.disable`` afterwards to open the grippers
-and retrieve the item. A predicted collision aborts the run, returns the robot
-home, and disables the motors.
+and retrieve the item.
 
 Select a subset of joints and/or a single arm:
   --joints    Comma-separated joints present on the CAN bus (e.g.
@@ -36,14 +35,9 @@ import asyncio
 import math
 import time
 
-import jax
-import jax.numpy as jnp
 import numpy as np
-import pyroki as pk
-import yourdfpy
 
-from ...constants import ARM_JOINTS, CAN_LEFT, CAN_RIGHT, URDF_PATH, Joint
-from ...kinematics.solver import _LEFT_JOINT_NAMES, _RIGHT_JOINT_NAMES
+from ...constants import ARM_JOINTS, CAN_LEFT, CAN_RIGHT, Joint
 from ...motor import ControlMode
 from ...robot.axol import (
     ELBOW_LEFT_LIMITS,
@@ -113,56 +107,6 @@ def _joint_frame(arm: AxolArm, idx: int, joint: Joint, raw: float) -> float:
         gi = arm._gripper_i
         return (raw - arm._limits_hi[gi]) / (arm._limits_lo[gi] - arm._limits_hi[gi])
     return raw + float(arm._joint_offsets[idx])
-
-
-class CollisionChecker:
-    def __init__(self, margin: float = 0.01) -> None:  # margin in meters
-        print("Loading collision model (pyroki) ...")
-        urdf = yourdfpy.URDF.load(str(URDF_PATH), mesh_dir=str(URDF_PATH.parent))
-        robot = pk.Robot.from_urdf(urdf)
-        robot_collision = pk.collision.RobotCollision.from_urdf(urdf)
-
-        actuated = list(robot.joints.actuated_names)
-        name_to_index = {n: i for i, n in enumerate(actuated)}
-        self.left_indices = [name_to_index[n] for n in _LEFT_JOINT_NAMES]
-        self.right_indices = [name_to_index[n] for n in _RIGHT_JOINT_NAMES]
-        self.num_actuated = robot.joints.num_actuated_joints
-        self.margin = margin
-
-        @jax.jit
-        def check_collision(q: jax.Array) -> jax.Array:
-            return robot_collision.compute_self_collision_distance(robot, q)
-
-        home_distances = np.asarray(
-            check_collision(jnp.zeros(self.num_actuated, dtype=jnp.float32))
-        )
-        self.baseline = float(home_distances.min())
-        self.check_collision = check_collision
-        print(f"Collision model ready. Home baseline: {self.baseline:.4f} m\n")
-
-    def is_safe(
-        self,
-        left_q: np.ndarray,  # rad
-        right_q: np.ndarray,  # rad
-    ) -> tuple[bool, float]:
-        full_q = np.zeros(self.num_actuated, dtype=np.float32)
-        full_q[self.left_indices] = left_q[:7]
-        full_q[self.right_indices] = right_q[:7]
-        distances = np.asarray(self.check_collision(jnp.asarray(full_q)))
-        min_distance = float(distances.min())
-        return min_distance > self.baseline - self.margin, min_distance
-
-
-class CollisionAbort(Exception):
-    def __init__(
-        self,
-        msg: str,
-        left_q: np.ndarray,  # rad
-        right_q: np.ndarray,  # rad
-    ) -> None:
-        super().__init__(msg)
-        self.left_q = left_q
-        self.right_q = right_q
 
 
 def home_pose() -> np.ndarray:
@@ -340,28 +284,13 @@ async def move_grippers(
 
 async def sweep_to_target(
     robot: Axol | HardwareController,
-    checker: CollisionChecker,
     left_q: np.ndarray,  # rad
     right_q: np.ndarray,  # rad
     left_target: np.ndarray,  # rad
     right_target: np.ndarray,  # rad
     speed: float,  # rad/s
     pause: float,  # seconds
-    abort_on_collision: bool,
 ) -> tuple[np.ndarray, np.ndarray]:
-    safe, min_distance = checker.is_safe(left_target, right_target)
-    if not safe:
-        if abort_on_collision:
-            raise CollisionAbort(
-                f"collision detected (min dist {min_distance:.4f} m)",
-                left_q,
-                right_q,
-            )
-        print(
-            f"    ⚠  collision detected (min dist {min_distance:.4f} m) — waypoint skipped"
-        )
-        return left_q, right_q
-
     max_joint_delta = max(
         float(np.max(np.abs(left_target - left_q))),
         float(np.max(np.abs(right_target - right_q))),
@@ -424,7 +353,6 @@ def with_joint(
 
 async def sweep_joint_range(
     robot: Axol | HardwareController,
-    checker: CollisionChecker,
     left_q: np.ndarray,  # rad
     right_q: np.ndarray,  # rad
     joint: Joint,
@@ -433,7 +361,6 @@ async def sweep_joint_range(
     label: str,
     speed: float,  # rad/s
     pause: float,  # seconds
-    abort_on_collision: bool,
     home_value: float = 0.0,  # rad
 ) -> tuple[np.ndarray, np.ndarray]:
     print(f"  {label}  {[round(w, 3) for w in waypoints]} → {round(home_value, 3)}")
@@ -450,14 +377,12 @@ async def sweep_joint_range(
         )
         left_q, right_q = await sweep_to_target(
             robot,
-            checker,
             left_q,
             right_q,
             left_target,
             right_target,
             speed,
             pause,
-            abort_on_collision,
         )
     left_target = (
         with_joint(left_q, joint, home_value)
@@ -471,27 +396,23 @@ async def sweep_joint_range(
     )
     left_q, right_q = await sweep_to_target(
         robot,
-        checker,
         left_q,
         right_q,
         left_target,
         right_target,
         speed,
         pause,
-        abort_on_collision,
     )
     return left_q, right_q
 
 
 async def run_rom_cycle(
     robot: Axol | HardwareController,
-    checker: CollisionChecker,
     left_q: np.ndarray,  # rad
     right_q: np.ndarray,  # rad
     speed: float,  # rad/s
     pre_pose_speed: float,  # rad/s
     pause: float,  # seconds
-    abort_on_collision: bool,
     shoulder3_mirror: bool,
     present: set[Joint] = FULL_JOINT_SET,
     run_left: bool = True,
@@ -524,14 +445,12 @@ async def run_rom_cycle(
         )
         left_q, right_q = await sweep_to_target(
             robot,
-            checker,
             left_q,
             right_q,
             left_target,
             right_target,
             spd,
             pause,
-            abort_on_collision,
         )
 
     # Shoulder_1 limits are mirrored across arms: the right arm's range is the
@@ -604,7 +523,6 @@ async def run_rom_cycle(
         label = f"{wrist.value.replace('_', ' ').upper():<11} ({arm_sel})"
         left_q, right_q = await sweep_joint_range(
             robot,
-            checker,
             left_q,
             right_q,
             wrist,
@@ -613,7 +531,6 @@ async def run_rom_cycle(
             label,
             speed,
             pause,
-            abort_on_collision,
         )
 
     if elbow_prepose:
@@ -670,8 +587,6 @@ async def run_axol(
     no_left: bool = False,
     no_right: bool = False,
 ) -> None:
-    checker = CollisionChecker()
-
     run_left = not no_left
     run_right = not no_right
     has_gripper = Joint.GRIPPER in present
@@ -785,13 +700,11 @@ async def run_axol(
 
             left_q, right_q = await run_rom_cycle(
                 robot,
-                checker,
                 left_q,
                 right_q,
                 speed=AXOL_SPEED,
                 pre_pose_speed=AXOL_PRE_POSE_SPEED,
                 pause=AXOL_WAYPOINT_PAUSE,
-                abort_on_collision=True,
                 shoulder3_mirror=False,
                 present=present,
                 run_left=run_left,
@@ -810,29 +723,18 @@ async def run_axol(
         home_left, home_right = home_with_grippers_closed()
         left_q, right_q = await sweep_to_target(
             robot,
-            checker,
             left_q,
             right_q,
             home_left,
             home_right,
             AXOL_HOME_SPEED,
             AXOL_WAYPOINT_PAUSE,
-            abort_on_collision=True,
         )
 
         # On a full-robot grasp run, leave the robot holding the item with the
         # motors enabled; the operator runs rom.disable to open the grippers and
         # retrieve it. Otherwise there is nothing to hold and we disable.
         keep_enabled = grasp
-
-    except CollisionAbort as e:
-        print(f"\n⚠  COLLISION ABORT: {e}")
-        print("Returning to home position ...")
-        safe_left, safe_right = home_with_grippers_closed()
-        await sweep_unchecked(
-            robot, e.left_q, e.right_q, safe_left, safe_right, speed=AXOL_SPEED
-        )
-        print("Home reached.")
 
     except (KeyboardInterrupt, asyncio.CancelledError):
         if grasp:

--- a/almond_axol/utils/jetson.py
+++ b/almond_axol/utils/jetson.py
@@ -45,6 +45,14 @@ _CPU_GOVERNOR = "performance"
 # Jetson, so the governor and engine pins can reach the real max clocks.
 _MAXN_MODE = "0"
 
+# Where nvpmodel persists the active mode across reboots (``pmode:%.4d``).
+# The nvpmodel boot service runs ``nvpmodel -f /etc/nvpmodel.conf`` with no
+# ``-m``, which reads the mode from this file and applies it — before the GPU
+# golden context exists, so no reboot prompt. Writing the desired mode here is
+# therefore the way to make a mode take effect on the next boot without
+# rebooting now (see :func:`_set_max_power_mode`).
+_NVPMODEL_STATUS = Path("/var/lib/nvpmodel/status")
+
 # Canonical L4T marker present on every Jetson. CPU-governor pinning is gated
 # on Jetson detection so ``jetson.setup`` on a non-Tegra Linux host never
 # touches that machine's system-wide cpufreq governor (engine pinning is
@@ -147,6 +155,19 @@ class _RootEscalator:
         return False, _combine_output(sudo) or detail
 
 
+def _query_power_mode(nvpmodel: str) -> str | None:
+    """Return the mode id ``nvpmodel -q`` reports, or ``None`` when unreadable.
+
+    ``nvpmodel -q`` prints the active mode id on its last non-empty line.
+    """
+    try:
+        query = subprocess.run([nvpmodel, "-q"], capture_output=True, text=True)
+    except OSError:
+        return None
+    lines = [ln.strip() for ln in query.stdout.splitlines() if ln.strip()]
+    return lines[-1] if lines else None
+
+
 def _set_max_power_mode(escalator: _RootEscalator) -> None:
     """Select the MAXN ``nvpmodel`` power mode (uncaps the clock ceiling).
 
@@ -163,33 +184,48 @@ def _set_max_power_mode(escalator: _RootEscalator) -> None:
     if nvpmodel is None:
         _logger.debug("nvpmodel not found; leaving the power mode unchanged")
         return
-    # ``nvpmodel -q`` prints the active mode id on its last non-empty line;
-    # skip the (root-only) switch when it already reports MAXN.
-    try:
-        query = subprocess.run([nvpmodel, "-q"], capture_output=True, text=True)
-        lines = [ln.strip() for ln in query.stdout.splitlines() if ln.strip()]
-        if lines and lines[-1] == _MAXN_MODE:
-            return
-    except OSError:
-        pass
-    # Answer "n" to any confirmation prompt. On some Jetsons switching to MAXN
-    # warns that it needs a reboot and asks to reboot *now* ([y/N]); we must
-    # never reboot the box here -- jetson.setup runs mid-install (over the
-    # operator's SSH session) and at boot, and an in-place reboot would drop
-    # that session and restart the robot. "n" declines the reboot; nvpmodel
-    # still records the pending mode, which applies on the next *natural* reboot
-    # (when the boot service re-pins the clocks). Feeding stdin also stops the
+    # Skip the (root-only) switch when the mode already reports MAXN — either
+    # live, or persisted for the next boot by a previous run (see below).
+    if _query_power_mode(nvpmodel) == _MAXN_MODE:
+        return
+    # Answer "n" to any confirmation prompt. Once the GPU golden context
+    # exists (always, by the time the installer or the boot ExecStartPre gets
+    # here — nvpmodel.service runs earlier in boot), switching to MAXN asks to
+    # reboot *now* (``DO YOU WANT TO REBOOT NOW? enter YES/yes to confirm:``).
+    # We must never reboot the box here -- jetson.setup runs mid-install (over
+    # the operator's SSH session) and at boot, and an in-place reboot would
+    # drop that session and restart the robot. Feeding stdin also stops the
     # interactive `axol jetson.setup` run from blocking on the prompt.
     ok, detail = escalator.run([nvpmodel, "-m", _MAXN_MODE], input_text="n\n")
-    if ok:
+    if _query_power_mode(nvpmodel) == _MAXN_MODE:
         _logger.info("set Jetson power mode to MAXN (nvpmodel -m %s)", _MAXN_MODE)
-    elif "reboot" in detail.lower():
-        _logger.warning(
-            "Jetson power mode MAXN needs a reboot to take effect — declined the "
-            "in-place reboot so this session/robot isn't restarted. It will apply "
-            "on the next reboot (the boot service re-pins the clocks then); the "
-            "engine/CPU pins below still help at the current mode's ceiling.",
-        )
+        return
+    if ok or "reboot" in detail.lower():
+        # Declining the reboot prompt CANCELS the switch — nvpmodel records
+        # nothing, so left alone the mode would never change, on this boot or
+        # any later one. Persist the mode ourselves in nvpmodel's status file:
+        # the boot service applies the mode saved there before the GPU golden
+        # context exists, so MAXN takes effect cleanly on the next *natural*
+        # reboot (and the earlier -q short-circuit keeps re-runs quiet).
+        pending = f"pmode:{int(_MAXN_MODE):04d}"
+        wrote, write_detail = escalator.write(_NVPMODEL_STATUS, pending)
+        if wrote:
+            _logger.warning(
+                "Jetson power mode MAXN needs a reboot to take effect — declined "
+                "the in-place reboot so this session/robot isn't restarted, and "
+                "recorded MAXN in %s so it applies on the next reboot (the boot "
+                "service re-pins the clocks then). The engine/CPU pins below "
+                "still help at the current mode's ceiling.",
+                _NVPMODEL_STATUS,
+            )
+        else:
+            _logger.warning(
+                "Jetson power mode MAXN needs a reboot, and recording it for the "
+                "next boot failed (%s) — fix manually with: sudo nvpmodel -m %s "
+                "(confirm the reboot prompt, or reboot afterwards).",
+                write_detail or "write failed",
+                _MAXN_MODE,
+            )
     else:
         _logger.warning(
             "cannot set the Jetson power mode to MAXN (nvpmodel -m %s failed%s) — "


### PR DESCRIPTION
## Summary

- **Jetson MAXN fix**: `jetson.setup` fed `"n"` to nvpmodel's reboot prompt assuming the pending mode would still be recorded — but declining cancels the mode change entirely, so the box never reached MAXN on any boot. Now when the live switch is refused, we persist `pmode:0000` to `/var/lib/nvpmodel/status` ourselves (the file the nvpmodel boot service applies early in boot, before the GPU golden context exists), so MAXN genuinely takes effect on the next natural reboot. Success is verified by re-querying `nvpmodel -q` instead of trusting the exit code, and the log messages now describe what actually happened.
- Also carries earlier ROM-diagnostics work on this branch: joint/arm subset selection for ROM diagnostics, full gripper-range sweep on subset runs, and removal of collision checking from `rom.enable`.

## Test plan

- [x] `ruff check` / `ruff format --check` pass on the edited module
- [x] Exercised both nvpmodel branches with mocked escalators: reboot-declined writes exactly `pmode:0000` to the status file; a successful live switch performs no status write
- [ ] On a Jetson in a non-MAXN mode: run the installer, confirm the pending-reboot warning, reboot, and verify `nvpmodel -q` reports mode 0

Made with [Cursor](https://cursor.com)