### PR TITLE
Always close the dataset's parquet writers when a recording session ends

### DIFF
--- a/almond_axol/recording/record_proc.py
+++ b/almond_axol/recording/record_proc.py
@@ -1296,11 +1296,12 @@ def _verify_episodes_readable(dataset_root: "Path | str") -> None:
     footer) is invisible until something downstream tries to load the dataset —
     by which point the session is over and the operator has moved on. Reading
     the metadata back here names the bad file while the log still has the
-    context that produced it. Best-effort: never raises.
+    context that produced it.     Best-effort: never raises — it runs from a ``finally``, where an escaping
+    exception would mask the failure that got us here.
     """
-    from lerobot.datasets.utils import load_episodes
-
     try:
+        from lerobot.datasets.io_utils import load_episodes
+
         load_episodes(Path(dataset_root))
     except Exception as exc:  # noqa: BLE001 - diagnostic only
         _logger.error(
@@ -1320,9 +1321,15 @@ def _finalize_dataset(
 ) -> None:
     from lerobot.utils.utils import log_say
 
-    _close_dataset_writers(dataset)
+    try:
+        _close_dataset_writers(dataset)
+    finally:
+        # In a finally because the recovery path re-raises, and that is the
+        # case this check exists for: the writers have been closed by then
+        # either way, so this is where we find out whether the salvage worked.
+        if episodes_recorded > 0:
+            _verify_episodes_readable(config["dataset_root"])
     if episodes_recorded > 0:
-        _verify_episodes_readable(config["dataset_root"])
         with contextlib.suppress(Exception):
             _verify_videos_decodable(config["dataset_root"], since=session_start)
     if config["push_to_hub"] and episodes_recorded > 0:

--- a/almond_axol/recording/record_proc.py
+++ b/almond_axol/recording/record_proc.py
@@ -1254,6 +1254,64 @@ def _verify_videos_decodable(
     return bad
 
 
+def _close_dataset_writers(dataset: "LeRobotDataset") -> None:
+    """Run ``dataset.finalize()``, guaranteeing the parquet footers get written.
+
+    A parquet file is only readable once its writer is closed — that is what
+    appends the row-group index and the trailing ``PAR1`` magic. LeRobot keeps
+    two writers open for a whole session (the data rows, and ``meta/episodes``,
+    which buffers ten episodes per row group) and closes both in
+    ``DatasetWriter.finalize()`` — but only as steps 3 and 4, behind the image
+    writer drain (step 1) and the video encoder flush (step 2). Anything raising
+    in those first two steps leaves both files footerless, which loses *every*
+    episode the session recorded: pyarrow can't locate a single row group
+    without the footer, so ``load_episodes`` fails and the dataset can no longer
+    be read, resumed, or shipped.
+
+    Video and image teardown failures are real but recoverable (at worst one
+    episode's video is bad); losing the metadata is not. So close the writers
+    even when ``finalize()`` blows up, and re-raise afterwards so the caller
+    still reports the original failure.
+    """
+    try:
+        dataset.finalize()
+    except Exception:
+        _logger.exception(
+            "dataset.finalize() failed — closing the parquet writers directly so "
+            "the episodes recorded this session stay readable"
+        )
+        writer = getattr(dataset, "writer", None)
+        if writer is not None:
+            with contextlib.suppress(Exception):
+                writer.close_writer()
+        with contextlib.suppress(Exception):
+            dataset.meta.finalize()
+        raise
+
+
+def _verify_episodes_readable(dataset_root: "Path | str") -> None:
+    """Log loudly if ``meta/episodes`` can't be read back after finalize.
+
+    The failure mode this guards against (a parquet file left without its
+    footer) is invisible until something downstream tries to load the dataset —
+    by which point the session is over and the operator has moved on. Reading
+    the metadata back here names the bad file while the log still has the
+    context that produced it. Best-effort: never raises.
+    """
+    from lerobot.datasets.utils import load_episodes
+
+    try:
+        load_episodes(Path(dataset_root))
+    except Exception as exc:  # noqa: BLE001 - diagnostic only
+        _logger.error(
+            "meta/episodes at %s is unreadable after finalize (%s) — the episode "
+            "metadata parquet is corrupt, so the dataset cannot be resumed or "
+            "shipped as-is",
+            dataset_root,
+            exc,
+        )
+
+
 def _finalize_dataset(
     dataset: "LeRobotDataset",
     config: dict,
@@ -1262,8 +1320,9 @@ def _finalize_dataset(
 ) -> None:
     from lerobot.utils.utils import log_say
 
-    dataset.finalize()
+    _close_dataset_writers(dataset)
     if episodes_recorded > 0:
+        _verify_episodes_readable(config["dataset_root"])
         with contextlib.suppress(Exception):
             _verify_videos_decodable(config["dataset_root"], since=session_start)
     if config["push_to_hub"] and episodes_recorded > 0:
@@ -1623,10 +1682,16 @@ def _recorder_main(
                 conn.send(("cancelled",))
     finally:
         stop_capture()
-        with contextlib.suppress(Exception):
+        try:
             _finalize_dataset(
                 dataset, config, episodes_recorded, session_start=session_start
             )
+        except Exception:
+            # Never let this take the subprocess down before the cameras are
+            # released, but do not swallow it either: a failed finalize is how
+            # a session's episode metadata ends up unreadable, and suppressing
+            # it left the operator with only the downstream parquet error.
+            _logger.exception("recorder failed to finalize the dataset")
         for cam in cameras.values():
             with contextlib.suppress(Exception):
                 cam.close()
@@ -1757,8 +1822,30 @@ class DatasetRecorderProcess:
             pass
         self._proc.join(timeout=_SAVE_TIMEOUT_S)
         if self._proc.is_alive():
+            # SIGTERM: the child dies where it stands, without running the
+            # finally that finalizes the dataset. Nothing here can recover from
+            # that, so at least say so — the alternative is an unreadable
+            # dataset with no explanation anywhere in the log.
+            _logger.error(
+                "recorder did not shut down within %.0fs — killing it; the "
+                "dataset was not finalized and its parquet files are likely "
+                "unreadable",
+                _SAVE_TIMEOUT_S,
+            )
             self._proc.terminate()
             self._proc.join(timeout=5.0)
+        elif self._proc.exitcode:
+            # A child that died on its own (a crash, or the OOM killer) never
+            # ran its finalize either, and until now that was indistinguishable
+            # from a clean shutdown: join() returns instantly on an already-dead
+            # process, so the session went on to validate and upload as if all
+            # was well.
+            _logger.error(
+                "recorder subprocess exited with %s before shutdown — the "
+                "dataset was not finalized and its parquet files are likely "
+                "unreadable",
+                self._proc.exitcode,
+            )
         with contextlib.suppress(Exception):
             self._conn.close()
         with contextlib.suppress(Exception):


### PR DESCRIPTION
## What happened

A `collect-data` session on the debur station lost all 40 episodes it had just recorded. Both `data/chunk-000/file-003.parquet` and `meta/episodes/chunk-000/file-003.parquet` were left without their footers:

```
✗ Dataset validation FAILED with 1 error(s) for .../debur_072826
Could not open Parquet input source '.../meta/episodes/chunk-000/file-003.parquet':
Parquet magic bytes not found in footer.
```

## Why

A parquet file only becomes readable when its writer is closed — that is what appends the row-group index and the trailing `PAR1` magic. LeRobot holds two writers open for a whole session (the data rows, and `meta/episodes`, which buffers ten episodes per row group) and closes both in `DatasetWriter.finalize()`, but only as steps 3 and 4:

```python
def finalize(self) -> None:
    # 1. Wait for async image writes to complete, then stop
    # 2. Flush pending video encoding (streaming or batch)
    # 3. Close own parquet writer
    # 4. Finalize metadata (idempotent)
```

Anything raising in steps 1 or 2 takes the entire session's data and metadata with it. And `_recorder_main` ran finalize under `contextlib.suppress(Exception)`, so the failure left no trace anywhere — the first sign was the Pi validator failing minutes later, by which point the operator had moved on.

A recorder subprocess that dies on its own has the same effect and was equally silent: `join()` returns instantly on an already-dead child, so `close()` could not tell that apart from a clean shutdown.

## What this changes

- `_close_dataset_writers` closes both parquet writers even when `dataset.finalize()` raises, then re-raises so the original failure is still reported. Video and image teardown failures are recoverable; losing every episode's metadata is not.
- `_recorder_main` logs a failed finalize instead of suppressing it.
- `_verify_episodes_readable` reads `meta/episodes` back after finalize, so a bad file gets named while the log still has the context that produced it.
- `DatasetRecorderProcess.close()` reports a recorder that died on its own or had to be killed, instead of returning as if the shutdown was clean.

No behaviour change on the happy path.

## Verification

Ran against the station's own lerobot, with `DatasetWriter.flush_pending_videos` made to raise the way a real encoder teardown failure would:

```
=== stock: dataset.finalize() ===
  finalize raised RuntimeError: simulated video encoder teardown failure
  {'data/chunk-000/file-000.parquet': False, 'meta/tasks.parquet': True}

=== fixed: _close_dataset_writers() ===
  finalize raised RuntimeError: simulated video encoder teardown failure
  {'data/chunk-000/file-000.parquet': True,
   'meta/episodes/chunk-000/file-000.parquet': True,
   'meta/tasks.parquet': True}

RESULT: PASS
```

The stock path leaves the data parquet unreadable and never writes `meta/episodes` at all; the new path leaves every parquet readable.

The affected dataset itself was recovered separately by rebuilding the missing footers from the intact page stream — all 144,916 frames and 48 episode rows came back and the Pi validator now passes on it.

Made with [Cursor](https://cursor.com)