### PR TITLE
Bump package version to 1.0.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "almond-axol"
-version = "0.1.2"
+version = "1.0.3"
 description = "Almond Axol SDK"
 license = { text = "MIT" }
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Bump `almond-axol` package version in `pyproject.toml` from `0.1.2` to `1.0.3`.

## Test plan
- [ ] Verify `pyproject.toml` reports version `1.0.3`
- [ ] Confirm package metadata resolves correctly after install/build


Made with [Cursor](https://cursor.com)