### PR TITLE
Disable depth for stereo camera previews

### DIFF
--- a/almond_axol/video/gst_zed.py
+++ b/almond_axol/video/gst_zed.py
@@ -1054,7 +1054,8 @@ class ZedGstStereoCamera(_GstPipelineBase):
         src = (
             f"zedsrc camera-sn={self.serial} "
             f"camera-resolution={_STEREO_RESOLUTION_ENUM[self.resolution]} "
-            f"camera-fps={self.fps} stream-type=7 do-timestamp=false "
+            f"camera-fps={self.fps} stream-type=7 depth-mode=0 "
+            "do-timestamp=false "
             "! video/x-raw(memory:NVMM),format=NV12 ! tee name=split"
         )
         branches = "  ".join(

--- a/almond_axol/zed/snapshot.py
+++ b/almond_axol/zed/snapshot.py
@@ -63,6 +63,9 @@ def snapshot_jpeg_inproc(serial: int) -> bytes:
     if stereo:
         cam: object = sl.Camera()
         params: object = sl.InitParameters()
+        # Preview only retrieves the left image. Disable depth so opening the
+        # camera does not load or optimize a depth model on the Jetson.
+        params.depth_mode = sl.DEPTH_MODE.NONE
     else:
         cam = sl.CameraOne()
         params = sl.InitParametersOne()


### PR DESCRIPTION
## Summary
- disable ZED depth initialization for control-panel stereo previews
- explicitly disable depth in the GStreamer stereo image pipeline
- avoid neural model download and optimization when only camera images are needed

## Validation
- `uv run ruff check almond_axol/zed/snapshot.py almond_axol/video/gst_zed.py`
- `uv run ruff format --check almond_axol/zed/snapshot.py almond_axol/video/gst_zed.py`
- verified generated `zedsrc` pipeline contains `depth-mode=0`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small configuration changes on image-only stereo paths; no auth, data, or recording pipeline logic changes.
> 
> **Overview**
> Stereo **image-only** paths no longer initialize ZED depth, so Jetson does not download or optimize neural depth models when only camera frames are needed.
> 
> For **control-panel previews**, stereo opens in `snapshot.py` now set `depth_mode` to `NONE` (same idea as other rectified-image-only stereo code). For the **GStreamer stereo pipeline** in `gst_zed.py`, `zedsrc` is built with `depth-mode=0` alongside the existing `do-timestamp=false` settings.
> 
> Behavior for teleop/recording that already relied on video only should stay the same, with less GPU and startup cost on stereo preview and gst image pipelines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61a3a7fb09d87615b0f75a6fbb7050a73bf54a36. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->