### PR TITLE
Allow SVGA capture on the stereo ZED X

### DIFF
--- a/almond_axol/video/gst_zed.py
+++ b/almond_axol/video/gst_zed.py
@@ -63,9 +63,10 @@ _RESOLUTION_DIMS: dict[str, tuple[int, int]] = {
     "HD1080": (1920, 1080),
     "HD1200": (1920, 1200),
 }
-# zedsrc camera-resolution enum (GstZedSrcRes) for the stereo ZED X. Only the
-# GMSL2 60-fps modes are exposed (SVGA is ZED-X-One-only).
-_STEREO_RESOLUTION_ENUM: dict[str, int] = {"HD1080": 1, "HD1200": 2}
+# zedsrc camera-resolution enum (GstZedSrcRes) for the stereo ZED X. Note the
+# enum values differ from zedxonesrc's: SVGA is 4 here but 0 there (HD1080 and
+# HD1200 happen to share 1/2 in both).
+_STEREO_RESOLUTION_ENUM: dict[str, int] = {"SVGA": 4, "HD1080": 1, "HD1200": 2}
 
 # Per-subscriber AU queue depth. A healthy consumer pops every AU as it
 # arrives; the bound only matters for a stalled consumer, where the oldest


### PR DESCRIPTION
## Summary
- `_STEREO_RESOLUTION_ENUM` in `almond_axol/video/gst_zed.py` omitted SVGA on the assumption it was ZED-X-One-only, so selecting SVGA for a stereo ZED X raised `unsupported stereo ZED X resolution 'SVGA'`. The ZED X does support SVGA (960x600, GMSL2), and the installed `zedsrc` plugin exposes it as enum value 4.
- Adds `"SVGA": 4` to the stereo enum and corrects the comment. Note the enum values differ between plugins: SVGA is 4 in `zedsrc` but 0 in `zedxonesrc` (HD1080/HD1200 happen to share 1/2 in both), which is likely how it got dropped.
- Covers both branches: the stereo pipeline captures once and tees into the headset (encoded) and dataset (raw) branches, and the rejection was at capture setup — so SVGA streaming and record-only-at-SVGA both work now. Everything downstream already handled SVGA dims via `_RESOLUTION_DIMS`.

## Test plan
- [ ] On a Jetson with a stereo ZED X: set stream resolution to SVGA in the control panel and confirm the camera opens and streams.
- [ ] Record a short dataset with a record-only stereo camera at SVGA and confirm frames land at 960x600.

Made with [Cursor](https://cursor.com)