### PR TITLE
Warn when the control panel UI and backend are on different code

### DIFF
--- a/almond_axol/serve/app.py
+++ b/almond_axol/serve/app.py
@@ -234,6 +234,13 @@ def create_app(static_dir: Path | None = None) -> FastAPI:
             "viewerPort": _VIEWER_PORT,
             "vrPort": _VR_PORT,
             "version": updater.version,
+            # Backend git commit, compared against the commit baked into the
+            # web bundle at build time to warn about a UI/backend mismatch.
+            # Against a release (tag-pinned) install a hosted UI compares
+            # versions instead — its commit tracks main and legitimately
+            # differs between releases.
+            "commit": updater.commit,
+            "releaseInstall": updater.release_install,
         }
 
     @app.get("/api/update/status")

--- a/almond_axol/serve/update.py
+++ b/almond_axol/serve/update.py
@@ -44,13 +44,16 @@ no-ops.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
 import re
 import shutil
+import subprocess
 import time
 from importlib.metadata import PackageNotFoundError, distribution
+from pathlib import Path
 from typing import Callable
 
 _logger = logging.getLogger(__name__)
@@ -112,6 +115,49 @@ def installed_origin() -> tuple[str, str] | None:
     return url, commit
 
 
+def _git(repo_root: Path, *args: str) -> bytes | None:
+    """Raw stdout of a git command in ``repo_root``; ``None`` on any failure."""
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(repo_root), *args],
+            capture_output=True,
+            timeout=10.0,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    return proc.stdout if proc.returncode == 0 else None
+
+
+def installed_commit() -> str | None:
+    """The git commit this backend is running, or ``None`` when unknown.
+
+    For a git tool install it is the PEP 610 pinned commit; for a dev checkout
+    it is the checkout's HEAD, with a ``-dirty.<hash>`` suffix over any
+    uncommitted changes so two different working-tree states never share an
+    identity. The web bundle bakes its own build commit in at build time
+    (``buildCommit()`` in web/app/vite.config.ts — the dirty-hash scheme must
+    stay identical), so the control panel can compare the two and warn when
+    the UI and the backend are on different code. Works on forks too — it
+    never references the upstream repository.
+    """
+    origin = installed_origin()
+    if origin is not None:
+        return origin[1]
+    repo_root = Path(__file__).resolve().parents[2]
+    if not (repo_root / ".git").exists():
+        return None
+    head = _git(repo_root, "rev-parse", "HEAD")
+    commit = head.decode("utf-8", "replace").strip() if head else ""
+    if not commit:
+        return None
+    status = _git(repo_root, "status", "--porcelain")
+    if status is None or not status.strip():
+        return commit
+    diff = _git(repo_root, "diff", "HEAD") or b""
+    digest = hashlib.sha256(status + diff).hexdigest()[:8]
+    return f"{commit}-dirty.{digest}"
+
+
 def installed_version() -> str | None:
     """Installed release version (the pyproject ``version``), e.g. ``"0.1.2"``.
 
@@ -139,6 +185,7 @@ class SelfUpdater:
         self._is_idle = is_idle
         self._origin = installed_origin()
         self._version = installed_version()
+        self._commit = installed_commit()
         # Cached newest release (tag + parsed-out version) and when it was last
         # resolved, so the polled status endpoint answers immediately and only
         # re-runs `git ls-remote --tags` at most once per debounce window
@@ -170,6 +217,22 @@ class SelfUpdater:
     @property
     def version(self) -> str | None:
         return self._version
+
+    @property
+    def commit(self) -> str | None:
+        """Git commit of the running backend (see :func:`installed_commit`)."""
+        return self._commit
+
+    @property
+    def release_install(self) -> bool:
+        """Whether this backend is a tag-pinned git tool install.
+
+        Release installs only ever sit on release-tag commits, so the control
+        panel compares *versions* against them (a hosted UI built from main
+        legitimately differs in commit between releases). Dev checkouts can be
+        on any commit, so the panel compares commits directly.
+        """
+        return self._origin is not None
 
     @property
     def enabled(self) -> bool:

--- a/web/app/src/build-info.d.ts
+++ b/web/app/src/build-info.d.ts
@@ -1,0 +1,7 @@
+/** Build-time constants injected by vite.config.ts `define`. */
+
+/** Git commit this bundle was built from; null when unknown at build time. */
+declare const __AXOL_BUILD_COMMIT__: string | null
+
+/** pyproject.toml version at build time; null when unknown. */
+declare const __AXOL_BUILD_VERSION__: string | null

--- a/web/app/src/components/version-mismatch-banner.tsx
+++ b/web/app/src/components/version-mismatch-banner.tsx
@@ -1,0 +1,44 @@
+import { RefreshCw } from "lucide-react"
+import type { VersionMismatch } from "@/lib/version"
+import { Button } from "@/components/ui/button"
+
+function label(commit: string, version: string | null): string {
+  const short = commit.slice(0, 7)
+  return version ? `v${version} (${short})` : short
+}
+
+/**
+ * Banner shown in the update-banner spot when this UI and the backend are on
+ * different code (see lib/version.ts). Warning only — nothing is blocked,
+ * since a mismatched panel must still be able to stop a running operation.
+ */
+export function VersionMismatchBanner({ mismatch }: { mismatch: VersionMismatch }) {
+  const reloadFixes = !mismatch.local && !mismatch.serverDev && !mismatch.serverOlder
+  const hint = mismatch.local
+    ? "The web bundle this machine serves is out of date — rebuild it (`npm run build` in web/), then reload."
+    : mismatch.serverDev
+      ? "The robot is running a development build from a different commit — use the UI served by the robot itself, or match the two checkouts."
+      : mismatch.serverOlder
+        ? "The robot software is older than this UI and some features may not work — update it."
+        : "Reload to pick up the UI matching the robot software."
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-amber-400/25 bg-amber-400/[0.05] p-3 text-xs text-amber-200/80">
+      <div className="flex min-w-0 flex-col gap-0.5">
+        <span className="font-medium text-amber-200">
+          This UI doesn&apos;t match the robot software
+        </span>
+        <span className="font-mono text-amber-200/60">
+          UI {label(mismatch.uiCommit, mismatch.uiVersion)} &middot; robot{" "}
+          {label(mismatch.serverCommit, mismatch.serverVersion)}
+        </span>
+        <span className="text-amber-200/60">{hint}</span>
+      </div>
+      {reloadFixes && (
+        <Button variant="outline" size="sm" onClick={() => window.location.reload()}>
+          <RefreshCw />
+          Reload
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/web/app/src/components/version-mismatch-banner.tsx
+++ b/web/app/src/components/version-mismatch-banner.tsx
@@ -3,7 +3,10 @@ import type { VersionMismatch } from "@/lib/version"
 import { Button } from "@/components/ui/button"
 
 function label(commit: string, version: string | null): string {
-  const short = commit.slice(0, 7)
+  // Shorten only the SHA, keeping any -dirty.<hash> suffix — two identities
+  // sharing HEAD but differing in working-tree state must render differently.
+  const [sha, ...suffix] = commit.split("-")
+  const short = [sha.slice(0, 7), ...suffix].join("-")
   return version ? `v${version} (${short})` : short
 }
 

--- a/web/app/src/lib/supervisor.ts
+++ b/web/app/src/lib/supervisor.ts
@@ -102,9 +102,11 @@ export function apiUrl(path: string): string {
  * Only a production build on the backend's own origin qualifies: the Vite dev
  * server also proxies /api same-origin, but it serves its own working-tree
  * code, not the backend's dist, so dev is never "served by the backend".
+ * An explicit server base still counts when it points back at the origin
+ * that served the page (e.g. a host entered on this panel earlier).
  */
 export function servedByBackend(): boolean {
-  return !import.meta.env.DEV && apiBase === ""
+  return !import.meta.env.DEV && (apiBase === "" || apiBase === window.location.origin)
 }
 
 /** WebSocket origin for the current server base (ws(s)://host[:port]). */

--- a/web/app/src/lib/supervisor.ts
+++ b/web/app/src/lib/supervisor.ts
@@ -96,6 +96,17 @@ export function apiUrl(path: string): string {
   return `${apiBase}${path}`
 }
 
+/**
+ * Whether this bundle is the one `axol serve` hosts from web/app/dist — a
+ * commit mismatch with the backend then means that local bundle is stale.
+ * Only a production build on the backend's own origin qualifies: the Vite dev
+ * server also proxies /api same-origin, but it serves its own working-tree
+ * code, not the backend's dist, so dev is never "served by the backend".
+ */
+export function servedByBackend(): boolean {
+  return !import.meta.env.DEV && apiBase === ""
+}
+
 /** WebSocket origin for the current server base (ws(s)://host[:port]). */
 export function wsBaseUrl(): string {
   const base = apiBase || window.location.origin
@@ -119,6 +130,10 @@ export interface ServerInfo {
   vrPort: number
   /** Installed release version of the serve host, e.g. "0.1.2". */
   version?: string | null
+  /** Git commit the serve host is running (PEP 610 pin or checkout HEAD). */
+  commit?: string | null
+  /** Tag-pinned git tool install (true) vs dev checkout (false). */
+  releaseInstall?: boolean
 }
 
 export async function fetchInfo(): Promise<ServerInfo> {

--- a/web/app/src/lib/version.ts
+++ b/web/app/src/lib/version.ts
@@ -1,0 +1,61 @@
+import type { ServerInfo } from "@/lib/supervisor"
+import { servedByBackend } from "@/lib/supervisor"
+
+/** What the UI/backend skew check found (see {@link versionMismatch}). */
+export interface VersionMismatch {
+  /** The mismatched bundle is the one the backend itself serves (stale dist). */
+  local: boolean
+  /** The backend is a dev checkout (any commit), not a tag-pinned install. */
+  serverDev: boolean
+  /** The backend is on an older release than this UI was built for. */
+  serverOlder: boolean
+  uiCommit: string
+  serverCommit: string
+  uiVersion: string | null
+  serverVersion: string | null
+}
+
+/** Numeric dotted-version comparison; null when either side isn't parseable. */
+function olderThan(a: string, b: string): boolean | null {
+  const pa = a.split(".").map(Number)
+  const pb = b.split(".").map(Number)
+  if (pa.some(Number.isNaN) || pb.some(Number.isNaN)) return null
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const da = pa[i] ?? 0
+    const db = pb[i] ?? 0
+    if (da !== db) return da < db
+  }
+  return false
+}
+
+/**
+ * Decide whether this bundle and the backend it is talking to are meaningfully
+ * out of sync. Compares the commit baked in at build time against the
+ * backend's commit (/api/info), so it works on forks too — nothing here
+ * references the upstream repository.
+ *
+ * Commits are compared directly, with one exception: a hosted bundle
+ * (axol.almond.bot) talking to a *release install*. Release installs only
+ * ever sit on release-tag commits while the hosted bundle is rebuilt from
+ * every push, so their commits legitimately differ between releases; only a
+ * release *version* difference is reported there to keep the warning
+ * meaningful. Dev-checkout backends can be on any commit, so any difference
+ * against them is real skew and is always reported — as is any difference
+ * with the bundle the backend itself serves (a stale web/app/dist).
+ */
+export function versionMismatch(info: ServerInfo | null): VersionMismatch | null {
+  const uiCommit = __AXOL_BUILD_COMMIT__
+  const uiVersion = __AXOL_BUILD_VERSION__
+  const serverCommit = info?.commit ?? null
+  const serverVersion = info?.version ?? null
+  if (!uiCommit || !serverCommit || uiCommit === serverCommit) return null
+  const local = servedByBackend()
+  const serverDev = !(info?.releaseInstall ?? false)
+  const sameVersion = uiVersion !== null && uiVersion === serverVersion
+  if (!local && !serverDev && sameVersion) return null
+  const serverOlder =
+    uiVersion !== null && serverVersion !== null
+      ? (olderThan(serverVersion, uiVersion) ?? false)
+      : false
+  return { local, serverDev, serverOlder, uiCommit, serverCommit, uiVersion, serverVersion }
+}

--- a/web/app/src/routes/ControlPanel.tsx
+++ b/web/app/src/routes/ControlPanel.tsx
@@ -42,6 +42,8 @@ import {
   type UsbStatus,
 } from "@/lib/supervisor"
 import { UpdateBanner } from "@/components/update-banner"
+import { VersionMismatchBanner } from "@/components/version-mismatch-banner"
+import { versionMismatch } from "@/lib/version"
 import { ConnectionsBar } from "@/components/connections-bar"
 import { OperationPanel } from "@/components/operation-panel"
 import { LogConsole } from "@/components/log-console"
@@ -302,6 +304,9 @@ export default function ControlPanel() {
   // Poll the update indicator slowly while online (its server-side `ls-remote`
   // is debounced, so a tight interval would buy nothing). Paused while an
   // update is in flight — handleUpdate drives its own faster restart-watch poll.
+  // Host identity (/api/info) rides along so a backend upgraded/restarted from
+  // outside this tab (installer, another terminal) refreshes the commit the
+  // version-mismatch check compares against.
   useEffect(() => {
     if (conn.state !== "ok" || updating) return
     let active = true
@@ -309,6 +314,13 @@ export default function ControlPanel() {
       fetchUpdateStatus()
         .then((u) => {
           if (active) setUpdate(u)
+        })
+        .catch(() => {})
+      fetchInfo()
+        .then((info) => {
+          if (!active) return
+          setViewerPort(info.viewerPort)
+          setHostInfo(info)
         })
         .catch(() => {})
     }
@@ -763,6 +775,15 @@ export default function ControlPanel() {
 
   const viewerHost = serverHost || hostInfo?.lanIp || ""
 
+  // UI/backend skew warning (stale local bundle, or hosted UI on a different
+  // release than the robot). Suppressed while the update banner covers the
+  // same ground — an available update *is* the mismatch's remediation — and
+  // while an update is applying (the page hard-reloads when it lands).
+  const mismatch = useMemo(
+    () => (conn.state === "ok" ? versionMismatch(hostInfo) : null),
+    [conn.state, hostInfo]
+  )
+
   return (
     <div className="min-h-screen">
       <SiteNav current="control" />
@@ -776,6 +797,10 @@ export default function ControlPanel() {
             busyReason={updateBusyReason}
             onUpdate={handleUpdate}
           />
+        )}
+
+        {mismatch && !updating && !update?.updateAvailable && (
+          <VersionMismatchBanner mismatch={mismatch} />
         )}
 
         <ConnectionsBar

--- a/web/app/vite.config.ts
+++ b/web/app/vite.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from "vite"
 import react from "@vitejs/plugin-react-swc"
 import basicSsl from "@vitejs/plugin-basic-ssl"
 import tailwindcss from "@tailwindcss/vite"
+import { execSync } from "node:child_process"
+import { createHash } from "node:crypto"
+import { readFileSync } from "node:fs"
 import { fileURLToPath, URL } from "node:url"
 
 // The control panel talks to `axol serve` (default :8001). In dev we proxy
@@ -9,8 +12,53 @@ import { fileURLToPath, URL } from "node:url"
 // both dev and the production bundle served by the Python backend.
 const SUPERVISOR = process.env.AXOL_SERVE_URL ?? "http://localhost:8001"
 
+/**
+ * Git commit this bundle is built from, baked in so the control panel can
+ * compare it against the backend's commit (/api/info) and warn on a mismatch.
+ * Vercel builds read the env var (the clone there can be shallow/absent);
+ * local builds ask git. Null when neither source is available.
+ *
+ * A dirty working tree gets a "-dirty.<hash>" suffix over the uncommitted
+ * changes, so a dist built from one dirty state still mismatches a backend
+ * running another. The scheme (status + diff, sha256, 8 hex chars) must stay
+ * identical to `installed_commit()` in almond_axol/serve/update.py.
+ */
+function buildCommit(): string | null {
+  const fromEnv = process.env.VERCEL_GIT_COMMIT_SHA
+  if (fromEnv) return fromEnv
+  const git = { encoding: "buffer", maxBuffer: 256 * 1024 * 1024 } as const
+  try {
+    const head = execSync("git rev-parse HEAD", git).toString("utf8").trim()
+    if (!head) return null
+    const status = execSync("git status --porcelain", git)
+    if (!status.toString("utf8").trim()) return head
+    const diff = execSync("git diff HEAD", git)
+    const digest = createHash("sha256").update(status).update(diff).digest("hex")
+    return `${head}-dirty.${digest.slice(0, 8)}`
+  } catch {
+    return null
+  }
+}
+
+/** Release version from the repo-root pyproject.toml (the backend's version source). */
+function buildVersion(): string | null {
+  try {
+    const pyproject = readFileSync(
+      fileURLToPath(new URL("../../pyproject.toml", import.meta.url)),
+      "utf8"
+    )
+    return /^version\s*=\s*"([^"]+)"/m.exec(pyproject)?.[1] ?? null
+  } catch {
+    return null
+  }
+}
+
 export default defineConfig({
   plugins: [react(), basicSsl(), tailwindcss()],
+  define: {
+    __AXOL_BUILD_COMMIT__: JSON.stringify(buildCommit()),
+    __AXOL_BUILD_VERSION__: JSON.stringify(buildVersion()),
+  },
   resolve: {
     alias: {
       "@": fileURLToPath(new URL("./src", import.meta.url)),

--- a/web/app/vite.config.ts
+++ b/web/app/vite.config.ts
@@ -26,7 +26,13 @@ const SUPERVISOR = process.env.AXOL_SERVE_URL ?? "http://localhost:8001"
 function buildCommit(): string | null {
   const fromEnv = process.env.VERCEL_GIT_COMMIT_SHA
   if (fromEnv) return fromEnv
-  const git = { encoding: "buffer", maxBuffer: 256 * 1024 * 1024 } as const
+  // Run from the repo root — the backend computes its identity there, and
+  // status/diff output must be byte-identical for the hashes to agree.
+  const git = {
+    encoding: "buffer",
+    maxBuffer: 256 * 1024 * 1024,
+    cwd: fileURLToPath(new URL("../..", import.meta.url)),
+  } as const
   try {
     const head = execSync("git rev-parse HEAD", git).toString("utf8").trim()
     if (!head) return null


### PR DESCRIPTION
## Summary

- Bakes the git commit + release version into the web bundle at build time (`vite.config.ts` define; `VERCEL_GIT_COMMIT_SHA` on Vercel, `git rev-parse HEAD` locally) and reports the backend's commit + install kind via `/api/info`.
- Shows a warning banner in the control panel (same spot as the update banner) when the two don't match, with a case-specific hint: rebuild for a stale locally served `web/app/dist`, update for an older release install, reload for a stale hosted page, or align checkouts against a dev backend. Warning only — nothing is blocked, so a mismatched panel can still stop a running operation.
- Commits are compared directly, with one exception: a hosted bundle vs a tag-pinned release install compares release versions instead, since the hosted UI tracks `main` and its commit legitimately differs between releases. Suppressed while the update banner already offers the fix.
- Dirty checkouts get a `-dirty.<hash>` suffix (sha256 over `git status --porcelain` + `git diff HEAD`, identical scheme in `vite.config.ts` and `serve/update.py`) so a dist built from one working-tree state mismatches a backend running another.
- Host identity is re-fetched on the existing 60s poll so a backend upgraded/restarted outside the tab is picked up. The check is self-contained (build stamp vs `/api/info`), so it works on forks unchanged.

## Test plan

- [x] `ruff check` / `ruff format --check` clean; `tsc -b`, eslint (touched files), and production build pass
- [x] `/api/info` from a live `axol serve` dev checkout returns `commit` (with dirty suffix) and `releaseInstall: false`
- [x] Node and Python compute identical identities on the same dirty checkout (incl. from a subdirectory)
- [ ] On a robot: open axol.almond.bot against a release install one version behind and confirm the banner + hint
- [ ] Rebuild `web/app/dist` at a different commit than the running backend and confirm the stale-bundle banner

Made with [Cursor](https://cursor.com)