### PR TITLE
Add download-logs button to control panel log console

### DIFF
--- a/web/app/src/components/log-console.tsx
+++ b/web/app/src/components/log-console.tsx
@@ -19,7 +19,7 @@ export function LogConsole({ lines }: { lines: string[] }) {
     const stamp = new Date().toISOString().replace(/[:.]/g, "-")
     const a = document.createElement("a")
     a.href = url
-    a.download = `axol-logs-${stamp}.txt`
+    a.download = `axol-logs-${stamp}.log`
     document.body.appendChild(a)
     a.click()
     a.remove()

--- a/web/app/src/components/log-console.tsx
+++ b/web/app/src/components/log-console.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react"
-import { Terminal } from "lucide-react"
+import { Download, Terminal } from "lucide-react"
+import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { cn } from "@/lib/utils"
 
@@ -12,11 +13,35 @@ export function LogConsole({ lines }: { lines: string[] }) {
     if (el) el.scrollTop = el.scrollHeight
   }, [lines])
 
+  function downloadLogs() {
+    const blob = new Blob([lines.join("\n") + "\n"], { type: "text/plain" })
+    const url = URL.createObjectURL(blob)
+    const stamp = new Date().toISOString().replace(/[:.]/g, "-")
+    const a = document.createElement("a")
+    a.href = url
+    a.download = `axol-logs-${stamp}.txt`
+    document.body.appendChild(a)
+    a.click()
+    a.remove()
+    URL.revokeObjectURL(url)
+  }
+
   return (
     <Card className="min-h-0 flex-1 gap-3 p-0">
       <div className="flex items-center gap-2 border-b border-white/10 px-4 py-3">
         <Terminal className="size-4 text-white/40" />
         <span className="font-heading text-sm font-semibold">Logs</span>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="ml-auto size-7 text-white/30 hover:bg-white/[0.04] hover:text-white/70"
+          onClick={downloadLogs}
+          disabled={lines.length === 0}
+          aria-label="Download logs"
+          title="Download logs"
+        >
+          <Download />
+        </Button>
       </div>
       <div
         ref={scrollRef}


### PR DESCRIPTION
## Summary
- Adds a subtle, icon-only download button to the **Logs** panel header of the web control panel.
- Clicking it exports the currently buffered log lines as a timestamped `.txt` file (`axol-logs-<timestamp>.txt`) generated client-side from the lines already streamed over WebSocket—no backend changes needed.
- The button is disabled when there are no logs, and includes an `aria-label`/tooltip ("Download logs") for accessibility.

## Test plan
- [ ] Run `axol serve` + the web dev server, open `/control`.
- [ ] Confirm the download icon appears in the Logs header, muted until hovered.
- [ ] Confirm it's disabled when there's no log output.
- [ ] Start an operation (e.g. `axol teleop --sim`), then click the button and verify a `axol-logs-*.txt` file downloads containing the visible log lines.

Made with [Cursor](https://cursor.com)