### PR TITLE
Log CPU/memory diagnostics during collect-data at INFO

### DIFF
--- a/almond_axol/cli/collect_data.py
+++ b/almond_axol/cli/collect_data.py
@@ -529,29 +529,28 @@ def _run(cfg: CollectDataConfig, stop_event: "threading.Event | None" = None) ->
             relay.shutdown()
         raise
 
-    # Background perf samplers (per-second /proc CPU breakdown + Jetson GPU/EMC/
-    # NVENC/thermal). These were the instrumentation for the recording-jitter
-    # investigation; keep them available but only run + print them at DEBUG so the
-    # default INFO output stays the single loop-rate line. Labels map the known
-    # subprocesses (mp spawn children all report comm=python) so the IK solver,
-    # video relay, and dataset recorder are legible in the breakdown.
-    diag: SystemDiag | None = None
-    tegra: TegraStatsDiag | None = None
-    if _logger.isEnabledFor(logging.DEBUG):
-        diag_labels: dict[int, str] = {os.getpid(): "main"}
-        ik_proc = getattr(teleop, "_ik_process", None)
-        if ik_proc is not None and getattr(ik_proc, "pid", None):
-            diag_labels[ik_proc.pid] = "ik"
-        if relay is not None and getattr(relay, "_proc", None) is not None:
-            relay_pid = getattr(relay._proc, "pid", None)
-            if relay_pid:
-                diag_labels[relay_pid] = "relay"
-        if getattr(recorder, "pid", None):
-            diag_labels[recorder.pid] = "recorder"  # type: ignore[union-attr]
-        diag = SystemDiag(diag_labels, _logger)
-        diag.start()
-        tegra = TegraStatsDiag(_logger)  # no-op off-Tegra
-        tegra.start()
+    # Background perf samplers (per-second /proc CPU + memory breakdown and
+    # Jetson GPU/EMC/NVENC/thermal), started unconditionally as in `axol teleop`
+    # so the two flows' lines line up and a collection session can be compared
+    # against the teleop baseline. Both keep their heavy system-wide tiers at
+    # DEBUG, so the default INFO output stays a couple of lines per second.
+    # Labels map the known subprocesses (mp spawn children all report
+    # comm=python) so the IK solver, video relay, and dataset recorder are
+    # legible in the breakdown.
+    diag_labels: dict[int, str] = {os.getpid(): "main"}
+    ik_proc = getattr(teleop, "_ik_process", None)
+    if ik_proc is not None and getattr(ik_proc, "pid", None):
+        diag_labels[ik_proc.pid] = "ik"
+    if relay is not None and getattr(relay, "_proc", None) is not None:
+        relay_pid = getattr(relay._proc, "pid", None)
+        if relay_pid:
+            diag_labels[relay_pid] = "relay"
+    if getattr(recorder, "pid", None):
+        diag_labels[recorder.pid] = "recorder"  # type: ignore[union-attr]
+    diag = SystemDiag(diag_labels, _logger)
+    diag.start()
+    tegra = TegraStatsDiag(_logger)  # no-op off-Tegra
+    tegra.start()
 
     # Keep the relay's raw dataset branch closed until an episode records: the
     # raw VIC convert + shared-memory copy for every camera is the bulk of the
@@ -784,10 +783,8 @@ def _run(cfg: CollectDataConfig, stop_event: "threading.Event | None" = None) ->
     finally:
         log_say("Stopping.")
 
-        if diag is not None:
-            diag.stop()
-        if tegra is not None:
-            tegra.stop()
+        diag.stop()
+        tegra.stop()
 
         robot.disconnect()
         teleop.disconnect()


### PR DESCRIPTION
## What

`axol collect-data` was already constructing the same background samplers as `axol teleop` — `SystemDiag` (`/proc` per-core saturation, memory/swap, per-process CPU% and RSS) and `TegraStatsDiag` (GPU/EMC load, NVENC clock, CPU frequency, temperature, throttle state) — but only when the logger was at `DEBUG`. At the default `INFO` level a collection session printed neither line.

This starts both unconditionally, matching teleop.

## Why

Recording is the run where CPU and memory contention actually matters: the video relay, the NVENC encoders, and the dataset recorder are all live alongside the 120 Hz control loop. It's also the run that needs to be diffed against the teleop baseline, which is why `SystemDiag` is shared by the two flows in the first place — but that comparison was only possible if you knew to re-run with `--log_level DEBUG`.

Both samplers already separate a cheap tier from an expensive one. `SystemDiag`'s `INFO` tier reads a handful of `/proc` files for the labelled pids and their children; the system-wide `/proc` walk and the per-thread breakdown stay at `DEBUG`. So the default output grows by the two per-second `diag:` / `tegra:` lines next to the existing loop-rate line, not by a firehose.

The labels are unchanged and already cover `main`, `ik`, `relay`, and `recorder` (plus each one's gst encode children), so the breakdown names the process eating cores rather than reporting four anonymous `python` entries.

## Notes

- `TegraStatsDiag` is a clean no-op off a Jetson, so this adds nothing on a dev machine beyond the `diag:` line.
- This is terminal logging only. Wiring these numbers into the control panel next to the motor telemetry hub would be a separate change; the samplers currently hold a logger and have no fan-out path.

## Test plan

- [ ] `axol collect-data` on the Jetson at default log level emits a `diag:` and a `tegra:` line each second, through both the pre-record teleop phase and an active episode.
- [ ] The per-process breakdown names `main` / `ik` / `relay` / `recorder` rather than `python`.
- [ ] Control loop still holds its rate — the `loop:` line during recording is unchanged versus before this patch.

Made with [Cursor](https://cursor.com)