### PR TITLE
Set up dev environment + document sim/web run notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,13 @@ Almond Axol is a Python CLI + SDK for the Almond Axol dual-arm robot. Since no p
 ### Running the application
 
 - **Sim teleop** (the primary way to exercise the app without hardware): `uv run axol teleop --sim`
-  - Opens a viser 3D viewer at `http://localhost:8002` and a VR WebSocket server on port 8000.
+ - Opens a viser 3D viewer at `http://localhost:8002` and a VR WebSocket server on port 8000.
+ - With no VR headset connected the arms just hold the rest pose. To actually drive them, either use the `Sim` SDK directly (`sim.motion_control(left=..., right=...)`, see the `Sim` docstring in `almond_axol/robot/sim.py`) or connect a WebSocket client to `wss://localhost:8000/ws` (self-signed cert — disable TLS verification) and stream `VRFrame` JSON with both `l_lock`/`r_lock` true to engage tracking.
+ - The viser server persists engage/IK state across teleop restarts only within one process; if a WebSocket client leaves tracking engaged and reconnects, restart the `teleop` process for a clean engage.
+
+### Web front-end (second product)
+
+The browser UIs live under `web/` (a Vite + React monorepo: the WebXR `/vr` teleop app and the `/control` panel served by `axol serve`). Node 22 is available; `web/` is **not** covered by `uv sync`. Standard install/build/dev commands are in `web/README.md` (build the `packages/axol-vr-client` workspace before `app`).
 
 ### Linting
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for the Almond Axol SDK, and adds durable, non-obvious run notes to `AGENTS.md` for future agents.

No product code was modified. The only committed change is `AGENTS.md`.

## Environment setup

- **Python**: `uv sync --extra sim` (uv auto-installs the pinned Python 3.13).
- **Lint**: `ruff@0.9.7` (version pinned in `.pre-commit-config.yaml`).
- **Web front-end**: `npm --prefix web install` + workspace builds.

Update script (runs on VM startup):
```
uv sync --extra sim
npm --prefix web install
```

## Verification

| Service | Command | Result |
|---|---|---|
| SDK/CLI lint | `ruff check .` / `ruff format --check .` | pass (117 files) |
| CLI | `uv run axol --help` / `teleop --help` | pass |
| Sim teleop app | `uv run axol teleop --sim` | viser on :8002, VR WS on :8000, 120 Hz control loop; a synthetic VR client engaged tracking and drove the full WebSocket → IK → control pipeline (vr ~78 Hz, ik ~108 Hz) |
| Web build | `npm run build --workspace=packages/axol-vr-client` then `--workspace=app` | pass |

Hello-world: drove the `Sim` robot via `motion_control` and confirmed the dual arms animate live in the viser viewer.

[axol_sim_robot_motion.mp4](https://cursor.com/agents/bc-d1db208c-5ea5-4f0c-87f1-045561f2bedc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faxol_sim_robot_motion.mp4)

[Axol dual-arm robot in viser viewer](https://cursor.com/agents/bc-d1db208c-5ea5-4f0c-87f1-045561f2bedc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Faxol_sim_robot_view.webp)

## AGENTS.md changes

- Clarified that sim arms only move when driven (SDK `motion_control` or a WebSocket VR client with both grips locked).
- Noted the teleop engage-state caveat across reconnects.
- Added a short pointer to the `web/` front-end (second product), noting it is not covered by `uv sync`.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1db208c-5ea5-4f0c-87f1-045561f2bedc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1db208c-5ea5-4f0c-87f1-045561f2bedc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

