### PR TITLE
Show episode number in VR HUD during data collection

### DIFF
--- a/almond_axol/cli/collect_data.py
+++ b/almond_axol/cli/collect_data.py
@@ -697,6 +697,9 @@ def _run(cfg: CollectDataConfig, stop_event: "threading.Event | None" = None) ->
     try:
         while not _stopped():
             episode_idx = recorder.episode_count()
+            # Surface the (1-based) episode number in the headset HUD so the
+            # operator can see which episode they're about to record.
+            teleop.send_feedback_episode(episode_idx + 1)
             log_say(
                 f"Episode {episode_idx + 1}: robot is at rest pose. Press record on the VR controller when ready."
             )

--- a/almond_axol/lerobot/teleop/teleop_vr.py
+++ b/almond_axol/lerobot/teleop/teleop_vr.py
@@ -395,6 +395,24 @@ class AxolVRTeleop(Teleoperator):
             self._vr_server.broadcast_text(text), self._loop
         )
 
+    def send_feedback_episode(self, episode: int) -> None:
+        """Broadcast the current episode number to all connected VR clients.
+
+        ``episode`` is the 1-based index of the episode being collected, shown
+        in the in-headset HUD during data collection. Also stored on the server
+        so a headset that connects mid-session picks up the current value on
+        connect. Safe to call from any thread.
+        """
+        if self._vr_server is None or self._loop is None:
+            return
+        # Seed the connect-time announce for late-joining clients, then push the
+        # live update to everyone already connected.
+        self._vr_server.set_episode(episode)
+        text = json.dumps({"type": "episode", "value": episode})
+        asyncio.run_coroutine_threadsafe(
+            self._vr_server.broadcast_text(text), self._loop
+        )
+
     def send_feedback_error(self, timeout: float = 2.0) -> None:
         """Broadcast the error state to all connected VR clients.
 

--- a/almond_axol/vr/server.py
+++ b/almond_axol/vr/server.py
@@ -84,6 +84,13 @@ class VRServer:
         # in its legacy free-toggle behaviour (older backends that never set it).
         self._mode: str | None = None
 
+        # Current episode number to show in the headset HUD during data
+        # collection (the 1-based index of the episode being recorded next).
+        # Broadcast whenever it changes and re-sent to any client that connects
+        # mid-session (see the WebSocket accept handler). ``None`` hides the HUD
+        # readout — the default for plain teleop, which never sets it.
+        self._episode: int | None = None
+
         # The headset streams identical frames (same ``seq``) over both the USB
         # tunnel and the network (WebRTC data channel / WebSocket). We process
         # each ``seq`` once, from whichever transport delivers it first — the
@@ -151,6 +158,17 @@ class VRServer:
         call before :meth:`enable`.
         """
         self._mode = mode
+
+    def set_episode(self, episode: int | None) -> None:
+        """Record the current episode number announced to headsets on connect.
+
+        ``episode`` is the 1-based index shown in the in-headset HUD during data
+        collection; ``None`` hides it. Stored so a client connecting mid-session
+        gets the current value in the WebSocket accept handler — live updates are
+        pushed separately via :meth:`broadcast_text`. Safe to call from any
+        thread (a plain attribute assignment).
+        """
+        self._episode = episode
 
     def set_video_sources(self, sources: dict[str, Any] | None) -> None:
         """Register per-camera video sources to stream to the headset.
@@ -458,6 +476,16 @@ class VRServer:
                     )
                 except Exception as exc:  # noqa: BLE001 - best-effort announce
                     _logger.warning("failed to send mode to client: %s", exc)
+            # Likewise seed the current episode number so a headset joining
+            # mid-session shows the right value immediately, not on the next
+            # episode. Best-effort for the same reason as the mode announce.
+            if server._episode is not None:
+                try:
+                    await websocket.send_text(
+                        json.dumps({"type": "episode", "value": server._episode})
+                    )
+                except Exception as exc:  # noqa: BLE001 - best-effort announce
+                    _logger.warning("failed to send episode to client: %s", exc)
             try:
                 while True:
                     data = await websocket.receive_text()

--- a/web/app/src/App.tsx
+++ b/web/app/src/App.tsx
@@ -933,6 +933,29 @@ function StateDisplay({
   )
 }
 
+// Current episode number, shown top-right just under the recording status
+// during data collection. Null (plain teleop, or before the server announces
+// one) renders nothing.
+function EpisodeDisplay({ episode }: { episode: number | null }) {
+  if (episode === null) return null
+
+  return (
+    <HudText
+      position={[0.2, 0.06, -0.5]}
+      fontSize={0.016}
+      fontWeight="bold"
+      color="white"
+      anchorX="right"
+      anchorY="top"
+      renderOrder={999}
+      material-depthTest={false}
+      {...hudBg}
+    >
+      {`Episode ${episode}`}
+    </HudText>
+  )
+}
+
 function HelpPanel({ onDismiss, mode }: { onDismiss: () => void; mode: AxolMode | null }) {
   const W = 0.44
   const H = 0.133
@@ -1198,6 +1221,9 @@ export default function App() {
   // Operating mode the server locked us to (null until it announces one on
   // connect). Drives which HUD/hint controls are shown.
   const [vrMode, setVrMode] = useState<AxolMode | null>(null)
+  // Current 1-based episode number during data collection (null until the
+  // server announces one; stays null in plain teleop).
+  const [episode, setEpisode] = useState<number | null>(null)
   const { status, connect, disconnect, wsRef } = useAxolVRClient(hostname)
   // Controller poses can ride a wired USB `adb reverse` tunnel (localhost) to
   // avoid WiFi latency; camera video keeps using the LAN host above. The pose
@@ -1416,6 +1442,7 @@ export default function App() {
               onPendingRecording={setRecordingPendingAt}
               onPendingConfirm={setPendingConfirm}
               onMode={setVrMode}
+              onEpisode={setEpisode}
               onExit={() => store.getState().session?.end()}
             />
             <ImmersiveCameraFeed wsRef={wsRef} />
@@ -1423,6 +1450,7 @@ export default function App() {
               <ExitButton />
               <HelpIcon mode={vrMode} />
               <StateDisplay state={vrState} isRecordingPending={recordingPendingAt !== null} />
+              <EpisodeDisplay episode={episode} />
               <CountdownDisplay recordingPendingAt={recordingPendingAt} />
               <ConfirmDisplay action={pendingConfirm} />
             </XRHud>

--- a/web/packages/axol-vr-client/src/AxolVRClient.tsx
+++ b/web/packages/axol-vr-client/src/AxolVRClient.tsx
@@ -96,6 +96,17 @@ export function AxolVRClient({
     const currentWs = wsRef.current
     if (currentWs !== wsWithHandlerRef.current) {
       wsWithHandlerRef.current = currentWs
+      // A new (or dropped) connection invalidates the previous session's
+      // episode number: the HUD readout only advances on a server `episode`
+      // message, and plain teleop never sends one, so without this a prior
+      // collect-data session's number would linger (even into a later teleop
+      // session). Clear it here; a reconnecting collect-data session re-announces
+      // the current episode on connect and repopulates it moments later.
+      // Reset to the -1 "handled" sentinel (dropping any pending value) since we
+      // notify here directly — the frame's apply block is gated behind an active
+      // XR session, but a reconnect commonly happens outside one.
+      serverEpisodeRef.current = -1
+      onEpisode?.(null)
       if (currentWs) {
         currentWs.onmessage = (event: MessageEvent) => {
           try {

--- a/web/packages/axol-vr-client/src/AxolVRClient.tsx
+++ b/web/packages/axol-vr-client/src/AxolVRClient.tsx
@@ -38,6 +38,7 @@ export function AxolVRClient({
   onPendingRecording,
   onPendingConfirm,
   onMode,
+  onEpisode,
   onExit,
 }: {
   wsRef: RefObject<WebSocket | null>
@@ -57,6 +58,9 @@ export function AxolVRClient({
   onPendingConfirm?: (action: ConfirmAction | null) => void
   // Called when the server announces its operating mode (once per connection).
   onMode?: (mode: AxolMode) => void
+  // Called with the current 1-based episode number while collecting data (and
+  // null if the server ever clears it). Drives the in-headset episode readout.
+  onEpisode?: (episode: number | null) => void
   onExit?: () => void
 }) {
   const { gl } = useThree()
@@ -79,6 +83,10 @@ export function AxolVRClient({
   const modeRef = useRef<AxolMode | null>(null)
   // Server-pushed mode announcement, applied at the start of the next frame.
   const serverModeRef = useRef<AxolMode | null>(null)
+  // Server-pushed episode number, applied at the start of the next frame. -1 is
+  // the "unset" sentinel (distinct from a real episode value or an explicit
+  // null the server could send); replaced with the parsed value on each push.
+  const serverEpisodeRef = useRef<number | null | -1>(-1)
   // Track which WebSocket we have attached onmessage to avoid re-attaching.
   const wsWithHandlerRef = useRef<WebSocket | null>(null)
 
@@ -91,11 +99,16 @@ export function AxolVRClient({
       if (currentWs) {
         currentWs.onmessage = (event: MessageEvent) => {
           try {
-            const msg = JSON.parse(event.data as string) as { type: string; value: string }
+            const msg = JSON.parse(event.data as string) as {
+              type: string
+              value: string | number | null
+            }
             if (msg.type === "state") {
               serverStateRef.current = msg.value as AxolState
             } else if (msg.type === "mode") {
               serverModeRef.current = msg.value as AxolMode
+            } else if (msg.type === "episode") {
+              serverEpisodeRef.current = typeof msg.value === "number" ? msg.value : null
             }
           } catch {
             // ignore malformed messages
@@ -155,6 +168,13 @@ export function AxolVRClient({
         setState(AxolState.DataCollection)
       }
       onMode?.(mode)
+    }
+
+    // Surface any server-pushed episode number (purely informational — it
+    // doesn't feed the state machine below).
+    if (serverEpisodeRef.current !== -1) {
+      onEpisode?.(serverEpisodeRef.current)
+      serverEpisodeRef.current = -1
     }
 
     // Apply server-pushed state override before processing button presses.


### PR DESCRIPTION
## Summary
Surfaces the current **1-based episode number** in the in-headset VR HUD while running `axol collect-data`, so the operator can see which episode they're about to record. It flows server → headset over the existing WebSocket, mirroring the established `mode`/`state` message pattern.

## Changes
**Backend (Python)**
- `almond_axol/vr/server.py` — new `_episode` field + `set_episode()`; announces `{"type":"episode","value":N}` on WebSocket connect so a headset joining mid-session gets the current value immediately.
- `almond_axol/lerobot/teleop/teleop_vr.py` — `send_feedback_episode(episode)` seeds `set_episode()` (for late joiners) and broadcasts the live update to connected clients.
- `almond_axol/cli/collect_data.py` — broadcasts `episode_idx + 1` at the top of each episode loop, alongside the existing "Episode N" voice prompt.

**Frontend (TypeScript)**
- `web/packages/axol-vr-client/src/AxolVRClient.tsx` — parses the new `episode` message and exposes an `onEpisode` callback (purely informational; doesn't touch the state machine).
- `web/app/src/App.tsx` — new `EpisodeDisplay` HUD element ("Episode N") shown top-right just under the recording-status indicator; renders nothing in plain teleop or before the server announces one.

## Notes
The HUD shows the episode being recorded **next** (`episode_count + 1`), matching the spoken "Episode N" prompt — not a count of already-saved episodes.

## Testing
- `tsc -b` on the web app passes clean
- eslint clean
- `ruff check` clean on all touched Python files
- prettier formatting matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only HUD and best-effort WebSocket feedback; no changes to recording, robot control, or VR state machine.
> 
> **Overview**
> Adds a **1-based episode readout** in the VR HUD during `axol collect-data`, aligned with the spoken “Episode N” prompt (next episode to record, not saved count).
> 
> **Backend** stores the current episode on `VRServer`, re-sends it on WebSocket connect for late joiners, and broadcasts `{"type":"episode","value":N}` on each episode loop via new `send_feedback_episode` from `collect_data`.
> 
> **Frontend** parses `episode` in `AxolVRClient` (informational only), exposes `onEpisode`, and renders top-right **Episode N** under the status line; hidden in teleop or before the server announces a value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 167d815d7474695bbf840badc727ae55fada4324. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->