### PR TITLE
Fix teleop stuck-then-lurch, boundary/singularity jitter, and bad-wifi lurches

### DIFF
--- a/almond_axol/kinematics/config.py
+++ b/almond_axol/kinematics/config.py
@@ -21,7 +21,14 @@ class KinematicsConfig:
         posture_weight: Weight penalising deviation from the global preferred posture.
             Acts as a persistent attractor toward the home/rest configuration,
             preventing slow null-space drift (e.g. unnecessary shoulder twist).
-        manipulability_weight: Weight rewarding configurations with high manipulability.
+        manipulability_weight: Weight rewarding configurations with high
+            manipulability — the null-space bias that keeps the arm *away* from
+            singular configurations (e.g. the shoulder gimbal region where
+            s1/s3 align and small hand motions demand fast s1/s2 swings). 0.2
+            raises the worst-case Yoshikawa measure through singular-region
+            sweeps by 60-80% versus the old 0.05 token weight, at no measured
+            cost to tracking error or smoothness; 0.5+ starts fighting the
+            pose targets (velocity spikes, higher tracking error).
         limit_weight: Weight penalising joint-limit violations.
         self_collision_margin: Minimum clearance (m) enforced between collision
             bodies. Keep this below the arm-torso clearance of normal teleop
@@ -71,7 +78,7 @@ class KinematicsConfig:
     elbow_weight: float = 5.0
     rest_weight: float = 7.5
     posture_weight: float = 5.0
-    manipulability_weight: float = 0.05
+    manipulability_weight: float = 0.2
     limit_weight: float = 75.0
     self_collision_margin: float = 0.025
     self_collision_weight: float = 75.0

--- a/almond_axol/kinematics/config.py
+++ b/almond_axol/kinematics/config.py
@@ -24,10 +24,36 @@ class KinematicsConfig:
             preventing slow null-space drift (e.g. unnecessary shoulder twist).
         manipulability_weight: Weight rewarding configurations with high manipulability.
         limit_weight: Weight penalising joint-limit violations.
-        self_collision_margin: Minimum clearance (m) enforced between collision bodies.
+        self_collision_margin: Minimum clearance (m) enforced between collision
+            bodies. Keep this below the arm-torso clearance of normal teleop
+            poses: a margin that is already violated at the folded rest pose
+            (e.g. the old 0.1 default) keeps the nonsmooth collision hinge
+            active during ordinary tracking, which makes the trust-region
+            solver reject steps — the arm freezes while small target errors
+            accumulate, then lurches once the error is large enough to punch
+            through (the teleop "stuck, then jumps" failure). 0.025 matches
+            ``VRTeleopConfig.reset_collision_margin``.
         self_collision_weight: Weight on the self-collision penalty.
         max_iterations: Maximum solver iterations per call.
-        cost_tolerance: Solver convergence tolerance.
+        cost_tolerance: Solver convergence tolerance — terminate when the
+            relative cost change of an iteration falls below this. jaxls also
+            applies it to *rejected* proposals (whose cost change is ~0), so a
+            loose value (the old 1e-2) makes one rejected step read as
+            "converged" and return the seed unchanged. Keep it small enough
+            that only genuine convergence trips it.
+        lambda_initial: Initial Levenberg-Marquardt damping. The per-tick solve
+            re-seeds from the previous solution, so the first proposal is taken
+            in a region where the linearisation may be poor (e.g. with the
+            self-collision cost active); a moderately damped start gets an
+            acceptable step in fewer rejections than the jaxls default (5e-4).
+        lambda_factor: Multiplier applied to the LM damping after each rejected
+            step. With the jaxls default (2.0) and ``max_iterations`` of 8,
+            damping can only grow 256x per solve — not enough to recover from a
+            rejected near-Gauss-Newton step near an active collision
+            constraint, so the solver used to return its seed unchanged for
+            many consecutive ticks (teleop froze) and then lurch once the
+            accumulated target error finally made a full step acceptable. 10.0
+            spans the useful damping range within the iteration budget.
         max_joint_delta: Maximum joint change per :meth:`KinematicsSolver.ik` call, in radians.
         max_reach: Maximum allowed distance (m) from shoulder to end-effector target.
     """
@@ -39,9 +65,11 @@ class KinematicsConfig:
     posture_weight: float = 5.0
     manipulability_weight: float = 0.05
     limit_weight: float = 75.0
-    self_collision_margin: float = 0.1
+    self_collision_margin: float = 0.025
     self_collision_weight: float = 75.0
     max_iterations: int = 8
-    cost_tolerance: float = 1e-2
+    cost_tolerance: float = 1e-4
+    lambda_initial: float = 1e-2
+    lambda_factor: float = 10.0
     max_joint_delta: float = 0.0055 * 2 * math.pi
     max_reach: float = 0.8

--- a/almond_axol/kinematics/config.py
+++ b/almond_axol/kinematics/config.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import math
 from dataclasses import dataclass
 
 
@@ -40,7 +39,9 @@ class KinematicsConfig:
             applies it to *rejected* proposals (whose cost change is ~0), so a
             loose value (the old 1e-2) makes one rejected step read as
             "converged" and return the seed unchanged. Keep it small enough
-            that only genuine convergence trips it.
+            that only genuine convergence trips it: 1e-6 halves the residual
+            freeze rate at the reach boundary versus 1e-4 (the iteration
+            budget, not this tolerance, bounds the solve time).
         lambda_initial: Initial Levenberg-Marquardt damping. The per-tick solve
             re-seeds from the previous solution, so the first proposal is taken
             in a region where the linearisation may be poor (e.g. with the
@@ -54,7 +55,14 @@ class KinematicsConfig:
             many consecutive ticks (teleop froze) and then lurch once the
             accumulated target error finally made a full step acceptable. 10.0
             spans the useful damping range within the iteration budget.
-        max_joint_delta: Maximum joint change per :meth:`KinematicsSolver.ik` call, in radians.
+        max_joint_delta: Maximum joint change per :meth:`KinematicsSolver.ik` call,
+            in radians. This bounds the release velocity of any residual solver
+            stall (stall ticks accumulate target error that is paid back at
+            this rate), so it directly caps command-velocity spikes at
+            kinematic boundaries and near shoulder singularities: 0.02 rad at
+            the ~72 Hz frame rate is ~1.4 rad/s per joint, comfortably above
+            normal tracking demand but half the old 0.0345-rad cap that let
+            catch-up sweeps hit 2.5+ rad/s on s1/s2.
         max_reach: Maximum allowed distance (m) from shoulder to end-effector target.
     """
 
@@ -68,8 +76,8 @@ class KinematicsConfig:
     self_collision_margin: float = 0.025
     self_collision_weight: float = 75.0
     max_iterations: int = 8
-    cost_tolerance: float = 1e-4
+    cost_tolerance: float = 1e-6
     lambda_initial: float = 1e-2
     lambda_factor: float = 10.0
-    max_joint_delta: float = 0.0055 * 2 * math.pi
+    max_joint_delta: float = 0.02
     max_reach: float = 0.8

--- a/almond_axol/kinematics/solver.py
+++ b/almond_axol/kinematics/solver.py
@@ -135,6 +135,8 @@ def _solve_ik(
     elbow_weight: float,
     max_iterations: int,
     cost_tolerance: float,
+    lambda_initial: float,
+    lambda_factor: float,
 ) -> jax.Array:
     JointVar = robot.joint_var_cls
 
@@ -218,7 +220,10 @@ def _solve_ik(
         initial_vals=initial_vals,
         verbose=False,
         linear_solver="dense_cholesky",
-        trust_region=jaxls.TrustRegionConfig(),
+        trust_region=jaxls.TrustRegionConfig(
+            lambda_initial=lambda_initial,
+            lambda_factor=lambda_factor,
+        ),
         termination=jaxls.TerminationConfig(
             max_iterations=max_iterations,
             cost_tolerance=cost_tolerance,
@@ -513,6 +518,8 @@ class KinematicsSolver:
             cfg.elbow_weight,
             cfg.max_iterations,
             cfg.cost_tolerance,
+            cfg.lambda_initial,
+            cfg.lambda_factor,
         )
         q_result_np = np.asarray(q_result, dtype=np.float32)
         delta = np.clip(

--- a/almond_axol/teleop/worker.py
+++ b/almond_axol/teleop/worker.py
@@ -8,10 +8,12 @@ All intermediate computations stay in NumPy; the single JAX boundary is the
 
 from __future__ import annotations
 
+import logging
 import math
 import multiprocessing
 import multiprocessing.connection
 import os
+import time
 
 import jax.numpy as jnp
 import jaxlie
@@ -23,6 +25,18 @@ from ..vr.models import VRFrame
 from .config import VRTeleopConfig
 from .filter import OneEuroFilter
 from .trajectory import plan_collision_aware_trajectory
+
+_logger = logging.getLogger(__name__)
+
+# Freeze detection (see IKWorker._note_solve): warn when the solver keeps
+# returning its seed unchanged while the tracked targets move away — the
+# operator experiences the arm as stuck, then lurching once the solve breaks
+# free. Thresholds: how long the output must be frozen before warning, how far
+# the targets must have moved (so a still hand doesn't warn), and how often to
+# re-warn while the freeze persists.
+_FREEZE_WARN_AFTER_S = 0.5
+_FREEZE_MIN_TARGET_DRIFT_M = 0.005
+_FREEZE_REWARN_EVERY_S = 2.0
 
 # ---------------------------------------------------------------------------
 # NumPy-only helpers (no JAX dispatch overhead)
@@ -161,6 +175,14 @@ class IKWorker:
         self._solver.set_posture_pose(self.get_rest_q())
 
         self._active: bool = False
+        # Freeze detection state: when the last solve returned its seed
+        # unchanged, `_freeze_since` holds the wall time the freeze started and
+        # `_freeze_targets` the EE/elbow target positions at that moment, so a
+        # warning fires only when the targets kept moving away (a still hand
+        # legitimately produces an unchanged solution).
+        self._freeze_since: float | None = None
+        self._freeze_targets: np.ndarray | None = None
+        self._freeze_next_warn: float = _FREEZE_WARN_AFTER_S
         # Snap poses as (pos_3, rot_3x3) numpy tuples — no jaxlie overhead
         self._snap_ctrl: dict[str, tuple[np.ndarray, np.ndarray]] = {}
         self._snap_fk: dict[str, tuple[np.ndarray, np.ndarray]] = {}
@@ -216,6 +238,7 @@ class IKWorker:
         enabled = frame.l_lock and frame.r_lock
         if not enabled:
             self._active = False
+            self._clear_freeze()
             return q_current
 
         if not self._active:
@@ -279,6 +302,7 @@ class IKWorker:
 
         if not self._active:
             self._active = True
+            self._clear_freeze()
             self._engage_snap(
                 left_pos, left_rot, right_pos, right_rot, left_e, right_e, q_current
             )
@@ -310,13 +334,18 @@ class IKWorker:
             right_e - self._snap_elbow_ctrl["right"]
         )
 
-        return self._solver.ik(
+        q_new = self._solver.ik(
             q_current,
             left_pose=(tl_pos, tl_rot),
             right_pose=(tr_pos, tr_rot),
             left_elbow_pos=elbow_l,
             right_elbow_pos=elbow_r,
         )
+        self._note_solve(
+            bool(np.array_equal(q_new, q_current)),
+            np.concatenate([tl_pos, tr_pos, elbow_l, elbow_r]),
+        )
+        return q_new
 
     def compute_reset_trajectory(
         self, q_current: np.ndarray, q_target: np.ndarray
@@ -345,6 +374,7 @@ class IKWorker:
         performs a fresh engage-snap from the current IK pose.
         """
         self._active = False
+        self._clear_freeze()
         self._snap_ctrl = {}
         self._snap_fk = {}
         self._snap_elbow_ctrl = {}
@@ -355,6 +385,49 @@ class IKWorker:
         self._solver.set_posture_pose(self.get_rest_q())
 
     # -- Internal -----------------------------------------------------------
+
+    def _clear_freeze(self) -> None:
+        """Forget any in-progress freeze run (disengage / engage / reset)."""
+        self._freeze_since = None
+        self._freeze_targets = None
+        self._freeze_next_warn = _FREEZE_WARN_AFTER_S
+
+    def _note_solve(self, frozen: bool, targets: np.ndarray) -> None:
+        """Track seed-returning solves; WARN when the output freezes.
+
+        A single unchanged solution is normal (e.g. the hand is still, or the
+        target is held against a constraint). The failure mode worth flagging is
+        a *run* of solves that return the seed while the EE/elbow targets keep
+        moving away — the operator sees the arm stop responding, and the
+        accumulated error is released as a lurch once a solve finally makes
+        progress (see ``KinematicsConfig`` for the tuning that minimises this).
+
+        Args:
+            frozen: True when this solve returned ``q_current`` bit-identically.
+            targets: Concatenated EE + elbow target positions (m) of this solve,
+                used to measure how far the targets drifted during the freeze.
+        """
+        if not frozen:
+            self._clear_freeze()
+            return
+        now = time.monotonic()
+        if self._freeze_since is None or self._freeze_targets is None:
+            self._freeze_since = now
+            self._freeze_targets = targets
+            return
+        duration = now - self._freeze_since
+        drift = float(np.max(np.abs(targets - self._freeze_targets)))
+        if duration >= self._freeze_next_warn and drift >= _FREEZE_MIN_TARGET_DRIFT_M:
+            _logger.warning(
+                "IK frozen for %.1fs: solver keeps returning its seed while the "
+                "EE/elbow targets moved %.0f mm — it cannot make progress "
+                "(target likely conflicts with the self-collision margin or "
+                "joint limits); the arm holds, then catches up in a lurch when "
+                "the solve breaks free.",
+                duration,
+                drift * 1e3,
+            )
+            self._freeze_next_warn = duration + _FREEZE_REWARN_EVERY_S
 
     def _reset_pose_filters(self) -> None:
         """Clear the OneEuroFilter state for every controller and elbow stream."""

--- a/almond_axol/utils/jetson_diag.py
+++ b/almond_axol/utils/jetson_diag.py
@@ -9,8 +9,10 @@ version-fragile sysfs/debugfs nodes. ``tegrastats`` ships with every L4T and
 normalizes all of them into one line per interval, so we parse that instead.
 
 The sampler runs on its own thread, is Jetson-only (a clean no-op off-Tegra or
-when ``tegrastats`` is absent), and logs one compact INFO line per period so the
-record-start transition is visible next to the ``loop:`` / ``diag:`` lines. It
+when ``tegrastats`` is absent), and logs one compact DEBUG line per period so
+the record-start transition is visible next to the ``diag:`` lines when running
+with ``--log_level DEBUG`` (resource readouts stay out of the default INFO
+output). It
 also re-checks the engine-clock and CPU-governor pins at runtime (the boot-time
 ``axol jetson.setup`` is the only thing that sets them, and nothing verified they
 held under load).
@@ -125,7 +127,7 @@ class TegraStatsDiag(threading.Thread):
             parts.append(f"tmax={max(temps):.1f}C")
 
         parts.append("throttle=yes" if "throttl" in line.lower() else "throttle=none")
-        self._logger.info("tegra: %s", "  ".join(parts))
+        self._logger.debug("tegra: %s", "  ".join(parts))
 
     def _check_pins(self) -> None:
         """WARN if the NVENC/VIC engine clocks or CPU governor aren't pinned.

--- a/almond_axol/utils/proc_diag.py
+++ b/almond_axol/utils/proc_diag.py
@@ -235,7 +235,9 @@ class SystemDiag(threading.Thread):
             percpu.sort()
             percpu_str = "[" + ",".join(f"{f:.0f}" for _, f in percpu) + "]"
 
-            # INFO tier: labelled procs (+ their gst children) CPU% / RSS + memory.
+            # First DEBUG tier: labelled procs (+ their gst children) CPU% /
+            # RSS + memory. Diagnostics stay out of the default INFO output;
+            # run with --log_level DEBUG to see them.
             cur_labeled = self._scan_labeled()
             lab_pct: list[tuple[float, str]] = []
             for pid, (jif, label) in cur_labeled.items():
@@ -252,7 +254,7 @@ class SystemDiag(threading.Thread):
             top_labeled = "  ".join(s for _, s in lab_pct) or "n/a"
 
             mem_avail, swap_free, swap_total = read_meminfo()
-            self._logger.info(
+            self._logger.debug(
                 "diag: cores>85%%=%d/%d sys=%.0f%% cpu%%=%s  %s  memavail=%s swap=%s/%s",
                 busy_cores,
                 ncpu,
@@ -264,8 +266,9 @@ class SystemDiag(threading.Thread):
                 _gib(swap_total),
             )
 
-            # DEBUG tier: full system-wide proc + main-thread breakdown (every
-            # /proc/<pid> + every thread of this process — too costly for INFO).
+            # Second DEBUG tier: full system-wide proc + main-thread breakdown
+            # (every /proc/<pid> + every thread of this process — costly, so
+            # still gated on the effective level before doing the scans).
             if not self._logger.isEnabledFor(logging.DEBUG):
                 continue
 

--- a/almond_axol/vr/config.py
+++ b/almond_axol/vr/config.py
@@ -23,7 +23,12 @@ class VRServerConfig:
             consumer sees the raw latest-wins frame.
         interp_min_delay_s: Floor on the adaptive playout delay (seconds).
         interp_max_delay_s: Cap on the adaptive playout delay (seconds); bounds
-            the teleop latency added in exchange for smoothness.
+            the teleop latency added in exchange for smoothness. The delay is
+            adaptive, so this cap only matters on impaired links: it must cover
+            the wifi stall/burst lengths actually seen in the field (~250 ms),
+            or the playout buffer runs dry mid-stall and the target lurches
+            when the burst flushes. 0.35 rides through such stalls with
+            clean-link smoothness; a clean LAN still runs at ~zero added delay.
     """
 
     port: int = VR_PORT
@@ -31,4 +36,4 @@ class VRServerConfig:
     keyfile: str | None = None
     interp_enabled: bool = True
     interp_min_delay_s: float = 0.0
-    interp_max_delay_s: float = 0.1
+    interp_max_delay_s: float = 0.35

--- a/almond_axol/vr/interp.py
+++ b/almond_axol/vr/interp.py
@@ -52,7 +52,10 @@ class PoseInterpolator:
             (pure latest-wins, the original behaviour).
         min_delay_s: Floor on the playout delay (seconds).
         max_delay_s: Cap on the playout delay (seconds) — bounds the added
-            latency. Bursts longer than this still cause a small catch-up.
+            latency. Bursts longer than this still cause a small catch-up, so
+            it must cover the stall lengths seen on a bad wifi link (~250 ms);
+            the delay only grows when jitter is actually observed, so a clean
+            link runs at ~zero regardless of the cap.
         window_s: Sliding window over which arrival jitter is measured.
         max_frames: Hard cap on buffered frames (safety bound).
         pos_eps: Position change (metres) below which a re-render is considered
@@ -63,7 +66,7 @@ class PoseInterpolator:
         self,
         enabled: bool = True,
         min_delay_s: float = 0.0,
-        max_delay_s: float = 0.1,
+        max_delay_s: float = 0.35,
         window_s: float = 2.0,
         max_frames: int = 512,
         pos_eps: float = 1e-4,


### PR DESCRIPTION
## Problem

During teleop / data collection the robot would stop responding to VR motion for up to several seconds, then suddenly snap toward an unexpected pose. Not CPU/RAM, not the headset, not the network path. Follow-up reports covered three more symptoms: jitter at kinematic boundaries once solving stops, step jumps / too-fast s1-s2 near shoulder singularities, and jittery teleop under bad wifi / packet bunching.

## Replication

Reproduced in sim: `VRTeleop(Sim())` instrumented to log every commanded joint vector and raw IK target, driven by a scripted WebSocket client streaming realistic 72 Hz VR frames on localhost. The commanded output froze for 0.3–1.6 s dozens of times per 110 s session (8.5 s once) while frames kept arriving, then jumped by exactly `max_joint_delta` per tick. The pose interpolator, engage state machine, and IK dispatch pipe were all ruled out by direct measurement.

The follow-up symptoms were replicated on a virtual-time bench driving the full chain (VR frames → `PoseInterpolator` → `IKWorker` → EMA/trapezoid smoothing):

- **Boundary jitter**: a push past the reach boundary froze 34 % of solves, and every boundary/singular-region sweep saturated the per-solve clamp — releases passed through the smoothing as 2.5–3.6 rad/s command spikes.
- **Shoulder singularity**: raise-and-sweep moves through the gimbal region hit 2.5 rad/s spikes on s1/s2 — same stick-slip mechanism.
- **Bad wifi**: with 250 ms stalls + jitter (packets queue, then flush in a burst), commanded spikes hit 2.1 rad/s vs 0.8 clean, and the rendered target stream jumped at up to 5 m/s.

## Root cause

Dissecting a captured frozen state showed the LM solve rejecting all 8 iterations (every proposal *raised* cost: 92.14 → 93.17) and returning its seed bit-identically, tick after tick:

- `self_collision_margin = 0.1` — 10 cm is already violated at the folded rest pose, so the nonsmooth collision cost is active during ordinary tracking, exactly where the linearisation is poor (the `umi` branch independently benchmarked this and chose 2 cm).
- `lambda_initial = 5e-4`, `lambda_factor = 2` (jaxls defaults) — after a rejected near-Gauss-Newton step, damping can only grow 256× within the 8-iteration budget: never enough to find an acceptable damped step.
- `cost_tolerance = 1e-2` — jaxls applies the convergence check to **rejected** proposals too (cost change ≈ 0), so one rejected step reads as "converged" and the seed is returned.

The arm freezes while the operator's hand keeps moving; once the accumulated error finally makes a full step acceptable, the solver lurches toward the now-distant target, saturating the 0.0346 rad/tick clamp — the "sudden random pose". The boundary/singularity spikes are the small-scale version of the same stick-slip, and the wifi lurches came from the interpolator's playout-delay cap (0.1 s) being shorter than real stall lengths, so the buffer drained mid-stall and the target jumped when the burst flushed.

## Fix

- `self_collision_margin` 0.1 → 0.025 (matches `reset_collision_margin`)
- `cost_tolerance` 1e-2 → 1e-6 (1e-4 still let rejected proposals end solves early near active constraints; 1e-6 halves the residual boundary freeze rate, solve time still bounded by the iteration budget)
- expose `lambda_initial` / `lambda_factor` in `KinematicsConfig` and set 1e-2 / 10.0 so damping spans the useful range within the iteration budget
- `max_joint_delta` 0.0346 → 0.02 rad: bounds the release velocity of any residual stall, capping boundary/singularity command spikes at ~1.5 rad/s while staying comfortably above normal tracking demand
- `interp_max_delay_s` 0.1 → 0.35: lets the *adaptive* playout delay grow enough to ride through real wifi stalls; a clean LAN still runs at ~zero added delay
- `manipulability_weight` 0.05 → 0.2: active singularity *avoidance*, not just spike capping — raises the worst-case Yoshikawa manipulability through gimbal-region sweeps by 60–80 % with no measured cost to tracking error or smoothness (0.5+ starts fighting the pose targets)
- WARN log when the solver freezes while the target keeps moving (`IKWorker`), and CPU/RAM + tegrastats diagnostics demoted INFO → DEBUG

Values selected by sweeping on the bench (higher pose weights and `ik_alpha` changes were tried and rejected — they measured worse or added lag for no gain).

## Verification

| Metric | Before | After |
|---|---|---|
| Longest seed-return run (bench) | 8.6 s | 0.3 s |
| Free-space EE tracking lag | 36 mm | 13 mm |
| Solve time (mean) | ~7 ms | ~8 ms |
| Boundary-push freeze rate (bench) | 34 % | 14 %, only while the clamped target is stationary |
| s1/s2 command spikes, singular-region sweeps (bench) | 2.5 rad/s | ≤1.5 rad/s |
| Bad-wifi command spikes / render jumps (bench) | 2.1 rad/s / 5.2 m/s | 0.83 rad/s / 0.45 m/s (clean = 0.80 / 0.42) |
| Worst-case manipulability, singular-region sweeps (bench) | 0.026–0.033 | 0.042–0.049 |
| Post-freeze lurch | 0.0346 rad (= clamp) every time | gone |

End-to-end sim rerun (120 Hz teleop, impaired client with 250 ms stalls, boundary pushes + gimbal-region sweeps, 130 s): commanded p99.9 velocity 1.46 rad/s, max per-tick step 0.013 rad, no stuck-then-lurch, no spurious freeze warnings.

`ruff check` and `ruff format --check` pass.

Made with [Cursor](https://cursor.com)

