### PR TITLE
Make live web-app state transfer to other computers

### DIFF
--- a/almond_axol/cli/run_policy.py
+++ b/almond_axol/cli/run_policy.py
@@ -189,6 +189,10 @@ class _StdinPolicyControl:
         if self._stop is not None:
             self._stop.set()
 
+    def note_saved(self) -> None:
+        # Web-control-only bookkeeping; the terminal path shows saves via log_say.
+        pass
+
     def close(self) -> None:
         self.end_episode()
 
@@ -206,9 +210,30 @@ class _QueuePolicyControl:
         self._q: "queue.Queue[str]" = queue.Queue()
         self._stop = stop_event
         self._choice: str | None = None
+        # Episode phase/count, read by the serve runner so the web control panel
+        # on ANY connected computer can show the right controls (see snapshot()).
+        self._state_lock = threading.Lock()
+        self._phase = "preparing"
+        self._episodes_recorded = 0
 
     def push(self, command: str) -> None:
         self._q.put(command)
+
+    def _set_phase(self, phase: str) -> None:
+        with self._state_lock:
+            self._phase = phase
+
+    def note_saved(self) -> None:
+        with self._state_lock:
+            self._episodes_recorded += 1
+
+    def snapshot(self) -> dict[str, Any]:
+        """Thread-safe episode phase/count for the /api/op/status API."""
+        with self._state_lock:
+            return {
+                "phase": self._phase,
+                "episodesRecorded": self._episodes_recorded,
+            }
 
     def _drain(self) -> None:
         import queue
@@ -225,6 +250,7 @@ class _QueuePolicyControl:
         from lerobot.utils.utils import log_say
 
         log_say(message)
+        self._set_phase("ready")
         while not self._stop.is_set():
             try:
                 cmd = self._q.get(timeout=0.25)
@@ -239,6 +265,7 @@ class _QueuePolicyControl:
     def begin_episode(self) -> None:
         self._choice = None
         self._drain()
+        self._set_phase("recording")
 
     def poll_choice(self) -> str | None:
         import queue
@@ -272,7 +299,8 @@ class _QueuePolicyControl:
         return "q"
 
     def end_episode(self) -> None:
-        pass
+        # The episode ended; the loop returns to rest before the next gate.
+        self._set_phase("resetting")
 
     def close(self) -> None:
         pass
@@ -1157,6 +1185,7 @@ def _run(
             if dataset is not None:
                 dataset.save_episode()
             episodes_recorded += 1
+            control.note_saved()
             log_say(f"Saved episode {episodes_recorded}.")
             log_say("Returning to rest pose.")
             reset_controller.return_to_rest(robot)

--- a/almond_axol/cli/run_policy.py
+++ b/almond_axol/cli/run_policy.py
@@ -289,12 +289,17 @@ class _QueuePolicyControl:
         log_say(
             f"Episode time cap ({episode_time_s}s) reached — choose save/rerecord/quit."
         )
+        # The cap stopped recording, but the operator still owes a save/rerecord/
+        # quit decision — keep the choice controls live (begin/end_episode leave
+        # the phase at "recording"/"resetting", neither of which enables them).
+        self._set_phase("deciding")
         while not self._stop.is_set():
             try:
                 cmd = self._q.get(timeout=0.25)
             except queue.Empty:
                 continue
             if cmd in ("s", "r", "q"):
+                self._set_phase("resetting")
                 return cmd
         return "q"
 

--- a/almond_axol/serve/app.py
+++ b/almond_axol/serve/app.py
@@ -424,6 +424,7 @@ def create_app(static_dir: Path | None = None) -> FastAPI:
         return {
             "running": runner.is_running(),
             "session": session.to_dict() if session else None,
+            "policy": runner.policy_state(),
         }
 
     @app.post("/api/op/start")

--- a/almond_axol/serve/runner.py
+++ b/almond_axol/serve/runner.py
@@ -557,6 +557,15 @@ class OperationRunner:
         control.push(command)
         return True
 
+    def policy_state(self) -> dict[str, Any] | None:
+        """run-policy episode phase/message/count, or None if no policy is running.
+
+        Read by /api/op/status so the control panel reflects whether an episode
+        is recording or sitting at the between-episode gate on any computer.
+        """
+        control = self._policy_control
+        return control.snapshot() if control is not None else None
+
     async def shutdown(self) -> None:
         # Server shutdown: stop and block until the op is actually gone (unlike
         # the API stop, which returns early and lets the watchdog finish).

--- a/web/app/src/components/operation-panel.tsx
+++ b/web/app/src/components/operation-panel.tsx
@@ -19,6 +19,7 @@ import {
   type CommandSpec,
   type FormValue,
   type OperationMeta,
+  type PolicyState,
   type RobotStatus,
   type SchemaNode,
   type SessionInfo,
@@ -47,6 +48,7 @@ export function OperationPanel({
   host,
   viewerPort,
   startPhase,
+  policy,
   onStart,
   onStop,
   onEpisode,
@@ -69,6 +71,8 @@ export function OperationPanel({
   viewerPort: number
   /** Progress label shown on the Start button while preparing (e.g. camera check). */
   startPhase: string | null
+  /** run-policy episode phase/count (null unless run-policy is the live op). */
+  policy: PolicyState | null
   onStart: () => void
   onStop: () => void
   onEpisode: (command: string) => void
@@ -231,7 +235,9 @@ export function OperationPanel({
                 </div>
               )}
 
-              {meta.id === "run-policy" && live && <EpisodeControls onEpisode={onEpisode} />}
+              {meta.id === "run-policy" && live && (
+                <EpisodeControls policy={policy} onEpisode={onEpisode} />
+              )}
 
               <RunningHints
                 op={meta.id}
@@ -298,20 +304,44 @@ function OptionalSettings({
   )
 }
 
-function EpisodeControls({ onEpisode }: { onEpisode: (command: string) => void }) {
+function EpisodeControls({
+  policy,
+  onEpisode,
+}: {
+  policy: PolicyState | null
+  onEpisode: (command: string) => void
+}) {
+  const phase = policy?.phase ?? "preparing"
+  const ready = phase === "ready" // between-episode gate: start the next episode
+  const recording = phase === "recording" // episode in flight: save or discard
+  // Status line so both the initiator and any other computer see what's happening.
+  const status =
+    phase === "recording"
+      ? "Recording — Save to keep, Discard to re-record."
+      : phase === "ready"
+        ? "Reset the scene, then start the episode."
+        : phase === "resetting"
+          ? "Returning to rest…"
+          : "Preparing…"
   return (
     <div className="flex flex-col gap-2 rounded-lg border border-[#eff483]/25 bg-[#eff483]/[0.04] p-3">
-      <span className="font-mono text-xs tracking-widest text-[#eff483]/80 uppercase">
-        Episode control
-      </span>
+      <div className="flex items-center justify-between gap-2">
+        <span className="font-mono text-xs tracking-widest text-[#eff483]/80 uppercase">
+          Episode control
+        </span>
+        <span className="font-mono text-[0.65rem] text-white/40">
+          {policy?.episodesRecorded ?? 0} saved
+        </span>
+      </div>
+      <span className="text-xs text-white/50">{status}</span>
       <div className="flex flex-wrap gap-2">
-        <Button size="sm" onClick={() => onEpisode("start")}>
-          Start Episode
+        <Button size="sm" disabled={!ready} onClick={() => onEpisode("start")}>
+          Start episode
         </Button>
-        <Button variant="outline" size="sm" onClick={() => onEpisode("s")}>
+        <Button variant="outline" size="sm" disabled={!recording} onClick={() => onEpisode("s")}>
           Save
         </Button>
-        <Button variant="outline" size="sm" onClick={() => onEpisode("r")}>
+        <Button variant="outline" size="sm" disabled={!recording} onClick={() => onEpisode("r")}>
           Discard
         </Button>
       </div>

--- a/web/app/src/components/operation-panel.tsx
+++ b/web/app/src/components/operation-panel.tsx
@@ -313,16 +313,19 @@ function EpisodeControls({
 }) {
   const phase = policy?.phase ?? "preparing"
   const ready = phase === "ready" // between-episode gate: start the next episode
-  const recording = phase === "recording" // episode in flight: save or discard
+  // Episode in flight, or the safety-cap decision after it — Save/Discard apply.
+  const canChoose = phase === "recording" || phase === "deciding"
   // Status line so both the initiator and any other computer see what's happening.
   const status =
     phase === "recording"
       ? "Recording — Save to keep, Discard to re-record."
-      : phase === "ready"
-        ? "Reset the scene, then start the episode."
-        : phase === "resetting"
-          ? "Returning to rest…"
-          : "Preparing…"
+      : phase === "deciding"
+        ? "Time cap reached — Save to keep, Discard to re-record."
+        : phase === "ready"
+          ? "Reset the scene, then start the episode."
+          : phase === "resetting"
+            ? "Returning to rest…"
+            : "Preparing…"
   return (
     <div className="flex flex-col gap-2 rounded-lg border border-[#eff483]/25 bg-[#eff483]/[0.04] p-3">
       <div className="flex items-center justify-between gap-2">
@@ -338,10 +341,10 @@ function EpisodeControls({
         <Button size="sm" disabled={!ready} onClick={() => onEpisode("start")}>
           Start episode
         </Button>
-        <Button variant="outline" size="sm" disabled={!recording} onClick={() => onEpisode("s")}>
+        <Button variant="outline" size="sm" disabled={!canChoose} onClick={() => onEpisode("s")}>
           Save
         </Button>
-        <Button variant="outline" size="sm" disabled={!recording} onClick={() => onEpisode("r")}>
+        <Button variant="outline" size="sm" disabled={!canChoose} onClick={() => onEpisode("r")}>
           Discard
         </Button>
       </div>

--- a/web/app/src/lib/supervisor.ts
+++ b/web/app/src/lib/supervisor.ts
@@ -254,9 +254,20 @@ export type OperationId =
   | "run-policy"
   | "replay-dataset"
 
+/** run-policy episode lifecycle phase, surfaced so the control panel on any
+ *  computer shows the right episode controls (not just the tab that started it). */
+export type PolicyPhase = "preparing" | "ready" | "recording" | "resetting"
+
+export interface PolicyState {
+  phase: PolicyPhase
+  episodesRecorded: number
+}
+
 export interface OpStatus {
   running: boolean
   session: SessionInfo | null
+  /** Present only while run-policy is the running op; null otherwise. */
+  policy: PolicyState | null
 }
 
 export async function fetchOpStatus(): Promise<OpStatus> {

--- a/web/app/src/lib/supervisor.ts
+++ b/web/app/src/lib/supervisor.ts
@@ -256,7 +256,7 @@ export type OperationId =
 
 /** run-policy episode lifecycle phase, surfaced so the control panel on any
  *  computer shows the right episode controls (not just the tab that started it). */
-export type PolicyPhase = "preparing" | "ready" | "recording" | "resetting"
+export type PolicyPhase = "preparing" | "ready" | "recording" | "deciding" | "resetting"
 
 export interface PolicyState {
   phase: PolicyPhase

--- a/web/app/src/routes/ControlPanel.tsx
+++ b/web/app/src/routes/ControlPanel.tsx
@@ -100,12 +100,16 @@ export default function ControlPanel() {
   const [update, setUpdate] = useState<UpdateStatus | null>(null)
   // Bridges the gap between clicking Update and the server's status first
   // reporting the in-flight update, so the banner switches to the spinner
-  // immediately. Steady state is derived from the server (see `updating`).
+  // immediately; the watcher clears it once the real server state is known.
   const [startingUpdate, setStartingUpdate] = useState(false)
+  // Set when the watcher gives up (deadline) so the banner drops the spinner and
+  // offers a retry even if the server is still/again reporting "updating".
+  // Cleared when a new update is kicked off (and on disconnect).
+  const [updateAbandoned, setUpdateAbandoned] = useState(false)
   // Whether the server is applying an update. Derived from its authoritative
   // status (not a local click) so EVERY connected computer shows the in-flight
   // update — spinner + phase — rather than a stale, clickable Update button.
-  const updating = startingUpdate || update?.state === "updating"
+  const updating = !updateAbandoned && (startingUpdate || update?.state === "updating")
   // Current step shown in the banner while updating (so it isn't an opaque
   // spinner). Sourced from the server's reported phase, except "restarting"
   // which we infer locally once the server stops responding (it exited).
@@ -320,6 +324,7 @@ export default function ControlPanel() {
     setCameraDetectError(null)
     setUpdate(null)
     setStartingUpdate(false)
+    setUpdateAbandoned(false)
     setUpdatePhase(null)
     autoRobotRef.current = false
   }
@@ -511,14 +516,25 @@ export default function ControlPanel() {
     const t = setInterval(async () => {
       if (Date.now() > deadline) {
         clearInterval(t)
-        toast.error("Update is taking longer than expected. Reload to retry.")
+        if (active) {
+          // Give up auto-watching so the banner leaves the spinner and offers a
+          // retry, even if the server is still/again reporting "updating".
+          setUpdateAbandoned(true)
+          setStartingUpdate(false)
+          setUpdatePhase(null)
+          toast.error("Update is taking longer than expected. Reload to retry.")
+        }
         return
       }
       try {
         const u = await fetchUpdateStatus()
         if (!active) return
         setUpdate(u)
+        // Real server state is known now — drop the optimistic bridge so a
+        // failed status fetch in handleUpdate can't wedge `updating` on.
+        setStartingUpdate(false)
         if (u.state === "error") {
+          setUpdatePhase(null)
           toast.error(u.error ?? "Update failed.")
           return
         }
@@ -646,6 +662,7 @@ export default function ControlPanel() {
   // hard-reloads once the backend is back on the new release.
   async function handleUpdate() {
     if (!update?.remoteVersion) return
+    setUpdateAbandoned(false)
     setStartingUpdate(true)
     setUpdatePhase("upgrading")
     try {

--- a/web/app/src/routes/ControlPanel.tsx
+++ b/web/app/src/routes/ControlPanel.tsx
@@ -30,6 +30,7 @@ import {
   type CommandSpec,
   type FormValue,
   type OperationId,
+  type PolicyState,
   type RobotStatus,
   type ServerInfo,
   type SessionInfo,
@@ -97,8 +98,14 @@ export default function ControlPanel() {
   const [hostInfo, setHostInfo] = useState<ServerInfo | null>(null)
   const [viewerPort, setViewerPort] = useState(8002)
   const [update, setUpdate] = useState<UpdateStatus | null>(null)
-  // Drives the banner's "Updating…" state while the server upgrades + restarts.
-  const [updating, setUpdating] = useState(false)
+  // Bridges the gap between clicking Update and the server's status first
+  // reporting the in-flight update, so the banner switches to the spinner
+  // immediately. Steady state is derived from the server (see `updating`).
+  const [startingUpdate, setStartingUpdate] = useState(false)
+  // Whether the server is applying an update. Derived from its authoritative
+  // status (not a local click) so EVERY connected computer shows the in-flight
+  // update — spinner + phase — rather than a stale, clickable Update button.
+  const updating = startingUpdate || update?.state === "updating"
   // Current step shown in the banner while updating (so it isn't an opaque
   // spinner). Sourced from the server's reported phase, except "restarting"
   // which we infer locally once the server stops responding (it exited).
@@ -121,6 +128,9 @@ export default function ControlPanel() {
   const [settingsByOp, setSettingsByOp] = useState<OpSettings>(() => loadAllOpSettings())
 
   const [session, setSession] = useState<SessionInfo | null>(null)
+  // run-policy episode phase/count, from the server so the episode controls are
+  // correct on any computer (not just the tab that started the run).
+  const [policy, setPolicy] = useState<PolicyState | null>(null)
   const [busy, setBusy] = useState(false)
   // Short label shown on the Start button while a start is being prepared (e.g.
   // "Checking cameras…"), so the wait isn't an opaque spinner — mirrors the
@@ -183,6 +193,7 @@ export default function ControlPanel() {
             setSession(op.session)
             setSelectedOp(op.session.command as OperationId)
           }
+          setPolicy(op.running ? op.policy : null)
         })
         .catch(() => {})
     },
@@ -304,10 +315,11 @@ export default function ControlPanel() {
     setCommands([])
     setRobot(null)
     setSession(null)
+    setPolicy(null)
     setCameraDevices(null)
     setCameraDetectError(null)
     setUpdate(null)
-    setUpdating(false)
+    setStartingUpdate(false)
     setUpdatePhase(null)
     autoRobotRef.current = false
   }
@@ -461,7 +473,9 @@ export default function ControlPanel() {
     const t = setInterval(() => {
       fetchOpStatus()
         .then((op) => {
-          if (active && op.session) setSession(op.session)
+          if (!active) return
+          if (op.session) setSession(op.session)
+          setPolicy(op.running ? op.policy : null)
         })
         .catch(() => {})
     }, 1500)
@@ -481,6 +495,48 @@ export default function ControlPanel() {
       .then(setUpdate)
       .catch(() => {})
   }, [conn.state, updating, isLive])
+
+  // Drive an in-flight update to completion on ANY connected computer: advance
+  // the phase, surface a failure, and hard-reload once the backend is back on
+  // the target release (the hosted front-end is on Vercel, so a reload also
+  // pulls the latest UI and reconnects to the restarted server). Keys off the
+  // server's "updating" state rather than a local click, so a second computer
+  // that opens the panel mid-update behaves like the initiator. Replaces the
+  // per-click watch loop handleUpdate used to run itself.
+  useEffect(() => {
+    if (conn.state !== "ok" || !updating) return
+    const target = update?.remoteVersion ?? null
+    const deadline = Date.now() + 5 * 60_000
+    let active = true
+    const t = setInterval(async () => {
+      if (Date.now() > deadline) {
+        clearInterval(t)
+        toast.error("Update is taking longer than expected. Reload to retry.")
+        return
+      }
+      try {
+        const u = await fetchUpdateStatus()
+        if (!active) return
+        setUpdate(u)
+        if (u.state === "error") {
+          toast.error(u.error ?? "Update failed.")
+          return
+        }
+        // Reflect the server's current step so the banner shows progress.
+        if (u.phase) setUpdatePhase(u.phase)
+        // Back on the new release — done.
+        if (target && u.version === target) window.location.reload()
+      } catch {
+        // Server stopped responding: it exited to relaunch (or is briefly
+        // unreachable). Show "restarting" and keep watching for it to return.
+        if (active) setUpdatePhase("restarting")
+      }
+    }, 2000)
+    return () => {
+      active = false
+      clearInterval(t)
+    }
+  }, [conn.state, updating, update?.remoteVersion, toast])
 
   const meta = operationMeta(selectedOp)
   const spec = useMemo(
@@ -555,6 +611,8 @@ export default function ControlPanel() {
       const spec = meta.requiresCameras || cameraCount(cameras) > 0 ? cameras : undefined
       const result = await startOperation(selectedOp, settings, spec)
       setSession(result)
+      // Fresh run — clear any stale phase; the live poll repopulates it.
+      setPolicy(null)
     } catch (e) {
       toast.error(String(e))
     } finally {
@@ -582,58 +640,30 @@ export default function ControlPanel() {
     sendEpisodeCommand(command).catch((e) => toast.error(String(e)))
   }
 
-  // Apply the available update, then hard-reload once the server is back on the
-  // new release. The server upgrades and exits (systemd relaunches it), so the
-  // start request and the watch polls below tolerate it briefly going away.
+  // Kick off the available update. The server upgrades and exits (systemd
+  // relaunches it); the update-watcher effect — which runs on any computer while
+  // the server reports an update in flight — then advances the phase and
+  // hard-reloads once the backend is back on the new release.
   async function handleUpdate() {
-    const target = update?.remoteVersion
-    if (!target) return
-    setUpdating(true)
+    if (!update?.remoteVersion) return
+    setStartingUpdate(true)
     setUpdatePhase("upgrading")
     try {
       await startUpdate()
     } catch (e) {
       toast.error(`Update failed to start: ${e}`)
-      setUpdating(false)
+      setStartingUpdate(false)
       setUpdatePhase(null)
       return
     }
-    // The hosted UI is served by Vercel, so a hard reload also pulls the latest
-    // front-end; reconnecting to the restarted backend re-runs loadServer.
-    const reload = () => window.location.reload()
-    const deadline = Date.now() + 5 * 60_000
-    const watch = setInterval(async () => {
-      if (Date.now() > deadline) {
-        clearInterval(watch)
-        setUpdating(false)
-        setUpdatePhase(null)
-        toast.error("Update is taking longer than expected. Reload to retry.")
-        return
-      }
-      try {
-        const u = await fetchUpdateStatus()
+    // Pull the now-"updating" status so `updating` derives true and the watcher
+    // takes over; then drop the optimistic flag (server state carries it now).
+    fetchUpdateStatus()
+      .then((u) => {
         setUpdate(u)
-        if (u.state === "error") {
-          clearInterval(watch)
-          setUpdating(false)
-          setUpdatePhase(null)
-          toast.error(u.error ?? "Update failed.")
-          return
-        }
-        // Reflect the server's current step (upgrading/provisioning) so the
-        // banner shows progress rather than an opaque spinner.
-        if (u.phase) setUpdatePhase(u.phase)
-        // Server is back and now running the target release — done.
-        if (u.version === target) {
-          clearInterval(watch)
-          reload()
-        }
-      } catch {
-        // Server stopped responding: it exited to restart (or is briefly
-        // unreachable). Show "restarting" and keep watching for it to return.
-        setUpdatePhase("restarting")
-      }
-    }, 2000)
+        setStartingUpdate(false)
+      })
+      .catch(() => {})
   }
 
   const viewerHost = serverHost || hostInfo?.lanIp || ""
@@ -701,6 +731,7 @@ export default function ControlPanel() {
           host={viewerHost}
           viewerPort={viewerPort}
           startPhase={startPhase}
+          policy={selectedLive ? policy : null}
           onStart={handleStart}
           onStop={handleStop}
           onEpisode={handleEpisode}

--- a/web/app/src/routes/Diagnostics.tsx
+++ b/web/app/src/routes/Diagnostics.tsx
@@ -22,6 +22,7 @@ import { cn } from "@/lib/utils"
 import {
   fetchCommands,
   fetchRobotStatus,
+  fetchSessions,
   robotConnect,
   sendSessionInput,
   setServerBase,
@@ -66,6 +67,13 @@ const STATE_BADGE: Record<
   error: { variant: "destructive", text: "error" },
 }
 
+// Commands this dashboard launches as manager sessions besides the fetched
+// Diagnostics-category catalog: the CAN quick buttons and the motor calibration
+// tools. Used to recognise an already-running session and adopt it (see the
+// adoption effect) so its Stop button shows on any browser, not just the tab
+// that started it.
+const PAGE_COMMAND_IDS = ["can.setup", "can.enable", "motor.set-can-id", "motor.set-zero-pos"]
+
 /**
  * Motor diagnostics dashboard: live per-motor status (health, temperature,
  * voltage), always-running position / velocity / torque charts with joint
@@ -101,21 +109,32 @@ export default function Diagnostics() {
     session: SessionInfo
   } | null>(null)
   const [launchBusy, setLaunchBusy] = useState(false)
-  const { lines: activeLines, status: activeStatus } = useSessionLogs(
-    activeRun?.session.id ?? null
-  )
-  // Hands-on steps (the ROM tests' gripper prompts) print a "[prompt] …"
-  // marker and then block on stdin; the run's Continue button answers them.
-  // Prompts are strictly ordered, so the pending one is the (answered+1)th.
-  const prompts = useMemo(
-    () =>
-      activeLines
-        .filter((l) => l.startsWith("[prompt] "))
-        .map((l) => l.slice("[prompt] ".length).trim()),
-    [activeLines]
-  )
-  const [answered, setAnswered] = useState(0)
-  const pendingPrompt = answered < prompts.length ? prompts[answered] : null
+  const { lines: activeLines, status: activeStatus } = useSessionLogs(activeRun?.session.id ?? null)
+  // Hands-on steps (the ROM tests' gripper prompts) print a "[prompt] …" marker
+  // and then block on stdin; the run's Continue button answers them. The run is
+  // waiting on one iff its most recent output is that marker — after the operator
+  // answers, the script always prints more output, so a non-prompt tail means
+  // nothing is pending. Deriving the pending prompt from the log tail (instead of
+  // counting how many were answered) keeps it correct on any browser, including
+  // one that adopted a run already in flight from another computer.
+  const promptTail = useMemo(() => {
+    for (let i = activeLines.length - 1; i >= 0; i--) {
+      const l = activeLines[i]
+      if (!l.trim() || l.startsWith("[serve]")) continue
+      return l.startsWith("[prompt] ") ? l.slice("[prompt] ".length).trim() : null
+    }
+    return null
+  }, [activeLines])
+  // Hide the Continue button the instant it's clicked (until the next line
+  // arrives) so a double-click can't send two newlines and skip the following
+  // prompt. Tagged with the session id so the suppression never bleeds from one
+  // run into the next.
+  const [dismissed, setDismissed] = useState<{ id: string; len: number } | null>(null)
+  const pendingPrompt =
+    promptTail &&
+    !(dismissed && dismissed.id === activeRun?.session.id && dismissed.len === activeLines.length)
+      ? promptTail
+      : null
   // Latest meaningful output line, surfaced on the running action card as
   // secondary progress context.
   const activeLine =
@@ -193,8 +212,7 @@ export default function Diagnostics() {
     if (activeStatus.status !== "exited" && activeStatus.status !== "error") return
     if (notifiedRef.current === activeRun.session.id) return
     notifiedRef.current = activeRun.session.id
-    const label =
-      commands.find((c) => c.id === activeRun.command)?.label ?? activeRun.command
+    const label = commands.find((c) => c.id === activeRun.command)?.label ?? activeRun.command
     if (activeStatus.status === "exited" && (activeStatus.exitCode ?? 0) === 0) {
       toast.success(`${label} finished.`)
     } else {
@@ -212,7 +230,6 @@ export default function Diagnostics() {
       setLaunchBusy(true)
       try {
         const { run, session } = await startDiagnosticsRun(command, args)
-        setAnswered(0)
         setActiveRun({ command, session })
         if (run) setRuns((prev) => [run, ...prev])
       } catch (e) {
@@ -226,17 +243,16 @@ export default function Diagnostics() {
 
   const continuePrompt = useCallback(async () => {
     if (!activeRun) return
-    // Optimistically advance so the button hides until the next prompt marker
-    // arrives — this also guards against a double-click sending two newlines
-    // (which would skip the following prompt).
-    setAnswered((n) => n + 1)
+    // Hide the button until the next line arrives (double-click guard); restore
+    // it if the input fails to send.
+    setDismissed({ id: activeRun.session.id, len: activeLines.length })
     try {
       await sendSessionInput(activeRun.session.id)
     } catch (e) {
-      setAnswered((n) => Math.max(0, n - 1))
+      setDismissed(null)
       toast.error(String(e))
     }
-  }, [activeRun, toast])
+  }, [activeRun, activeLines.length, toast])
 
   const stopActive = useCallback(async () => {
     if (!activeRun) return
@@ -312,6 +328,41 @@ export default function Diagnostics() {
   )
   const canCommand = (id: string) => commands.find((c) => c.id === id) ?? null
 
+  // Adopt a diagnostics/CAN run that's already in flight so its Stop button,
+  // live output and Continue prompt appear on *any* browser — not just the tab
+  // that launched it. Without this, opening the dashboard on a second computer
+  // while a run is going gives no way to cancel it. Poll only while nothing is
+  // tracked locally; once a run is adopted (or launched) activeRun is set and
+  // this stops. The completion effect clears activeRun when the run ends, which
+  // re-arms the poll (the finished session is then no longer "live").
+  useEffect(() => {
+    if (!serverOk || activeRun != null) return
+    const ours = (command: string) =>
+      PAGE_COMMAND_IDS.includes(command) || diagCommands.some((c) => c.id === command)
+    let active = true
+    const poll = () => {
+      fetchSessions()
+        .then((sessions) => {
+          if (!active) return
+          const live = sessions
+            .filter(
+              (s) =>
+                (s.status === "starting" || s.status === "running" || s.status === "stopping") &&
+                ours(s.command)
+            )
+            .sort((a, b) => b.startedAt - a.startedAt)[0]
+          if (live) setActiveRun({ command: live.command, session: live })
+        })
+        .catch(() => {})
+    }
+    poll()
+    const t = setInterval(poll, 2000)
+    return () => {
+      active = false
+      clearInterval(t)
+    }
+  }, [serverOk, activeRun, diagCommands])
+
   // Motor calibration tools surfaced as buttons in the Motors header. Zeroing
   // is one button whose dialog tabs between "specific motor" and the guided
   // walk of every joint (both back motor.set-zero-pos via presets).
@@ -366,8 +417,7 @@ export default function Diagnostics() {
   // Follow mode anchors the window to the newest sample; the page re-renders
   // on every stream tick, so the live edge advances with the data (and holds
   // still while the stream is paused). Zoom/pan pins a fixed range.
-  const lastT =
-    stream.frames.length > 0 ? stream.frames[stream.frames.length - 1].t : windowSec
+  const lastT = stream.frames.length > 0 ? stream.frames[stream.frames.length - 1].t : windowSec
   const view: ChartView = pinnedView ?? { t0: lastT - windowSec, t1: lastT }
 
   return (
@@ -420,10 +470,7 @@ export default function Diagnostics() {
                     size="sm"
                     title={cmd.description}
                     disabled={
-                      !serverOk ||
-                      launchBusy ||
-                      busyElsewhere ||
-                      (activeRun != null && !running)
+                      !serverOk || launchBusy || busyElsewhere || (activeRun != null && !running)
                     }
                     onClick={() => (running ? stopActive() : launch(id, {}))}
                   >
@@ -586,12 +633,7 @@ export default function Diagnostics() {
         </section>
 
         {/* Run history */}
-        <RunHistory
-          runs={runs}
-          loading={runsLoading}
-          onRefresh={refreshRuns}
-          onClear={clearRuns}
-        />
+        <RunHistory runs={runs} loading={runsLoading} onRefresh={refreshRuns} onClear={clearRuns} />
       </main>
 
       {/* Motor calibration tool dialog (Set CAN ID / Set zero position) */}


### PR DESCRIPTION
## Problem

Robot state driven from the web app only lived in the browser tab that *started* the action, so opening the app on a second computer while something was running showed none of it. Notably: a running diagnostic's **Stop button never appeared on another computer** (the original report — someone logged in from another machine to cancel a run and had no way to). This reconstructs that live state from the server instead.

## Changes

**Diagnostics — Stop on any browser** (`Diagnostics.tsx`)
- `activeRun` was set only inside `launch()`, so only the launching tab could Stop/Continue a run. Now poll `GET /api/sessions` and adopt any live diagnostics/CAN/motor-tool session, so the Stop button, live output, and Continue prompt appear on any computer.
- Pending-prompt detection is now **tail-based** (a prompt is pending iff the log tail is a `[prompt]` marker). The logs WebSocket replays the backlog on connect, so the old answered-counter would have resurfaced already-answered prompts as a stale Continue button on an adopting tab.

**Control panel self-update — progress on any browser** (`ControlPanel.tsx`)
- `updating`/`updatePhase` were local to the initiating tab. A second computer opening the panel mid-update saw an enabled **Update** button (→ 409) and never reloaded onto the new release. `updating` is now derived from the server's `update.state`, and the watch loop moved into a **shared effect** that runs on any computer while an update is in flight (advancing phase + auto-reloading).

**run-policy episode control — non-stateless buttons on every client** (`run_policy.py`, `runner.py`, `app.py`, `operation-panel.tsx`)
- `/api/op/status` exposed no episode state, so Start/Save/Discard were always enabled regardless of phase — on *every* client, not just second computers. `_QueuePolicyControl` now tracks a phase (`preparing`/`ready`/`recording`/`resetting`) and saved count via a thread-safe `snapshot()`, surfaced through `runner.policy_state()` and `/api/op/status`. The panel enables **Start** only at the between-episode gate and **Save/Discard** only while recording, with a status line and an episode counter.

## Verification
- Python byte-compiles; pre-commit `ruff`/`ruff-format`/`prettier` all pass.
- Frontend `tsc -b`, `eslint` (only two pre-existing `robotConnectClick`/`usbConnectClick` warnings remain), and `vite build` all pass.
- **Not exercised against live hardware** — the runtime flows (a real diagnostic Stop from a second computer, a self-update restart, and run-policy phase transitions with a policy server) were not driven end-to-end. Worth a hardware check before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live operation control (episode commands, update reload, diagnostic stop/adopt) via polling; logic is additive but wrong phase or session adoption could confuse operators or send commands at the wrong time.
> 
> **Overview**
> **Live web UI state now comes from the serve host** so a second browser (or machine) matches the tab that started an action.
> 
> **Diagnostics** polls `GET /api/sessions` and **adopts** in-flight diagnostics/CAN/motor-tool runs, so Stop, logs, and Continue work on any client. Pending prompts are inferred from the **log tail** (`[prompt]` marker) instead of a local answer counter, so reconnecting tabs don’t show a stale Continue after the WebSocket backlog replays.
> 
> **Control panel updates** treat `update.state === "updating"` as authoritative (`updating` is no longer click-local). A shared effect watches progress, shows phases, and reloads when the server is back on the target version—so mid-update panels don’t offer a clickable Update that 409s.
> 
> **run-policy episode UI** reads phase and saved count from `/api/op/status` (`_QueuePolicyControl.snapshot()` → `runner.policy_state()`). **Start** is enabled only at the between-episode gate; **Save/Discard** only while recording, with a status line and counter on every client.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdc22cf7a9768a850d25c43a21b25213e28557b8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->