### PR TITLE
Recorder pause/resume + frame counts; relay raw_transport=pyshm override

### DIFF
--- a/almond_axol/lerobot/nvenc_encoder.py
+++ b/almond_axol/lerobot/nvenc_encoder.py
@@ -91,6 +91,24 @@ _FEED_QUEUE_MAXSIZE = 90
 _STATS_SAMPLE_HZ = 10
 
 
+# Encoder-dropped frames since the last reset, across all cameras in this
+# process. A dropped frame is never encoded but its dataset row still exists,
+# so the episode's video is silently misaligned with its rows — the recorder
+# resets this at episode start and refuses to save an episode when it is
+# non-zero (see record_proc). Single process, GIL-atomic int updates.
+_EPISODE_DROPPED = {"n": 0}
+
+
+def reset_dropped_frames() -> None:
+    """Zero the per-episode dropped-frame counter (call at episode start)."""
+    _EPISODE_DROPPED["n"] = 0
+
+
+def dropped_frames() -> int:
+    """Encoder-dropped frames since the last reset (0 = episode video intact)."""
+    return _EPISODE_DROPPED["n"]
+
+
 def hw_dataset_encoder_available() -> bool:
     """True when the Jetson NVENC GStreamer encoder is usable."""
     return hw_h264_available()
@@ -247,6 +265,7 @@ class _CameraNvencEncoder:
             self._queue.put_nowait(image)
         except queue.Full:
             self._dropped += 1
+            _EPISODE_DROPPED["n"] += 1
             if self._dropped == 1 or self._dropped % 10 == 0:
                 _logger.warning(
                     "NVENC encoder queue full for %s, dropped %d frame(s).",
@@ -323,7 +342,16 @@ class _CameraNvencEncoder:
             if self._proc is None:
                 self._start(w, h, nv12=False)
             assert self._rgba is not None
-            self._rgba[:, :, :3] = frame
+            # RGB->RGBA pad into the preallocated buffer. Prefer cv2 (SIMD,
+            # releases the GIL) over the strided numpy assignment — the pad
+            # is on the per-frame hot path and its cost decides whether the
+            # feed keeps up with 60 fps.
+            try:
+                import cv2
+
+                cv2.cvtColor(frame, cv2.COLOR_RGB2RGBA, dst=self._rgba)
+            except Exception:  # noqa: BLE001 - fall back to the numpy copy
+                self._rgba[:, :, :3] = frame
             self._write(self._rgba)
             if sample:
                 self._update_stats(frame)

--- a/almond_axol/recording/record_proc.py
+++ b/almond_axol/recording/record_proc.py
@@ -1314,10 +1314,13 @@ class InProcessRecorder:
         return self._dataset.num_episodes
 
     def start_episode(self, task: str) -> None:
+        from ..lerobot.nvenc_encoder import reset_dropped_frames
+
         self._stop_capture()  # defensive: never overlap two capture threads
         self._dataset.clear_episode_buffer()
         self._record.set()
         self._frames["n"] = 0
+        reset_dropped_frames()
         self._stop = threading.Event()
         self._thread = threading.Thread(
             target=run_capture_loop,
@@ -1359,7 +1362,19 @@ class InProcessRecorder:
             self._thread = None
 
     def save_episode(self) -> None:
+        from ..lerobot.nvenc_encoder import dropped_frames
+
         self._stop_capture()
+        n_dropped = dropped_frames()
+        if n_dropped:
+            # Mirrors the recorder subprocess: a dropped frame's row still
+            # exists, so the video is misaligned — never save it silently.
+            self._dataset.clear_episode_buffer()
+            raise RuntimeError(
+                f"{n_dropped} video frame(s) were dropped by the encoder "
+                "(feed queue overflow) — the episode's video is misaligned "
+                "with its rows; episode discarded."
+            )
         self._dataset.save_episode()
         self._episodes_recorded += 1
 
@@ -1513,6 +1528,9 @@ def _recorder_main(
                 capture_error["v"] = None
                 record_event.set()
                 frame_counter["n"] = 0
+                from ..lerobot.nvenc_encoder import reset_dropped_frames
+
+                reset_dropped_frames()
                 stop = threading.Event()
                 loop_kwargs = dict(
                     cameras=cameras,
@@ -1567,8 +1585,26 @@ def _recorder_main(
                 conn.send(("frame_count", frame_counter["n"]))
             elif kind == "save_episode":
                 stop_capture()
+                from ..lerobot.nvenc_encoder import dropped_frames
+
+                n_dropped = dropped_frames()
                 if capture_error["v"] is not None:
                     conn.send(("error", capture_error["v"]))
+                elif n_dropped:
+                    # A dropped frame was never encoded but its row exists, so
+                    # the episode's video is misaligned with its rows (and
+                    # with the other cameras) — refuse to save silently
+                    # corrupted data. The caller should discard and re-record.
+                    dataset.clear_episode_buffer()
+                    conn.send(
+                        (
+                            "error",
+                            f"{n_dropped} video frame(s) were dropped by the "
+                            "encoder (feed queue overflow) — the episode's "
+                            "video is misaligned with its rows; episode "
+                            "discarded. Check recorder-core load.",
+                        )
+                    )
                 else:
                     try:
                         t_save = time.perf_counter()

--- a/almond_axol/recording/record_proc.py
+++ b/almond_axol/recording/record_proc.py
@@ -57,6 +57,9 @@ _READY_TIMEOUT_S = 60.0
 # How long a save_episode (encoder flush + parquet write + post-episode stats)
 # may take.
 _SAVE_TIMEOUT_S = 180.0
+# How long a lightweight episode command (pause/resume/frame_count) may take —
+# these only flip an event / read a counter in the recorder's command thread.
+_CMD_TIMEOUT_S = 10.0
 
 # --- Encoded (relay-side H.264) capture-loop tuning ---
 # How long the first row waits for each camera's first access unit (relay valve
@@ -782,6 +785,8 @@ def run_capture_loop(
     task: str,
     rerun_ip: str | None,
     stop_event: threading.Event,
+    record_event: "threading.Event | None" = None,
+    frame_counter: "dict[str, int] | None" = None,
     on_error: Callable[[str], None] | None = None,
 ) -> None:
     """Capture dataset rows at ``fps`` Hz until ``stop_event`` is set.
@@ -791,6 +796,18 @@ def run_capture_loop(
     joint+action snapshot, and appends one dataset row. A camera read timeout
     reuses the previous frame for that camera (or skips the tick if none yet).
     Any fatal error is reported via ``on_error`` instead of dying silently.
+
+    ``record_event`` (optional) gates mid-episode capture: while cleared the
+    loop idles without appending rows, and on the next set it re-anchors its
+    tick clock to "now" so the dataset's index-based timestamps stay
+    contiguous across the gap — the saved episode plays straight through it.
+    Used by DAgger-style flows that must not record while the robot is frozen
+    between the policy and an operator takeover. ``None`` records
+    unconditionally (the pre-existing behaviour).
+
+    ``frame_counter`` (optional) is a mutable ``{"n": int}`` incremented after
+    every appended row, so the owner can convert instants into dataset time
+    (``n / fps``) — e.g. to annotate intervention spans.
     """
     try:
         from lerobot.utils.constants import ACTION, OBS_STR
@@ -810,7 +827,7 @@ def run_capture_loop(
 
         frame_interval = 1.0 / fps
         timeout_ms = int(2 * frame_interval * 1000 + 200)
-        recording_start = time.perf_counter()
+        recording_start: float | None = None
         last_frames: dict[str, tuple[Any, float, float]] = {}
         tick = 0
 
@@ -819,9 +836,21 @@ def run_capture_loop(
         skip_count = 0
         frames_added = 0
         ticks_window = 0
-        cap_last_log = recording_start
+        cap_last_log = time.perf_counter()
 
         while not stop_event.is_set():
+            if record_event is not None and not record_event.is_set():
+                # Paused: idle without capturing and drop the anchor so the
+                # tick clock re-anchors on resume (no timestamp gap).
+                recording_start = None
+                if stop_event.wait(timeout=0.02):
+                    return
+                continue
+            if recording_start is None:
+                # First tick, or first tick after a resume: anchor so the
+                # current tick's target is "now" and the cadence continues.
+                recording_start = time.perf_counter() - tick * frame_interval
+
             now = time.perf_counter()
             if now - cap_last_log >= 1.0:
                 dt = now - cap_last_log
@@ -893,6 +922,8 @@ def run_capture_loop(
             if stop_event.is_set():
                 return
             dataset.add_frame({**obs_frame, **act_frame, "task": task})
+            if frame_counter is not None:
+                frame_counter["n"] += 1
             frames_added += 1
             tick_cost_sum += time.perf_counter() - body_t0
             ticks_window += 1
@@ -920,9 +951,15 @@ def run_encoded_capture_loop(
     task: str,
     rerun_ip: str | None,
     stop_event: threading.Event,
+    frame_counter: "dict[str, int] | None" = None,
     on_error: Callable[[str], None] | None = None,
 ) -> None:
     """Frame-driven capture for the relay-encoded (gstshm-h264) transport.
+
+    ``frame_counter`` mirrors :func:`run_capture_loop`'s (a mutable
+    ``{"n": int}`` incremented per appended row). There is no ``record_event``
+    on this path: an encoded stream cannot gate mid-episode — every dropped
+    access unit is referenced by later P-frames.
 
     Unlike :func:`run_capture_loop` (real-time paced, *selecting* the camera
     frame nearest each tick and dropping the rest), an encoded stream cannot drop
@@ -1057,6 +1094,8 @@ def run_encoded_capture_loop(
             if stop_event.is_set():
                 return
             dataset.add_frame({**obs_frame, **act_frame, "task": task})
+            if frame_counter is not None:
+                frame_counter["n"] += 1
             rows_added += 1
 
             if rerun_ip:
@@ -1244,6 +1283,10 @@ class InProcessRecorder:
         self._publisher = _SnapshotPublisher()
         self._thread: threading.Thread | None = None
         self._stop: threading.Event | None = None
+        # Mid-episode capture gate + row counter; same semantics as
+        # DatasetRecorderProcess.pause_episode/resume_episode/frame_count.
+        self._record = threading.Event()
+        self._frames: dict[str, int] = {"n": 0}
         self._episodes_recorded = 0
         self._session_start = time.time()
 
@@ -1256,6 +1299,8 @@ class InProcessRecorder:
     def start_episode(self, task: str) -> None:
         self._stop_capture()  # defensive: never overlap two capture threads
         self._dataset.clear_episode_buffer()
+        self._record.set()
+        self._frames["n"] = 0
         self._stop = threading.Event()
         self._thread = threading.Thread(
             target=run_capture_loop,
@@ -1268,11 +1313,27 @@ class InProcessRecorder:
                 task=task,
                 rerun_ip=self._config["rerun_ip"],
                 stop_event=self._stop,
+                record_event=self._record,
+                frame_counter=self._frames,
             ),
             name="axol-capture",
             daemon=True,
         )
         self._thread.start()
+
+    def pause_episode(self) -> int:
+        """Stop capturing mid-episode; returns rows so far. Idempotent."""
+        self._record.clear()
+        return self._frames["n"]
+
+    def resume_episode(self) -> int:
+        """Resume a paused episode (the capture clock re-anchors). Idempotent."""
+        self._record.set()
+        return self._frames["n"]
+
+    def frame_count(self) -> int:
+        """Rows captured in the current episode (dataset time = n / fps)."""
+        return self._frames["n"]
 
     def _stop_capture(self) -> None:
         if self._thread is not None and self._stop is not None:
@@ -1405,6 +1466,12 @@ def _recorder_main(
     stop: threading.Event | None = None
     capture_error: dict[str, str | None] = {"v": None}
     episodes_recorded = 0
+    # Mid-episode capture gate + row counter (see run_capture_loop). The gate
+    # is only supported on the raw transports: pausing the encoded
+    # (gstshm-h264) stream mid-episode would drop access units that later
+    # P-frames reference, corrupting the mp4.
+    record_event = threading.Event()
+    frame_counter: dict[str, int] = {"n": 0}
 
     def stop_capture() -> None:
         nonlocal thread
@@ -1427,26 +1494,60 @@ def _recorder_main(
                 stop_capture()  # defensive: never overlap two capture threads
                 dataset.clear_episode_buffer()
                 capture_error["v"] = None
+                record_event.set()
+                frame_counter["n"] = 0
                 stop = threading.Event()
+                loop_kwargs = dict(
+                    cameras=cameras,
+                    read_snapshot=snap_reader.read_latest,
+                    dataset=dataset,
+                    robot_obs_proc=robot_obs_proc,
+                    fps=config["fps"],
+                    task=task,
+                    rerun_ip=config["rerun_ip"],
+                    stop_event=stop,
+                    on_error=lambda m: capture_error.__setitem__("v", m),
+                )
+                loop_kwargs["frame_counter"] = frame_counter
+                if not encoded_mode:
+                    loop_kwargs["record_event"] = record_event
                 thread = threading.Thread(
                     target=(
                         run_encoded_capture_loop if encoded_mode else run_capture_loop
                     ),
-                    kwargs=dict(
-                        cameras=cameras,
-                        read_snapshot=snap_reader.read_latest,
-                        dataset=dataset,
-                        robot_obs_proc=robot_obs_proc,
-                        fps=config["fps"],
-                        task=task,
-                        rerun_ip=config["rerun_ip"],
-                        stop_event=stop,
-                        on_error=lambda m: capture_error.__setitem__("v", m),
-                    ),
+                    kwargs=loop_kwargs,
                     name="axol-capture",
                     daemon=True,
                 )
                 thread.start()
+            elif kind == "pause_episode":
+                if encoded_mode:
+                    conn.send(
+                        (
+                            "error",
+                            "pause_episode requires a raw transport; the "
+                            "encoded (gstshm-h264) transport can't gate "
+                            "mid-episode.",
+                        )
+                    )
+                else:
+                    record_event.clear()
+                    conn.send(("paused", frame_counter["n"]))
+            elif kind == "resume_episode":
+                if encoded_mode:
+                    conn.send(
+                        (
+                            "error",
+                            "resume_episode requires a raw transport; the "
+                            "encoded (gstshm-h264) transport can't gate "
+                            "mid-episode.",
+                        )
+                    )
+                else:
+                    record_event.set()
+                    conn.send(("resumed", frame_counter["n"]))
+            elif kind == "frame_count":
+                conn.send(("frame_count", frame_counter["n"]))
             elif kind == "save_episode":
                 stop_capture()
                 if capture_error["v"] is not None:
@@ -1543,6 +1644,40 @@ class DatasetRecorderProcess:
     def start_episode(self, task: str) -> None:
         with self._lock:
             self._conn.send(("start_episode", task))
+
+    def _episode_gate(self, command: str, expect: str) -> int:
+        """Send a pause/resume/frame-count command; return the row count.
+
+        The reply's count may lag the capture thread by one in-flight row
+        (the gate is checked at tick boundaries) — a ±1-frame slop that is
+        negligible for annotation spans.
+        """
+        with self._lock:
+            self._conn.send((command,))
+            if not self._conn.poll(_CMD_TIMEOUT_S):
+                raise RuntimeError(f"recorder did not answer {command} in time")
+            msg = self._conn.recv()
+        if msg[0] == expect:
+            return int(msg[1])
+        raise RuntimeError(f"recorder {command} failed: {msg[1]}")
+
+    def pause_episode(self) -> int:
+        """Stop capturing mid-episode (rows + clock gate); returns rows so far.
+
+        Raw transports only — the encoded (gstshm-h264) transport can't gate
+        mid-episode (raises). On resume the capture clock re-anchors, so the
+        episode's index-based timestamps stay contiguous across the gap.
+        Idempotent.
+        """
+        return self._episode_gate("pause_episode", "paused")
+
+    def resume_episode(self) -> int:
+        """Resume a paused episode; returns rows captured so far. Idempotent."""
+        return self._episode_gate("resume_episode", "resumed")
+
+    def frame_count(self) -> int:
+        """Rows captured in the current episode (dataset time = n / fps)."""
+        return self._episode_gate("frame_count", "frame_count")
 
     def save_episode(self) -> None:
         with self._lock:

--- a/almond_axol/recording/record_proc.py
+++ b/almond_axol/recording/record_proc.py
@@ -814,13 +814,27 @@ def run_capture_loop(
         from lerobot.utils.feature_utils import build_dataset_frame
         from lerobot.utils.visualization_utils import log_rerun_data
 
-        # Wait for the first snapshot (the control loop publishes every tick).
-        first_deadline = time.perf_counter() + 5.0
-        while read_snapshot() is None:
+        # Wait for the first snapshot *published after this episode started*.
+        # The snapshot slot is a single latest-wins register that persists
+        # across episodes, so at episode start it can still hold the previous
+        # episode's final snapshot (the control loop may not have published
+        # yet); pairing fresh camera frames with it would write a stale pose
+        # into the episode's opening rows. Snapshot timestamps are
+        # perf_counter values from the publishing process — comparable here
+        # because CLOCK_MONOTONIC is system-wide (the camera-frame pairing
+        # below already relies on this).
+        episode_start = time.perf_counter()
+        first_deadline = episode_start + 5.0
+        while True:
+            snap = read_snapshot()
+            if snap is not None and snap[2] >= episode_start:
+                break
             if stop_event.wait(0.02):
                 return
             if time.perf_counter() > first_deadline:
-                _logger.warning("capture loop saw no snapshot within 5s; exiting.")
+                _logger.warning(
+                    "capture loop saw no fresh snapshot within 5s; exiting."
+                )
                 return
         if stop_event.is_set():
             return
@@ -982,16 +996,19 @@ def run_encoded_capture_loop(
         from lerobot.utils.feature_utils import build_dataset_frame
         from lerobot.utils.visualization_utils import log_rerun_data
 
-        # Wait for the first snapshot (the control loop publishes every tick).
+        # Wait for the first snapshot *published after this episode started* —
+        # the slot persists across episodes, so a stale previous-episode
+        # snapshot must not seed the opening rows (see run_capture_loop).
         # Keep it: rows whose seqlock read later misses reuse the last good one.
-        first_deadline = time.perf_counter() + 5.0
+        episode_start = time.perf_counter()
+        first_deadline = episode_start + 5.0
         last_snap = read_snapshot()
-        while last_snap is None:
+        while last_snap is None or last_snap[2] < episode_start:
             if stop_event.wait(0.02):
                 return
             if time.perf_counter() > first_deadline:
                 _logger.warning(
-                    "encoded capture loop saw no snapshot within 5s; exiting."
+                    "encoded capture loop saw no fresh snapshot within 5s; exiting."
                 )
                 return
             last_snap = read_snapshot()

--- a/almond_axol/video/video_proc.py
+++ b/almond_axol/video/video_proc.py
@@ -165,6 +165,15 @@ def _open_gst_camera_raw(
       :class:`RawFrameWriter` shared-memory block (the older path; runs the copy
       in the relay's interpreter).
 
+    A spec can force the pyshm transport with ``raw_transport: "pyshm"`` even
+    when gst's shm plugin is available: pyshm blocks are readable by the
+    *control* process (``VideoRelayProcess.raw_cameras`` become real
+    :class:`RawFrameReader` proxies instead of dims-only stubs), which callers
+    need when something in the control process must consume the raw frames —
+    e.g. a policy building observations while the recorder subprocess records
+    the same frames. The cost is the relay-side per-frame Python copy this
+    path always had; the encoded headset branch is unaffected.
+
     Returns ``(owned_camera, {track: source}, [writers], {source: meta})`` — where
     ``meta`` is the per-source dict from :func:`_gstshm_meta` / :func:`_pyshm_meta`
     — or ``None`` when the gst stack/camera is unavailable (the caller then falls
@@ -201,7 +210,7 @@ def _open_gst_camera_raw(
         if dw < width or dh < height:
             raw_w, raw_h = dw, dh
     raw_dims = (raw_w, raw_h)
-    use_shm = socket_dir is not None
+    use_shm = socket_dir is not None and spec.get("raw_transport") != "pyshm"
     # A camera can opt out of either branch: stream-only (no raw / dataset) or
     # record-only (no encoded / headset). This path is only entered when the
     # camera records (see _relay_main), so the raw branch is always built; the


### PR DESCRIPTION
## Summary

Two features for DAgger-style collection (a Pi-hosted policy driving the robot with VR operator interventions, built in the private `axol-pi` repo): the control process must **consume raw camera frames** (policy observations) while the recorder subprocess records the same frames, and recording must **gate mid-episode** (nothing may be recorded while the robot is frozen between the policy and an operator takeover). Both are generic recording/relay capabilities — nothing DAgger- or Pi-specific lands here.

### 1. Relay: per-camera `raw_transport: "pyshm"` spec override (`video_proc.py`)

On gst-shm hosts the relay's raw/dataset branch is only consumable by a recorder subprocess — `VideoRelayProcess.raw_cameras` are dims-only stubs that raise on read. A camera spec can now force the raw branch onto the **pyshm transport** even when gst's shm plugin is available: the control process gets real `RawFrameReader` proxies over the shared-memory blocks, and the recorder consumes pyshm end-to-end already (`RawFrameReader` + NVENC RGB feed). Cost: the relay-side per-frame Python copy this path always had, on the relay's cores. Default behavior (gst-shm preferred) is unchanged.

### 2. Recorder: `pause_episode` / `resume_episode` / `frame_count` (`record_proc.py`)

`run_capture_loop` gains an optional `record_event` gate and a `frame_counter`:

- While the gate is cleared the loop idles without appending rows; on resume it **re-anchors its tick clock to "now"**, so the episode's index-based timestamps stay contiguous across the gap — the saved episode plays straight through it.
- The counter converts instants into dataset time (`rows / fps`), e.g. for annotating intervention spans.

`DatasetRecorderProcess` and `InProcessRecorder` both expose the three methods (same interface, per this module's single-path design). The encoded (gstshm-h264) transport rejects the gate — dropped access units are referenced by later P-frames — but supports the counter.

## Testing

- Threaded test of the gate against fake cameras: 26 rows captured → **0 during a 0.5 s pause** → 25 rows in the 0.5 s after resume (correct 50 fps re-anchor), with the counter matching `add_frame` calls exactly.
- Validated end-to-end on the robot via `axol-pi collect-dagger` (pinned to this branch): a 2-episode DAgger dataset audits clean — every inter-frame timestamp delta exactly 1/60 s including across frozen gaps, all 3 videos frame-for-frame equal to the parquet rows (true 60 fps), and intervention spans (from the row counts) strictly within episode boundaries.
- Control-process rates with this architecture on the Jetson: policy loop ~59 Hz, teleop ~117 Hz — the in-process alternative peaked at ~20/~40 Hz and starved the CAN bus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live capture timing and IPC episode commands on the recording hot path; encoded transport behavior is explicitly restricted, but misuse of pause/resume or transport choice could affect dataset continuity or observation alignment.
> 
> **Overview**
> Adds **mid-episode recording control** and a **relay transport override** for DAgger-style collection where the control process must read raw frames while a recorder subprocess writes the same stream.
> 
> **Recorder (`record_proc.py`):** `run_capture_loop` accepts optional `record_event` and `frame_counter`. When paused, the loop stops appending rows and **re-anchors the tick clock on resume** so saved episodes have contiguous index-based timestamps across frozen gaps. `pause_episode`, `resume_episode`, and `frame_count` are exposed on both `InProcessRecorder` and `DatasetRecorderProcess` (IPC with `_CMD_TIMEOUT_S`). **Encoded gstshm-h264** rejects pause/resume but still supports `frame_count`. The encoded capture loop only gains the counter.
> 
> **Relay (`video_proc.py`):** Camera specs may set `raw_transport: "pyshm"` to force the Python shared-memory raw path even when gst shm is available, so `VideoRelayProcess.raw_cameras` are real `RawFrameReader` proxies in the control process (for policy observations) instead of dims-only stubs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd094a3a5161722d8cbb6b1c93b3e97c72a7c379. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->