### PR TITLE
Fix replay-dataset playback speed and jitter; add optional interpolated playback

### DIFF
--- a/almond_axol/cli/collect_data.py
+++ b/almond_axol/cli/collect_data.py
@@ -415,6 +415,36 @@ def _run(cfg: CollectDataConfig, stop_event: "threading.Event | None" = None) ->
         relay.shutdown()
         relay = None
 
+    # On the relay's encoded (gstshm-h264) transport the dataset capture loop
+    # is paced by camera frame arrival — exactly one encoded frame per dataset
+    # row — so rows land at the camera rate no matter what fps was requested,
+    # while ``meta/info.json`` is stamped with the requested value. A mismatch
+    # therefore records a dataset whose metadata lies about its timing, and
+    # every consumer (replay-dataset, training) plays it back at the wrong
+    # speed. Fail fast with the rates the relay actually opened the cameras at
+    # (they can fall back, e.g. to 30 fps) instead of recording bad data.
+    if use_relay:
+        mismatched = {
+            src: int(m["fps"])
+            for src, m in relay.raw_meta.items()
+            if src in expected
+            and m["transport"] == "gstshm-h264"
+            and int(m["fps"]) != fps
+        }
+        if mismatched:
+            relay.shutdown()
+            rates = ", ".join(
+                f"{src} at {v} fps" for src, v in sorted(mismatched.items())
+            )
+            raise ValueError(
+                f"Recording fps is {fps}, but dataset frames are captured at "
+                f"the camera rate ({rates}) — the episode would actually "
+                f"record at the camera rate while claiming {fps} fps, so "
+                f"replay and training would run at the wrong speed. Set the "
+                f"recording fps to the camera rate, or raise the camera fps "
+                f"to {fps}."
+            )
+
     # Connect first — cameras auto-detect resolution and FPS on open, which
     # is then used to define the dataset observation features. With the relay
     # the robot's cameras are shared-memory proxies, so this only opens the arms.

--- a/almond_axol/cli/replay_dataset.py
+++ b/almond_axol/cli/replay_dataset.py
@@ -14,7 +14,10 @@ The robot is moved to the rest pose before playback so the arm starts from the
 same place every episode does in ``collect-data`` (episodes are recorded from
 rest, so the first replayed action is ~rest and there's no jump). Each frame's
 action is sent at the dataset's recorded fps to reproduce the original timing,
-then a final return-to-rest leaves the arm parked.
+then a final return-to-rest leaves the arm parked. Playback runs on the
+robot's event loop with absolute-deadline pacing (like collect-data's control
+loop) so command intervals stay regular; ``--interpolate`` additionally
+upsamples the recorded actions to ~120 Hz commands for smoother tracking.
 
 With ``--loop`` the episode replays continuously (returning to rest between
 takes) until stopped with Ctrl+C, or Stop in the control panel; either way the
@@ -23,6 +26,7 @@ arm returns to the rest pose before the operation exits.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import threading
 import time
@@ -34,6 +38,11 @@ from ..lerobot.robot.config_axol import AxolRobotConfig
 from .config import LogLevel, parse
 
 _logger = logging.getLogger(__name__)
+
+# Command rate interpolated playback upsamples to — the teleop control rate,
+# so the arm receives setpoints at the same cadence it was driven with when
+# the episode was recorded.
+_INTERP_HZ = 120
 
 
 def _default_robot_config() -> AxolRobotConfig:
@@ -68,6 +77,11 @@ class ReplayDatasetConfig:
     # Playback rate. ``0`` (the default) replays at the dataset's recorded fps,
     # reproducing the original timing; set a positive value to override it.
     fps: int = 0
+    # Smooth playback by linearly interpolating between recorded actions and
+    # commanding the arms at ~120 Hz (the teleop control rate) instead of the
+    # dataset fps. Episode timing is unchanged; only the command granularity
+    # increases. Off by default (each recorded action is sent once, as-is).
+    interpolate: bool = False
     # Replay the episode on a loop until stopped (Ctrl+C, or Stop in the UI),
     # returning to rest between takes. Off by default (a single replay). Either
     # way the arm returns to the rest pose before the operation exits.
@@ -102,6 +116,7 @@ def _run(cfg: ReplayDatasetConfig, stop_event: "threading.Event | None" = None) 
     """Load the episode, return to rest, replay its actions, then return to rest."""
     from pathlib import Path
 
+    import numpy as np
     from lerobot.datasets.lerobot_dataset import LeRobotDataset
     from lerobot.utils.constants import ACTION, HF_LEROBOT_HOME
     from lerobot.utils.utils import log_say
@@ -166,7 +181,14 @@ def _run(cfg: ReplayDatasetConfig, stop_event: "threading.Event | None" = None) 
             f"expects (recorded actions: {action_names}). It wasn't recorded for "
             "this robot."
         )
+    # Pull the whole episode's actions into one numpy array up front: indexing
+    # the Arrow-backed dataset per frame inside the timed playback loop has
+    # variable latency (chunk decode), which would land directly in the command
+    # interval and show up as jerk (see the pacing note in the playback loop).
     actions = dataset.select_columns(ACTION)
+    action_matrix = np.stack(
+        [np.asarray(actions[i][ACTION], dtype=np.float64) for i in range(num_frames)]
+    )
 
     # Spawn the IK worker now so its JAX JIT (~10-20 s) overlaps with the robot
     # connect, exactly as run-policy does before its policy load.
@@ -188,6 +210,60 @@ def _run(cfg: ReplayDatasetConfig, stop_event: "threading.Event | None" = None) 
     def _stopped() -> bool:
         return stop_event.is_set()
 
+    # Interpolated playback commands the arms at ~_INTERP_HZ (the teleop rate)
+    # by linearly blending between consecutive recorded actions. Episode timing
+    # is unchanged — substeps subdivide each recorded frame's period. Linear
+    # blending is exact for joint targets and a good small-step approximation
+    # for Cartesian poses (positions are linear; consecutive rotation vectors
+    # are close enough that lerp ~= slerp at these deltas).
+    substeps = max(1, round(_INTERP_HZ / fps)) if cfg.interpolate else 1
+
+    async def _play_episode() -> None:
+        """Stream the episode's actions from the robot's event loop.
+
+        Runs *on* the robot's event loop so each command is dispatched inline
+        via ``send_action_async`` — no per-frame cross-thread hop — and paces
+        with absolute deadlines so a late wakeup is corrected on the next
+        cycle instead of stretching the command interval (both mirror
+        collect-data's hot loop). Regular command timing matters because
+        ``motion_control`` derives its velocity/acceleration feedforward by
+        differentiating commanded positions against wall time, so interval
+        jitter comes out of the arm as torque jitter.
+        """
+        send_period = 1.0 / (fps * substeps)
+        deadline = time.perf_counter()
+        for idx in range(num_frames):
+            base = action_matrix[idx]
+            # Hold the last recorded action for its full frame; never
+            # extrapolate past the end of the episode.
+            nxt = action_matrix[idx + 1] if idx + 1 < num_frames else base
+            for sub in range(substeps):
+                if _stopped():
+                    return
+                deadline += send_period
+                values = base if sub == 0 else base + (nxt - base) * (sub / substeps)
+                action = {name: float(values[i]) for i, name in enumerate(action_names)}
+                await robot.send_action_async(action)
+                await asyncio.sleep(max(0.0, deadline - time.perf_counter()))
+
+    def _play_episode_blocking() -> None:
+        """Run the playback coroutine on the robot's loop; block until done.
+
+        On Ctrl+C, signal the coroutine to unwind and wait for it to finish so
+        it stops commanding the robot before teardown, then re-raise (the
+        outer handler falls through to the return-to-rest teardown).
+        """
+        fut = asyncio.run_coroutine_threadsafe(_play_episode(), robot.event_loop)
+        try:
+            fut.result()
+        except KeyboardInterrupt:
+            stop_event.set()
+            try:
+                fut.result(timeout=5.0)
+            except BaseException:  # noqa: BLE001 - best-effort unwind
+                fut.cancel()
+            raise
+
     try:
         log_say("Connecting robot...")
         robot.connect()
@@ -204,7 +280,9 @@ def _run(cfg: ReplayDatasetConfig, stop_event: "threading.Event | None" = None) 
         _go_to_rest()
 
         loop = bool(cfg.loop)
-        period = 1.0 / fps
+        interp_note = (
+            f", interpolated to {fps * substeps} Hz commands" if substeps > 1 else ""
+        )
         iteration = 0
         # Replay once, or repeatedly when ``loop`` is set, until stopped (Ctrl+C
         # or the UI's Stop). The arm is parked at rest before the op exits — on a
@@ -215,22 +293,14 @@ def _run(cfg: ReplayDatasetConfig, stop_event: "threading.Event | None" = None) 
             if loop:
                 log_say(
                     f"Replaying episode {episode} (loop {iteration}): "
-                    f"{num_frames} frames at {fps} fps."
+                    f"{num_frames} frames at {fps} fps{interp_note}."
                 )
             else:
                 log_say(
-                    f"Replaying episode {episode}: {num_frames} frames at {fps} fps."
+                    f"Replaying episode {episode}: {num_frames} frames at "
+                    f"{fps} fps{interp_note}."
                 )
-            for idx in range(num_frames):
-                if _stopped():
-                    break
-                t0 = time.perf_counter()
-                action_array = actions[idx][ACTION]
-                action = {
-                    name: float(action_array[i]) for i, name in enumerate(action_names)
-                }
-                robot.send_action(action)
-                time.sleep(max(0.0, period - (time.perf_counter() - t0)))
+            _play_episode_blocking()
 
             if not loop or _stopped():
                 break

--- a/almond_axol/serve/runner.py
+++ b/almond_axol/serve/runner.py
@@ -687,14 +687,33 @@ class OperationRunner:
         A camera that takes part in neither branch is omitted entirely. Capture
         resolution per camera is the streaming resolution when it streams, else
         the recording resolution (no point grabbing larger than it records).
+
+        A recording fps above the cameras' default capture rate raises each
+        *recording* camera's capture fps to match: on the encoded relay
+        transport dataset rows are paced by camera frame arrival, so
+        collect-data requires the recording fps to equal the capture rate —
+        without this, setting a higher recording fps in Settings would just
+        fail that validation. (Higher rates may still be rejected by the
+        camera at large capture resolutions; that surfaces as the same clear
+        validation error.)
         """
-        from ..lerobot.camera.configuration_zed import ZED_RESOLUTION_DIMS
+        from ..lerobot.camera.configuration_zed import (
+            ZED_RESOLUTION_DIMS,
+            ZedCameraConfig,
+        )
 
         merged = dict(args)
         serials = self._camera_serials(cameras)
         stream_res = self._resolution(cameras, "stream_resolution", legacy="resolution")
         record_res = self._resolution(cameras, "record_resolution")
         detected = stereo_serials()
+
+        # The op's recording fps (settings already folded in; 0 = unset).
+        try:
+            recording_fps = int(float(str(args.get("fps") or 0)))
+        except (TypeError, ValueError):
+            recording_fps = 0
+        default_capture_fps = ZedCameraConfig.fps or 0
 
         for slot, serial in serials.items():
             streams, s_eyes = self._branch(
@@ -726,6 +745,12 @@ class OperationRunner:
                 dims = ZED_RESOLUTION_DIMS[cap]
                 merged[f"{prefix}.width"] = dims[0]
                 merged[f"{prefix}.height"] = dims[1]
+            # Recording cameras must capture at least at the recording fps
+            # (rows are paced by frame arrival on the relay's encoded
+            # transport); raise their capture fps when the setting asks for
+            # more than the default rate.
+            if records and recording_fps > default_capture_fps:
+                merged[f"{prefix}.fps"] = recording_fps
 
         if record_res is not None:
             merged["dataset_resolution"] = record_res

--- a/almond_axol/serve/settings.py
+++ b/almond_axol/serve/settings.py
@@ -400,7 +400,13 @@ SETTINGS: tuple[SettingCategory, ...] = (
                 key="recording.fps",
                 label="Recording fps",
                 type="number",
-                help="Frame rate of the recorded dataset (and policy control rate).",
+                help=(
+                    "Frame rate of the recorded dataset (and policy control "
+                    "rate). Recording cameras' capture fps is raised "
+                    "automatically to match when this is set above their "
+                    "default 60 — note the ZED X only supports rates above "
+                    "60 at SVGA resolution."
+                ),
                 targets={
                     "collect-data": ("fps",),
                     "run-policy": ("fps",),

--- a/docs/cli/collect-data.mdx
+++ b/docs/cli/collect-data.mdx
@@ -15,7 +15,7 @@ This command is configured via draccus. The robot and teleop subsystems are expo
 |---|---|
 | `--repo_id <user>/<dataset>` | HuggingFace dataset repo ID (required) |
 | `--task TEXT` | Natural language task description (required) |
-| `--fps INT` | Dataset recording frame rate — camera frames captured at this rate (default: 60) |
+| `--fps INT` | Dataset recording frame rate — camera frames captured at this rate (default: 60). On the Jetson recording path dataset rows are paced by camera frame arrival, so this **must match the camera capture fps** — a mismatch would stamp the dataset with a frame rate it wasn't captured at (replay/training would run at the wrong speed), so collect-data errors early instead. |
 | `--dataset_resolution {SVGA,HD1080,HD1200}` | Resolution the **dataset** video is recorded at (default: `SVGA` = 960×600), downscaled from the camera capture on the GPU's VIC. SVGA is ~4× lighter to encode and store than `HD1200` while the **headset still gets the full-resolution stream**. Resuming an existing dataset keeps its original resolution regardless of this flag. |
 | `--vcodec STR` | Video codec recorded for the dataset (default: per-platform — `h264` on Jetson/aarch64, `auto` elsewhere). Accepts any LeRobot codec (e.g. `auto`, `h264`, `libsvtav1`). On the Jetson `h264` is encoded on the NVENC hardware via GStreamer, in **VBR mode with a peak cap** (~0.17 bits/pixel target, ≈6 Mbps at SVGA/60fps) so every camera's dataset video stays bounded and uniformly sized — a pathologically noisy sensor is compressed down to the target instead of ballooning the dataset. |
 | `--teleop_hz INT` | Motor command rate in Hz; decoupled from `--fps` for smooth control (default: 120) |

--- a/docs/cli/replay-dataset.mdx
+++ b/docs/cli/replay-dataset.mdx
@@ -16,6 +16,7 @@ This command is configured via draccus. The robot subsystem is exposed as the ne
 | `--repo_id <user>/<dataset>` | HuggingFace dataset repo ID (required) |
 | `--episode INT` | Index of the episode to replay, 0-indexed — the first recorded episode is `0` (required) |
 | `--fps INT` | Playback frame rate. `0` (default) replays at the dataset's recorded fps, reproducing the original timing; set a positive value to override it. |
+| `--interpolate true` | Smooth playback: linearly interpolate between recorded actions and command the arms at ~120 Hz (the teleop control rate) instead of the dataset fps. Episode timing is unchanged — only the command granularity increases. Default: off (each recorded action is sent once, as-is). |
 | `--loop true` | Replay the episode continuously (returning to rest between takes) until stopped with `Ctrl+C` / **Stop**, then return to rest. Default: off (a single replay). |
 | `--root PATH` | Local dataset root (default: `$HF_LEROBOT_HOME`) |
 | `--robot_config.axol_config.left_stiffness S` | Compliance↔stiffness blend for the left arm in `[0, 1]`. Scalar or 7-element list (one per arm joint, in `Joint` enum order). `0` = fully compliant; `1` = pre-tuning industrial gains; `0.5` (default) is the geometric mean. Use `right_stiffness` for the right arm. Match the stiffness used at data-collection time so the arm tracks the recorded actions the same way. See [`AxolConfig.left_stiffness`](/api/robot). |

--- a/docs/guides/control-panel.mdx
+++ b/docs/guides/control-panel.mdx
@@ -76,7 +76,7 @@ Almost nothing you configure is actually per-run — camera assignment, arm stif
 | **Teleop & VR** | Teleop control rate, position and rotation multipliers. |
 | **Rest pose** | An **interactive 3D pose editor**: the robot model (loaded from the host's URDF) rendered live, with a slider per joint for each arm. The pose you set here is where the arms start from — and return to — in teleop and data collection. |
 | **Kinematics** | The IK solver's main cost weights (position / orientation / elbow / rest) and the per-step joint delta cap. |
-| **Recording** | Dataset fps, video codec, dataset root, push-to-hub, Rerun viewer address. |
+| **Recording** | Dataset fps, video codec, dataset root, push-to-hub, Rerun viewer address. Setting the recording fps above the cameras' default 60 automatically raises the recording cameras' capture rate to match (the ZED X only supports rates above 60 at SVGA). |
 | **Inference** | Device, remote inference server host/port, episode length, chunking and aggregation. |
 | **System** | Log level. |
 | **Advanced** | Every remaining config field, organized by subsystem (*Axol*, *Teleop*, *Kinematics*, *VR server*, *LeRobot robot*) with a search box across all of it. There is **one value per knob, applied to every operation** — the host translates it to each operation's config path, so there are never different per-task copies of the same setting. Runs of identical sub-configs — the per-joint gains — render as **one table per arm** (a row per joint, a column per parameter), and vector values like a link's CoM are entered as separate **x / y / z** fields, never raw arrays. Nothing is hidden behind collapsed groups. |

--- a/docs/guides/control-panel.mdx
+++ b/docs/guides/control-panel.mdx
@@ -113,7 +113,7 @@ Pick an operation from the selector. Each panel asks only for its **per-run inpu
 | **Teleoperation** | Axol (or sim) | Drive the arms from the VR headset. Toggle **sim** to use the browser visualizer with no hardware. If camera slots are assigned, the camera feeds are relayed to the headset automatically — see [Camera views](/guides/vr-interface#camera-views). |
 | **Gravity compensation** | Axol | Hold the arms weightless for hand-guiding. |
 | **Collect data** | Axol + Cameras | Record VR teleop episodes to a LeRobot dataset with the cameras. |
-| **Replay dataset** | Axol | Replay a recorded [`collect-data`](/cli/replay-dataset) episode on the arms, then return to rest. No cameras needed. Toggle **loop** to replay continuously until **Stop**. |
+| **Replay dataset** | Axol | Replay a recorded [`collect-data`](/cli/replay-dataset) episode on the arms, then return to rest. No cameras needed. Toggle **loop** to replay continuously until **Stop**, and **interpolate** to smooth playback by upsampling the recorded actions to ~120 Hz commands. |
 | **Run policy** | Axol + Cameras | Run a trained policy via LeRobot async inference — locally or on a remote [inference server](/cli/inference-server). |
 
 ### Before you can start

--- a/docs/operations/replay-dataset.mdx
+++ b/docs/operations/replay-dataset.mdx
@@ -26,7 +26,7 @@ No VR, cameras, or policy server are involved — replay only drives the arms, s
       </Step>
 
       <Step title="Select Replay Dataset and fill the fields">
-        Pick **Replay Dataset**. Set the dataset **repo&nbsp;id** (e.g. `myorg/pick-place`), the **episode** index (0-indexed), and the **loop** toggle — the per-run inputs. Playback fps and stiffness live in the [Settings](/guides/control-panel#settings) tabs.
+        Pick **Replay Dataset**. Set the dataset **repo&nbsp;id** (e.g. `myorg/pick-place`), the **episode** index (0-indexed), the **loop** toggle, and optionally **interpolate** (smooths playback by upsampling the recorded actions to ~120&nbsp;Hz commands; timing is unchanged) — the per-run inputs. Playback fps and stiffness live in the [Settings](/guides/control-panel#settings) tabs.
       </Step>
 
       <Step title="Start">

--- a/web/app/src/lib/supervisor.ts
+++ b/web/app/src/lib/supervisor.ts
@@ -662,7 +662,7 @@ export const OPERATIONS: OperationMeta[] = [
     id: "replay-dataset",
     label: "Replay dataset",
     description: "Replay a recorded episode of a LeRobot dataset on Axol, then return to rest.",
-    fields: ["repo_id", "episode", "loop"],
+    fields: ["repo_id", "episode", "loop", "interpolate"],
     requiresRobot: true,
     requiresCameras: false,
     simCapable: false,


### PR DESCRIPTION
## Summary

- **Wrong playback speed (e.g. 2x):** on the encoded relay transport (the standard Jetson path), dataset rows are paced by camera frame arrival, so a recording fps that doesn't match the camera rate produced a dataset stamped with an fps it wasn't captured at — replay and training then ran at the wrong speed. `collect-data` now validates the recording fps against the rates the relay actually opened the cameras at and fails fast with guidance.
- **Jittery replay:** the playback loop used per-frame relative sleeps and a cross-thread `send_action()` round trip per frame, so command intervals jittered — which `motion_control`'s velocity/accel feedforward (differentiation of commanded positions against wall time) turns into torque jitter. Playback now runs on the robot's event loop via `send_action_async` with absolute-deadline pacing (mirroring collect-data's hot loop), and the episode's actions are pre-extracted into a numpy array so Arrow access latency stays out of the command interval. Ctrl+C unwinds the coroutine before the return-to-rest teardown.
- **Optional smoothing:** new `--interpolate` flag on `replay-dataset` (default off), exposed as a per-run toggle in the control panel. It linearly blends between recorded actions and commands the arms at ~120 Hz (the teleop rate) without changing episode timing; the last frame is held, never extrapolated.

Docs updated (`cli/replay-dataset`, `cli/collect-data`, `operations/replay-dataset`, `guides/control-panel`).

## Test plan

- [ ] On the robot: start collect-data with recording fps 120 and 60 fps cameras — expect an immediate, clear error naming the camera rates.
- [ ] Record an episode with matching fps and replay it — confirm playback duration matches the recording and motion is smooth.
- [ ] Replay with **interpolate** on — confirm identical timing with smoother tracking.
- [ ] Ctrl+C / Stop mid-replay — arm stops commanding, returns to rest, op exits cleanly.
- [ ] Control panel shows the **interpolate** toggle on the Replay dataset panel and passes it through.

_Verified locally: pinned ruff check/format pass (pre-commit), `ReplayDatasetConfig` field present, serve schema exposes the flag with help text and `--interpolate` emission._

Made with [Cursor](https://cursor.com)

### Follow-up (second commit)

- **Recording fps auto-raises camera capture fps:** setting "Recording fps" in the control panel above the cameras' default 60 previously just tripped the new collect-data validation, with no UI control to raise the camera rate. The serve camera-spec fold-in now sets each *recording* camera's capture fps to the recording fps when it exceeds the default, so the one setting drives the whole pipeline. (ZED X supports >60 fps only at SVGA; an unsupported combination still surfaces as the clear validation error.)
