### PR TITLE
Headset-off operation: dashboard operator view + teleop stuck-then-lurch fixes

### DIFF
--- a/almond_axol/kinematics/config.py
+++ b/almond_axol/kinematics/config.py
@@ -24,10 +24,36 @@ class KinematicsConfig:
             preventing slow null-space drift (e.g. unnecessary shoulder twist).
         manipulability_weight: Weight rewarding configurations with high manipulability.
         limit_weight: Weight penalising joint-limit violations.
-        self_collision_margin: Minimum clearance (m) enforced between collision bodies.
+        self_collision_margin: Minimum clearance (m) enforced between collision
+            bodies. Keep this below the arm-torso clearance of normal teleop
+            poses: a margin that is already violated at the folded rest pose
+            (e.g. the old 0.1 default) keeps the nonsmooth collision hinge
+            active during ordinary tracking, which makes the trust-region
+            solver reject steps — the arm freezes while small target errors
+            accumulate, then lurches once the error is large enough to punch
+            through (the teleop "stuck, then jumps" failure). 0.025 matches
+            ``VRTeleopConfig.reset_collision_margin``.
         self_collision_weight: Weight on the self-collision penalty.
         max_iterations: Maximum solver iterations per call.
-        cost_tolerance: Solver convergence tolerance.
+        cost_tolerance: Solver convergence tolerance — terminate when the
+            relative cost change of an iteration falls below this. jaxls also
+            applies it to *rejected* proposals (whose cost change is ~0), so a
+            loose value (the old 1e-2) makes one rejected step read as
+            "converged" and return the seed unchanged. Keep it small enough
+            that only genuine convergence trips it.
+        lambda_initial: Initial Levenberg-Marquardt damping. The per-tick solve
+            re-seeds from the previous solution, so the first proposal is taken
+            in a region where the linearisation may be poor (e.g. with the
+            self-collision cost active); a moderately damped start gets an
+            acceptable step in fewer rejections than the jaxls default (5e-4).
+        lambda_factor: Multiplier applied to the LM damping after each rejected
+            step. With the jaxls default (2.0) and ``max_iterations`` of 8,
+            damping can only grow 256x per solve — not enough to recover from a
+            rejected near-Gauss-Newton step near an active collision
+            constraint, so the solver used to return its seed unchanged for
+            many consecutive ticks (teleop froze) and then lurch once the
+            accumulated target error finally made a full step acceptable. 10.0
+            spans the useful damping range within the iteration budget.
         max_joint_delta: Maximum joint change per :meth:`KinematicsSolver.ik` call, in radians.
         max_reach: Maximum allowed distance (m) from shoulder to end-effector target.
     """
@@ -39,9 +65,11 @@ class KinematicsConfig:
     posture_weight: float = 5.0
     manipulability_weight: float = 0.05
     limit_weight: float = 75.0
-    self_collision_margin: float = 0.1
+    self_collision_margin: float = 0.025
     self_collision_weight: float = 75.0
     max_iterations: int = 8
-    cost_tolerance: float = 1e-2
+    cost_tolerance: float = 1e-4
+    lambda_initial: float = 1e-2
+    lambda_factor: float = 10.0
     max_joint_delta: float = 0.0055 * 2 * math.pi
     max_reach: float = 0.8

--- a/almond_axol/kinematics/solver.py
+++ b/almond_axol/kinematics/solver.py
@@ -135,6 +135,8 @@ def _solve_ik(
     elbow_weight: float,
     max_iterations: int,
     cost_tolerance: float,
+    lambda_initial: float,
+    lambda_factor: float,
 ) -> jax.Array:
     JointVar = robot.joint_var_cls
 
@@ -218,7 +220,10 @@ def _solve_ik(
         initial_vals=initial_vals,
         verbose=False,
         linear_solver="dense_cholesky",
-        trust_region=jaxls.TrustRegionConfig(),
+        trust_region=jaxls.TrustRegionConfig(
+            lambda_initial=lambda_initial,
+            lambda_factor=lambda_factor,
+        ),
         termination=jaxls.TerminationConfig(
             max_iterations=max_iterations,
             cost_tolerance=cost_tolerance,
@@ -513,6 +518,8 @@ class KinematicsSolver:
             cfg.elbow_weight,
             cfg.max_iterations,
             cfg.cost_tolerance,
+            cfg.lambda_initial,
+            cfg.lambda_factor,
         )
         q_result_np = np.asarray(q_result, dtype=np.float32)
         delta = np.clip(

--- a/almond_axol/serve/runner.py
+++ b/almond_axol/serve/runner.py
@@ -58,6 +58,17 @@ _logger = logging.getLogger(__name__)
 _STOP_GRACE_S = 6.0
 _FORCE_GRACE_S = 5.0
 
+# The dataset recorder subprocess (``record_proc``'s "dataset-recorder") is
+# the one child the fast kill must spare: after Stop it is *finalizing* the
+# dataset — encoding the last episode, closing the parquet writers, writing
+# meta — and a SIGKILL there leaves unreadable parquet with no error anywhere.
+# Its shutdown is already bounded on its own (``DatasetRecorderProcess.close``
+# joins for up to 180s, then terminates it with a loud log), so the watchdog
+# first kills everything else (relay, IK worker — the joins the thread is
+# usually stuck on) and gives the recorder that long before killing it too.
+_RECORDER_PROC_NAME = "dataset-recorder"
+_FINALIZE_GRACE_S = 200.0
+
 # Loggers whose records we never forward to the UI: webserver lifecycle,
 # access logs, low-level asyncio chatter. We still want the underlying ops'
 # own logs (``almond_axol.*``, ``can.*``, lerobot, jaxls, pyroki, etc.).
@@ -518,15 +529,29 @@ class OperationRunner:
         return True
 
     def _await_stop(self, session: Session, thread: threading.Thread | None) -> None:
-        """Wait for the op to exit, force-killing its children if it stalls."""
+        """Wait for the op to exit, force-killing its children if it stalls.
+
+        Two-phase: the fast kill spares the dataset recorder (it is finalizing
+        the dataset — killing it corrupts the parquet files), which then gets
+        its own, much longer grace before it too is killed.
+        """
         if thread is None:
             return
         thread.join(timeout=_STOP_GRACE_S)
         if thread.is_alive():
             session.emit(
                 f"[serve] still stopping after {_STOP_GRACE_S:.0f}s — "
-                "force-killing the operation's child processes"
+                "force-killing the operation's child processes (sparing the "
+                "dataset recorder)"
             )
+            spared = self._kill_op_children(session, spare={_RECORDER_PROC_NAME})
+            if spared and thread.is_alive():
+                session.emit(
+                    "[serve] waiting for the dataset recorder to finalize the "
+                    f"dataset (up to {_FINALIZE_GRACE_S:.0f}s)…"
+                )
+                thread.join(timeout=_FINALIZE_GRACE_S)
+        if thread.is_alive():
             self._kill_op_children(session)
             thread.join(timeout=_FORCE_GRACE_S)
         if thread.is_alive():
@@ -539,7 +564,9 @@ class OperationRunner:
                 "abandoned — restart axol serve if it persists"
             )
 
-    def _kill_op_children(self, session: Session) -> None:
+    def _kill_op_children(
+        self, session: Session, spare: set[str] | None = None
+    ) -> bool:
         """SIGKILL every subprocess this op spawned (relay, recorder, IK worker).
 
         The worker thread blocks on these children either while tearing down
@@ -547,6 +574,10 @@ class OperationRunner:
         joins) or while starting up (waiting on the IK worker's "ready" message
         across the pipe while it compiles JAX). Killing the children makes the
         blocked join/recv return so the thread can finish.
+
+        Children whose process name is in ``spare`` are left running (the
+        dataset recorder mid-finalize). Returns ``True`` if any such child was
+        spared, so the caller knows to keep waiting for it.
         """
         # Snapshot the targets under the lock and only if this is still the
         # op being stopped: a slow watchdog could otherwise wake after the
@@ -556,13 +587,21 @@ class OperationRunner:
         # we see the swap and bail — never a mix.
         with self._lock:
             if self._session is not session:
-                return
+                return False
             targets = [
                 c
                 for c in multiprocessing.active_children()
                 if c.pid not in self._baseline_children
             ]
+        spared_any = False
         for child in targets:
+            if spare and child.name in spare:
+                session.emit(
+                    f"[serve] sparing child process {child.name} "
+                    f"(pid {child.pid}) — dataset finalize in progress"
+                )
+                spared_any = True
+                continue
             session.emit(
                 f"[serve] killing child process {child.name} (pid {child.pid})"
             )
@@ -570,6 +609,7 @@ class OperationRunner:
                 child.kill()
             except Exception as exc:  # noqa: BLE001 - best-effort
                 session.emit(f"[serve] failed to kill pid {child.pid}: {exc}")
+        return spared_any
 
     def episode_command(self, command: str) -> bool:
         """Forward an episode command (start/s/r/q) to the live op's control."""

--- a/almond_axol/serve/runner.py
+++ b/almond_axol/serve/runner.py
@@ -341,7 +341,8 @@ class OperationRunner:
         # asyncio op plumbing (set while an async op runs).
         self._async_loop: asyncio.AbstractEventLoop | None = None
         self._async_task: asyncio.Task[Any] | None = None
-        # run-policy episode control (set while run-policy runs).
+        # Episode control of the live op (set while an op declaring
+        # episode_control runs, e.g. run-policy).
         self._policy_control: Any = None
 
     # -- lookup / subscribe (mirrors SessionManager so app.py can reuse it) --
@@ -571,7 +572,7 @@ class OperationRunner:
                 session.emit(f"[serve] failed to kill pid {child.pid}: {exc}")
 
     def episode_command(self, command: str) -> bool:
-        """Forward a run-policy episode command (start/s/r/q) to its control."""
+        """Forward an episode command (start/s/r/q) to the live op's control."""
         control = self._policy_control
         if control is None:
             return False
@@ -579,7 +580,7 @@ class OperationRunner:
         return True
 
     def policy_state(self) -> dict[str, Any] | None:
-        """run-policy episode phase/message/count, or None if no policy is running.
+        """The live op's episode phase/message/count, or None if there is none.
 
         Read by /api/op/status so the control panel reflects whether an episode
         is recording or sitting at the between-episode gate on any computer.

--- a/almond_axol/teleop/worker.py
+++ b/almond_axol/teleop/worker.py
@@ -8,10 +8,12 @@ All intermediate computations stay in NumPy; the single JAX boundary is the
 
 from __future__ import annotations
 
+import logging
 import math
 import multiprocessing
 import multiprocessing.connection
 import os
+import time
 
 import jax.numpy as jnp
 import jaxlie
@@ -23,6 +25,18 @@ from ..vr.models import VRFrame
 from .config import VRTeleopConfig
 from .filter import OneEuroFilter
 from .trajectory import plan_collision_aware_trajectory
+
+_logger = logging.getLogger(__name__)
+
+# Freeze detection (see IKWorker._note_solve): warn when the solver keeps
+# returning its seed unchanged while the tracked targets move away — the
+# operator experiences the arm as stuck, then lurching once the solve breaks
+# free. Thresholds: how long the output must be frozen before warning, how far
+# the targets must have moved (so a still hand doesn't warn), and how often to
+# re-warn while the freeze persists.
+_FREEZE_WARN_AFTER_S = 0.5
+_FREEZE_MIN_TARGET_DRIFT_M = 0.005
+_FREEZE_REWARN_EVERY_S = 2.0
 
 # ---------------------------------------------------------------------------
 # NumPy-only helpers (no JAX dispatch overhead)
@@ -161,6 +175,14 @@ class IKWorker:
         self._solver.set_posture_pose(self.get_rest_q())
 
         self._active: bool = False
+        # Freeze detection state: when the last solve returned its seed
+        # unchanged, `_freeze_since` holds the wall time the freeze started and
+        # `_freeze_targets` the EE/elbow target positions at that moment, so a
+        # warning fires only when the targets kept moving away (a still hand
+        # legitimately produces an unchanged solution).
+        self._freeze_since: float | None = None
+        self._freeze_targets: np.ndarray | None = None
+        self._freeze_next_warn: float = _FREEZE_WARN_AFTER_S
         # Snap poses as (pos_3, rot_3x3) numpy tuples — no jaxlie overhead
         self._snap_ctrl: dict[str, tuple[np.ndarray, np.ndarray]] = {}
         self._snap_fk: dict[str, tuple[np.ndarray, np.ndarray]] = {}
@@ -216,6 +238,7 @@ class IKWorker:
         enabled = frame.l_lock and frame.r_lock
         if not enabled:
             self._active = False
+            self._clear_freeze()
             return q_current
 
         if not self._active:
@@ -279,6 +302,7 @@ class IKWorker:
 
         if not self._active:
             self._active = True
+            self._clear_freeze()
             self._engage_snap(
                 left_pos, left_rot, right_pos, right_rot, left_e, right_e, q_current
             )
@@ -310,13 +334,18 @@ class IKWorker:
             right_e - self._snap_elbow_ctrl["right"]
         )
 
-        return self._solver.ik(
+        q_new = self._solver.ik(
             q_current,
             left_pose=(tl_pos, tl_rot),
             right_pose=(tr_pos, tr_rot),
             left_elbow_pos=elbow_l,
             right_elbow_pos=elbow_r,
         )
+        self._note_solve(
+            bool(np.array_equal(q_new, q_current)),
+            np.concatenate([tl_pos, tr_pos, elbow_l, elbow_r]),
+        )
+        return q_new
 
     def compute_reset_trajectory(
         self, q_current: np.ndarray, q_target: np.ndarray
@@ -345,6 +374,7 @@ class IKWorker:
         performs a fresh engage-snap from the current IK pose.
         """
         self._active = False
+        self._clear_freeze()
         self._snap_ctrl = {}
         self._snap_fk = {}
         self._snap_elbow_ctrl = {}
@@ -355,6 +385,49 @@ class IKWorker:
         self._solver.set_posture_pose(self.get_rest_q())
 
     # -- Internal -----------------------------------------------------------
+
+    def _clear_freeze(self) -> None:
+        """Forget any in-progress freeze run (disengage / engage / reset)."""
+        self._freeze_since = None
+        self._freeze_targets = None
+        self._freeze_next_warn = _FREEZE_WARN_AFTER_S
+
+    def _note_solve(self, frozen: bool, targets: np.ndarray) -> None:
+        """Track seed-returning solves; WARN when the output freezes.
+
+        A single unchanged solution is normal (e.g. the hand is still, or the
+        target is held against a constraint). The failure mode worth flagging is
+        a *run* of solves that return the seed while the EE/elbow targets keep
+        moving away — the operator sees the arm stop responding, and the
+        accumulated error is released as a lurch once a solve finally makes
+        progress (see ``KinematicsConfig`` for the tuning that minimises this).
+
+        Args:
+            frozen: True when this solve returned ``q_current`` bit-identically.
+            targets: Concatenated EE + elbow target positions (m) of this solve,
+                used to measure how far the targets drifted during the freeze.
+        """
+        if not frozen:
+            self._clear_freeze()
+            return
+        now = time.monotonic()
+        if self._freeze_since is None or self._freeze_targets is None:
+            self._freeze_since = now
+            self._freeze_targets = targets
+            return
+        duration = now - self._freeze_since
+        drift = float(np.max(np.abs(targets - self._freeze_targets)))
+        if duration >= self._freeze_next_warn and drift >= _FREEZE_MIN_TARGET_DRIFT_M:
+            _logger.warning(
+                "IK frozen for %.1fs: solver keeps returning its seed while the "
+                "EE/elbow targets moved %.0f mm — it cannot make progress "
+                "(target likely conflicts with the self-collision margin or "
+                "joint limits); the arm holds, then catches up in a lurch when "
+                "the solve breaks free.",
+                duration,
+                drift * 1e3,
+            )
+            self._freeze_next_warn = duration + _FREEZE_REWARN_EVERY_S
 
     def _reset_pose_filters(self) -> None:
         """Clear the OneEuroFilter state for every controller and elbow stream."""

--- a/almond_axol/utils/jetson_diag.py
+++ b/almond_axol/utils/jetson_diag.py
@@ -9,8 +9,10 @@ version-fragile sysfs/debugfs nodes. ``tegrastats`` ships with every L4T and
 normalizes all of them into one line per interval, so we parse that instead.
 
 The sampler runs on its own thread, is Jetson-only (a clean no-op off-Tegra or
-when ``tegrastats`` is absent), and logs one compact INFO line per period so the
-record-start transition is visible next to the ``loop:`` / ``diag:`` lines. It
+when ``tegrastats`` is absent), and logs one compact DEBUG line per period so
+the record-start transition is visible next to the ``diag:`` lines when running
+with ``--log_level DEBUG`` (resource readouts stay out of the default INFO
+output). It
 also re-checks the engine-clock and CPU-governor pins at runtime (the boot-time
 ``axol jetson.setup`` is the only thing that sets them, and nothing verified they
 held under load).
@@ -125,7 +127,7 @@ class TegraStatsDiag(threading.Thread):
             parts.append(f"tmax={max(temps):.1f}C")
 
         parts.append("throttle=yes" if "throttl" in line.lower() else "throttle=none")
-        self._logger.info("tegra: %s", "  ".join(parts))
+        self._logger.debug("tegra: %s", "  ".join(parts))
 
     def _check_pins(self) -> None:
         """WARN if the NVENC/VIC engine clocks or CPU governor aren't pinned.

--- a/almond_axol/utils/proc_diag.py
+++ b/almond_axol/utils/proc_diag.py
@@ -235,7 +235,9 @@ class SystemDiag(threading.Thread):
             percpu.sort()
             percpu_str = "[" + ",".join(f"{f:.0f}" for _, f in percpu) + "]"
 
-            # INFO tier: labelled procs (+ their gst children) CPU% / RSS + memory.
+            # First DEBUG tier: labelled procs (+ their gst children) CPU% /
+            # RSS + memory. Diagnostics stay out of the default INFO output;
+            # run with --log_level DEBUG to see them.
             cur_labeled = self._scan_labeled()
             lab_pct: list[tuple[float, str]] = []
             for pid, (jif, label) in cur_labeled.items():
@@ -252,7 +254,7 @@ class SystemDiag(threading.Thread):
             top_labeled = "  ".join(s for _, s in lab_pct) or "n/a"
 
             mem_avail, swap_free, swap_total = read_meminfo()
-            self._logger.info(
+            self._logger.debug(
                 "diag: cores>85%%=%d/%d sys=%.0f%% cpu%%=%s  %s  memavail=%s swap=%s/%s",
                 busy_cores,
                 ncpu,
@@ -264,8 +266,9 @@ class SystemDiag(threading.Thread):
                 _gib(swap_total),
             )
 
-            # DEBUG tier: full system-wide proc + main-thread breakdown (every
-            # /proc/<pid> + every thread of this process — too costly for INFO).
+            # Second DEBUG tier: full system-wide proc + main-thread breakdown
+            # (every /proc/<pid> + every thread of this process — costly, so
+            # still gated on the effective level before doing the scans).
             if not self._logger.isEnabledFor(logging.DEBUG):
                 continue
 

--- a/almond_axol/vr/server.py
+++ b/almond_axol/vr/server.py
@@ -91,6 +91,15 @@ class VRServer:
         # readout — the default for plain teleop, which never sets it.
         self._episode: int | None = None
 
+        # Latest headset HUD state (armed save/discard confirmation popup,
+        # record countdown) published by the driving client via a ``hud``
+        # signaling message, and that client's id. Relayed to every *other*
+        # client so a dashboard can mirror what the headset would show (the
+        # operator may drive with the controllers while the headset is off);
+        # cleared — with a null broadcast — when the publisher disconnects.
+        self._hud: dict[str, Any] | None = None
+        self._hud_client: int | None = None
+
         # The headset streams identical frames (same ``seq``) over both the USB
         # tunnel and the network (WebRTC data channel / WebSocket). We process
         # each ``seq`` once, from whichever transport delivers it first — the
@@ -235,6 +244,17 @@ class VRServer:
                 await ws.send_text(text)
             except Exception as exc:
                 _logger.warning("Failed to send feedback to client: %s", exc)
+
+    async def _broadcast_hud(self, exclude: WebSocket | None = None) -> None:
+        """Relay the current headset HUD state to (other) connected clients."""
+        text = json.dumps({"type": "hud", "value": self._hud})
+        for ws in list(self._active_clients):
+            if ws is exclude:
+                continue
+            try:
+                await ws.send_text(text)
+            except Exception as exc:
+                _logger.warning("Failed to relay hud to client: %s", exc)
 
     async def enable(self) -> None:
         """Start the WSS server in the background.
@@ -414,6 +434,16 @@ class VRServer:
                 await self._control.set_answer(client_id, sdp)
             return
 
+        # Headset HUD state (armed confirmation popup, record countdown):
+        # store it and relay to every other client so a dashboard can mirror
+        # the in-headset popups (see ``self._hud``).
+        if msg_type == "hud":
+            value = obj.get("value")
+            self._hud = value if isinstance(value, dict) else None
+            self._hud_client = client_id
+            await self._broadcast_hud(exclude=websocket)
+            return
+
         if self._webrtc is None:
             if msg_type == "webrtc-request":
                 await websocket.send_text(json.dumps({"type": "webrtc-unavailable"}))
@@ -486,6 +516,15 @@ class VRServer:
                     )
                 except Exception as exc:  # noqa: BLE001 - best-effort announce
                     _logger.warning("failed to send episode to client: %s", exc)
+            # And any live headset HUD state (armed popup / countdown), so a
+            # dashboard joining mid-dialog mirrors it immediately.
+            if server._hud is not None:
+                try:
+                    await websocket.send_text(
+                        json.dumps({"type": "hud", "value": server._hud})
+                    )
+                except Exception as exc:  # noqa: BLE001 - best-effort announce
+                    _logger.warning("failed to send hud to client: %s", exc)
             try:
                 while True:
                     data = await websocket.receive_text()
@@ -501,6 +540,13 @@ class VRServer:
             finally:
                 server._active_clients.discard(websocket)
                 server._client_count = max(0, server._client_count - 1)
+                # The HUD publisher (the headset) left: clear its popups from
+                # every mirror so a dashboard doesn't show a stale dialog.
+                if server._hud_client == client_id:
+                    server._hud_client = None
+                    if server._hud is not None:
+                        server._hud = None
+                        await server._broadcast_hud()
                 if server._webrtc is not None:
                     await server._webrtc.close(client_id)
                 await server._control.close(client_id)

--- a/web/app/src/components/camera-feeds.tsx
+++ b/web/app/src/components/camera-feeds.tsx
@@ -1,0 +1,242 @@
+import { useEffect, useMemo, useRef, useState } from "react"
+import { Loader2, ShieldCheck, VideoOff } from "lucide-react"
+import { useAxolVideo, type CameraStreams } from "@almond/axol-vr-client"
+import { authorizeCert } from "@/lib/cert-accept"
+import { serverHttpBase } from "@/lib/supervisor"
+import { Button } from "@/components/ui/button"
+
+/**
+ * Live camera feeds in the control panel, for driving a session with the
+ * headset off.
+ *
+ * The panel joins the running operation's VR server (`wss://host:vrPort/ws`)
+ * as one more view-only client and negotiates the same WebRTC camera tracks
+ * the headset would receive — no new backend video path, and the relay's
+ * encoders are shared. A stereo camera streaming both eyes arrives as a
+ * single side-by-side track (`{name}_sbs`); only its left half is shown.
+ * When both eyes arrive as separate tracks, only the left one is shown.
+ *
+ * The VR server's self-signed certificate must be accepted per origin, so a
+ * connection that keeps failing offers the same authorize-popup flow the VR
+ * app uses (see lib/cert-accept.ts).
+ */
+export function CameraFeeds({ host, vrPort }: { host: string; vrPort: number }) {
+  const wsRef = useRef<WebSocket | null>(null)
+  const [wsOpen, setWsOpen] = useState(false)
+  // Consecutive failed connection attempts without ever opening — the
+  // signature of an unaccepted self-signed cert (or a server still starting).
+  const [failedAttempts, setFailedAttempts] = useState(0)
+
+  // Bare hostname of the serve machine: the stored host may carry a scheme
+  // or the control-panel port; same-origin panels have no host at all.
+  const hostname = useMemo(() => {
+    const base = serverHttpBase(host)
+    if (base) {
+      try {
+        return new URL(base).hostname
+      } catch {
+        // fall through to the page's own host
+      }
+    }
+    return window.location.hostname
+  }, [host])
+  const vrOrigin = `https://${hostname}:${vrPort}`
+
+  // Own the WebSocket to the VR server, reconnecting while mounted: the
+  // server only comes up partway through the operation's startup (after the
+  // teleop stack connects), and its video manager is registered later still —
+  // reconnecting also re-triggers useAxolVideo's one-shot webrtc-request.
+  useEffect(() => {
+    let closed = false
+    let timer: ReturnType<typeof setTimeout> | null = null
+
+    function connect() {
+      let ws: WebSocket
+      try {
+        ws = new WebSocket(`wss://${hostname}:${vrPort}/ws`)
+      } catch {
+        timer = setTimeout(connect, 3000)
+        return
+      }
+      let opened = false
+      wsRef.current = ws
+      ws.onopen = () => {
+        opened = true
+        setWsOpen(true)
+        setFailedAttempts(0)
+      }
+      ws.onclose = () => {
+        if (wsRef.current === ws) wsRef.current = null
+        if (closed) return
+        setWsOpen(false)
+        if (!opened) setFailedAttempts((n) => n + 1)
+        timer = setTimeout(connect, 3000)
+      }
+    }
+
+    connect()
+    return () => {
+      closed = true
+      if (timer) clearTimeout(timer)
+      const ws = wsRef.current
+      wsRef.current = null
+      if (ws) {
+        ws.onclose = null
+        ws.close()
+      }
+    }
+  }, [hostname, vrPort])
+
+  const { streams, available } = useAxolVideo(wsRef, true)
+
+  // `available === false` means this socket's webrtc-request landed before the
+  // op registered its video manager (or video is off). Recycle the socket on a
+  // timer so the next request can succeed once video comes up.
+  useEffect(() => {
+    if (available !== false) return
+    const t = setTimeout(() => wsRef.current?.close(), 5000)
+    return () => clearTimeout(t)
+  }, [available])
+
+  const feeds = useMemo(() => selectFeeds(streams), [streams])
+  // A repeatedly-failing connection is either the unaccepted self-signed cert
+  // or the VR server still starting; offer the one-tap cert authorize either
+  // way (harmless while starting).
+  const certHint = !wsOpen && failedAttempts >= 2
+
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border border-white/10 bg-white/[0.02] p-3">
+      <div className="flex items-center justify-between gap-2">
+        <span className="font-mono text-xs tracking-widest text-white/40 uppercase">
+          Camera feeds
+        </span>
+        {feeds.length > 0 && <span className="font-mono text-[0.65rem] text-white/40">live</span>}
+      </div>
+
+      {feeds.length > 0 ? (
+        <div className="grid grid-cols-2 gap-2">
+          {feeds.map((feed) => (
+            <FeedTile
+              key={feed.name}
+              feed={feed}
+              wide={feeds.length % 2 === 1 && feed === feeds[0]}
+            />
+          ))}
+        </div>
+      ) : available === false ? (
+        <p className="flex items-center gap-2 text-xs text-white/45">
+          <VideoOff className="size-3.5 shrink-0" />
+          No camera stream from this operation — check that streaming is enabled in the camera
+          settings.
+        </p>
+      ) : (
+        <p className="flex items-center gap-2 text-xs text-white/45">
+          <Loader2 className="size-3.5 shrink-0 animate-spin" />
+          {wsOpen ? "Waiting for video…" : "Connecting to the camera stream…"}
+        </p>
+      )}
+
+      {certHint && (
+        <div className="flex flex-wrap items-center gap-2 text-xs text-white/45">
+          <span>
+            If the feed never connects, authorize the camera server&apos;s certificate once:
+          </span>
+          <Button variant="outline" size="sm" onClick={() => authorizeCert(vrOrigin)}>
+            <ShieldCheck />
+            Authorize
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface Feed {
+  /** Camera slot name shown as the label (e.g. "overhead", "left_arm"). */
+  name: string
+  stream: MediaStream
+  /** Side-by-side stereo track: display only the left half (the left eye). */
+  leftHalf: boolean
+}
+
+/**
+ * Pick one displayable feed per camera from the negotiated tracks.
+ *
+ * - `{name}_sbs` (both eyes packed side-by-side) → shown cropped to the left
+ *   eye, labelled `{name}`; any accompanying per-eye tracks are dropped.
+ * - `{name}_left` / `{name}_right` (per-eye tracks) → only the left is shown.
+ * - anything else (mono or single-eye) → shown as-is.
+ */
+function selectFeeds(streams: CameraStreams): Feed[] {
+  const names = new Set(Object.keys(streams))
+  const feeds: Feed[] = []
+  for (const [name, stream] of Object.entries(streams)) {
+    if (name.endsWith("_sbs")) {
+      feeds.push({ name: name.slice(0, -4), stream, leftHalf: true })
+      continue
+    }
+    if (name.endsWith("_left")) {
+      const base = name.slice(0, -5)
+      if (names.has(`${base}_sbs`)) continue
+      feeds.push({ name: base, stream, leftHalf: false })
+      continue
+    }
+    if (name.endsWith("_right")) {
+      const base = name.slice(0, -6)
+      if (names.has(`${base}_sbs`) || names.has(`${base}_left`)) continue
+      feeds.push({ name: base, stream, leftHalf: false })
+      continue
+    }
+    if (names.has(`${name}_sbs`)) continue
+    feeds.push({ name, stream, leftHalf: false })
+  }
+  // Stable, overhead-first ordering so the primary feed leads the grid.
+  return feeds.sort((a, b) =>
+    a.name === "overhead" ? -1 : b.name === "overhead" ? 1 : a.name.localeCompare(b.name)
+  )
+}
+
+function FeedTile({ feed, wide }: { feed: Feed; wide: boolean }) {
+  const videoRef = useRef<HTMLVideoElement>(null)
+  // Displayed aspect (width/height of the visible region). ZED streams are
+  // 16:10 per eye; corrected from the track's real dimensions on metadata.
+  const [aspect, setAspect] = useState(1.6)
+
+  useEffect(() => {
+    const video = videoRef.current
+    if (!video) return
+    video.srcObject = feed.stream
+    video.play().catch(() => {
+      // Autoplay of a muted video is allowed everywhere modern; best-effort.
+    })
+  }, [feed.stream])
+
+  return (
+    <div
+      className={`relative overflow-hidden rounded-lg border border-white/10 bg-black ${
+        wide ? "col-span-2" : ""
+      }`}
+      style={{ aspectRatio: aspect }}
+    >
+      {/* For a side-by-side track the container is sized to one eye, and the
+          height-fitted video is naturally twice its width — so exactly the
+          left eye is visible. */}
+      <video
+        ref={videoRef}
+        autoPlay
+        muted
+        playsInline
+        onLoadedMetadata={() => {
+          const v = videoRef.current
+          if (v && v.videoWidth > 0 && v.videoHeight > 0) {
+            setAspect(v.videoWidth / (feed.leftHalf ? 2 : 1) / v.videoHeight)
+          }
+        }}
+        className={feed.leftHalf ? "h-full w-auto max-w-none" : "h-full w-full object-contain"}
+      />
+      <span className="absolute bottom-1 left-1.5 rounded bg-black/60 px-1.5 py-0.5 font-mono text-[0.6rem] text-white/70">
+        {feed.name.replace(/_/g, " ")}
+      </span>
+    </div>
+  )
+}

--- a/web/app/src/components/camera-feeds.tsx
+++ b/web/app/src/components/camera-feeds.tsx
@@ -195,12 +195,23 @@ export function CameraFeeds({
       </div>
 
       {feeds.length > 0 ? (
-        <div className={`grid grid-cols-2 ${expanded ? "content-start gap-3" : "gap-2"}`}>
+        <div
+          className={`grid grid-cols-2 ${expanded ? "min-h-0 flex-1 gap-3" : "gap-2"}`}
+          // In the fullscreen operator view the grid fills the remaining
+          // viewport height and splits it evenly across rows, so every feed
+          // (and the episode state above) is visible without scrolling.
+          style={
+            expanded
+              ? { gridTemplateRows: `repeat(${Math.ceil(feeds.length / 2)}, minmax(0, 1fr))` }
+              : undefined
+          }
+        >
           {feeds.map((feed) => (
             <FeedTile
               key={feed.name}
               feed={feed}
               wide={feeds.length % 2 === 1 && feed === feeds[0]}
+              fit={expanded}
             />
           ))}
         </div>
@@ -277,11 +288,29 @@ function selectFeeds(streams: CameraStreams): Feed[] {
   )
 }
 
-function FeedTile({ feed, wide }: { feed: Feed; wide: boolean }) {
+function FeedTile({ feed, wide, fit }: { feed: Feed; wide: boolean; fit: boolean }) {
   const videoRef = useRef<HTMLVideoElement>(null)
   // Displayed aspect (width/height of the visible region). ZED streams are
   // 16:10 per eye; corrected from the track's real dimensions on metadata.
   const [aspect, setAspect] = useState(1.6)
+
+  // `fit` (the fullscreen operator view): the grid cell's height is fixed by
+  // the viewport, so size the tile to the largest aspect-true box inside the
+  // cell — like object-contain, but done by hand because the side-by-side
+  // crop needs the box itself (not just the video) at the single-eye aspect.
+  const cellRef = useRef<HTMLDivElement>(null)
+  const [cell, setCell] = useState<{ w: number; h: number } | null>(null)
+  useEffect(() => {
+    if (!fit) return
+    const el = cellRef.current
+    if (!el) return
+    const ro = new ResizeObserver(() => {
+      const r = el.getBoundingClientRect()
+      setCell({ w: r.width, h: r.height })
+    })
+    ro.observe(el)
+    return () => ro.disconnect()
+  }, [fit])
 
   useEffect(() => {
     const video = videoRef.current
@@ -292,12 +321,21 @@ function FeedTile({ feed, wide }: { feed: Feed; wide: boolean }) {
     })
   }, [feed.stream])
 
-  return (
+  const box = (
     <div
       className={`relative overflow-hidden rounded-lg border border-white/10 bg-black ${
-        wide ? "col-span-2" : ""
+        !fit && wide ? "col-span-2" : ""
       }`}
-      style={{ aspectRatio: aspect }}
+      style={
+        fit
+          ? cell
+            ? {
+                width: Math.floor(Math.min(cell.w, cell.h * aspect)),
+                height: Math.floor(Math.min(cell.w, cell.h * aspect) / aspect),
+              }
+            : { width: 0, height: 0 }
+          : { aspectRatio: aspect }
+      }
     >
       {/* For a side-by-side track the container is sized to one eye, and the
           height-fitted video is naturally twice its width — so exactly the
@@ -318,6 +356,16 @@ function FeedTile({ feed, wide }: { feed: Feed; wide: boolean }) {
       <span className="absolute bottom-1 left-1.5 rounded bg-black/60 px-1.5 py-0.5 font-mono text-[0.6rem] text-white/70">
         {feed.name.replace(/_/g, " ")}
       </span>
+    </div>
+  )
+
+  if (!fit) return box
+  return (
+    <div
+      ref={cellRef}
+      className={`flex min-h-0 min-w-0 items-center justify-center ${wide ? "col-span-2" : ""}`}
+    >
+      {box}
     </div>
   )
 }

--- a/web/app/src/components/camera-feeds.tsx
+++ b/web/app/src/components/camera-feeds.tsx
@@ -1,9 +1,21 @@
 import { useEffect, useMemo, useRef, useState } from "react"
-import { Loader2, ShieldCheck, VideoOff } from "lucide-react"
+import { Loader2, Maximize2, Minimize2, ShieldCheck, VideoOff } from "lucide-react"
 import { useAxolVideo, type CameraStreams } from "@almond/axol-vr-client"
 import { authorizeCert } from "@/lib/cert-accept"
 import { serverHttpBase } from "@/lib/supervisor"
 import { Button } from "@/components/ui/button"
+
+/**
+ * Headset HUD state relayed by the VR server (`{"type":"hud",...}` messages):
+ * the armed save/discard confirmation popup and the record-start countdown.
+ * The headset app publishes it so the panel can mirror the popups the
+ * operator would see in VR — they may be driving with the controllers while
+ * the headset is off. Null when nothing is armed (or no headset connected).
+ */
+export interface VrHud {
+  confirm: "save" | "discard" | null
+  countdownRemainingMs: number | null
+}
 
 /**
  * Live camera feeds in the control panel, for driving a session with the
@@ -16,11 +28,30 @@ import { Button } from "@/components/ui/button"
  * single side-by-side track (`{name}_sbs`); only its left half is shown.
  * When both eyes arrive as separate tracks, only the left one is shown.
  *
+ * The same socket also carries the relayed headset HUD messages (see VrHud),
+ * surfaced through `onHud` so the episode UI can mirror the in-headset
+ * popups.
+ *
  * The VR server's self-signed certificate must be accepted per origin, so a
  * connection that keeps failing offers the same authorize-popup flow the VR
  * app uses (see lib/cert-accept.ts).
  */
-export function CameraFeeds({ host, vrPort }: { host: string; vrPort: number }) {
+export function CameraFeeds({
+  host,
+  vrPort,
+  expanded = false,
+  onToggleFullscreen,
+  onHud,
+}: {
+  host: string
+  vrPort: number
+  /** Fullscreen operator view: let the feed grid grow to fill the screen. */
+  expanded?: boolean
+  /** Renders a fullscreen toggle in the header when provided. */
+  onToggleFullscreen?: () => void
+  /** Relayed headset HUD state (must be referentially stable, e.g. a setState). */
+  onHud?: (hud: VrHud | null) => void
+}) {
   const wsRef = useRef<WebSocket | null>(null)
   const [wsOpen, setWsOpen] = useState(false)
   // Consecutive failed connection attempts without ever opening — the
@@ -65,8 +96,32 @@ export function CameraFeeds({ host, vrPort }: { host: string; vrPort: number }) 
         setWsOpen(true)
         setFailedAttempts(0)
       }
+      // Mirror the headset HUD: the server relays the driving client's
+      // popup/countdown state as `hud` messages on this same socket.
+      ws.addEventListener("message", (event: MessageEvent) => {
+        if (!onHud) return
+        try {
+          const msg = JSON.parse(event.data as string) as { type?: string; value?: unknown }
+          if (msg.type !== "hud") return
+          const v = msg.value as Partial<VrHud> | null
+          onHud(
+            v && typeof v === "object"
+              ? {
+                  confirm: v.confirm === "save" || v.confirm === "discard" ? v.confirm : null,
+                  countdownRemainingMs:
+                    typeof v.countdownRemainingMs === "number" ? v.countdownRemainingMs : null,
+                }
+              : null
+          )
+        } catch {
+          // not JSON (or not for us)
+        }
+      })
       ws.onclose = () => {
         if (wsRef.current === ws) wsRef.current = null
+        // The HUD publisher is unreachable through a dead socket: drop any
+        // mirrored popup rather than leave a stale dialog up.
+        onHud?.(null)
         if (closed) return
         setWsOpen(false)
         if (!opened) setFailedAttempts((n) => n + 1)
@@ -85,7 +140,7 @@ export function CameraFeeds({ host, vrPort }: { host: string; vrPort: number }) 
         ws.close()
       }
     }
-  }, [hostname, vrPort])
+  }, [hostname, vrPort, onHud])
 
   const { streams, available } = useAxolVideo(wsRef, true)
 
@@ -115,16 +170,32 @@ export function CameraFeeds({ host, vrPort }: { host: string; vrPort: number }) 
   const certHint = !wsOpen && failedAttempts >= 2
 
   return (
-    <div className="flex flex-col gap-2 rounded-lg border border-white/10 bg-white/[0.02] p-3">
+    <div
+      className={`flex flex-col gap-2 rounded-lg border border-white/10 bg-white/[0.02] p-3 ${
+        expanded ? "min-h-0 flex-1" : ""
+      }`}
+    >
       <div className="flex items-center justify-between gap-2">
         <span className="font-mono text-xs tracking-widest text-white/40 uppercase">
           Camera feeds
         </span>
-        {feeds.length > 0 && <span className="font-mono text-[0.65rem] text-white/40">live</span>}
+        <div className="flex items-center gap-2">
+          {feeds.length > 0 && <span className="font-mono text-[0.65rem] text-white/40">live</span>}
+          {onToggleFullscreen && (
+            <button
+              type="button"
+              onClick={onToggleFullscreen}
+              title={expanded ? "Exit fullscreen (Esc)" : "Fullscreen operator view"}
+              className="text-white/40 transition-colors hover:text-white/80"
+            >
+              {expanded ? <Minimize2 className="size-4" /> : <Maximize2 className="size-4" />}
+            </button>
+          )}
+        </div>
       </div>
 
       {feeds.length > 0 ? (
-        <div className="grid grid-cols-2 gap-2">
+        <div className={`grid grid-cols-2 ${expanded ? "content-start gap-3" : "gap-2"}`}>
           {feeds.map((feed) => (
             <FeedTile
               key={feed.name}

--- a/web/app/src/components/camera-feeds.tsx
+++ b/web/app/src/components/camera-feeds.tsx
@@ -91,12 +91,22 @@ export function CameraFeeds({ host, vrPort }: { host: string; vrPort: number }) 
 
   // `available === false` means this socket's webrtc-request landed before the
   // op registered its video manager (or video is off). Recycle the socket on a
-  // timer so the next request can succeed once video comes up.
+  // timer so the next request can succeed once video comes up, and count the
+  // consecutive unavailable replies: the first few are the expected startup
+  // race, so only a persistent run means streaming is actually off.
+  const [unavailableRuns, setUnavailableRuns] = useState(0)
   useEffect(() => {
+    if (available === true) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setUnavailableRuns(0)
+      return
+    }
     if (available !== false) return
+    setUnavailableRuns((n) => n + 1)
     const t = setTimeout(() => wsRef.current?.close(), 5000)
     return () => clearTimeout(t)
   }, [available])
+  const videoOff = available === false && unavailableRuns >= 3
 
   const feeds = useMemo(() => selectFeeds(streams), [streams])
   // A repeatedly-failing connection is either the unaccepted self-signed cert
@@ -123,7 +133,7 @@ export function CameraFeeds({ host, vrPort }: { host: string; vrPort: number }) 
             />
           ))}
         </div>
-      ) : available === false ? (
+      ) : videoOff ? (
         <p className="flex items-center gap-2 text-xs text-white/45">
           <VideoOff className="size-3.5 shrink-0" />
           No camera stream from this operation — check that streaming is enabled in the camera

--- a/web/app/src/components/operation-panel.tsx
+++ b/web/app/src/components/operation-panel.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react"
+import { useEffect, useMemo, useState } from "react"
 import {
   AlertTriangle,
   ExternalLink,
@@ -15,6 +15,7 @@ import {
   perRunFields,
   type CameraSpec,
   type CommandSpec,
+  type EpisodeControlSpec,
   type FormValue,
   type OperationMeta,
   type PolicyState,
@@ -23,6 +24,7 @@ import {
 } from "@/lib/supervisor"
 import { CuratedForm } from "@/components/config-form"
 import { ArmJointPicker } from "@/components/arm-joint-picker"
+import { CameraFeeds } from "@/components/camera-feeds"
 import { Card, CardContent } from "@/components/ui/card"
 import { Button, buttonVariants } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -50,6 +52,7 @@ export function OperationPanel({
   session,
   host,
   viewerPort,
+  vrPort,
   startPhase,
   policy,
   onStart,
@@ -71,6 +74,8 @@ export function OperationPanel({
   session: SessionInfo | null
   host: string
   viewerPort: number
+  /** VR/teleop WebSocket port on the serve host (camera-feed signaling). */
+  vrPort: number
   /** Progress label shown on the Start button while preparing (e.g. camera check). */
   startPhase: string | null
   /** run-policy episode phase/count (null unless run-policy is the live op). */
@@ -214,6 +219,10 @@ export function OperationPanel({
                 <EpisodeControls policy={policy} onEpisode={onEpisode} />
               )}
 
+              {/* Headset-driven ops stream their cameras over WebRTC; mirror
+                  the feeds here so a session can run with the headset off. */}
+              {meta.usesHeadset && live && !isSim && <CameraFeeds host={host} vrPort={vrPort} />}
+
               <RunningHints
                 usesHeadset={meta.usesHeadset}
                 session={live ? session : null}
@@ -229,6 +238,39 @@ export function OperationPanel({
   )
 }
 
+/** How long an armed confirm button waits for its second click (ms). */
+const CONFIRM_ARM_MS = 5000
+
+/**
+ * The panel's built-in run-policy button set, used when the server's snapshot
+ * doesn't carry its own `controls` (hosts predating server-driven controls).
+ */
+function legacyControls(phase: string): EpisodeControlSpec[] {
+  if (phase === "ready") return [{ command: "start", label: "Start episode" }]
+  if (phase === "recording" || phase === "deciding") {
+    return [
+      { command: "s", label: "Save" },
+      { command: "r", label: "Discard" },
+    ]
+  }
+  return []
+}
+
+function legacyStatus(phase: string): string {
+  switch (phase) {
+    case "recording":
+      return "Recording — Save to keep, Discard to re-record."
+    case "deciding":
+      return "Time cap reached — Save to keep, Discard to re-record."
+    case "ready":
+      return "Reset the scene, then start the episode."
+    case "resetting":
+      return "Returning to rest…"
+    default:
+      return "Preparing…"
+  }
+}
+
 function EpisodeControls({
   policy,
   onEpisode,
@@ -237,20 +279,34 @@ function EpisodeControls({
   onEpisode: (command: string) => void
 }) {
   const phase = policy?.phase ?? "preparing"
-  const ready = phase === "ready" // between-episode gate: start the next episode
-  // Episode in flight, or the safety-cap decision after it — Save/Discard apply.
-  const canChoose = phase === "recording" || phase === "deciding"
-  // Status line so both the initiator and any other computer see what's happening.
-  const status =
-    phase === "recording"
-      ? "Recording — Save to keep, Discard to re-record."
-      : phase === "deciding"
-        ? "Time cap reached — Save to keep, Discard to re-record."
-        : phase === "ready"
-          ? "Reset the scene, then start the episode."
-          : phase === "resetting"
-            ? "Returning to rest…"
-            : "Preparing…"
+  // Server-driven status/buttons when the op provides them (mirrors what the
+  // headset HUD would show, so a session can be driven with the headset off);
+  // the built-in run-policy set otherwise.
+  const controls = policy?.controls ?? legacyControls(phase)
+  const status = policy?.message ?? legacyStatus(phase)
+  // Which confirm-gated command is armed and awaiting its second click — the
+  // panel's stand-in for the headset's double-press save/discard confirmation.
+  const [armed, setArmed] = useState<string | null>(null)
+  useEffect(() => {
+    if (armed == null) return
+    const t = setTimeout(() => setArmed(null), CONFIRM_ARM_MS)
+    return () => clearTimeout(t)
+  }, [armed])
+  // A phase change invalidates a pending confirmation (the episode moved on).
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setArmed(null)
+  }, [phase])
+
+  function click(control: EpisodeControlSpec) {
+    if (control.confirm && armed !== control.command) {
+      setArmed(control.command)
+      return
+    }
+    setArmed(null)
+    onEpisode(control.command)
+  }
+
   return (
     <div className="flex flex-col gap-2 rounded-lg border border-[#eff483]/25 bg-[#eff483]/[0.04] p-3">
       <div className="flex items-center justify-between gap-2">
@@ -258,21 +314,25 @@ function EpisodeControls({
           Episode control
         </span>
         <span className="font-mono text-[0.65rem] text-white/40">
+          {policy?.episode != null && <span className="mr-2">episode {policy.episode}</span>}
           {policy?.episodesRecorded ?? 0} saved
         </span>
       </div>
       <span className="text-xs text-white/50">{status}</span>
-      <div className="flex flex-wrap gap-2">
-        <Button size="sm" disabled={!ready} onClick={() => onEpisode("start")}>
-          Start episode
-        </Button>
-        <Button variant="outline" size="sm" disabled={!canChoose} onClick={() => onEpisode("s")}>
-          Save
-        </Button>
-        <Button variant="outline" size="sm" disabled={!canChoose} onClick={() => onEpisode("r")}>
-          Discard
-        </Button>
-      </div>
+      {controls.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {controls.map((c, i) => (
+            <Button
+              key={c.command}
+              variant={i === 0 ? "default" : armed === c.command ? "destructive" : "outline"}
+              size="sm"
+              onClick={() => click(c)}
+            >
+              {armed === c.command ? `Confirm: ${c.label}?` : c.label}
+            </Button>
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/web/app/src/components/operation-panel.tsx
+++ b/web/app/src/components/operation-panel.tsx
@@ -24,7 +24,7 @@ import {
 } from "@/lib/supervisor"
 import { CuratedForm } from "@/components/config-form"
 import { ArmJointPicker } from "@/components/arm-joint-picker"
-import { CameraFeeds } from "@/components/camera-feeds"
+import { CameraFeeds, type VrHud } from "@/components/camera-feeds"
 import { Card, CardContent } from "@/components/ui/card"
 import { Button, buttonVariants } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -215,13 +215,21 @@ export function OperationPanel({
                 </div>
               )}
 
-              {meta.episodeControl && live && (
-                <EpisodeControls policy={policy} onEpisode={onEpisode} />
+              {/* Everything the operator watches during a session — episode
+                  status/controls, the mirrored headset popups, and the live
+                  camera feeds — grouped so it can expand to a fullscreen
+                  operator view (the headset-off replacement for the HUD). */}
+              {live && (meta.episodeControl || (meta.usesHeadset && !isSim)) && (
+                <OperatorDeck
+                  label={meta.label}
+                  episodeControl={meta.episodeControl}
+                  showFeeds={meta.usesHeadset && !isSim}
+                  policy={policy}
+                  onEpisode={onEpisode}
+                  host={host}
+                  vrPort={vrPort}
+                />
               )}
-
-              {/* Headset-driven ops stream their cameras over WebRTC; mirror
-                  the feeds here so a session can run with the headset off. */}
-              {meta.usesHeadset && live && !isSim && <CameraFeeds host={host} vrPort={vrPort} />}
 
               <RunningHints
                 usesHeadset={meta.usesHeadset}
@@ -271,12 +279,210 @@ function legacyStatus(phase: string): string {
   }
 }
 
+/**
+ * How each episode phase is presented: a short label, its colour scheme, and
+ * whether the badge pulses (live activity) or spins (the server is working).
+ * Unknown phases (from newer hosts) fall back to a neutral badge.
+ */
+const PHASE_STYLES: Record<string, { label: string; cls: string; kind: "dot" | "pulse" | "spin" }> =
+  {
+    preparing: {
+      label: "Preparing",
+      cls: "border-white/20 bg-white/[0.06] text-white/70",
+      kind: "spin",
+    },
+    ready: { label: "Ready", cls: "border-sky-400/40 bg-sky-400/10 text-sky-200", kind: "dot" },
+    countdown: {
+      label: "Starting",
+      cls: "border-amber-400/50 bg-amber-400/10 text-amber-200",
+      kind: "pulse",
+    },
+    recording: {
+      label: "Recording",
+      cls: "border-red-500/60 bg-red-500/15 text-red-200",
+      kind: "pulse",
+    },
+    deciding: {
+      label: "Decide",
+      cls: "border-amber-400/50 bg-amber-400/10 text-amber-200",
+      kind: "pulse",
+    },
+    saving: {
+      label: "Saving",
+      cls: "border-emerald-400/50 bg-emerald-400/10 text-emerald-200",
+      kind: "spin",
+    },
+    resetting: {
+      label: "Resetting",
+      cls: "border-sky-400/40 bg-sky-400/10 text-sky-200",
+      kind: "spin",
+    },
+  }
+
+function PhaseBadge({ phase }: { phase: string }) {
+  const s = PHASE_STYLES[phase] ?? {
+    label: phase,
+    cls: "border-white/20 bg-white/[0.06] text-white/70",
+    kind: "dot" as const,
+  }
+  return (
+    <span
+      className={`flex items-center gap-2 rounded-md border px-2.5 py-1 font-mono text-xs font-semibold tracking-widest uppercase ${s.cls}`}
+    >
+      {s.kind === "spin" ? (
+        <Loader2 className="size-3 animate-spin" />
+      ) : (
+        <span className="relative flex size-2">
+          {s.kind === "pulse" && (
+            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-current opacity-60" />
+          )}
+          <span className="relative inline-flex size-2 rounded-full bg-current" />
+        </span>
+      )}
+      {s.label}
+    </span>
+  )
+}
+
+/**
+ * The label to headline the mirrored controller-confirmation popup with: the
+ * matching panel button's label when the server drives the controls ("save"
+ * pairs with the `s` command, "discard" with `r` — e.g. axol-pi's "Save
+ * success" / "Save failure"), a generic fallback otherwise.
+ */
+function confirmLabel(action: "save" | "discard", policy: PolicyState | null): string {
+  const controls = policy?.controls ?? legacyControls(policy?.phase ?? "recording")
+  const command = action === "save" ? "s" : "r"
+  const label = controls.find((c) => c.command === command)?.label
+  return label ?? (action === "save" ? "Save episode" : "Discard episode")
+}
+
+/**
+ * Mirror of the in-headset confirmation popup, driven by the relayed HUD
+ * state: the operator armed a stop (save/discard) on the VR controller and
+ * the headset is waiting for the second, confirming press.
+ */
+function ConfirmPopup({
+  action,
+  policy,
+}: {
+  action: "save" | "discard"
+  policy: PolicyState | null
+}) {
+  return (
+    <div className="fixed inset-0 z-[70] flex items-center justify-center bg-black/70 p-6">
+      <div className="flex w-full max-w-md flex-col items-center gap-3 rounded-xl border-2 border-amber-400/60 bg-[#151515] p-8 text-center shadow-2xl">
+        <AlertTriangle className="size-7 text-amber-300" />
+        <p className="font-heading text-2xl font-semibold">{confirmLabel(action, policy)}?</p>
+        <p className="text-sm leading-relaxed text-white/60">
+          Press the same controller button again to confirm — the other button cancels and keeps
+          recording.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Everything the operator watches during a live session, grouped so it can
+ * expand to a fullscreen view: the episode status/controls, the camera
+ * feeds, and the mirrored headset popups (confirmation dialog and record
+ * countdown). This is the headset-off replacement for the in-headset HUD —
+ * the VR controllers still drive the robot, and whatever they arm shows up
+ * here.
+ */
+function OperatorDeck({
+  label,
+  episodeControl,
+  showFeeds,
+  policy,
+  onEpisode,
+  host,
+  vrPort,
+}: {
+  label: string
+  episodeControl: boolean
+  showFeeds: boolean
+  policy: PolicyState | null
+  onEpisode: (command: string) => void
+  host: string
+  vrPort: number
+}) {
+  const [fullscreen, setFullscreen] = useState(false)
+  // Relayed headset HUD state (armed confirm popup / record countdown), from
+  // the camera-feed socket. Null when nothing is armed or no headset drives.
+  const [hud, setHud] = useState<VrHud | null>(null)
+
+  function toggleFullscreen() {
+    const next = !fullscreen
+    setFullscreen(next)
+    if (next) {
+      // Best-effort browser fullscreen on top of the overlay (we're in a
+      // click handler, so the user-gesture requirement is met).
+      document.documentElement.requestFullscreen?.().catch(() => {})
+    }
+  }
+
+  useEffect(() => {
+    if (!fullscreen) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setFullscreen(false)
+    }
+    // Leaving browser fullscreen (Esc there never reaches our key handler)
+    // also collapses the overlay, so the two stay in sync.
+    const onFsChange = () => {
+      if (!document.fullscreenElement) setFullscreen(false)
+    }
+    window.addEventListener("keydown", onKey)
+    document.addEventListener("fullscreenchange", onFsChange)
+    return () => {
+      window.removeEventListener("keydown", onKey)
+      document.removeEventListener("fullscreenchange", onFsChange)
+      if (document.fullscreenElement) document.exitFullscreen().catch(() => {})
+    }
+  }, [fullscreen])
+
+  const body = (
+    <>
+      {episodeControl && <EpisodeControls policy={policy} onEpisode={onEpisode} hud={hud} />}
+      {showFeeds && (
+        <CameraFeeds
+          host={host}
+          vrPort={vrPort}
+          expanded={fullscreen}
+          onToggleFullscreen={toggleFullscreen}
+          onHud={setHud}
+        />
+      )}
+      {hud?.confirm && <ConfirmPopup action={hud.confirm} policy={policy} />}
+    </>
+  )
+
+  if (!fullscreen) return <div className="flex flex-col gap-5">{body}</div>
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col gap-4 overflow-y-auto bg-[#0a0a0a] p-4 sm:p-6">
+      <div className="flex items-center justify-between gap-2">
+        <span className="font-mono text-xs tracking-widest text-white/40 uppercase">
+          {label} — operator view
+        </span>
+        <Button variant="outline" size="sm" onClick={toggleFullscreen}>
+          Exit fullscreen
+        </Button>
+      </div>
+      {body}
+    </div>
+  )
+}
+
 function EpisodeControls({
   policy,
   onEpisode,
+  hud,
 }: {
   policy: PolicyState | null
   onEpisode: (command: string) => void
+  /** Relayed headset HUD state (drives the VR record-countdown readout). */
+  hud: VrHud | null
 }) {
   const phase = policy?.phase ?? "preparing"
   // Server-driven status/buttons when the op provides them (mirrors what the
@@ -298,6 +504,30 @@ function EpisodeControls({
     setArmed(null)
   }, [phase])
 
+  // A record countdown started from the VR controller (A press) reaches us
+  // through the relayed HUD, not the op's snapshot — the backend only learns
+  // about it when the headset flips to recording 3 s later. Anchor a local
+  // deadline when the message arrives and tick the remaining seconds down.
+  const [vrCountdownS, setVrCountdownS] = useState<number | null>(null)
+  useEffect(() => {
+    const remaining = hud?.countdownRemainingMs
+    const deadline = remaining != null ? Date.now() + remaining : null
+    const update = () =>
+      setVrCountdownS(
+        deadline != null ? Math.max(0, Math.ceil((deadline - Date.now()) / 1000)) : null
+      )
+    update()
+    if (deadline == null) return
+    const t = setInterval(update, 250)
+    return () => clearInterval(t)
+  }, [hud])
+
+  const vrCounting = vrCountdownS != null && vrCountdownS > 0 && phase !== "recording"
+  const displayPhase = vrCounting ? "countdown" : phase
+  const displayStatus = vrCounting
+    ? `Recording starts in ${vrCountdownS} s — controller countdown; press A again to cancel.`
+    : status
+
   function click(control: EpisodeControlSpec) {
     if (control.confirm && armed !== control.command) {
       setArmed(control.command)
@@ -308,17 +538,21 @@ function EpisodeControls({
   }
 
   return (
-    <div className="flex flex-col gap-2 rounded-lg border border-[#eff483]/25 bg-[#eff483]/[0.04] p-3">
-      <div className="flex items-center justify-between gap-2">
-        <span className="font-mono text-xs tracking-widest text-[#eff483]/80 uppercase">
-          Episode control
-        </span>
+    <div className="flex flex-col gap-3 rounded-lg border border-[#eff483]/25 bg-[#eff483]/[0.04] p-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <PhaseBadge phase={displayPhase} />
+          {policy?.episode != null && (
+            <span className="font-heading text-lg font-semibold text-white/90">
+              Episode {policy.episode}
+            </span>
+          )}
+        </div>
         <span className="font-mono text-[0.65rem] text-white/40">
-          {policy?.episode != null && <span className="mr-2">episode {policy.episode}</span>}
           {policy?.episodesRecorded ?? 0} saved
         </span>
       </div>
-      <span className="text-xs text-white/50">{status}</span>
+      <span className="text-sm text-white/60">{displayStatus}</span>
       {controls.length > 0 && (
         <div className="flex flex-wrap gap-2">
           {controls.map((c, i) => (

--- a/web/app/src/components/operation-panel.tsx
+++ b/web/app/src/components/operation-panel.tsx
@@ -460,7 +460,9 @@ function OperatorDeck({
 
   if (!fullscreen) return <div className="flex flex-col gap-5">{body}</div>
   return (
-    <div className="fixed inset-0 z-50 flex flex-col gap-4 overflow-y-auto bg-[#0a0a0a] p-4 sm:p-6">
+    // overflow-hidden: the feed grid shrinks to the leftover height instead,
+    // so the episode state and every camera stay visible without scrolling.
+    <div className="fixed inset-0 z-50 flex flex-col gap-3 overflow-hidden bg-[#0a0a0a] p-4 sm:p-5">
       <div className="flex items-center justify-between gap-2">
         <span className="font-mono text-xs tracking-widest text-white/40 uppercase">
           {label} — operator view

--- a/web/app/src/components/operation-panel.tsx
+++ b/web/app/src/components/operation-panel.tsx
@@ -324,7 +324,7 @@ function EpisodeControls({
           {controls.map((c, i) => (
             <Button
               key={c.command}
-              variant={i === 0 ? "default" : armed === c.command ? "destructive" : "outline"}
+              variant={armed === c.command ? "destructive" : i === 0 ? "default" : "outline"}
               size="sm"
               onClick={() => click(c)}
             >

--- a/web/app/src/lib/supervisor.ts
+++ b/web/app/src/lib/supervisor.ts
@@ -349,12 +349,34 @@ export async function usbConnect(): Promise<UsbStatus> {
 export type OperationId = string
 
 /** Episode lifecycle phase, surfaced so the control panel on any
- *  computer shows the right episode controls (not just the tab that started it). */
-export type PolicyPhase = "preparing" | "ready" | "recording" | "deciding" | "resetting"
+ *  computer shows the right episode controls (not just the tab that started it).
+ *  Open-ended: a downstream package's episode control can define its own
+ *  phases (e.g. collect-data's "countdown" / "saving") — the panel renders the
+ *  server-driven `message`/`controls` then and never needs to know them. */
+export type PolicyPhase = string
+
+/** One episode-control button the running op offers right now (server-driven). */
+export interface EpisodeControlSpec {
+  /** Command pushed to /api/op/episode when clicked. */
+  command: string
+  label: string
+  /** Arm on first click and require a second, confirming click — the panel's
+   *  stand-in for the headset's double-press save/discard confirmation. */
+  confirm?: boolean
+}
 
 export interface PolicyState {
   phase: PolicyPhase
   episodesRecorded: number
+  /** Operator status line; when present it replaces the panel's built-in
+   *  phase text (lets the op mirror what the headset HUD would say). */
+  message?: string
+  /** Buttons to render; when present they replace the panel's built-in
+   *  run-policy Start/Save/Discard set. */
+  controls?: EpisodeControlSpec[]
+  /** 1-based number of the episode being recorded next/now, when the op
+   *  tracks a dataset episode index (mirrors the headset HUD readout). */
+  episode?: number
 }
 
 export interface OpStatus {

--- a/web/app/src/routes/ControlPanel.tsx
+++ b/web/app/src/routes/ControlPanel.tsx
@@ -870,6 +870,7 @@ export default function ControlPanel() {
           session={selectedLive ? effectiveStatus : null}
           host={viewerHost}
           viewerPort={viewerPort}
+          vrPort={hostInfo?.vrPort ?? 8000}
           startPhase={startPhase}
           policy={selectedLive ? policy : null}
           onStart={handleStart}

--- a/web/packages/axol-vr-client/src/AxolVRClient.tsx
+++ b/web/packages/axol-vr-client/src/AxolVRClient.tsx
@@ -89,6 +89,8 @@ export function AxolVRClient({
   const serverEpisodeRef = useRef<number | null | -1>(-1)
   // Track which WebSocket we have attached onmessage to avoid re-attaching.
   const wsWithHandlerRef = useRef<WebSocket | null>(null)
+  // Change key of the last HUD state published to the server (see below).
+  const lastHudKeyRef = useRef("")
 
   useFrame(() => {
     // Attach onmessage to the WebSocket whenever it changes so we can receive
@@ -298,6 +300,34 @@ export function AxolVRClient({
       setState(AxolState.Recording)
       recordingPendingAtRef.current = null
       onPendingRecording?.(null)
+    }
+
+    // Publish the HUD-only state (armed confirmation popup, record countdown)
+    // to the server whenever it changes, so a dashboard watching the session
+    // can mirror what this headset would show — the operator may be driving
+    // with the controllers while the headset is off. Sent over the main
+    // WebSocket (the signaling transport); the server relays it to the other
+    // connected clients and clears it when we disconnect.
+    {
+      const pendingAt = recordingPendingAtRef.current
+      const confirm = pendingConfirmRef.current
+      const hudKey = `${confirm ?? ""}|${pendingAt !== null}`
+      if (hudKey !== lastHudKeyRef.current) {
+        lastHudKeyRef.current = hudKey
+        const ws = wsRef.current
+        if (ws && ws.readyState === WebSocket.OPEN) {
+          ws.send(
+            JSON.stringify({
+              type: "hud",
+              value: {
+                confirm,
+                countdownRemainingMs:
+                  pendingAt !== null ? Math.max(0, 3000 - (Date.now() - pendingAt)) : null,
+              },
+            })
+          )
+        }
+      }
     }
 
     // Send each frame over every open transport: the wired USB `adb reverse`


### PR DESCRIPTION
Unified PR: the headset-off dashboard work plus the teleop stuck-then-lurch fix from #149 (merged into this branch through 8954513; that PR is closed in favour of this one — see its description for the full replication/root-cause writeup). The later kinematic-smoothing commits on that branch (10b04b5 boundary/wifi smoothing, 541216b manipulability weight) made teleop worse on the robot and are deliberately **not** included.

## Dashboard operator view (headset-off data collection)

Lets episode-controlled operations run with the headset off (pairs with almond-bot/axol-pi#17).

- **Server-driven episode controls**: `PolicyState` gains optional `message` (operator status line), `episode` (1-based number), and `controls` (buttons with an optional `confirm` flag). `EpisodeControls` renders whatever the backend sends — with a two-step click confirmation for `confirm: true` buttons — and falls back to the old hardcoded run-policy set for hosts that don't send controls.
- **Camera feeds in the panel**: headset-driven operations show live feeds while running. The new `CameraFeeds` component joins the operation's VR WebSocket server as one more WebRTC client, so the panel receives the same tracks the headset would — no new backend video path, shared encoders. Side-by-side stereo streams are cropped to the left eye; separate stereo tracks prefer the left one. Repeated TLS failures surface the same certificate-authorize flow the VR app uses; the "no camera stream" message only shows after the unavailable reply persists (the first few are the startup race).
- **Fullscreen operator view**: a toggle on the camera-feeds header expands the episode status/controls and the feeds to a full-screen overlay (plus best-effort browser fullscreen); Esc exits. Nothing scrolls: the feed grid takes the height left under the episode box and each tile sizes to the largest aspect-true box in its cell (the side-by-side crop needs the box itself at single-eye aspect, so cells are measured with a ResizeObserver).
- **Clearer episode status**: the episode-control box leads with a colored phase badge (pulsing red RECORDING, amber countdown, spinning Saving/Resetting) and a prominent "Episode N" readout next to the saved count.
- **Mirrored headset popups**: the save/discard confirmation (armed by the controller's A/X press while recording) and the record countdown only existed inside the headset app, invisible with the headset off. The headset now publishes its HUD state over the teleop WebSocket as a `hud` signaling message; the VR server stores it, relays it to every other client (seeding late joiners), and clears it — with a null broadcast — when the publisher disconnects. The panel shows a popup dialog labelled from the op's own controls (e.g. "Save success?") and the live countdown.

## Teleop stuck-then-lurch fix (from #149, through 8954513)

IK trust-region starvation near the active collision margin froze solves for up to seconds, then lurched at the clamp. Kept fixes: `self_collision_margin` 0.1→0.025 (the old margin is violated at the folded rest pose, keeping the nonsmooth collision hinge active during normal tracking), `cost_tolerance` 1e-2→1e-4 (jaxls applies it to rejected proposals, so a loose value returns the seed as "converged"), LM damping exposed as `lambda_initial`/`lambda_factor` and set to 1e-2/10.0, a WARN when the solver freezes while the target keeps moving, and CPU/RAM diag lines demoted to DEBUG. Full analysis in #149.

## Verification

- `tsc --noEmit`, `eslint`, `prettier --check`, `vite build`, and `ruff check/format` all pass (pre-existing lint findings on `main` excepted).
- The VR server's hud relay store/relay/seed/clear logic is covered by a stub-websocket smoke test.