### PR TITLE
Optimize web control panel and diagnostics for mobile

### DIFF
--- a/web/app/index.html
+++ b/web/app/index.html
@@ -3,8 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="color-scheme" content="dark" />
+    <meta name="theme-color" content="#121212" />
 
     <!-- Critical inline styles so the first paint is always the dark theme
          with a loading spinner — never a black/white flash while the JS,

--- a/web/app/src/components/diagnostics/diagnostic-actions.tsx
+++ b/web/app/src/components/diagnostics/diagnostic-actions.tsx
@@ -133,7 +133,7 @@ export function ActiveRunPanel({
   return (
     <Card
       className={cn(
-        "fixed right-4 bottom-4 left-4 z-40 gap-2.5 bg-[#1a1a1a] p-4 shadow-2xl sm:left-auto sm:w-80",
+        "fixed right-[max(1rem,env(safe-area-inset-right))] bottom-[max(1rem,env(safe-area-inset-bottom))] left-[max(1rem,env(safe-area-inset-left))] z-40 gap-2.5 bg-[#1a1a1a] p-4 shadow-2xl sm:left-auto sm:w-80",
         prompt ? "border-amber-400/50" : "border-emerald-400/30"
       )}
     >

--- a/web/app/src/components/diagnostics/diagnostic-actions.tsx
+++ b/web/app/src/components/diagnostics/diagnostic-actions.tsx
@@ -133,7 +133,7 @@ export function ActiveRunPanel({
   return (
     <Card
       className={cn(
-        "fixed right-4 bottom-4 z-40 w-80 gap-2.5 bg-[#1a1a1a] p-4 shadow-2xl",
+        "fixed right-4 bottom-4 left-4 z-40 gap-2.5 bg-[#1a1a1a] p-4 shadow-2xl sm:left-auto sm:w-80",
         prompt ? "border-amber-400/50" : "border-emerald-400/30"
       )}
     >
@@ -159,9 +159,7 @@ export function ActiveRunPanel({
           </Button>
         </div>
       ) : (
-        line && (
-          <span className="truncate font-mono text-[0.7rem] text-white/45">{line}</span>
-        )
+        line && <span className="truncate font-mono text-[0.7rem] text-white/45">{line}</span>
       )}
       <Button
         variant="ghost"
@@ -201,8 +199,14 @@ function JointPicker({
     const next = new Set(selected)
     if (next.has(joint)) next.delete(joint)
     else next.add(joint)
-    if (next.size === JOINTS.length) onChange(null) // all = command default
-    else onChange(JOINTS.filter((j) => next.has(j)).map((j) => j.toLowerCase()).join(","))
+    if (next.size === JOINTS.length)
+      onChange(null) // all = command default
+    else
+      onChange(
+        JOINTS.filter((j) => next.has(j))
+          .map((j) => j.toLowerCase())
+          .join(",")
+      )
   }
 
   return (
@@ -433,8 +437,8 @@ export function ActionDialog({
         {hasWebPrompts && (
           <p className="flex items-start gap-2 rounded-md border border-white/10 bg-white/[0.02] p-2.5 text-xs leading-relaxed text-white/45">
             <Hand className="mt-0.5 size-3.5 shrink-0 text-white/35" />
-            Hands-on steps pause the run and show a Continue button — the run waits for
-            you, then proceeds when you click it.
+            Hands-on steps pause the run and show a Continue button — the run waits for you, then
+            proceeds when you click it.
           </p>
         )}
 

--- a/web/app/src/components/quickstart-dialog.tsx
+++ b/web/app/src/components/quickstart-dialog.tsx
@@ -12,14 +12,14 @@ const QUICKSTART: { label: string; hint?: string; cmd: string }[] = [
 ]
 
 /** Nav-bar button that opens the Quickstart install/run cheatsheet. */
-export function QuickstartButton() {
+export function QuickstartButton({ className }: { className?: string }) {
   const [open, setOpen] = useState(false)
   return (
     <>
       <button
         type="button"
         onClick={() => setOpen(true)}
-        className={cn(buttonVariants({ variant: "ghost", size: "sm" }))}
+        className={cn(buttonVariants({ variant: "ghost", size: "sm" }), className)}
       >
         <Rocket />
         Quickstart
@@ -69,8 +69,8 @@ function QuickstartDialog({ open, onClose }: { open: boolean; onClose: () => voi
             </div>
           ))}
           <p className="text-xs text-white/45">
-            Then press <span className="text-white/70">Connect</span> and enter the
-            machine&apos;s IP.
+            Then press <span className="text-white/70">Connect</span> and enter the machine&apos;s
+            IP.
           </p>
         </div>
       </div>

--- a/web/app/src/components/quickstart-dialog.tsx
+++ b/web/app/src/components/quickstart-dialog.tsx
@@ -1,8 +1,6 @@
 import { useEffect, useState } from "react"
 import { createPortal } from "react-dom"
 import { Check, Copy, Rocket, X } from "lucide-react"
-import { buttonVariants } from "@/components/ui/button"
-import { cn } from "@/lib/utils"
 
 const QUICKSTART: { label: string; hint?: string; cmd: string }[] = [
   {
@@ -11,25 +9,12 @@ const QUICKSTART: { label: string; hint?: string; cmd: string }[] = [
   },
 ]
 
-/** Nav-bar button that opens the Quickstart install/run cheatsheet. */
-export function QuickstartButton({ className }: { className?: string }) {
-  const [open, setOpen] = useState(false)
-  return (
-    <>
-      <button
-        type="button"
-        onClick={() => setOpen(true)}
-        className={cn(buttonVariants({ variant: "ghost", size: "sm" }), className)}
-      >
-        <Rocket />
-        Quickstart
-      </button>
-      <QuickstartDialog open={open} onClose={() => setOpen(false)} />
-    </>
-  )
-}
-
-function QuickstartDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
+/**
+ * The Quickstart install/run cheatsheet dialog. State lives with the caller
+ * (the nav) so the trigger can sit inside the collapsible mobile menu — whose
+ * unmount on close must not take the open dialog down with it.
+ */
+export function QuickstartDialog({ open, onClose }: { open: boolean; onClose: () => void }) {
   useEffect(() => {
     if (!open) return
     const onKey = (e: KeyboardEvent) => e.key === "Escape" && onClose()

--- a/web/app/src/components/site-nav.tsx
+++ b/web/app/src/components/site-nav.tsx
@@ -1,7 +1,7 @@
 import { useState, type ReactNode } from "react"
-import { ExternalLink, Menu, X } from "lucide-react"
+import { ExternalLink, Menu, Rocket, X } from "lucide-react"
 import { buttonVariants } from "@/components/ui/button"
-import { QuickstartButton } from "@/components/quickstart-dialog"
+import { QuickstartDialog } from "@/components/quickstart-dialog"
 import { cn } from "@/lib/utils"
 
 /**
@@ -18,7 +18,15 @@ const PAGE_LABEL: Record<string, string> = {
   diagnostics: "Diagnostics",
 }
 
-function NavLinks({ current, itemClass }: { current: string; itemClass?: string }) {
+function NavLinks({
+  current,
+  onQuickstart,
+  itemClass,
+}: {
+  current: string
+  onQuickstart: () => void
+  itemClass?: string
+}) {
   const item = cn(buttonVariants({ variant: "ghost", size: "sm" }), itemClass)
   return (
     <>
@@ -26,7 +34,12 @@ function NavLinks({ current, itemClass }: { current: string; itemClass?: string 
         Docs
         <ExternalLink />
       </a>
-      {current === "control" && <QuickstartButton className={itemClass} />}
+      {current === "control" && (
+        <button type="button" onClick={onQuickstart} className={item}>
+          <Rocket />
+          Quickstart
+        </button>
+      )}
       {current !== "control" && (
         <a href="/control" className={item}>
           Control Panel
@@ -54,9 +67,12 @@ export function SiteNav({
   right?: ReactNode
 }) {
   const [menuOpen, setMenuOpen] = useState(false)
+  // Owned here, not by the menu item: closing the menu unmounts its contents,
+  // which must not take an opening Quickstart dialog down with it.
+  const [quickstartOpen, setQuickstartOpen] = useState(false)
   return (
-    <header className="sticky top-0 z-40 border-b border-white/10 bg-[#121212]/85 backdrop-blur-md">
-      <div className="relative mx-auto flex h-14 max-w-6xl items-center justify-between gap-2 px-4 sm:h-16 sm:px-6">
+    <header className="sticky top-0 z-40 border-b border-white/10 bg-[#121212]/85 pt-[env(safe-area-inset-top)] backdrop-blur-md">
+      <div className="safe-x relative mx-auto flex h-14 max-w-6xl items-center justify-between gap-2 sm:h-16">
         <div className="flex min-w-0 items-center gap-2 sm:gap-3">
           <img src="/almond.svg" alt="Almond" className="h-6 w-6 shrink-0" />
           <span className="font-heading text-base font-semibold tracking-tight whitespace-nowrap">
@@ -69,7 +85,7 @@ export function SiteNav({
         <div className="flex shrink-0 items-center gap-2">
           {right}
           <nav className="hidden items-center gap-2 md:flex">
-            <NavLinks current={current} />
+            <NavLinks current={current} onQuickstart={() => setQuickstartOpen(true)} />
           </nav>
           <button
             type="button"
@@ -83,13 +99,18 @@ export function SiteNav({
         </div>
         {menuOpen && (
           <nav
-            className="absolute inset-x-0 top-full flex flex-col gap-1 border-b border-white/10 bg-[#121212]/95 p-3 shadow-xl backdrop-blur-md md:hidden"
+            className="safe-x absolute inset-x-0 top-full flex flex-col gap-1 border-b border-white/10 bg-[#121212]/95 py-3 shadow-xl backdrop-blur-md md:hidden"
             onClick={() => setMenuOpen(false)}
           >
-            <NavLinks current={current} itemClass="w-full justify-start" />
+            <NavLinks
+              current={current}
+              onQuickstart={() => setQuickstartOpen(true)}
+              itemClass="w-full justify-start"
+            />
           </nav>
         )}
       </div>
+      <QuickstartDialog open={quickstartOpen} onClose={() => setQuickstartOpen(false)} />
     </header>
   )
 }

--- a/web/app/src/components/site-nav.tsx
+++ b/web/app/src/components/site-nav.tsx
@@ -1,5 +1,5 @@
-import type { ReactNode } from "react"
-import { ExternalLink } from "lucide-react"
+import { useState, type ReactNode } from "react"
+import { ExternalLink, Menu, X } from "lucide-react"
 import { buttonVariants } from "@/components/ui/button"
 import { QuickstartButton } from "@/components/quickstart-dialog"
 import { cn } from "@/lib/utils"
@@ -9,12 +9,41 @@ import { cn } from "@/lib/utils"
  * which cross-link is shown (control panel <-> VR app). Uses plain anchors so
  * switching routes does a full navigation (each route lazy-loads its bundle).
  * ``right`` injects route-specific controls (e.g. the connection pill) just
- * before the Docs / cross-link buttons.
+ * before the Docs / cross-link buttons. On narrow screens the links collapse
+ * into a hamburger menu so the bar never overflows the viewport.
  */
 const PAGE_LABEL: Record<string, string> = {
   control: "Control Panel",
   vr: "VR",
   diagnostics: "Diagnostics",
+}
+
+function NavLinks({ current, itemClass }: { current: string; itemClass?: string }) {
+  const item = cn(buttonVariants({ variant: "ghost", size: "sm" }), itemClass)
+  return (
+    <>
+      <a href="https://docs.almond.bot" target="_blank" rel="noreferrer" className={item}>
+        Docs
+        <ExternalLink />
+      </a>
+      {current === "control" && <QuickstartButton className={itemClass} />}
+      {current !== "control" && (
+        <a href="/control" className={item}>
+          Control Panel
+        </a>
+      )}
+      {current !== "diagnostics" && (
+        <a href="/diagnostics" className={item}>
+          Diagnostics
+        </a>
+      )}
+      {current !== "vr" && (
+        <a href="/vr" className={item}>
+          VR App
+        </a>
+      )}
+    </>
+  )
 }
 
 export function SiteNav({
@@ -24,45 +53,42 @@ export function SiteNav({
   current: "control" | "vr" | "diagnostics"
   right?: ReactNode
 }) {
+  const [menuOpen, setMenuOpen] = useState(false)
   return (
     <header className="sticky top-0 z-40 border-b border-white/10 bg-[#121212]/85 backdrop-blur-md">
-      <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-6">
-        <div className="flex items-center gap-3">
-          <img src="/almond.svg" alt="Almond" className="h-6 w-6" />
-          <span className="font-heading text-base font-semibold tracking-tight">Almond Axol</span>
-          <span className="hidden text-sm text-white/35 sm:inline">{PAGE_LABEL[current]}</span>
+      <div className="relative mx-auto flex h-14 max-w-6xl items-center justify-between gap-2 px-4 sm:h-16 sm:px-6">
+        <div className="flex min-w-0 items-center gap-2 sm:gap-3">
+          <img src="/almond.svg" alt="Almond" className="h-6 w-6 shrink-0" />
+          <span className="font-heading text-base font-semibold tracking-tight whitespace-nowrap">
+            Almond Axol
+          </span>
+          <span className="hidden truncate text-sm text-white/35 min-[420px]:inline">
+            {PAGE_LABEL[current]}
+          </span>
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex shrink-0 items-center gap-2">
           {right}
-          <a
-            href="https://docs.almond.bot"
-            target="_blank"
-            rel="noreferrer"
-            className={cn(buttonVariants({ variant: "ghost", size: "sm" }))}
+          <nav className="hidden items-center gap-2 md:flex">
+            <NavLinks current={current} />
+          </nav>
+          <button
+            type="button"
+            onClick={() => setMenuOpen((o) => !o)}
+            aria-label={menuOpen ? "Close menu" : "Open menu"}
+            aria-expanded={menuOpen}
+            className={cn(buttonVariants({ variant: "ghost", size: "icon" }), "size-8 md:hidden")}
           >
-            Docs
-            <ExternalLink />
-          </a>
-          {current === "control" && <QuickstartButton />}
-          {current !== "control" && (
-            <a href="/control" className={cn(buttonVariants({ variant: "ghost", size: "sm" }))}>
-              Control Panel
-            </a>
-          )}
-          {current !== "diagnostics" && (
-            <a
-              href="/diagnostics"
-              className={cn(buttonVariants({ variant: "ghost", size: "sm" }))}
-            >
-              Diagnostics
-            </a>
-          )}
-          {current !== "vr" && (
-            <a href="/vr" className={cn(buttonVariants({ variant: "ghost", size: "sm" }))}>
-              VR App
-            </a>
-          )}
+            {menuOpen ? <X /> : <Menu />}
+          </button>
         </div>
+        {menuOpen && (
+          <nav
+            className="absolute inset-x-0 top-full flex flex-col gap-1 border-b border-white/10 bg-[#121212]/95 p-3 shadow-xl backdrop-blur-md md:hidden"
+            onClick={() => setMenuOpen(false)}
+          >
+            <NavLinks current={current} itemClass="w-full justify-start" />
+          </nav>
+        )}
       </div>
     </header>
   )

--- a/web/app/src/components/ui/input.tsx
+++ b/web/app/src/components/ui/input.tsx
@@ -6,7 +6,7 @@ export const Input = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputE
     <input
       ref={ref}
       className={cn(
-        "h-9 w-full rounded-md border border-input bg-white/[0.02] px-3 text-sm text-foreground transition-colors outline-none placeholder:text-white/30 focus-visible:border-ring/70 focus-visible:ring-2 focus-visible:ring-ring/30 disabled:cursor-not-allowed disabled:opacity-50",
+        "h-9 w-full rounded-md border border-input bg-white/[0.02] px-3 text-base text-foreground sm:text-sm transition-colors outline-none placeholder:text-white/30 focus-visible:border-ring/70 focus-visible:ring-2 focus-visible:ring-ring/30 disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}

--- a/web/app/src/components/ui/select.tsx
+++ b/web/app/src/components/ui/select.tsx
@@ -7,7 +7,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectHTMLAttributes<HTMLSel
     <select
       ref={ref}
       className={cn(
-        "h-9 w-full rounded-md border border-input bg-white/[0.02] px-3 text-sm text-foreground transition-colors outline-none focus-visible:border-ring/70 focus-visible:ring-2 focus-visible:ring-ring/30 disabled:cursor-not-allowed disabled:opacity-50",
+        "h-9 w-full rounded-md border border-input bg-white/[0.02] px-3 text-base text-foreground sm:text-sm transition-colors outline-none focus-visible:border-ring/70 focus-visible:ring-2 focus-visible:ring-ring/30 disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}

--- a/web/app/src/index.css
+++ b/web/app/src/index.css
@@ -94,6 +94,19 @@ body {
   text-rendering: optimizeLegibility;
 }
 
+/* Horizontal page padding that also clears the notch in landscape
+   (viewport-fit=cover): the usual 1rem / 1.5rem gutters, grown to the
+   safe-area inset when the device reports a larger one. */
+@utility safe-x {
+  padding-left: max(1rem, env(safe-area-inset-left));
+  padding-right: max(1rem, env(safe-area-inset-right));
+
+  @media (min-width: 640px) {
+    padding-left: max(1.5rem, env(safe-area-inset-left));
+    padding-right: max(1.5rem, env(safe-area-inset-right));
+  }
+}
+
 /* The R3F canvas in the VR route fills its (fixed, full-screen) parent. */
 canvas {
   display: block;

--- a/web/app/src/routes/ControlPanel.tsx
+++ b/web/app/src/routes/ControlPanel.tsx
@@ -787,7 +787,7 @@ export default function ControlPanel() {
   return (
     <div className="min-h-screen">
       <SiteNav current="control" />
-      <main className="mx-auto flex max-w-5xl flex-col gap-6 px-6 py-8">
+      <main className="mx-auto flex max-w-5xl flex-col gap-6 px-4 py-6 sm:px-6 sm:py-8">
         {update?.updateAvailable && (
           <UpdateBanner
             update={update}
@@ -817,7 +817,7 @@ export default function ControlPanel() {
         />
 
         {conn.state === "ok" && (
-          <div ref={settingsRef} className="scroll-mt-4">
+          <div ref={settingsRef} className="scroll-mt-18 sm:scroll-mt-20">
             <SettingsSection
               open={settingsOpen}
               onOpenChange={setSettingsOpen}
@@ -894,7 +894,7 @@ function OperationSelector({
   onSelect: (op: OperationId) => void
 }) {
   return (
-    <div className="grid grid-cols-2 gap-3 sm:grid-cols-5">
+    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
       {OPERATIONS.map((op) => {
         const active = op.id === selected
         const running = op.id === runningOp

--- a/web/app/src/routes/ControlPanel.tsx
+++ b/web/app/src/routes/ControlPanel.tsx
@@ -787,7 +787,7 @@ export default function ControlPanel() {
   return (
     <div className="min-h-screen">
       <SiteNav current="control" />
-      <main className="mx-auto flex max-w-5xl flex-col gap-6 px-4 py-6 sm:px-6 sm:py-8">
+      <main className="safe-x mx-auto flex max-w-5xl flex-col gap-6 py-6 pb-[max(1.5rem,env(safe-area-inset-bottom))] sm:py-8">
         {update?.updateAvailable && (
           <UpdateBanner
             update={update}

--- a/web/app/src/routes/Diagnostics.tsx
+++ b/web/app/src/routes/Diagnostics.tsx
@@ -431,7 +431,7 @@ export default function Diagnostics() {
           </span>
         }
       />
-      <main className="mx-auto flex max-w-6xl flex-col gap-8 px-4 py-6 sm:px-6 sm:py-8">
+      <main className="safe-x mx-auto flex max-w-6xl flex-col gap-8 py-6 pb-[max(1.5rem,env(safe-area-inset-bottom))] sm:py-8">
         {/* Robot link gate */}
         {robot && robot.state === "disconnected" && (
           <div className="flex items-center gap-3 rounded-lg border border-white/10 bg-white/[0.02] p-3">

--- a/web/app/src/routes/Diagnostics.tsx
+++ b/web/app/src/routes/Diagnostics.tsx
@@ -431,7 +431,7 @@ export default function Diagnostics() {
           </span>
         }
       />
-      <main className="mx-auto flex max-w-6xl flex-col gap-8 px-6 py-8">
+      <main className="mx-auto flex max-w-6xl flex-col gap-8 px-4 py-6 sm:px-6 sm:py-8">
         {/* Robot link gate */}
         {robot && robot.state === "disconnected" && (
           <div className="flex items-center gap-3 rounded-lg border border-white/10 bg-white/[0.02] p-3">


### PR DESCRIPTION
## Summary

The control panel was unusable on phones — the header nav buttons (Docs / Quickstart / Diagnostics / VR App) overflowed off-screen and the logo text wrapped.

- **Header**: below `md`, nav links collapse into a hamburger menu that drops down under the bar; logo stays on one line; tighter bar height/padding on phones
- **Page layout**: responsive padding on `/control` and `/diagnostics`; operation selector grid steps 2 → 3 → 5 columns instead of jumping to 5 at 640px
- **iOS input zoom**: `Input`/`Select` use 16px text on mobile (`text-base sm:text-sm`) so Safari stops auto-zooming on focus
- **Diagnostics**: the fixed-width floating active-run panel spans the screen width on phones instead of clipping
- **Meta**: `viewport-fit=cover` and `theme-color: #121212` for notched phones / dark browser chrome
- Fix: settings scroll anchor (`scroll-mt`) now clears the sticky header (affected desktop too)

Replaces #145, which was accidentally based on `umi`.

## Testing

- `npm run build` (tsc + Vite) clean on main; eslint shows only pre-existing issues in untouched files; prettier clean

Made with [Cursor](https://cursor.com)