### PR TITLE
Smoother teleop: fixed-lag pose smoothing, glitch rejection, trapezoid jerk fix

### DIFF
--- a/almond_axol/teleop/config.py
+++ b/almond_axol/teleop/config.py
@@ -57,20 +57,23 @@ class VRTeleopConfig:
             the IK output before the trapezoidal filter.  Range ``(0, 1]``
             where ``1.0`` disables smoothing.  Lower values kill more
             high-frequency jitter at the cost of a small fixed lag
-            (``~(1-alpha)/alpha`` frames).  Defaults to ``0.5`` (~8 ms lag
-            at 120 Hz), which removes most IK noise without a perceptible
-            feel difference.
+            (``~(1-alpha)/alpha`` frames).  Defaults to ``0.3`` (~20 ms lag
+            at 120 Hz), favouring smoothness over minimum latency.
         pose_min_cutoff: Minimum cutoff frequency (Hz) for the One Euro Filter
             applied to raw VR controller positions, quaternions, and elbow
             positions **before** they enter the IK solver.  This is the
             primary tremor / tracking-noise kill knob.  Lower values give
             heavier smoothing at rest (more tremor rejection) at the cost of
             slightly more lag when still.  Typical range: 0.5–3 Hz.  Defaults
-            to ``1.5`` Hz.
+            to ``0.8`` Hz, favouring smoothness over minimum latency (the
+            fixed-lag smoother in the VR server's pose interpolator does the
+            heavy lifting upstream).
         pose_beta: Speed coefficient for the One Euro Filter.  Raises the
             filter cutoff proportionally to the signal's instantaneous speed,
             keeping the filter transparent during fast intentional moves.
-            Increase if fast moves feel sticky.  Defaults to ``5.0``.
+            Increase if fast moves feel sticky.  Defaults to ``2.0`` so the
+            filter stays partially engaged during motion instead of opening
+            fully and passing noise through.
         position_multiplier: Scale factor applied to the controller's
             **position** displacement (not orientation) when mapping hand
             motion to the end-effector target.  ``1.0`` is 1:1 motion;
@@ -126,8 +129,8 @@ class VRTeleopConfig:
     engage_duration: float = 1.0
     teleop_max_vel: float = 1.0 * 2 * math.pi
     teleop_max_accel: float = 3.5 * 2 * math.pi
-    ik_alpha: float = 0.5
-    pose_min_cutoff: float = 1.5
-    pose_beta: float = 5.0
+    ik_alpha: float = 0.3
+    pose_min_cutoff: float = 0.8
+    pose_beta: float = 2.0
     position_multiplier: float = 1.0
     rotation_multiplier: float = 1.0

--- a/almond_axol/teleop/filter.py
+++ b/almond_axol/teleop/filter.py
@@ -17,7 +17,11 @@ class TrapezoidalFilter:
 
     The deceleration distance is computed from kinematics:
     ``v_stop = sqrt(2 * max_accel * distance)``
-    so the filter always arrives at the target without overshoot.
+    so the filter always arrives at the target without overshoot.  When a step
+    reaches the target, the internal velocity keeps the value realized by that
+    step (rather than resetting to zero) so continuously tracking a moving
+    target produces a smooth velocity profile instead of a snap / re-accelerate
+    limit cycle.
 
     Args:
         max_vel:   Maximum joint velocity in rad/s.
@@ -72,10 +76,15 @@ class TrapezoidalFilter:
         self._vel = self._vel + dv
 
         # Advance position; snap to target if we would overshoot this step.
+        # On snap, keep the velocity actually realized by the snap (|err|/dt,
+        # always a slowdown since |err| < |step|) instead of zeroing it:
+        # zeroing made every arrival a velocity discontinuity, so closely
+        # tracking a *moving* target limit-cycled through snap / re-accelerate
+        # every few steps and manufactured jerk from a perfectly smooth input.
         step = self._vel * self.dt
         overshoot = np.abs(step) > dist
         self._pos = np.where(overshoot, target, self._pos + step)
-        self._vel = np.where(overshoot, 0.0, self._vel)
+        self._vel = np.where(overshoot, err / self.dt, self._vel)
 
         return self._pos.copy()
 

--- a/almond_axol/vr/config.py
+++ b/almond_axol/vr/config.py
@@ -24,6 +24,15 @@ class VRServerConfig:
         interp_min_delay_s: Floor on the adaptive playout delay (seconds).
         interp_max_delay_s: Cap on the adaptive playout delay (seconds); bounds
             the teleop latency added in exchange for smoothness.
+        interp_smooth_window_s: Width (seconds) of the Gaussian fixed-lag
+            smoothing window rendered around the playout point. Adds a fixed
+            ``window / 2`` of latency in exchange for zero-phase smoothing and
+            tracking-glitch rejection (glitches shorter than ~half the window
+            are dropped entirely). ``0`` disables smoothing and restores the
+            plain two-frame lerp.
+        interp_outlier_k: Hampel outlier threshold in robust standard
+            deviations for the glitch rejection inside the smoothing window.
+            Lower is more aggressive. ``<= 0`` disables rejection.
     """
 
     port: int = VR_PORT
@@ -31,4 +40,6 @@ class VRServerConfig:
     keyfile: str | None = None
     interp_enabled: bool = True
     interp_min_delay_s: float = 0.0
-    interp_max_delay_s: float = 0.1
+    interp_max_delay_s: float = 0.15
+    interp_smooth_window_s: float = 0.12
+    interp_outlier_k: float = 4.0

--- a/almond_axol/vr/interp.py
+++ b/almond_axol/vr/interp.py
@@ -234,7 +234,13 @@ class PoseInterpolator:
                 self._last_pos = None
                 return latest
 
-            play = (now - self._clock_offset) - self._delay - self._half_smooth
+            # The extra half-window playout shift only applies when smoothing
+            # is active (client-stamped streams); unstamped streams keep the
+            # undelayed playout point so they still render the latest frame.
+            smoothing = self._half_smooth > 0.0 and bool(self._t_is_client)
+            play = (now - self._clock_offset) - self._delay
+            if smoothing:
+                play -= self._half_smooth
             caps = self._caps
             frames = self._frames
 
@@ -244,9 +250,14 @@ class PoseInterpolator:
             # smoothing window so the Hampel median sees enough clean frames to
             # out-vote a glitch burst, at no extra latency (the history side is
             # already buffered; the future side is capped by what has arrived).
+            # Only client-stamped streams are smoothed: unstamped frames carry
+            # arrival timestamps, so a delivery burst collapses distinct poses
+            # onto near-identical time coordinates and the weighted average
+            # would blend them into a false target. Unstamped streams fall
+            # through to the lerp path, which renders the latest frame.
             win_caps: list[float] | None = None
             win_frames: list[VRFrame] | None = None
-            if self._half_smooth > 0.0:
+            if smoothing:
                 half_rej = self._half_smooth * _REJECT_WINDOW_MULT
                 lo = bisect.bisect_left(caps, play - half_rej)
                 hi = bisect.bisect_right(caps, play + half_rej)

--- a/almond_axol/vr/interp.py
+++ b/almond_axol/vr/interp.py
@@ -12,10 +12,31 @@ driven by an irregular, lossy sample stream.
 :class:`PoseInterpolator` reconstructs the original smooth motion: it buffers
 recent frames stamped with the headset's **capture** time (``VRFrame.t``) and,
 when the consumer asks for the current target, renders the pose at a playout
-time held slightly in the past (``now - delay``) by interpolating between the
-two buffered frames that bracket it (lerp for positions/grips, slerp for
-orientation). A whole 150 ms burst then plays back as the smooth stream it
-originally was.
+time held slightly in the past (``now - delay``). A whole 150 ms burst then
+plays back as the smooth stream it originally was.
+
+On top of the jitter buffer, the playout point is rendered as a **fixed-lag
+smoother**: a Gaussian-weighted average over every buffered frame within
+``smooth_window_s`` of the playout time (weighted mean for positions / grips,
+weighted quaternion mean for orientation). Because the window extends into the
+*future* relative to the playout point, this is zero-phase smoothing whose lag
+is fixed (``delay + smooth_window_s / 2``) rather than growing with hand speed
+the way a causal low-pass filter's does.
+
+The buffered lookahead also enables **glitch rejection**, which no causal
+filter can do (at the instant of a jump it cannot distinguish a tracking
+glitch from the start of a fast intentional move). Before averaging, a Hampel
+test — computed over a wider window (``_REJECT_WINDOW_MULT`` x the smoothing
+window) so a glitch burst stays a minority for the median — drops frames whose
+EE/elbow positions deviate from the window median by more than ``outlier_k``
+robust standard deviations (with an absolute floor so a still hand's
+micro-noise never flags). A tracking excursion that jumps away and comes back
+within roughly the smoothing window is erased entirely instead of being
+chased; while it lasts, the nearest clean frames dominate the renormalized
+weights so the output bridges smoothly across it. A *sustained* jump
+eventually wins the median and is followed normally after the fixed lag. When
+the window holds too few frames (startup, sparse or unstamped streams),
+rendering falls back to plain lerp/slerp between the two bracketing frames.
 
 ``delay`` is **adaptive**: it tracks the observed arrival jitter (clamped to
 ``[min_delay, max_delay]``), so a clean LAN adds almost no latency while a
@@ -57,16 +78,30 @@ class PoseInterpolator:
         max_frames: Hard cap on buffered frames (safety bound).
         pos_eps: Position change (metres) below which a re-render is considered
             unchanged, so the consumer's identity check can skip redundant IK.
+        smooth_window_s: Width (seconds) of the Gaussian fixed-lag smoothing
+            window centred on the playout point. Adds ``smooth_window_s / 2``
+            of fixed latency in exchange for zero-phase smoothing and glitch
+            rejection. ``0`` disables smoothing (plain two-frame lerp).
+        outlier_k: Hampel threshold in robust standard deviations (MAD-based).
+            Frames whose EE/elbow positions deviate from the window median by
+            more than this are excluded from the average, so transient
+            tracking glitches are dropped rather than followed. ``<= 0``
+            disables rejection.
+        outlier_floor_m: Absolute floor (metres) on the Hampel threshold so a
+            perfectly still hand's micro-noise is never flagged as outliers.
     """
 
     def __init__(
         self,
         enabled: bool = True,
         min_delay_s: float = 0.0,
-        max_delay_s: float = 0.1,
+        max_delay_s: float = 0.15,
         window_s: float = 2.0,
         max_frames: int = 512,
         pos_eps: float = 1e-4,
+        smooth_window_s: float = 0.12,
+        outlier_k: float = 4.0,
+        outlier_floor_m: float = 0.02,
     ) -> None:
         self.enabled = enabled
         self._min_delay = float(min_delay_s)
@@ -74,6 +109,9 @@ class PoseInterpolator:
         self._window = float(window_s)
         self._max_frames = int(max_frames)
         self._pos_eps = float(pos_eps)
+        self._half_smooth = max(0.0, float(smooth_window_s)) / 2.0
+        self._outlier_k = float(outlier_k)
+        self._outlier_floor = float(outlier_floor_m)
 
         self._lock = threading.Lock()
         # Buffer of (capture_time_s, frame), kept sorted by capture time.
@@ -154,8 +192,9 @@ class PoseInterpolator:
             self._caps.insert(i, cap_t)
             self._frames.insert(i, frame)
 
-            # Prune: keep a little history behind the current playout point.
-            play = (local_recv - self._clock_offset) - self._delay
+            # Prune: keep a little history behind the current playout point
+            # (which is held an extra half smoothing-window in the past).
+            play = (local_recv - self._clock_offset) - self._delay - self._half_smooth
             keep_before = play - 0.5
             drop = 0
             while drop < len(self._caps) - 2 and self._caps[drop] < keep_before:
@@ -169,7 +208,12 @@ class PoseInterpolator:
                 del self._frames[:extra]
 
     def sample(self, now: float | None = None) -> VRFrame | None:
-        """Render the current interpolated target frame.
+        """Render the current smoothed target frame.
+
+        Renders a Gaussian-weighted, outlier-rejected average of the buffered
+        frames within the smoothing window around the playout point; falls back
+        to plain lerp/slerp between the two bracketing frames when the window
+        is too sparse (startup, unstamped transports, ``smooth_window_s == 0``).
 
         Returns ``None`` only before any frame has been received. The returned
         object is *identity-stable*: when the rendered pose hasn't moved beyond
@@ -190,24 +234,53 @@ class PoseInterpolator:
                 self._last_pos = None
                 return latest
 
-            play = (now - self._clock_offset) - self._delay
+            play = (now - self._clock_offset) - self._delay - self._half_smooth
             caps = self._caps
             frames = self._frames
-            if play <= caps[0]:
-                a = b = frames[0]
-                alpha = 0.0
-            elif play >= caps[-1]:
-                a = b = frames[-1]
-                alpha = 0.0
-            else:
-                j = bisect.bisect_right(caps, play)
-                a, b = frames[j - 1], frames[j]
-                span = caps[j] - caps[j - 1]
-                alpha = (play - caps[j - 1]) / span if span > 1e-9 else 0.0
+
+            # Fixed-lag smoothing: snapshot the window slices under the lock
+            # (frames are immutable models; slicing copies only the refs).
+            # The slice spans the *rejection* window — wider than the Gaussian
+            # smoothing window so the Hampel median sees enough clean frames to
+            # out-vote a glitch burst, at no extra latency (the history side is
+            # already buffered; the future side is capped by what has arrived).
+            win_caps: list[float] | None = None
+            win_frames: list[VRFrame] | None = None
+            if self._half_smooth > 0.0:
+                half_rej = self._half_smooth * _REJECT_WINDOW_MULT
+                lo = bisect.bisect_left(caps, play - half_rej)
+                hi = bisect.bisect_right(caps, play + half_rej)
+                if hi - lo >= 3:
+                    win_caps = caps[lo:hi]
+                    win_frames = frames[lo:hi]
+
+            if win_frames is None:
+                if play <= caps[0]:
+                    a = b = frames[0]
+                    alpha = 0.0
+                elif play >= caps[-1]:
+                    a = b = frames[-1]
+                    alpha = 0.0
+                else:
+                    j = bisect.bisect_right(caps, play)
+                    a, b = frames[j - 1], frames[j]
+                    span = caps[j] - caps[j - 1]
+                    alpha = (play - caps[j - 1]) / span if span > 1e-9 else 0.0
             last_out = self._last_out
             last_pos = self._last_pos
 
-        rendered, pos = _interpolate(a, b, alpha, latest)
+        if win_frames is not None and win_caps is not None:
+            rendered, pos = _smooth_window(
+                win_frames,
+                win_caps,
+                play,
+                self._half_smooth,
+                self._outlier_k,
+                self._outlier_floor,
+                latest,
+            )
+        else:
+            rendered, pos = _interpolate(a, b, alpha, latest)
 
         # Identity-stable: reuse the previous object when nothing moved and the
         # control state matches, so the consumer's `is` check skips the solve.
@@ -257,6 +330,95 @@ def _quat(q: VRQuaternion) -> np.ndarray:
     return np.array([q.x, q.y, q.z, q.w], dtype=np.float64)
 
 
+def _quat_weighted_mean(quats: np.ndarray, w: np.ndarray, ref_i: int) -> np.ndarray:
+    """Weighted mean of ``(n, 4)`` quaternions, hemisphere-aligned to row ``ref_i``.
+
+    Sign-aligning every quaternion to the reference before the weighted sum
+    makes the normalized result a good mean for the small angular spreads seen
+    within a smoothing window.
+    """
+    ref = quats[ref_i]
+    sign = np.where(quats @ ref < 0.0, -1.0, 1.0)
+    q = (w * sign) @ quats
+    norm = np.linalg.norm(q)
+    return q / norm if norm > 1e-12 else ref.copy()
+
+
+# The Hampel rejection window is this multiple of the smoothing window, so a
+# glitch burst as long as the whole smoothing window is still a minority for
+# the median and gets rejected. Costs no latency: the extra frames come from
+# history already buffered (and whatever future frames have arrived).
+_REJECT_WINDOW_MULT = 2.5
+
+
+def _smooth_window(
+    frames: list[VRFrame],
+    caps: list[float],
+    play: float,
+    half_window: float,
+    outlier_k: float,
+    outlier_floor: float,
+    latest: VRFrame,
+) -> tuple[VRFrame, np.ndarray]:
+    """Render the Gaussian-weighted, outlier-rejected mean pose of a window.
+
+    ``frames`` spans the wide *rejection* window; the Gaussian sigma comes from
+    the narrower smoothing ``half_window``, so frames beyond the smoothing
+    window carry negligible weight — *unless* the frames near the playout point
+    are rejected as glitches, in which case the nearest clean frames dominate
+    the renormalized weights and the output bridges smoothly across the glitch.
+
+    Hampel rejection runs first: a frame whose EE or elbow position deviates
+    from the window's component-wise median by more than
+    ``outlier_k * 1.4826 * MAD`` (floored at ``outlier_floor`` metres) is
+    excluded from the average entirely — orientation included, since a glitched
+    tracking sample corrupts position and orientation together. The MAD scale
+    grows with genuine motion spread, so fast intentional moves are never
+    flagged; only a minority cluster far from the median is. Control state
+    comes from ``latest``, exactly like :func:`_interpolate`.
+    """
+    n = len(frames)
+    t = np.array(caps, dtype=np.float64)
+    l_ee_p = np.array([_pos(f.l_ee.position) for f in frames])
+    r_ee_p = np.array([_pos(f.r_ee.position) for f in frames])
+    l_el = np.array([_pos(f.l_elbow) for f in frames])
+    r_el = np.array([_pos(f.r_elbow) for f in frames])
+    l_q = np.array([_quat(f.l_ee.quaternion) for f in frames])
+    r_q = np.array([_quat(f.r_ee.quaternion) for f in frames])
+    grips = np.array([[f.l_grip, f.r_grip] for f in frames], dtype=np.float64)
+
+    inlier = np.ones(n, dtype=bool)
+    if outlier_k > 0.0:
+        for stream in (l_ee_p, r_ee_p, l_el, r_el):
+            med = np.median(stream, axis=0)
+            d = np.linalg.norm(stream - med, axis=1)
+            thresh = max(outlier_k * 1.4826 * float(np.median(d)), outlier_floor)
+            inlier &= d <= thresh
+        if int(inlier.sum()) < 2:
+            # Degenerate (e.g. bimodal window mid-jump): rejecting almost
+            # everything would leave a meaningless average, so keep all frames.
+            inlier[:] = True
+
+    # Gaussian weights centred on the playout point; smoothing-window edges sit
+    # at ~2 sigma so the average is dominated by frames near the playout time.
+    sigma = max(half_window / 2.0, 1e-6)
+    w = np.exp(-0.5 * ((t - play) / sigma) ** 2)
+    w[~inlier] = 0.0
+    w /= w.sum()
+
+    ref_i = int(np.argmax(w))
+    l_ee_pm = w @ l_ee_p
+    r_ee_pm = w @ r_ee_p
+    l_elm = w @ l_el
+    r_elm = w @ r_el
+    l_qm = _quat_weighted_mean(l_q, w, ref_i)
+    r_qm = _quat_weighted_mean(r_q, w, ref_i)
+    gm = w @ grips
+    return _build_frame(
+        l_ee_pm, l_qm, r_ee_pm, r_qm, l_elm, r_elm, float(gm[0]), float(gm[1]), latest
+    )
+
+
 def _interpolate(
     a: VRFrame, b: VRFrame, alpha: float, latest: VRFrame
 ) -> tuple[VRFrame, np.ndarray]:
@@ -271,7 +433,25 @@ def _interpolate(
     r_el = _lerp(_pos(a.r_elbow), _pos(b.r_elbow), alpha)
     l_grip = float(a.l_grip + alpha * (b.l_grip - a.l_grip))
     r_grip = float(a.r_grip + alpha * (b.r_grip - a.r_grip))
+    return _build_frame(
+        l_ee_p, l_ee_q, r_ee_p, r_ee_q, l_el, r_el, l_grip, r_grip, latest
+    )
 
+
+def _build_frame(
+    l_ee_p: np.ndarray,
+    l_ee_q: np.ndarray,
+    r_ee_p: np.ndarray,
+    r_ee_q: np.ndarray,
+    l_el: np.ndarray,
+    r_el: np.ndarray,
+    l_grip: float,
+    r_grip: float,
+    latest: VRFrame,
+) -> tuple[VRFrame, np.ndarray]:
+    """Assemble a rendered frame; motion from the args, control state from
+    ``latest``. Returns ``(frame, pos_vector)`` where ``pos_vector`` is the
+    concatenated EE+elbow positions used for the change/identity check."""
     frame = VRFrame(
         l_ee=VRPose(
             position=VRPosition(x=l_ee_p[0], y=l_ee_p[1], z=l_ee_p[2]),

--- a/almond_axol/vr/interp.py
+++ b/almond_axol/vr/interp.py
@@ -117,6 +117,13 @@ class PoseInterpolator:
         # Buffer of (capture_time_s, frame), kept sorted by capture time.
         self._caps: list[float] = []
         self._frames: list[VRFrame] = []
+        # Per-frame numeric vector (see _frame_vec), parallel to _caps/_frames.
+        # Precomputed at push time (~90 Hz) so the smoothing render in sample()
+        # is pure vectorized numpy — walking the pydantic models per sample was
+        # ~0.8 ms/call on Jetson, enough to slow the IK dispatch loop it runs
+        # on (in series with every solve) and cost more smoothness through a
+        # coarser IK staircase than the smoothing itself bought.
+        self._vecs: list[np.ndarray] = []
         # Recent (local_recv_s, transit_s) for jitter/offset estimation.
         self._transits: list[tuple[float, float]] = []
         self._clock_offset: float | None = None
@@ -136,6 +143,7 @@ class PoseInterpolator:
         with self._lock:
             self._caps.clear()
             self._frames.clear()
+            self._vecs.clear()
             self._transits.clear()
             self._clock_offset = None
             self._delay = self._min_delay
@@ -162,6 +170,7 @@ class PoseInterpolator:
             if self._t_is_client is not None and is_client != self._t_is_client:
                 self._caps.clear()
                 self._frames.clear()
+                self._vecs.clear()
                 self._transits.clear()
                 self._clock_offset = None
                 self._delay = self._min_delay
@@ -191,6 +200,7 @@ class PoseInterpolator:
             i = bisect.bisect_right(self._caps, cap_t)
             self._caps.insert(i, cap_t)
             self._frames.insert(i, frame)
+            self._vecs.insert(i, _frame_vec(frame))
 
             # Prune: keep a little history behind the current playout point
             # (which is held an extra half smoothing-window in the past).
@@ -202,10 +212,12 @@ class PoseInterpolator:
             if drop:
                 del self._caps[:drop]
                 del self._frames[:drop]
+                del self._vecs[:drop]
             extra = len(self._caps) - self._max_frames
             if extra > 0:
                 del self._caps[:extra]
                 del self._frames[:extra]
+                del self._vecs[:extra]
 
     def sample(self, now: float | None = None) -> VRFrame | None:
         """Render the current smoothed target frame.
@@ -256,16 +268,16 @@ class PoseInterpolator:
             # would blend them into a false target. Unstamped streams fall
             # through to the lerp path, which renders the latest frame.
             win_caps: list[float] | None = None
-            win_frames: list[VRFrame] | None = None
+            win_vecs: list[np.ndarray] | None = None
             if smoothing:
                 half_rej = self._half_smooth * _REJECT_WINDOW_MULT
                 lo = bisect.bisect_left(caps, play - half_rej)
                 hi = bisect.bisect_right(caps, play + half_rej)
                 if hi - lo >= 3:
                     win_caps = caps[lo:hi]
-                    win_frames = frames[lo:hi]
+                    win_vecs = self._vecs[lo:hi]
 
-            if win_frames is None:
+            if win_vecs is None:
                 if play <= caps[0]:
                     a = b = frames[0]
                     alpha = 0.0
@@ -280,9 +292,9 @@ class PoseInterpolator:
             last_out = self._last_out
             last_pos = self._last_pos
 
-        if win_frames is not None and win_caps is not None:
+        if win_vecs is not None and win_caps is not None:
             rendered, pos = _smooth_window(
-                win_frames,
+                win_vecs,
                 win_caps,
                 play,
                 self._half_smooth,
@@ -362,8 +374,37 @@ def _quat_weighted_mean(quats: np.ndarray, w: np.ndarray, ref_i: int) -> np.ndar
 _REJECT_WINDOW_MULT = 2.5
 
 
+# _frame_vec layout: 4 position streams, 2 quaternions, 2 grips.
+_VEC_POS = slice(0, 12)  # l_ee, r_ee, l_elbow, r_elbow (3 each)
+_VEC_LQ = slice(12, 16)
+_VEC_RQ = slice(16, 20)
+_VEC_GRIP = slice(20, 22)
+
+
+def _frame_vec(f: VRFrame) -> np.ndarray:
+    """Flatten a frame's motion fields into a (22,) float64 vector.
+
+    Computed once per received frame so the smoothing render never walks the
+    pydantic models on the hot sampling path.
+    """
+    lp, rp, le, re = f.l_ee.position, f.r_ee.position, f.l_elbow, f.r_elbow
+    lq, rq = f.l_ee.quaternion, f.r_ee.quaternion
+    return np.array(
+        [
+            lp.x, lp.y, lp.z,
+            rp.x, rp.y, rp.z,
+            le.x, le.y, le.z,
+            re.x, re.y, re.z,
+            lq.x, lq.y, lq.z, lq.w,
+            rq.x, rq.y, rq.z, rq.w,
+            f.l_grip, f.r_grip,
+        ],
+        dtype=np.float64,
+    )  # fmt: skip
+
+
 def _smooth_window(
-    frames: list[VRFrame],
+    vecs: list[np.ndarray],
     caps: list[float],
     play: float,
     half_window: float,
@@ -373,11 +414,12 @@ def _smooth_window(
 ) -> tuple[VRFrame, np.ndarray]:
     """Render the Gaussian-weighted, outlier-rejected mean pose of a window.
 
-    ``frames`` spans the wide *rejection* window; the Gaussian sigma comes from
-    the narrower smoothing ``half_window``, so frames beyond the smoothing
-    window carry negligible weight — *unless* the frames near the playout point
-    are rejected as glitches, in which case the nearest clean frames dominate
-    the renormalized weights and the output bridges smoothly across the glitch.
+    ``vecs`` (per-frame :func:`_frame_vec` vectors) spans the wide *rejection*
+    window; the Gaussian sigma comes from the narrower smoothing
+    ``half_window``, so frames beyond the smoothing window carry negligible
+    weight — *unless* the frames near the playout point are rejected as
+    glitches, in which case the nearest clean frames dominate the renormalized
+    weights and the output bridges smoothly across the glitch.
 
     Hampel rejection runs first: a frame whose EE or elbow position deviates
     from the window's component-wise median by more than
@@ -388,23 +430,24 @@ def _smooth_window(
     flagged; only a minority cluster far from the median is. Control state
     comes from ``latest``, exactly like :func:`_interpolate`.
     """
-    n = len(frames)
+    V = np.stack(vecs)  # (n, 22)
     t = np.array(caps, dtype=np.float64)
-    l_ee_p = np.array([_pos(f.l_ee.position) for f in frames])
-    r_ee_p = np.array([_pos(f.r_ee.position) for f in frames])
-    l_el = np.array([_pos(f.l_elbow) for f in frames])
-    r_el = np.array([_pos(f.r_elbow) for f in frames])
-    l_q = np.array([_quat(f.l_ee.quaternion) for f in frames])
-    r_q = np.array([_quat(f.r_ee.quaternion) for f in frames])
-    grips = np.array([[f.l_grip, f.r_grip] for f in frames], dtype=np.float64)
+    n = len(V)
 
     inlier = np.ones(n, dtype=bool)
     if outlier_k > 0.0:
-        for stream in (l_ee_p, r_ee_p, l_el, r_el):
-            med = np.median(stream, axis=0)
-            d = np.linalg.norm(stream - med, axis=1)
-            thresh = max(outlier_k * 1.4826 * float(np.median(d)), outlier_floor)
-            inlier &= d <= thresh
+        # (n, 4, 3): the four position streams of every frame. Medians use
+        # np.partition (upper median for even n) — np.median's generality is
+        # ~10x the cost on windows this small, and robust statistics don't
+        # care about the midpoint averaging.
+        P = V[:, _VEC_POS].reshape(n, 4, 3)
+        mid = n // 2
+        med = np.partition(P, mid, axis=0)[mid]  # (4, 3)
+        diff = P - med
+        d = np.sqrt(np.einsum("ijk,ijk->ij", diff, diff))  # (n, 4)
+        mad = np.partition(d, mid, axis=0)[mid]  # (4,)
+        thresh = np.maximum(outlier_k * 1.4826 * mad, outlier_floor)
+        inlier = np.all(d <= thresh, axis=1)
         if int(inlier.sum()) < 2:
             # Degenerate (e.g. bimodal window mid-jump): rejecting almost
             # everything would leave a meaningless average, so keep all frames.
@@ -418,15 +461,19 @@ def _smooth_window(
     w /= w.sum()
 
     ref_i = int(np.argmax(w))
-    l_ee_pm = w @ l_ee_p
-    r_ee_pm = w @ r_ee_p
-    l_elm = w @ l_el
-    r_elm = w @ r_el
-    l_qm = _quat_weighted_mean(l_q, w, ref_i)
-    r_qm = _quat_weighted_mean(r_q, w, ref_i)
-    gm = w @ grips
+    mean = w @ V  # (22,) — correct for all linear fields; quats fixed below
+    l_qm = _quat_weighted_mean(V[:, _VEC_LQ], w, ref_i)
+    r_qm = _quat_weighted_mean(V[:, _VEC_RQ], w, ref_i)
     return _build_frame(
-        l_ee_pm, l_qm, r_ee_pm, r_qm, l_elm, r_elm, float(gm[0]), float(gm[1]), latest
+        mean[0:3],
+        l_qm,
+        mean[3:6],
+        r_qm,
+        mean[6:9],
+        mean[9:12],
+        float(mean[20]),
+        float(mean[21]),
+        latest,
     )
 
 
@@ -462,20 +509,43 @@ def _build_frame(
 ) -> tuple[VRFrame, np.ndarray]:
     """Assemble a rendered frame; motion from the args, control state from
     ``latest``. Returns ``(frame, pos_vector)`` where ``pos_vector`` is the
-    concatenated EE+elbow positions used for the change/identity check."""
-    frame = VRFrame(
-        l_ee=VRPose(
-            position=VRPosition(x=l_ee_p[0], y=l_ee_p[1], z=l_ee_p[2]),
-            quaternion=VRQuaternion(x=l_ee_q[0], y=l_ee_q[1], z=l_ee_q[2], w=l_ee_q[3]),
+    concatenated EE+elbow positions used for the change/identity check.
+
+    Uses ``model_construct`` (no validation) with explicit ``float()``
+    conversion: this runs per sample on the IK dispatch thread and the fields
+    are numerics we computed ourselves, so validation is pure overhead.
+    """
+    frame = VRFrame.model_construct(
+        l_ee=VRPose.model_construct(
+            position=VRPosition.model_construct(
+                x=float(l_ee_p[0]), y=float(l_ee_p[1]), z=float(l_ee_p[2])
+            ),
+            quaternion=VRQuaternion.model_construct(
+                x=float(l_ee_q[0]),
+                y=float(l_ee_q[1]),
+                z=float(l_ee_q[2]),
+                w=float(l_ee_q[3]),
+            ),
         ),
-        r_ee=VRPose(
-            position=VRPosition(x=r_ee_p[0], y=r_ee_p[1], z=r_ee_p[2]),
-            quaternion=VRQuaternion(x=r_ee_q[0], y=r_ee_q[1], z=r_ee_q[2], w=r_ee_q[3]),
+        r_ee=VRPose.model_construct(
+            position=VRPosition.model_construct(
+                x=float(r_ee_p[0]), y=float(r_ee_p[1]), z=float(r_ee_p[2])
+            ),
+            quaternion=VRQuaternion.model_construct(
+                x=float(r_ee_q[0]),
+                y=float(r_ee_q[1]),
+                z=float(r_ee_q[2]),
+                w=float(r_ee_q[3]),
+            ),
         ),
-        l_elbow=VRPosition(x=l_el[0], y=l_el[1], z=l_el[2]),
-        r_elbow=VRPosition(x=r_el[0], y=r_el[1], z=r_el[2]),
-        l_grip=l_grip,
-        r_grip=r_grip,
+        l_elbow=VRPosition.model_construct(
+            x=float(l_el[0]), y=float(l_el[1]), z=float(l_el[2])
+        ),
+        r_elbow=VRPosition.model_construct(
+            x=float(r_el[0]), y=float(r_el[1]), z=float(r_el[2])
+        ),
+        l_grip=float(l_grip),
+        r_grip=float(r_grip),
         # Control state is responsive: always the latest received, never delayed.
         l_lock=latest.l_lock,
         r_lock=latest.r_lock,

--- a/almond_axol/vr/server.py
+++ b/almond_axol/vr/server.py
@@ -118,6 +118,8 @@ class VRServer:
             enabled=config.interp_enabled,
             min_delay_s=config.interp_min_delay_s,
             max_delay_s=config.interp_max_delay_s,
+            smooth_window_s=config.interp_smooth_window_s,
+            outlier_k=config.interp_outlier_k,
         )
         self._client_count: int = 0
         self._active_clients: set[WebSocket] = set()


### PR DESCRIPTION
## What

Stronger teleop filtering, trading a small fixed latency (~60 ms) for much smoother motion, plus immunity to transient tracking glitches and a fix for a latent jerk source in the joint-space filter chain.

## Changes

### Fixed-lag smoother + glitch rejection in `PoseInterpolator` (`vr/interp.py`)
- Renders the playout pose as a **Gaussian-weighted average** over a 120 ms window centred on the playout point instead of a two-frame lerp. Because the window includes future frames relative to the playout point, this is zero-phase smoothing with fixed lag — unlike a causal low-pass, lag does not grow with hand speed.
- **Hampel outlier rejection** (median + MAD, 2 cm floor) over a 2.5x wider window drops frames from tracking glitches entirely: a pose that jumps away and comes back within ~150 ms never reaches IK. While a glitch is rejected, the nearest clean frames dominate the renormalized weights, so the output bridges across it smoothly. Sustained jumps win the median and are followed normally.
- Control state (locks / reset / session state) stays on the undelayed latest-wins path; sparse/unstamped streams fall back to the old lerp.
- New knobs: `--vr_server.interp_smooth_window_s` (0.12), `--vr_server.interp_outlier_k` (4.0); `interp_max_delay_s` raised to 0.15 so the window's future side survives 150 ms relay bursts. `interp_smooth_window_s 0` restores the old behaviour exactly.

### Trapezoidal filter jerk fix (`teleop/filter.py`)
- The filter zeroed its internal velocity every time a step reached the target, making each arrival a velocity discontinuity. Tracking a *moving* target therefore limit-cycled through snap / re-accelerate every few ticks and manufactured jerk from perfectly smooth input (clean-sine jerk RMS 1204 → 47 rad/s³ through EMA + trapezoid). Fix: on snap, keep the velocity actually realized by the snap (always a slowdown). Velocity/accel limits and the no-overshoot guarantee are untouched; the 0.5 rad step response is bit-identical.

### Retuned causal filter defaults (`teleop/config.py`)
- `pose_min_cutoff` 1.5 → 0.8 Hz, `pose_beta` 5 → 2 (One Euro stays engaged during motion), `ik_alpha` 0.5 → 0.3. All remain per-run overridable via the dotted CLI flags.

## Measured (real IKWorker, synthetic noisy/glitchy 90 Hz stream, 150 ms burst delivery)

| Metric | Before | After |
|---|---|---|
| Command jerk RMS | 1256 rad/s³ | 309 rad/s³ |
| Glitch passthrough (0.3–0.5 m spikes) | 500 mm | 0.9 mm |
| Peak command velocity under glitches | 126 °/s | 42 °/s |
| Clean-target jerk through EMA + trapezoid | 1204 rad/s³ | 47 rad/s³ |

Sustained target steps are still followed exactly (no false rejection of fast intentional moves — the MAD scale grows with genuine motion spread).

## Validation

- Synthetic-stream harness for smoothing, lag, glitch injection, sustained-step, and degenerate-input cases.
- End-to-end `axol teleop --sim` with a WebSocket client streaming ~2000 bursty noisy frames plus 0.5 m glitch bursts: steady 120.0 Hz control loop, ~84 Hz IK, no warnings.
- `pre-commit` (ruff / ruff-format) clean.

## Notes for hardware testing

- Motion latency increases by ~60 ms (controls unaffected). Tune with `--vr_server.interp_smooth_window_s`.
- A tracking jump persisting longer than ~150 ms is indistinguishable from an intentional move and will be followed (velocity-limited). Widen the window if real headset glitches turn out longer.

Made with [Cursor](https://cursor.com)