### PR TITLE
Guard datasets against recording-crash corruption

### DIFF
--- a/almond_axol/cli/collect_data.py
+++ b/almond_axol/cli/collect_data.py
@@ -104,6 +104,46 @@ def _register_camera_video(robot: "AxolRobot", teleop: Any) -> None:
         _logger.warning("failed to enable camera video: %s", exc)
 
 
+def check_resume_consistency(dataset_root: "Path") -> None:
+    """Refuse to resume a dataset whose last session lost episodes.
+
+    A recorder subprocess killed before flushing (its "recorder subprocess
+    exited … before shutdown" error is in that session's log) loses the
+    episodes still buffered in its parquet writer, while ``info.json``'s
+    ``total_episodes`` — already bumped per save — survives. Resuming such a
+    dataset numbers the next episode past the lost ones, leaving a permanent
+    index gap. That gap is poison downstream: LeRobot's episode metadata
+    lookups are positional (``meta.episodes[i]`` is a row position, not a
+    key), so on a gapped dataset every episode after the gap silently
+    resolves to a *different* episode's video span. Refuse here, at the next
+    session's start, instead.
+    """
+    import json
+
+    import pyarrow.parquet as pq
+
+    total = int(
+        json.loads((dataset_root / "meta" / "info.json").read_text())["total_episodes"]
+    )
+    indices: list[int] = []
+    for f in sorted((dataset_root / "meta" / "episodes").glob("*/*.parquet")):
+        indices.extend(
+            pq.read_table(f, columns=["episode_index"])["episode_index"].to_pylist()
+        )
+    if sorted(indices) == list(range(total)):
+        return
+    missing = sorted(set(range(total)) - set(indices))
+    raise RuntimeError(
+        f"Dataset {dataset_root} is crash-inconsistent: info.json counts "
+        f"{total} episode(s) but meta/episodes holds {len(indices)}"
+        f"{f' (missing indices {missing})' if missing else ''}. A previous "
+        "session's recorder was killed before it flushed, so those episodes' "
+        "frames are gone. Recording more would number new episodes past the "
+        "gap. Renumber the surviving episodes to a contiguous 0..N-1 (data + "
+        "meta/episodes parquets, info.json totals) or start a fresh dataset."
+    )
+
+
 def _existing_dataset_resolution(dataset_root: "Path") -> str | None:
     """Resolution name of an existing dataset's recorded images, or ``None``.
 
@@ -354,6 +394,8 @@ def _run(cfg: CollectDataConfig, stop_event: "threading.Event | None" = None) ->
             f"Delete the directory and rerun to start fresh:\n"
             f"  rm -rf {dataset_root}"
         )
+    if is_complete:
+        check_resume_consistency(dataset_root)
 
     # A resumed dataset's image resolution is fixed by its existing metadata, so
     # the relay must record at it regardless of the configured dataset_resolution

--- a/almond_axol/cli/run_policy.py
+++ b/almond_axol/cli/run_policy.py
@@ -38,6 +38,7 @@ from ..lerobot.rollout import (
     IKResetController,
     RolloutCaptureThread,
 )
+from .collect_data import check_resume_consistency
 from .config import AggregateFn, LogLevel, PolicyType, parse
 
 if TYPE_CHECKING:
@@ -920,6 +921,7 @@ def _run(
             shutil.rmtree(dataset_root)
 
         if is_complete:
+            check_resume_consistency(dataset_root)
             log_say(f"Resuming existing dataset at {dataset_root}.")
             dataset = LeRobotDataset.resume(
                 repo_id=repo_id,

--- a/web/app/public/install
+++ b/web/app/public/install
@@ -188,6 +188,13 @@ ExecStartPre=-${BIN_DIR}/axol jetson.setup
 ExecStart=${BIN_DIR}/axol serve
 Restart=always
 RestartSec=3
+# A stop during a recording session must outlive the serve layer's dataset
+# teardown: its stop watchdog gives the recorder subprocess up to 200s to
+# finalize the dataset (encode the last episode, flush parquet, write meta).
+# systemd's default 90s would SIGKILL the whole cgroup mid-finalize — episodes
+# still buffered in the recorder are lost, and resuming the dataset numbers
+# the next episode past them, permanently corrupting its episode indexing.
+TimeoutStopSec=240
 # Include the sbin dirs: CAN bring-up shells out to modinfo/modprobe/ip/etc.
 Environment=PATH=${BIN_DIR}:/usr/sbin:/usr/bin:/sbin:/bin
 Environment=PYTHONUNBUFFERED=1


### PR DESCRIPTION
## Summary

A recorder subprocess killed before flushing (e.g. SIGKILL during service shutdown) loses the episodes still buffered in its parquet writer, while `info.json`'s `total_episodes` — bumped per save — survives. The next session then resumes numbering past the lost episodes, leaving a permanent index gap. LeRobot's episode metadata lookups are positional (`meta.episodes[i]` is a row position, not a key), so on a gapped dataset every episode after the gap silently resolves to a *different* episode's video span — the corruption only surfaces much later, if at all. This bit a real dataset on 07/28: two lost episodes misaligned every subsequent episode's video.

- `collect-data` and `run-policy` now check resume consistency before reusing an existing dataset: if `meta/episodes` doesn't hold contiguous indices `0..total_episodes-1`, they refuse with guidance (renumber the survivors or start fresh) instead of recording past the gap.
- The installer's systemd unit gets `TimeoutStopSec=240`. The serve layer's stop watchdog gives the recorder subprocess up to 200 s to finalize the dataset (encode the last episode, flush parquet, write meta), but systemd's default 90 s SIGKILLs the whole cgroup mid-finalize — which is exactly the crash above. Existing stations need the unit updated (rerun the installer or add the line manually).

Same guards were added to axol-pi in almond-bot/axol-pi#21; this ports the generally-applicable parts upstream.

## Test plan

- [ ] `ruff check` / `ruff format --check` pass (done locally at the pinned 0.9.7)
- [ ] Resume a healthy dataset with `axol collect-data` — starts normally
- [ ] Truncate a copy's `meta/episodes` parquet (or delete rows) and resume — refused with the crash-inconsistency message
- [ ] Fresh install writes the unit with `TimeoutStopSec=240`

Made with [Cursor](https://cursor.com)