### PR TITLE
Make the serve command catalog a registry

### DIFF
--- a/almond_axol/serve/__init__.py
+++ b/almond_axol/serve/__init__.py
@@ -1,14 +1,34 @@
 """Local web control panel + API server for the axol CLI.
 
 ``axol serve`` exposes a small FastAPI app that the bundled web UI talks to.
-The four core operations (teleop, gravity-comp, collect-data, run-policy) run
-*in-process* via :class:`~almond_axol.serve.runner.OperationRunner`, sharing
-one persistent robot connection; the remaining setup/calibration commands
-(``can.*``, ``motor.*``, ``tune.*``, …) are spawned as ``axol <command>``
-subprocesses by :class:`~almond_axol.serve.manager.SessionManager`. Either
-way the output streams to connected log WebSockets and the run can be stopped.
+The core operations (teleop, gravity-comp, collect-data, run-policy,
+replay-dataset) run *in-process* via
+:class:`~almond_axol.serve.runner.OperationRunner`, sharing one persistent
+robot connection; the remaining setup/calibration commands (``can.*``,
+``motor.*``, ``tune.*``, …) are spawned as ``axol <command>`` subprocesses by
+:class:`~almond_axol.serve.manager.SessionManager`. Either way the output
+streams to connected log WebSockets and the run can be stopped.
+
+Which commands exist is a registry, not a fixed list. A package built on
+``almond-axol`` adds its own by calling :func:`register` before
+:func:`create_app`; they then appear in the API and the web panel like the
+built-ins, with no changes needed here or in ``web/``::
+
+    from almond_axol.serve import CommandDef, create_app, register
+
+    register(CommandDef(
+        id="my-op", cli="my-op", label="My op", description="…",
+        category="Operate", kind="draccus", loader=lambda: MyOpConfig,
+        entrypoint=lambda: my_op_run, requires_hardware=True,
+        per_run_fields=("repo_id", "task"), settings_like="collect-data",
+    ))
+    app = create_app(static_dir)
+
+See :class:`~almond_axol.serve.commands.CommandDef` for the full set of
+declarations and the entrypoint protocol.
 """
 
 from .app import create_app
+from .commands import CommandDef, operation_ids, register
 
-__all__ = ["create_app"]
+__all__ = ["CommandDef", "create_app", "operation_ids", "register"]

--- a/almond_axol/serve/app.py
+++ b/almond_axol/serve/app.py
@@ -20,16 +20,13 @@ from pydantic import BaseModel
 from ..constants import URDF_PATH
 from ..utils import adb, ports
 from ..utils.certs import ACCEPT_PAGE_HTML
-from .commands import COMMANDS, command_specs
+from .commands import COMMANDS, command_specs, operation_ids
 from .manager import Session, SessionManager
 from .robot_link import RobotLink
 from .runner import OperationRunner
 from .settings import SettingsStore, advanced_schema, settings_schema
 from .telemetry import DiagnosticsRunStore, TelemetryHub
 from .update import SelfUpdater
-
-# The core operations run in-process via the OperationRunner.
-_OPERATIONS = {"teleop", "gravity-comp", "collect-data", "run-policy", "replay-dataset"}
 
 
 class RunRequest(BaseModel):
@@ -549,15 +546,16 @@ def create_app(static_dir: Path | None = None) -> FastAPI:
 
     @app.post("/api/op/start")
     async def op_start(req: OpStartRequest) -> JSONResponse:
-        if req.op not in _OPERATIONS:
+        if req.op not in operation_ids():
             return JSONResponse(
                 {"error": f"unknown operation: {req.op}"}, status_code=400
             )
         async with camera_reservation:
             # A faulted motor (over-temp, stall, encoder error, unreachable, …)
             # must block every hardware operation — driving through a fault risks
-            # the arm. Sim teleop never touches the motors, so it stays allowed.
-            is_sim = req.op == "teleop" and bool(req.args.get("sim"))
+            # the arm. A sim run never touches the motors, so it stays allowed.
+            sim_flag = COMMANDS[req.op].sim_flag
+            is_sim = sim_flag is not None and bool(req.args.get(sim_flag))
             if not is_sim:
                 fault_response = await _motor_fault_response()
                 if fault_response is not None:

--- a/almond_axol/serve/commands.py
+++ b/almond_axol/serve/commands.py
@@ -14,6 +14,14 @@ buttons, and motor calibration tools. Everything else — install-time commands
 one-off checks (``motor.info`` / ``motor.health``, whose read set the
 dashboard's motor tiles show live), the remote ``inference-server``, and
 ``serve`` itself — stays CLI-only.
+
+:data:`COMMANDS` is a registry rather than a fixed table: a package that builds
+on ``almond-axol`` can :func:`register` its own commands before calling
+:func:`~almond_axol.serve.create_app`, and they flow through the API and the
+web panel like the built-in ones. Everything the serve layer needs to launch a
+command — whether it runs in-process, what it does with cameras, which settings
+it inherits — is declared on its :class:`CommandDef` rather than branched on
+its id, so registration is the only integration point.
 """
 
 from __future__ import annotations
@@ -28,7 +36,22 @@ CATEGORY_ORDER = ["Operate", "Diagnostics", "Calibrate", "Setup"]
 
 
 class CommandDef:
-    """A launchable command and how to introspect its configuration."""
+    """A launchable command and how to introspect its configuration.
+
+    A command with an ``entrypoint`` is an *operation*: the serve layer runs it
+    in-process (:class:`~almond_axol.serve.runner.OperationRunner`) so it shares
+    the persistent robot connection, and the control panel gives it a panel of
+    its own. Everything else is spawned as a ``python -m <module> <cli>``
+    subprocess by :class:`~almond_axol.serve.manager.SessionManager`.
+
+    An operation's entrypoint must match one of::
+
+        def _run(cfg, *, stop_event=None, control=None) -> None:   # thread
+        async def _run(cfg) -> None:                               # async
+
+    ``control`` is passed only when ``episode_control`` is set; see that
+    argument for the object's protocol.
+    """
 
     def __init__(
         self,
@@ -44,6 +67,16 @@ class CommandDef:
         requires_hardware: bool = False,
         uses_can_bus: bool = True,
         drives_motors: bool = False,
+        entrypoint: Callable[[], Callable[..., Any]] | None = None,
+        execution: str = "thread",
+        requires_cameras: bool = False,
+        camera_mode: str = "none",
+        sim_flag: str | None = None,
+        uses_headset: bool = False,
+        episode_control: Callable[[], Callable[..., Any]] | None = None,
+        per_run_fields: tuple[str, ...] = (),
+        settings_like: str | None = None,
+        module: str = "almond_axol",
     ) -> None:
         self.id = id
         self.cli = cli
@@ -61,11 +94,68 @@ class CommandDef:
         # operations. Connectivity repair commands intentionally leave this
         # false so they remain available when a motor cannot be reached.
         self.drives_motors = drives_motors
+        # Lazy loader for the in-process entrypoint; None makes this a
+        # subprocess command. Deferred like ``loader`` so a missing optional
+        # extra only marks this one command unavailable.
+        self._entrypoint = entrypoint
+        # "thread" | "async". Async ops own an event loop for their whole run
+        # (teleop's VR server, gravity-comp's telemetry) and are awaited;
+        # thread ops are called synchronously on a worker thread.
+        self.execution = execution
+        # Needs at least one camera serial configured before it can start.
+        self.requires_cameras = requires_cameras
+        # How the operator's camera spec reaches the config: "argv" folds
+        # serials into the argv-style args (the cameras are required draccus
+        # inputs), "teleop" attaches them to a built config's camera dict
+        # (unreachable via flat argv), "none" ignores it.
+        self.camera_mode = camera_mode
+        # Arg name that means "no hardware" for this op, so a sim run skips the
+        # robot link and the motor-fault gate. None means it always needs the
+        # robot.
+        self.sim_flag = sim_flag
+        # Driven from the VR headset, so the panel tells the operator to point
+        # the headset at this machine once the op is running.
+        self.uses_headset = uses_headset
+        # Lazy loader for an episode-control class, constructed as
+        # ``cls(stop_event)`` and handed to the entrypoint as ``control``. It
+        # must expose ``push(command: str)`` for API-pushed decisions and
+        # ``snapshot() -> dict`` for the phase the panel renders.
+        self._episode_control = episode_control
+        # Config keys the panel surfaces per run; everything else comes from
+        # the shared settings, folded in server-side.
+        self.per_run_fields = per_run_fields
+        # Borrow another op's settings targets. Settings are declared as dotted
+        # config paths per op, so an op embedding the same config dataclasses
+        # inherits the whole mapping instead of re-declaring it.
+        self.settings_like = settings_like
+        # ``python -m <module>`` target for the subprocess path, so a command
+        # registered by a downstream package runs out of that package's CLI.
+        self.module = module
         self._loader = loader
+
+    @property
+    def is_operation(self) -> bool:
+        """Runs in-process (and gets a control-panel operation of its own)."""
+        return self._entrypoint is not None
+
+    @property
+    def has_episode_control(self) -> bool:
+        """Drives episodes the panel can save / rerecord / quit."""
+        return self._episode_control is not None
 
     def load(self) -> Any:
         """Return the config class (draccus) or ``add_parser`` fn (argparse)."""
         return self._loader()
+
+    def load_entrypoint(self) -> Callable[..., Any]:
+        """Return the in-process ``_run`` callable (operations only)."""
+        if self._entrypoint is None:
+            raise ValueError(f"{self.id} is not an in-process operation")
+        return self._entrypoint()
+
+    def load_episode_control(self) -> Callable[..., Any] | None:
+        """Return the episode-control class, or None when the op has none."""
+        return None if self._episode_control is None else self._episode_control()
 
 
 # -- draccus config-class loaders -------------------------------------------
@@ -101,6 +191,45 @@ def _run_policy() -> type:
     return RunPolicyConfig
 
 
+# -- in-process entrypoint loaders ------------------------------------------
+
+
+def _teleop_run() -> Callable[..., Any]:
+    from ..cli.teleop import _run
+
+    return _run
+
+
+def _gravity_comp_run() -> Callable[..., Any]:
+    from ..cli.gravity_comp import _run
+
+    return _run
+
+
+def _collect_data_run() -> Callable[..., Any]:
+    from ..cli.collect_data import _run
+
+    return _run
+
+
+def _replay_dataset_run() -> Callable[..., Any]:
+    from ..cli.replay_dataset import _run
+
+    return _run
+
+
+def _run_policy_run() -> Callable[..., Any]:
+    from ..cli.run_policy import _run
+
+    return _run
+
+
+def _run_policy_control() -> Callable[..., Any]:
+    from ..cli.run_policy import _QueuePolicyControl
+
+    return _QueuePolicyControl
+
+
 # -- argparse add_parser loaders --------------------------------------------
 
 
@@ -128,6 +257,12 @@ COMMANDS: dict[str, CommandDef] = {
         "draccus",
         _teleop,
         sim_capable=True,
+        entrypoint=_teleop_run,
+        execution="async",
+        camera_mode="teleop",
+        sim_flag="sim",
+        uses_headset=True,
+        per_run_fields=("sim",),
     ),
     "gravity-comp": CommandDef(
         "gravity-comp",
@@ -138,6 +273,9 @@ COMMANDS: dict[str, CommandDef] = {
         "draccus",
         _gravity_comp,
         requires_hardware=True,
+        entrypoint=_gravity_comp_run,
+        execution="async",
+        per_run_fields=("free_joints",),
     ),
     "collect-data": CommandDef(
         "collect-data",
@@ -148,6 +286,10 @@ COMMANDS: dict[str, CommandDef] = {
         "draccus",
         _collect_data,
         requires_hardware=True,
+        entrypoint=_collect_data_run,
+        requires_cameras=True,
+        camera_mode="argv",
+        per_run_fields=("repo_id", "task"),
     ),
     "replay-dataset": CommandDef(
         "replay-dataset",
@@ -159,6 +301,8 @@ COMMANDS: dict[str, CommandDef] = {
         "draccus",
         _replay_dataset,
         requires_hardware=True,
+        entrypoint=_replay_dataset_run,
+        per_run_fields=("repo_id", "episode", "loop", "interpolate"),
     ),
     "run-policy": CommandDef(
         "run-policy",
@@ -169,6 +313,11 @@ COMMANDS: dict[str, CommandDef] = {
         "draccus",
         _run_policy,
         requires_hardware=True,
+        entrypoint=_run_policy_run,
+        requires_cameras=True,
+        camera_mode="argv",
+        episode_control=_run_policy_control,
+        per_run_fields=("policy_path", "policy_type", "task", "repo_id"),
     ),
     # -- Diagnostics ----------------------------------------------------------
     "diag.rom-enable": CommandDef(
@@ -255,6 +404,25 @@ COMMANDS: dict[str, CommandDef] = {
 _schema_cache: dict[str, Schema] = {}
 
 
+def register(command: CommandDef) -> None:
+    """Add (or replace) a command in the catalog.
+
+    The integration point for packages built on ``almond-axol``: register
+    before :func:`~almond_axol.serve.create_app` and the command shows up in
+    the API and the web panel alongside the built-in ones. Re-registering an
+    id replaces it — a downstream package can substitute its own variant of a
+    built-in operation — and drops the stale schema so the new config is
+    introspected on next use.
+    """
+    COMMANDS[command.id] = command
+    _schema_cache.pop(command.id, None)
+
+
+def operation_ids() -> set[str]:
+    """Ids of the commands the serve layer runs in-process."""
+    return {cmd.id for cmd in COMMANDS.values() if cmd.is_operation}
+
+
 def get_schema(command_id: str) -> Schema:
     """Return (and memoize) the form schema for a command.
 
@@ -284,6 +452,15 @@ def command_specs() -> list[dict[str, Any]]:
             "simCapable": cmd.sim_capable,
             "requiresHardware": cmd.requires_hardware,
             "usesCanBus": cmd.uses_can_bus,
+            # Everything the panel needs to build an operation's tile and form
+            # without knowing the command: older panels ignore these and fall
+            # back to their built-in list.
+            "isOperation": cmd.is_operation,
+            "requiresCameras": cmd.requires_cameras,
+            "perRunFields": list(cmd.per_run_fields),
+            "episodeControl": cmd.has_episode_control,
+            "simFlag": cmd.sim_flag,
+            "usesHeadset": cmd.uses_headset,
         }
         try:
             schema = get_schema(cmd.id)

--- a/almond_axol/serve/manager.py
+++ b/almond_axol/serve/manager.py
@@ -25,15 +25,21 @@ _LOG_BUFFER = 4000
 _QUEUE_MAX = 1000
 _STOP_GRACE_S = 6.0
 
+# The CLI package subprocess commands run out of, unless a command names
+# another (``CommandDef.module``).
+DEFAULT_MODULE = "almond_axol"
+
 
 async def spawn_proc(
-    argv_tail: list[str], *, stdin_pipe: bool = False
+    argv_tail: list[str], *, stdin_pipe: bool = False, module: str = DEFAULT_MODULE
 ) -> asyncio.subprocess.Process:
-    """Spawn ``python -m almond_axol <argv_tail>`` with merged, streamed stdout.
+    """Spawn ``python -m <module> <argv_tail>`` with merged, streamed stdout.
 
     Runs in its own session (process group) so the whole tree can be signalled
     on teardown, and uses the serving interpreter so ``axol`` need not be on
-    PATH. ``stdin_pipe`` opens a writable stdin so the UI can answer a
+    PATH. ``module`` is the CLI package to run — the default is this one, and a
+    registered command can name its own so a downstream package's commands run
+    out of its CLI. ``stdin_pipe`` opens a writable stdin so the UI can answer a
     command's interactive prompts (see :meth:`Session.send_input`); otherwise
     stdin is ``/dev/null`` so any stray ``input()`` fails fast instead of
     hanging.
@@ -43,7 +49,7 @@ async def spawn_proc(
     return await asyncio.create_subprocess_exec(
         sys.executable,
         "-m",
-        "almond_axol",
+        module,
         *argv_tail,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
@@ -192,10 +198,14 @@ class SessionManager:
         if command_id not in COMMANDS:
             raise KeyError(command_id)
 
-        cli = COMMANDS[command_id].cli
+        cmd = COMMANDS[command_id]
         argv = build_argv(command_id, args)
         return await self.start_raw(
-            command_id, [cli, *argv], args=args, stdin_pipe=stdin_pipe
+            command_id,
+            [cmd.cli, *argv],
+            args=args,
+            stdin_pipe=stdin_pipe,
+            module=cmd.module,
         )
 
     async def start_raw(
@@ -205,16 +215,18 @@ class SessionManager:
         *,
         args: dict[str, Any] | None = None,
         stdin_pipe: bool = False,
+        module: str = DEFAULT_MODULE,
     ) -> Session:
         """Spawn an arbitrary ``axol`` invocation as a tracked session.
 
         ``argv_tail`` is the full CLI tail (subcommand + flags). ``stdin_pipe``
         keeps a writable stdin so the UI can answer interactive prompts.
+        ``module`` names the CLI package to run it out of.
         """
         session = Session(command_id, args or {})
         self._sessions[session.id] = session
         try:
-            proc = await spawn_proc(argv_tail, stdin_pipe=stdin_pipe)
+            proc = await spawn_proc(argv_tail, stdin_pipe=stdin_pipe, module=module)
         except OSError as exc:
             session.status = "error"
             session.error = f"Failed to launch command: {exc}"
@@ -223,7 +235,8 @@ class SessionManager:
 
         session.proc = proc
         session.status = "running"
-        session.emit(f"[serve] $ axol {' '.join(argv_tail)}".rstrip())
+        cli = "axol" if module == DEFAULT_MODULE else f"python -m {module}"
+        session.emit(f"[serve] $ {cli} {' '.join(argv_tail)}".rstrip())
         asyncio.create_task(self._pump(session))
         return session
 

--- a/almond_axol/serve/runner.py
+++ b/almond_axol/serve/runner.py
@@ -11,13 +11,19 @@ captured into a :class:`~almond_axol.serve.manager.Session` ring buffer (the
 same object the log WebSocket streams), so the UI sees live output exactly as
 it did for subprocesses.
 
-- teleop / gravity-comp are asyncio: they run on a dedicated event loop in a
-  worker thread and are stopped by cancelling the task (both already tear down
-  cleanly on ``CancelledError`` via their ``async with`` robot context).
-- collect-data / run-policy / replay-dataset are blocking/threaded: they run on
-  a worker thread and are stopped via a ``threading.Event`` (run-policy
-  additionally takes a queue-backed episode control for save/rerecord/quit from
-  the UI).
+Which operations exist, and how each one runs, comes entirely from the command
+registry (:mod:`.commands`) — nothing here is keyed on an operation's id, so a
+downstream package's registered operation runs on the same paths as the
+built-in five:
+
+- ``execution="async"`` (teleop / gravity-comp) runs ``await _run(cfg)`` on a
+  dedicated event loop in a worker thread, stopped by cancelling the task (both
+  tear down cleanly on ``CancelledError`` via their ``async with`` robot
+  context).
+- ``execution="thread"`` (collect-data / run-policy / replay-dataset) runs
+  ``_run(cfg, stop_event=...)`` on a worker thread, stopped via the
+  ``threading.Event``. An op declaring ``episode_control`` also gets
+  ``control=``, a queue-backed object taking save/rerecord/quit from the UI.
 
 Before a hardware operation starts the runner releases the robot link's CAN
 bus; when the operation ends it hands the bus back.
@@ -51,18 +57,6 @@ _logger = logging.getLogger(__name__)
 # from under it, which makes the blocked join/recv return.
 _STOP_GRACE_S = 6.0
 _FORCE_GRACE_S = 5.0
-
-# Operations that need exclusive ownership of the CAN bus (everything except
-# sim teleop, which is decided per-run from the ``sim`` arg).
-_HARDWARE_OPS = {
-    "teleop",
-    "gravity-comp",
-    "collect-data",
-    "run-policy",
-    "replay-dataset",
-}
-_ASYNC_OPS = {"teleop", "gravity-comp"}
-_OP_IDS = {"teleop", "gravity-comp", "collect-data", "run-policy", "replay-dataset"}
 
 # Loggers whose records we never forward to the UI: webserver lifecycle,
 # access logs, low-level asyncio chatter. We still want the underlying ops'
@@ -382,7 +376,10 @@ class OperationRunner:
         cameras: dict[str, Any] | None = None,
         loop: asyncio.AbstractEventLoop | None = None,
     ) -> Session:
-        if op_id not in _OP_IDS:
+        from .commands import COMMANDS
+
+        cmd = COMMANDS.get(op_id)
+        if cmd is None or not cmd.is_operation:
             raise KeyError(op_id)
         with self._lock:
             if self.is_running():
@@ -411,9 +408,9 @@ class OperationRunner:
                 if cameras is None:
                     cameras = self._settings.cameras()
 
-            # Fold the camera spec into the argv-style args for collect-data /
-            # run-policy (their camera serials are required draccus inputs).
-            if cameras and op_id in ("collect-data", "run-policy"):
+            # Fold the camera spec into the argv-style args for the ops whose
+            # camera serials are required draccus inputs.
+            if cameras and cmd.camera_mode == "argv":
                 args = self._merge_camera_args(args, cameras)
 
             cfg = self._build_config(op_id, args)
@@ -430,7 +427,7 @@ class OperationRunner:
         # the spec is now always present via the settings store — a host that
         # can't apply it (e.g. no ZED stack on a dev machine running sim) still
         # gets a camera-less teleop instead of a failed start.
-        if op_id == "teleop":
+        if cmd.camera_mode == "teleop":
             try:
                 self._attach_cameras_to_teleop(cfg, cameras, session)
             except Exception as exc:  # noqa: BLE001
@@ -439,8 +436,8 @@ class OperationRunner:
                     "continuing without cameras"
                 )
 
-        is_sim = op_id == "teleop" and bool(args.get("sim"))
-        needs_robot = op_id in _HARDWARE_OPS and not is_sim
+        is_sim = cmd.sim_flag is not None and bool(args.get(cmd.sim_flag))
+        needs_robot = cmd.uses_can_bus and not is_sim
         log_level = self._log_level(args)
 
         session.status = "running"
@@ -453,7 +450,7 @@ class OperationRunner:
             except Exception as exc:  # noqa: BLE001
                 session.emit(f"[serve] robot release warning: {exc}")
 
-        if op_id in _ASYNC_OPS:
+        if cmd.execution == "async":
             target = self._run_async
         else:
             target = self._run_thread
@@ -826,10 +823,9 @@ class OperationRunner:
         self._async_loop = loop
 
         async def _wrap() -> None:
-            if op_id == "teleop":
-                from ..cli.teleop import _run as core
-            else:
-                from ..cli.gravity_comp import _run as core
+            from .commands import COMMANDS
+
+            core = COMMANDS[op_id].load_entrypoint()
             await core(cfg)
 
         with _Capture(session, log_level):
@@ -864,21 +860,20 @@ class OperationRunner:
         log_level: int,
         needs_robot: bool,
     ) -> None:
+        from .commands import COMMANDS
+
+        cmd = COMMANDS[op_id]
         with _Capture(session, log_level):
             try:
-                if op_id == "collect-data":
-                    from ..cli.collect_data import _run as core
-
-                    core(cfg, stop_event=self._stop_event)
-                elif op_id == "replay-dataset":
-                    from ..cli.replay_dataset import _run as core
-
+                core = cmd.load_entrypoint()
+                control_cls = cmd.load_episode_control()
+                if control_cls is None:
                     core(cfg, stop_event=self._stop_event)
                 else:
-                    from ..cli.run_policy import _QueuePolicyControl
-                    from ..cli.run_policy import _run as core
-
-                    control = _QueuePolicyControl(self._stop_event)
+                    # Episode decisions (save / rerecord / quit) arrive from the
+                    # API rather than stdin; the op blocks on this object and the
+                    # panel reads its phase back via policy_state().
+                    control = control_cls(self._stop_event)
                     self._policy_control = control
                     core(cfg, stop_event=self._stop_event, control=control)
             except Exception as exc:  # noqa: BLE001

--- a/almond_axol/serve/settings.py
+++ b/almond_axol/serve/settings.py
@@ -40,7 +40,9 @@ _logger = logging.getLogger(__name__)
 
 SETTINGS_PATH = Path.home() / ".almond" / "settings.json"
 
-# Operation ids (mirrors serve.commands / serve.runner).
+# The built-in operations, whose dotted config paths the tables below spell
+# out. A registered operation joins the same tables through its
+# ``settings_like`` alias rather than re-declaring them (see _settings_op).
 _OPS = ("teleop", "gravity-comp", "collect-data", "run-policy", "replay-dataset")
 
 # Dotted paths into the lerobot-based ops' shared robot config.
@@ -83,6 +85,22 @@ class SettingCategory:
 
 def _all_ops(*keys: str) -> dict[str, tuple[str, ...]]:
     return {op: keys for op in _OPS}
+
+
+def _settings_op(op_id: str) -> str:
+    """Resolve an operation to the id whose targets it uses.
+
+    An operation registered by a downstream package usually embeds the same
+    config dataclasses as a built-in one, so its dotted paths are identical;
+    declaring ``settings_like="collect-data"`` on its
+    :class:`~almond_axol.serve.commands.CommandDef` inherits the whole table
+    instead of restating ~50 mappings. Unknown or unaliased ids resolve to
+    themselves and simply match nothing.
+    """
+    from .commands import COMMANDS
+
+    cmd = COMMANDS.get(op_id)
+    return cmd.settings_like if cmd is not None and cmd.settings_like else op_id
 
 
 def _lerobot_dataset_root() -> str:
@@ -956,8 +974,11 @@ class SettingsStore:
         Later wins: curated setting values → advanced values (canonical keys
         translated to this op's dotted paths) → the request's own args. Keys
         the op's schema doesn't know are dropped later by ``build_argv``, so a
-        stale entry can never inject anything.
+        stale entry can never inject anything — which is also what makes an
+        inherited target table safe when an aliased op only shares part of the
+        original's config.
         """
+        target_op = _settings_op(op_id)
         merged: dict[str, Any] = {}
         with self._lock:
             values = dict(self._data["values"])
@@ -966,14 +987,14 @@ class SettingsStore:
             setting = _SETTINGS_BY_KEY.get(key)
             if setting is None or value is None:
                 continue
-            for target in setting.targets.get(op_id, ()):
+            for target in setting.targets.get(target_op, ()):
                 merged[target] = value
         for key, value in advanced.items():
             section_key, _, subpath = key.partition(".")
             section = _ADVANCED_BY_KEY.get(section_key)
             if section is None or not subpath or value is None:
                 continue
-            prefix = section.targets.get(op_id)
+            prefix = section.targets.get(target_op)
             if prefix:
                 merged[f"{prefix}.{subpath}"] = value
         merged.update(args)

--- a/web/README.md
+++ b/web/README.md
@@ -155,6 +155,8 @@ npm run dev --workspace=app
 - **VR**: open the printed localhost URL on your Quest browser, enter the hostname of the machine running the Almond Axol SDK, press **Connect**, then **Start** to enter the AR session.
 - **Control panel**: open `/control` in a normal browser. It talks to the `axol serve` API (default `https://localhost:8001`).
 
+The control panel's operations aren't hardcoded here: `/api/commands` tells it which ones the connected host offers and what each needs (per-run fields, cameras, a sim flag, episode controls), so a host with extra operations registered — see `register()` in `almond_axol/serve/commands.py` — gets panels for them with no change to this app. A host predating that API answers without those fields, and the panel falls back to the built-in list in `app/src/lib/supervisor.ts` so an up-to-date panel still drives an older robot.
+
 **Build**
 
 ```bash

--- a/web/app/src/components/operation-panel.tsx
+++ b/web/app/src/components/operation-panel.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react"
 import {
   cameraCount,
+  isSimRun,
   motorFaultLabel,
   perRunFields,
   type CameraSpec,
@@ -85,7 +86,7 @@ export function OperationPanel({
   const jointField = runFields.find((f) => f.key === "free_joints")
   const textFields = useMemo(() => runFields.filter((f) => f.key !== "free_joints"), [runFields])
 
-  const isSim = meta.id === "teleop" && Boolean(settings.sim)
+  const isSim = isSimRun(meta, settings)
   const robotOk = robot?.state === "connected"
   const camCount = cameraCount(cameras)
 
@@ -209,12 +210,12 @@ export function OperationPanel({
                 </div>
               )}
 
-              {meta.id === "run-policy" && live && (
+              {meta.episodeControl && live && (
                 <EpisodeControls policy={policy} onEpisode={onEpisode} />
               )}
 
               <RunningHints
-                op={meta.id}
+                usesHeadset={meta.usesHeadset}
                 session={live ? session : null}
                 isSim={isSim}
                 host={host}
@@ -277,13 +278,13 @@ function EpisodeControls({
 }
 
 function RunningHints({
-  op,
+  usesHeadset,
   session,
   isSim,
   host,
   viewerPort,
 }: {
-  op: string
+  usesHeadset: boolean
   session: SessionInfo | null
   isSim: boolean
   host: string
@@ -304,7 +305,7 @@ function RunningHints({
           Open 3D viewer
         </a>
       )}
-      {op === "teleop" && (
+      {usesHeadset && (
         <p className="rounded-lg border border-white/10 bg-white/[0.02] p-3 text-xs leading-relaxed text-white/45">
           Put on the headset, open <span className="text-white/70">axol.almond.bot</span>, and
           connect to <span className="font-mono text-[#eff483]">{host || "this machine"}</span>.

--- a/web/app/src/lib/supervisor.ts
+++ b/web/app/src/lib/supervisor.ts
@@ -40,6 +40,21 @@ export interface CommandSpec {
   error: string | null
   schema: SchemaNode[]
   required: string[]
+  // The operation surface (serve/commands.py CommandDef). Optional because a
+  // serve host older than the command registry doesn't send them — the panel
+  // then falls back to its built-in operation list (see OPERATIONS).
+  /** Runs in-process, so it gets an operation panel of its own. */
+  isOperation?: boolean
+  /** Needs at least one camera serial configured before it can start. */
+  requiresCameras?: boolean
+  /** Config keys the panel asks for per run; the rest come from Settings. */
+  perRunFields?: string[]
+  /** Drives episodes the panel can start / save / discard. */
+  episodeControl?: boolean
+  /** Arg name that means "no hardware", or null when the robot is required. */
+  simFlag?: string | null
+  /** Driven from the VR headset, so the panel shows the connect hint. */
+  usesHeadset?: boolean
 }
 
 /** Catalog category display order (matches serve/commands.py CATEGORY_ORDER). */
@@ -289,14 +304,11 @@ export async function usbConnect(): Promise<UsbStatus> {
 // In-process operations (teleop / gravity-comp / collect-data / run-policy)
 // ---------------------------------------------------------------------------
 
-export type OperationId =
-  | "teleop"
-  | "gravity-comp"
-  | "collect-data"
-  | "run-policy"
-  | "replay-dataset"
+/** An in-process operation's id. Open-ended: the set comes from the connected
+ *  serve host's command registry, which a downstream package can add to. */
+export type OperationId = string
 
-/** run-policy episode lifecycle phase, surfaced so the control panel on any
+/** Episode lifecycle phase, surfaced so the control panel on any
  *  computer shows the right episode controls (not just the tab that started it). */
 export type PolicyPhase = "preparing" | "ready" | "recording" | "deciding" | "resetting"
 
@@ -609,11 +621,14 @@ export function computeArgs(
 }
 
 // ---------------------------------------------------------------------------
-// Per-run operation fields. Everything tunable-but-stable (stiffness, rates,
-// codecs, the inference server, …) lives in the shared Settings dialog and is
-// folded in server-side; the op panels only ask for what changes run to run.
-// Keys are the dotted draccus paths the backend understands (serve/commands.py
-// build_argv).
+// Operations. The connected serve host advertises which ones exist and what
+// each one needs (/api/commands), so a host with extra operations registered
+// gets panels for them here without a frontend change.
+//
+// Everything tunable-but-stable (stiffness, rates, codecs, the inference
+// server, …) lives in the shared Settings dialog and is folded in server-side;
+// the op panels only ask for what changes run to run. Field keys are the dotted
+// draccus paths the backend understands (serve/commands.py build_argv).
 // ---------------------------------------------------------------------------
 
 export interface OperationMeta {
@@ -628,8 +643,19 @@ export interface OperationMeta {
   requiresCameras: boolean
   /** Can run in sim (no hardware) — only teleop today. */
   simCapable: boolean
+  /** Arg that makes a run hardware-free; null when the robot is required. */
+  simFlag: string | null
+  /** Shows the episode start / save / discard controls while running. */
+  episodeControl: boolean
+  /** Shows the "point the headset at this machine" hint while running. */
+  usesHeadset: boolean
 }
 
+/**
+ * The operations every serve host has had since before the command registry.
+ * Used verbatim when the host's /api/commands predates it, so an up-to-date
+ * panel still drives an older robot.
+ */
 export const OPERATIONS: OperationMeta[] = [
   {
     id: "teleop",
@@ -639,6 +665,9 @@ export const OPERATIONS: OperationMeta[] = [
     requiresRobot: true,
     requiresCameras: false,
     simCapable: true,
+    simFlag: "sim",
+    episodeControl: false,
+    usesHeadset: true,
   },
   {
     id: "gravity-comp",
@@ -648,6 +677,9 @@ export const OPERATIONS: OperationMeta[] = [
     requiresRobot: true,
     requiresCameras: false,
     simCapable: false,
+    simFlag: null,
+    episodeControl: false,
+    usesHeadset: false,
   },
   {
     id: "collect-data",
@@ -657,6 +689,9 @@ export const OPERATIONS: OperationMeta[] = [
     requiresRobot: true,
     requiresCameras: true,
     simCapable: false,
+    simFlag: null,
+    episodeControl: false,
+    usesHeadset: false,
   },
   {
     id: "replay-dataset",
@@ -666,6 +701,9 @@ export const OPERATIONS: OperationMeta[] = [
     requiresRobot: true,
     requiresCameras: false,
     simCapable: false,
+    simFlag: null,
+    episodeControl: false,
+    usesHeadset: false,
   },
   {
     id: "run-policy",
@@ -676,11 +714,41 @@ export const OPERATIONS: OperationMeta[] = [
     requiresRobot: true,
     requiresCameras: true,
     simCapable: false,
+    simFlag: null,
+    episodeControl: true,
+    usesHeadset: false,
   },
 ]
 
-export function operationMeta(op: OperationId): OperationMeta {
-  return OPERATIONS.find((o) => o.id === op) as OperationMeta
+/**
+ * The operations the connected host offers, in catalog order.
+ *
+ * A host that predates the command registry answers /api/commands without the
+ * operation fields; there is then nothing to read them from, so fall back to
+ * the built-in list above rather than rendering an empty panel.
+ */
+export function operationsFromCommands(specs: CommandSpec[]): OperationMeta[] {
+  const ops = specs.filter((s) => s.isOperation)
+  if (ops.length === 0) return OPERATIONS
+  return ops.map((s) => ({
+    id: s.id,
+    label: s.label,
+    description: s.description,
+    fields: s.perRunFields ?? [],
+    // Every in-process operation drives the arms; only a sim run doesn't, and
+    // that's decided per run from simFlag.
+    requiresRobot: true,
+    requiresCameras: Boolean(s.requiresCameras),
+    simCapable: s.simCapable,
+    simFlag: s.simFlag ?? null,
+    episodeControl: Boolean(s.episodeControl),
+    usesHeadset: Boolean(s.usesHeadset),
+  }))
+}
+
+/** Whether this run is hardware-free (so it skips the robot / fault gates). */
+export function isSimRun(meta: OperationMeta, settings: Record<string, FormValue>): boolean {
+  return meta.simFlag != null && Boolean(settings[meta.simFlag])
 }
 
 /** Curated fields for an op, resolved from the introspected command schema. */

--- a/web/app/src/routes/ControlPanel.tsx
+++ b/web/app/src/routes/ControlPanel.tsx
@@ -11,9 +11,10 @@ import {
   fetchSettings,
   fetchUpdateStatus,
   fetchUsbStatus,
+  isSimRun,
   loadOpSettings,
   missingCameraSerials,
-  operationMeta,
+  operationsFromCommands,
   perRunFields,
   robotConnect,
   robotDisconnect,
@@ -31,6 +32,7 @@ import {
   type CommandSpec,
   type FormValue,
   type OperationId,
+  type OperationMeta,
   type PolicyState,
   type RobotStatus,
   type ServerInfo,
@@ -94,13 +96,6 @@ function persistLocalCameras(spec: CameraSpec) {
   }
 }
 
-function loadAllOpSettings(): OpSettings {
-  return OPERATIONS.reduce((acc, op) => {
-    acc[op.id] = loadOpSettings(op.id)
-    return acc
-  }, {} as OpSettings)
-}
-
 export default function ControlPanel() {
   const toast = useToast()
   const [commands, setCommands] = useState<CommandSpec[]>([])
@@ -146,9 +141,11 @@ export default function ControlPanel() {
   const [cameraDetecting, setCameraDetecting] = useState(false)
 
   const [selectedOp, setSelectedOp] = useState<OperationId>(
-    () => (localStorage.getItem("axolOp") as OperationId) || "teleop"
+    () => localStorage.getItem("axolOp") || OPERATIONS[0].id
   )
-  const [settingsByOp, setSettingsByOp] = useState<OpSettings>(() => loadAllOpSettings())
+  // Only the ops edited this session; the rest are read from localStorage on
+  // demand, since which ops exist isn't known until the host answers.
+  const [settingsByOp, setSettingsByOp] = useState<OpSettings>({})
 
   const [session, setSession] = useState<SessionInfo | null>(null)
   // run-policy episode phase/count, from the server so the episode controls are
@@ -436,13 +433,23 @@ export default function ControlPanel() {
     if (snap.cameras) setCameras(snap.cameras)
   }
 
+  // The operations this host offers, and the selected one resolved against
+  // them: a stored selection the host doesn't have lands on its first
+  // operation instead of an empty panel.
+  const operations = useMemo(() => operationsFromCommands(commands), [commands])
+  const meta = useMemo(
+    () => operations.find((o) => o.id === selectedOp) ?? operations[0],
+    [operations, selectedOp]
+  )
+  const opId = meta.id
+
   function selectOp(op: OperationId) {
     setSelectedOp(op)
     localStorage.setItem("axolOp", op)
   }
 
   // -- per-operation settings --
-  const settings = settingsByOp[selectedOp] ?? {}
+  const settings = useMemo(() => settingsByOp[opId] ?? loadOpSettings(opId), [settingsByOp, opId])
 
   const updateSettings = useCallback((op: OperationId, next: Record<string, FormValue>) => {
     setSettingsByOp((prev) => ({ ...prev, [op]: next }))
@@ -450,17 +457,17 @@ export default function ControlPanel() {
   }, [])
 
   function setSetting(key: string, value: FormValue) {
-    updateSettings(selectedOp, { ...settings, [key]: value })
+    updateSettings(opId, { ...settings, [key]: value })
   }
 
   function resetSetting(key: string) {
     const next = { ...settings }
     delete next[key]
-    updateSettings(selectedOp, next)
+    updateSettings(opId, next)
   }
 
   function resetAll() {
-    updateSettings(selectedOp, {})
+    updateSettings(opId, {})
   }
 
   // -- robot connection --
@@ -538,8 +545,8 @@ export default function ControlPanel() {
   // disabled "Stopping…" until a terminal status flips the op back to idle.
   const isStopping = isLive && sources.some((s) => s.status === "stopping")
   const runningOp = isLive ? (effectiveStatus?.command as OperationId) : null
-  const selectedLive = isLive && runningOp === selectedOp
-  const selectedStopping = isStopping && runningOp === selectedOp
+  const selectedLive = isLive && runningOp === opId
+  const selectedStopping = isStopping && runningOp === opId
 
   // Whether an update is currently unsafe to apply. `isLive` is the immediate,
   // local signal (reacts the instant an op starts/stops) so the banner blocks
@@ -638,11 +645,7 @@ export default function ControlPanel() {
     }
   }, [conn.state, updating, update?.remoteVersion, toast])
 
-  const meta = operationMeta(selectedOp)
-  const spec = useMemo(
-    () => commands.find((c) => c.id === selectedOp) ?? null,
-    [commands, selectedOp]
-  )
+  const spec = useMemo(() => commands.find((c) => c.id === opId) ?? null, [commands, opId])
 
   // Stop the running task (if any) and wait for it to actually exit before
   // returning, so a disconnect never tears the host/robot link down mid-cleanup.
@@ -673,7 +676,7 @@ export default function ControlPanel() {
       // Only ops that actually require cameras (collect-data / run-policy) are
       // gated on them. Teleop streams whatever cameras are configured but must
       // never be blocked by camera detection, and sim never touches hardware.
-      const isSimSelected = selectedOp === "teleop" && Boolean(settings.sim)
+      const isSimSelected = isSimRun(meta, settings)
       if (meta.requiresCameras && !isSimSelected) {
         // Reuse the detection we already ran (on connect / when the Cameras
         // dialog closed) instead of spawning a fresh enumeration on every start
@@ -715,7 +718,7 @@ export default function ControlPanel() {
       // the headset (and runs fine with none in sim). Newer hosts also hold the
       // spec in their settings store; sending it stays compatible with old ones.
       const camSpec = meta.requiresCameras || cameraCount(cameras) > 0 ? cameras : undefined
-      const result = await startOperation(selectedOp, args, camSpec)
+      const result = await startOperation(opId, args, camSpec)
       setSession(result)
       // Fresh run — clear any stale phase; the live poll repopulates it.
       setPolicy(null)
@@ -837,7 +840,12 @@ export default function ControlPanel() {
           </div>
         )}
 
-        <OperationSelector selected={selectedOp} runningOp={runningOp} onSelect={selectOp} />
+        <OperationSelector
+          operations={operations}
+          selected={opId}
+          runningOp={runningOp}
+          onSelect={selectOp}
+        />
 
         {isLive && !selectedLive && (
           <p className="rounded-lg border border-amber-400/25 bg-amber-400/[0.05] p-3 text-xs text-amber-200/80">
@@ -884,18 +892,35 @@ export default function ControlPanel() {
   )
 }
 
+/** One column per operation on wide screens, spelled out so Tailwind emits the
+ *  classes; a host offering more than five wraps rather than shrinking. */
+const WIDE_COLUMNS: Record<number, string> = {
+  1: "lg:grid-cols-1",
+  2: "lg:grid-cols-2",
+  3: "lg:grid-cols-3",
+  4: "lg:grid-cols-4",
+  5: "lg:grid-cols-5",
+}
+
 function OperationSelector({
+  operations,
   selected,
   runningOp,
   onSelect,
 }: {
+  operations: OperationMeta[]
   selected: OperationId
   runningOp: OperationId | null
   onSelect: (op: OperationId) => void
 }) {
   return (
-    <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
-      {OPERATIONS.map((op) => {
+    <div
+      className={cn(
+        "grid grid-cols-2 gap-3 sm:grid-cols-3",
+        WIDE_COLUMNS[Math.min(operations.length, 5)]
+      )}
+    >
+      {operations.map((op) => {
         const active = op.id === selected
         const running = op.id === runningOp
         return (


### PR DESCRIPTION
## Why

`axol serve`'s command catalog was a fixed table, and the serve layer branched
on operation ids in several places: `runner.py` kept its own `_HARDWARE_OPS` /
`_ASYNC_OPS` / `_OP_IDS` lists, `app.py` hardcoded which op was the sim one, and
the web panel shipped a hardcoded `OPERATIONS` array. A package built on
`almond-axol` had no way in short of monkey-patching or forking.

The motivating case is `axol-pi`, our private Pi companion: its `collect-data`,
`run-policy` and `collect-dagger` are the same flows plus Pi's data-sharing
pieces, and operators want them in the same panel rather than in a terminal.

## What

`COMMANDS` becomes a registry with a public `register()`. Everything the serve
layer needs to launch a command is declared on its `CommandDef` — whether it
runs in-process and how (`entrypoint`, `execution`), what it does with cameras
(`requires_cameras`, `camera_mode`), which arg means "no hardware"
(`sim_flag`), whether it drives episodes (`episode_control`), which fields the
panel shows per run (`per_run_fields`), and which package to spawn it from
(`module`). Nothing dispatches on an id any more.

`settings_like` lets a registered op inherit another's settings targets:
settings are declared as dotted config paths per op id, so an op embedding the
same dataclasses gets the whole table instead of restating ~50 mappings.

The frontend now builds its operation list from `/api/commands`. It falls back
to the previous hardcoded list when the backend doesn't send the new fields, so
the hosted panel at axol.almond.bot keeps working against older robots.

## Testing

No behaviour change intended for the built-in five: same ids, same order, same
schemas, same panels. Verified the catalog and each command's generated schema
are byte-identical before and after, and drove the panel against a running
`axol serve`.

Downstream registration is exercised by the companion axol-pi PR, which
registers three commands through this API — including one under a new id that
borrows `collect-data`'s settings via `settings_like`.

Made with [Cursor](https://cursor.com)