### PR TITLE
Upgrade the ZED Box Duo's bad factory camera driver during provisioning

### DIFF
--- a/almond_axol/cli/__init__.py
+++ b/almond_axol/cli/__init__.py
@@ -17,6 +17,7 @@ from .motor import health as motor_health
 from .motor import info as motor_info
 from .motor import set_can_id, set_zero_pos
 from .tune import friction, pid, repeatability
+from .zed import driver as zed_driver
 from .zed import install as zed_install
 
 # Commands that parse their config with draccus instead of argparse. Their
@@ -93,6 +94,7 @@ def main() -> None:
     motor_info.add_parser(subparsers)
     motor_health.add_parser(subparsers)
     zed_install.add_parser(subparsers)
+    zed_driver.add_parser(subparsers)
     gst_install.add_parser(subparsers)
     gst_build_zed.add_parser(subparsers)
     provision_cmd.add_parser(subparsers)

--- a/almond_axol/cli/provision.py
+++ b/almond_axol/cli/provision.py
@@ -7,6 +7,9 @@ The single idempotent provisioning path for the pieces ``uv tool install`` /
 * ``adb``           — Android Debug Bridge + the Oculus udev rule, for
                       streaming Quest controller poses over a USB
                       ``adb reverse`` tunnel (see :mod:`almond_axol.utils.adb`).
+* ``zed.driver``    — replaces the ZED Box Duo's known-bad factory GMSL
+                      capture driver with the pinned release (takes effect on
+                      the next reboot; never reboots itself).
 * ``zed.install``   — the pyzed bindings (not on PyPI; needs the ZED SDK).
 * ``gst.install``   — the GStreamer + PyGObject ``appsink`` stack (PyGObject
                       builds against the system gobject-introspection and is
@@ -34,6 +37,7 @@ from pathlib import Path
 from ..utils import adb
 from .gst import build_zed as gst_build_zed
 from .gst import install as gst_install
+from .zed import driver as zed_driver
 from .zed import install as zed_install
 
 _logger = logging.getLogger(__name__)
@@ -73,6 +77,11 @@ def run(_args: object = None) -> None:
     # poses over a USB `adb reverse` tunnel (avoids WiFi latency). Self-gates
     # on apt-get.
     _step("adb (Quest-over-USB)", adb.install)
+    # ZED Box Duo units ship with a known-bad factory GMSL capture driver;
+    # replace it with the pinned release. Self-gates on the factory package
+    # being present (a no-op everywhere else) and never reboots — the new
+    # kernel driver loads on the next reboot, so it just prints a notice.
+    _step("ZED Box camera driver (zed.driver)", zed_driver.run)
     have_sdk = _ZED_SDK.exists()
     if have_sdk:
         _step("pyzed (zed.install)", zed_install.run)

--- a/almond_axol/cli/provision.py
+++ b/almond_axol/cli/provision.py
@@ -58,7 +58,7 @@ def add_parser(subparsers) -> None:  # type: ignore[type-arg]
     ).set_defaults(func=run)
 
 
-def _step(label: str, fn: Callable[[], None]) -> None:
+def _step(label: str, fn: Callable[[], object]) -> None:
     """Run one provisioning step; log and continue on failure (best-effort)."""
     try:
         fn()
@@ -79,9 +79,10 @@ def run(_args: object = None) -> None:
     _step("adb (Quest-over-USB)", adb.install)
     # ZED Box Duo units ship with a known-bad factory GMSL capture driver;
     # replace it with the pinned release. Self-gates on the factory package
-    # being present (a no-op everywhere else) and never reboots — the new
-    # kernel driver loads on the next reboot, so it just prints a notice.
-    _step("ZED Box camera driver (zed.driver)", zed_driver.run)
+    # being present (ensure_driver, not run: a *quiet* no-op everywhere else)
+    # and never reboots — the new kernel driver loads on the next reboot, so
+    # it just prints a notice.
+    _step("ZED Box camera driver (zed.driver)", zed_driver.ensure_driver)
     have_sdk = _ZED_SDK.exists()
     if have_sdk:
         _step("pyzed (zed.install)", zed_install.run)

--- a/almond_axol/cli/zed/driver.py
+++ b/almond_axol/cli/zed/driver.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 import re
 import subprocess
 import sys
-import tempfile
 import urllib.request
 from pathlib import Path
 
@@ -44,6 +43,10 @@ _DEB_URL = (
 _L4T_RELEASE = "36"
 _L4T_REVISION_MAJOR = "4"
 _L4T_RELEASE_FILE = Path("/etc/nv_tegra_release")
+# Persistent cache (like zed.install's wheel cache) so a failed install can be
+# recovered by re-running — or by the manual `dpkg -i` the failure prints —
+# without re-downloading.
+_CACHE_DIR = Path.home() / ".almond" / "drivers"
 
 
 def _installed_version() -> str | None:
@@ -84,19 +87,59 @@ def _is_older(installed: str) -> bool:
     )
 
 
-def _upgrade() -> None:
-    """Download the pinned .deb and replace the installed package (needs root)."""
-    with tempfile.TemporaryDirectory(prefix="axol-zed-driver-") as tmp:
-        deb = Path(tmp) / _DEB_URL.rsplit("/", 1)[-1]
+def _download_deb() -> Path:
+    """Download the pinned .deb into the cache and verify it is a valid archive.
+
+    Everything that can fail without root — the download and the archive check
+    — happens here, *before* the factory package is removed, so a network error
+    or truncated download can never leave the box with no driver installed.
+    The cached copy also makes a re-run (or the printed manual recovery
+    command) work offline.
+    """
+    _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    deb = _CACHE_DIR / _DEB_URL.rsplit("/", 1)[-1]
+    if not deb.exists():
         print(f"Downloading {_DEB_URL}")
-        urllib.request.urlretrieve(_DEB_URL, deb)
-        # Remove the factory package first (per Stereolabs' upgrade procedure)
-        # rather than upgrading in place; best-effort since a half-removed
-        # package still gets replaced by the install below.
-        print(f"Removing the factory {_PACKAGE} package (requires sudo)...")
-        run_root(["dpkg", "-r", _PACKAGE])
-        print(f"Installing {deb.name}...")
+        # Download to a temp name and rename so an interrupted download can
+        # never be mistaken for a complete cached .deb on the next run.
+        partial = deb.with_suffix(".part")
+        urllib.request.urlretrieve(_DEB_URL, partial)
+        partial.rename(deb)
+    else:
+        print(f"Already downloaded: {deb}")
+    proc = subprocess.run(
+        ["dpkg-deb", "--info", str(deb)], capture_output=True, text=True
+    )
+    if proc.returncode != 0:
+        deb.unlink()  # corrupt — drop it so the next run re-downloads
+        raise RuntimeError(
+            f"downloaded .deb failed verification: {(proc.stderr or '').strip()}"
+        )
+    return deb
+
+
+def _upgrade() -> None:
+    """Replace the installed factory package with the pinned .deb (needs root)."""
+    deb = _download_deb()
+    # Remove the factory package first (per Stereolabs' upgrade procedure)
+    # rather than upgrading in place; best-effort since a half-removed
+    # package still gets replaced by the install below.
+    print(f"Removing the factory {_PACKAGE} package (requires sudo)...")
+    run_root(["dpkg", "-r", _PACKAGE])
+    print(f"Installing {deb.name}...")
+    try:
         run_root(["dpkg", "-i", str(deb)], check=True)
+    except RuntimeError:
+        # The factory package is already removed at this point, so don't fail
+        # silently: tell the operator exactly how to finish the install by
+        # hand (the verified .deb stays in the cache).
+        print(
+            f"ERROR: installing {deb.name} failed after the factory package "
+            f"was removed — the box has NO camera driver until this is fixed. "
+            f"Recover with: sudo dpkg -i {deb}",
+            file=sys.stderr,
+        )
+        raise
 
 
 def ensure_driver() -> bool:

--- a/almond_axol/cli/zed/driver.py
+++ b/almond_axol/cli/zed/driver.py
@@ -1,0 +1,162 @@
+"""
+axol zed.driver
+
+Upgrades the ZED Box Duo's factory-flashed GMSL capture driver
+(``stereolabs-zedbox-duo``) to the pinned known-good release. ZED Box Duo
+units ship with a buggy driver version, so this replaces it with the pinned
+release from Stereolabs' download server.
+
+Gated hard on the target hardware: it only acts when the
+``stereolabs-zedbox-duo`` package is already installed (i.e. the host is a
+factory-flashed ZED Box Duo) *and* the running L4T release matches the one the
+pinned .deb was built for — so it is a quiet no-op on any other machine and
+can never downgrade a newer driver (``dpkg --compare-versions`` guards that).
+
+The new driver is a kernel module + device-tree update, so it only takes
+effect after a reboot. This command NEVER reboots the box itself — it runs
+from ``axol provision`` (over the operator's SSH session during install, and
+from the running ``axol serve`` process after a self-update), where an
+in-place reboot would drop the session or kill the robot mid-use. It prints a
+reboot-required notice instead.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import tempfile
+import urllib.request
+from pathlib import Path
+
+from ...utils.sudo import run_root
+
+_PACKAGE = "stereolabs-zedbox-duo"
+_TARGET_VERSION = "1.4.2"
+_DEB_URL = (
+    "https://download.stereolabs.com/drivers/zedx/1.4.2/R36.4/"
+    "stereolabs-zedbox-duo_1.4.2-LI-MAX96712-ZEDBOX-L4T36.4.0_arm64.deb"
+)
+# The pinned .deb is built against L4T 36.4.x (JetPack 6.x on the ZED Box
+# Duo). Installing it on any other L4T would leave the cameras dead, so the
+# upgrade is skipped (with a warning) when the running release differs —
+# bump _DEB_URL/_TARGET_VERSION together with this when moving to a new L4T.
+_L4T_RELEASE = "36"
+_L4T_REVISION_MAJOR = "4"
+_L4T_RELEASE_FILE = Path("/etc/nv_tegra_release")
+
+
+def _installed_version() -> str | None:
+    """Installed ``stereolabs-zedbox-duo`` dpkg version, or None when absent."""
+    try:
+        proc = subprocess.run(
+            ["dpkg-query", "-W", "-f", "${Version}", _PACKAGE],
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return None
+    version = proc.stdout.strip()
+    return version if proc.returncode == 0 and version else None
+
+
+def _l4t_matches() -> bool:
+    """True when the running L4T release matches the pinned .deb's target."""
+    try:
+        first_line = _L4T_RELEASE_FILE.read_text().splitlines()[0]
+    except (OSError, IndexError):
+        return False
+    # e.g. "# R36 (release), REVISION: 4.0, GCID: ..."
+    match = re.search(r"R(\d+)\s*\(release\),\s*REVISION:\s*(\d+)", first_line)
+    if match is None:
+        return False
+    return match.group(1) == _L4T_RELEASE and match.group(2) == _L4T_REVISION_MAJOR
+
+
+def _is_older(installed: str) -> bool:
+    """True when ``installed`` is strictly older than the pinned target."""
+    return (
+        subprocess.run(
+            ["dpkg", "--compare-versions", installed, "lt", _TARGET_VERSION],
+            capture_output=True,
+        ).returncode
+        == 0
+    )
+
+
+def _upgrade() -> None:
+    """Download the pinned .deb and replace the installed package (needs root)."""
+    with tempfile.TemporaryDirectory(prefix="axol-zed-driver-") as tmp:
+        deb = Path(tmp) / _DEB_URL.rsplit("/", 1)[-1]
+        print(f"Downloading {_DEB_URL}")
+        urllib.request.urlretrieve(_DEB_URL, deb)
+        # Remove the factory package first (per Stereolabs' upgrade procedure)
+        # rather than upgrading in place; best-effort since a half-removed
+        # package still gets replaced by the install below.
+        print(f"Removing the factory {_PACKAGE} package (requires sudo)...")
+        run_root(["dpkg", "-r", _PACKAGE])
+        print(f"Installing {deb.name}...")
+        run_root(["dpkg", "-i", str(deb)], check=True)
+
+
+def ensure_driver() -> bool:
+    """Upgrade the ZED Box Duo camera driver when the factory one is outdated.
+
+    Returns True when the driver was upgraded (a reboot is then required for
+    it to load), False when there was nothing to do. Idempotent and self-gating
+    (a no-op on anything that isn't a ZED Box Duo on the pinned L4T), so it is
+    safe to run from ``axol provision`` on every host.
+    """
+    installed = _installed_version()
+    if installed is None:
+        # Not a factory-flashed ZED Box Duo (or dpkg-less host) — nothing to do.
+        return False
+    if not _is_older(installed):
+        print(f"{_PACKAGE} {installed} already >= {_TARGET_VERSION}.")
+        return False
+    if not _l4t_matches():
+        print(
+            f"WARNING: {_PACKAGE} {installed} is outdated, but the pinned "
+            f"{_TARGET_VERSION} driver targets L4T {_L4T_RELEASE}."
+            f"{_L4T_REVISION_MAJOR} and this host runs a different release — "
+            "skipping. Update the pin in almond_axol/cli/zed/driver.py.",
+            file=sys.stderr,
+        )
+        return False
+    print(
+        f"{_PACKAGE} {installed} is the known-bad factory driver — "
+        f"upgrading to {_TARGET_VERSION}."
+    )
+    _upgrade()
+    print()
+    print(
+        f"REBOOT REQUIRED: {_PACKAGE} {_TARGET_VERSION} is installed but the "
+        "new kernel driver only loads at boot. Reboot when convenient "
+        "(sudo reboot)."
+    )
+    return True
+
+
+def add_parser(subparsers) -> None:  # type: ignore[type-arg]
+    """Register the ``zed.driver`` subcommand."""
+    subparsers.add_parser(
+        "zed.driver",
+        help=(
+            "Upgrade the ZED Box Duo camera driver (stereolabs-zedbox-duo) "
+            "to the pinned release."
+        ),
+    ).set_defaults(func=run)
+
+
+def run(_args: object = None) -> None:
+    """Ensure the pinned ZED Box Duo camera driver is installed."""
+    try:
+        upgraded = ensure_driver()
+    except Exception as exc:  # noqa: BLE001 - network/dpkg failures land here
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
+    if not upgraded and _installed_version() is None:
+        print(
+            f"{_PACKAGE} is not installed — not a factory-flashed ZED Box Duo; "
+            "nothing to do."
+        )

--- a/docs/cli/provision.mdx
+++ b/docs/cli/provision.mdx
@@ -6,6 +6,7 @@ description: "Install or refresh the non-PyPI and system pieces — adb, pyzed, 
 Installs and refreshes the pieces `uv tool install` can't manage on its own:
 
 - **adb** + the Quest udev rule — for the [Quest-over-USB](/guides/quest-over-usb) controller transport (the `adb reverse` tunnel that streams poses over the cable). Self-gates on `apt`.
+- [`zed.driver`](/cli/zed-driver) — replaces the ZED Box Duo's known-bad factory **GMSL camera driver** (`stereolabs-zedbox-duo`) with the pinned release. Takes effect on the next reboot (prints a notice; never reboots itself). A no-op off a factory-flashed ZED Box Duo.
 - [`zed.install`](/cli/zed-install) — the **pyzed** bindings (not on PyPI; needs the ZED SDK).
 - [`gst.install`](/cli/gst-install) — the **GStreamer + PyGObject** `appsink` stack (PyGObject builds against the system gobject-introspection and is dropped whenever the tool environment is rebuilt, e.g. by a release upgrade).
 - [`gst.build-zed`](/cli/gst-build-zed) — the patched **`zedxonesrc` / `zedsrc`** plugins (sensor-accurate PTS so collected images line up with joint samples).

--- a/docs/cli/zed-driver.mdx
+++ b/docs/cli/zed-driver.mdx
@@ -1,0 +1,20 @@
+---
+title: "zed.driver"
+description: "Upgrade the ZED Box Duo camera driver (stereolabs-zedbox-duo) to the pinned known-good release."
+---
+
+Replaces the ZED Box Duo's factory-flashed GMSL capture driver (`stereolabs-zedbox-duo`) with the pinned known-good release from Stereolabs. ZED Box Duo units ship with a buggy driver version, which this command upgrades in place (`dpkg -r` the factory package, then `dpkg -i` the pinned `.deb`).
+
+```bash
+axol zed.driver
+```
+
+On any machine that isn't a factory-flashed ZED Box Duo — the `stereolabs-zedbox-duo` package isn't installed — this is a no-op. It also refuses to act when the installed driver is already at (or newer than) the pinned version, or when the running L4T release differs from the one the pinned `.deb` was built for.
+
+<Note>
+  [`provision`](/cli/provision) runs this automatically (the hosted installer and the `axol serve` self-updater both run `provision`), so you normally never need to invoke it directly.
+</Note>
+
+<Warning>
+  The new driver is a kernel module and only loads at boot, so a **reboot is required** after the upgrade. The command never reboots the box itself — it prints a notice instead — because it runs mid-install over SSH and from the running `axol serve` process.
+</Warning>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -74,6 +74,7 @@
               "cli/run-policy",
               "cli/inference-server",
               "cli/provision",
+              "cli/zed-driver",
               "cli/zed-install",
               "cli/gst-install",
               "cli/gst-build-zed",

--- a/web/app/public/install
+++ b/web/app/public/install
@@ -101,10 +101,18 @@ say "axol installed at $(command -v axol)."
 # idempotently -- the same command the `axol serve` self-updater runs after an
 # upgrade, so there is exactly one provisioning path. Each step self-gates
 # (a no-op without the ZED SDK / apt / NVENC).
-# Also installs adb + the Oculus udev rule (Quest-over-USB controller transport);
-# self-gates on apt and is a no-op where unavailable.
+# Also installs adb + the Oculus udev rule (Quest-over-USB controller transport)
+# and, on a factory-flashed ZED Box Duo, replaces the known-bad factory GMSL
+# camera driver with the pinned release (`axol zed.driver`); the new driver
+# only loads at boot, so provision prints a REBOOT REQUIRED notice we surface
+# in the summary below rather than rebooting the box mid-install.
 say "Provisioning system dependencies (pyzed + GStreamer camera stack + adb)..."
-axol provision || say "WARNING: provisioning failed; cameras may be unavailable or fall back to the slower ZED SDK path. Re-run 'axol provision'."
+PROVISION_LOG="$(mktemp)"
+axol provision 2>&1 | tee "${PROVISION_LOG}" \
+    || say "WARNING: provisioning failed; cameras may be unavailable or fall back to the slower ZED SDK path. Re-run 'axol provision'."
+REBOOT_REQUIRED=0
+if grep -q "REBOOT REQUIRED" "${PROVISION_LOG}"; then REBOOT_REQUIRED=1; fi
+rm -f "${PROVISION_LOG}"
 
 # -- Quest-over-USB operator access -------------------------------------------
 
@@ -217,3 +225,8 @@ fi
 say ""
 say "  Service logs  : journalctl -u ${SERVICE_NAME} -f"
 say "  Re-run this installer anytime to upgrade."
+if [ "${REBOOT_REQUIRED}" = "1" ]; then
+    say ""
+    say "REBOOT REQUIRED: the ZED Box camera driver was upgraded and only loads"
+    say "at boot. Reboot when convenient:  sudo reboot"
+fi


### PR DESCRIPTION
## Summary
- ZED Box Duo units ship with a buggy `stereolabs-zedbox-duo` GMSL capture driver; this adds `axol zed.driver`, which replaces it with the pinned 1.4.2 release (`dpkg -r` the factory package, then `dpkg -i` the pinned deb).
- Self-gating so it's safe on every host: no-op unless the factory package is installed, never downgrades (`dpkg --compare-versions`), and skips with a warning when the running L4T isn't R36.4 (what the pinned deb targets).
- Runs from `axol provision` (the single provisioning path), so both the hosted installer and the `axol serve` self-updater apply it. The new kernel driver only loads at boot, so the step prints a REBOOT REQUIRED notice — surfaced in the installer's final summary — instead of rebooting the box mid-install / mid-use.
- Docs: new `cli/zed-driver` page, listed in `docs.json` and the `provision` doc.

## Test plan
- [x] ruff check + format clean (pre-commit)
- [x] `bash -n` on the installer script
- [x] `axol zed.driver` no-ops on a non-ZED-Box host; `provision` imports OK
- [ ] On a ZED Box Duo with the factory driver: run `axol provision`, confirm the 1.4.2 deb installs and the reboot notice prints; reboot and confirm cameras work

Made with [Cursor](https://cursor.com)