### PR TITLE
Service motors over CAN from the SDK instead of the vendor setup software

### DIFF
--- a/almond_axol/cli/__init__.py
+++ b/almond_axol/cli/__init__.py
@@ -13,9 +13,13 @@ from .can import setup as can_setup
 from .gst import build_zed as gst_build_zed
 from .gst import install as gst_install
 from .jetson import setup as jetson_setup
+from .motor import dump_config as motor_dump_config
+from .motor import flash as motor_flash
 from .motor import health as motor_health
 from .motor import info as motor_info
+from .motor import restore_config as motor_restore_config
 from .motor import set_can_id, set_zero_pos
+from .motor import set_config as motor_set_config
 from .tune import friction, pid, repeatability
 from .zed import driver as zed_driver
 from .zed import install as zed_install
@@ -97,6 +101,10 @@ def main() -> None:
     set_zero_pos.add_parser(subparsers)
     motor_info.add_parser(subparsers)
     motor_health.add_parser(subparsers)
+    motor_flash.add_parser(subparsers)
+    motor_dump_config.add_parser(subparsers)
+    motor_set_config.add_parser(subparsers)
+    motor_restore_config.add_parser(subparsers)
     zed_install.add_parser(subparsers)
     zed_driver.add_parser(subparsers)
     gst_install.add_parser(subparsers)

--- a/almond_axol/cli/motor/dump_config.py
+++ b/almond_axol/cli/motor/dump_config.py
@@ -1,0 +1,151 @@
+"""
+axol motor.dump-config
+
+Read every configuration parameter from one or all motors on a bus and print
+them, optionally saving a JSON snapshot. The snapshot is what
+``axol motor.restore-config`` consumes, so this is the first thing to ask a
+remote customer for when their motors are misbehaving.
+
+Works for both motor families — MyActuator's 0xC0 parameters and Damiao's
+0x7FF registers — and the type is inferred from the CAN ID.
+
+If ``--id`` is omitted, every motor on the bus (IDs 1-8) is dumped.
+
+Examples:
+    axol motor.dump-config --l --id 0x01
+    axol motor.dump-config --l --out arm-left.json
+    axol motor.dump-config --l --id 0x01 --raw
+"""
+
+import argparse
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+from ...motor.bus import CanBus
+from ...motor.config import Access
+from ...motor.motor import make_driver
+
+
+def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    """Register the ``motor.dump-config`` subcommand."""
+    p = subparsers.add_parser(
+        "motor.dump-config",
+        help="Read all configuration parameters from a motor.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=__doc__,
+    )
+    side = p.add_mutually_exclusive_group(required=True)
+    side.add_argument("--l", action="store_true", help="Left arm (can_alm_axol_l)")
+    side.add_argument("--r", action="store_true", help="Right arm (can_alm_axol_r)")
+    p.add_argument(
+        "--id",
+        default=None,
+        type=lambda x: int(x, 0),
+        metavar="ID",
+        help="Motor CAN ID (hex or decimal, e.g. 0x01 or 1). "
+        "If omitted, all motors on the bus (IDs 1-8) are dumped.",
+    )
+    p.add_argument(
+        "--type",
+        choices=["myactuator", "damiao"],
+        default=None,
+        help="Motor driver type (inferred from ID if omitted)",
+    )
+    p.add_argument(
+        "--out",
+        default=None,
+        type=Path,
+        metavar="FILE",
+        help="Write a JSON snapshot for motor.restore-config",
+    )
+    p.add_argument(
+        "--raw",
+        action="store_true",
+        help="Sweep raw parameter indices instead of the known table, to "
+        "identify indices that are not yet named (MyActuator only — Damiao's "
+        "register table is complete)",
+    )
+    p.set_defaults(func=run)
+
+
+def run(args: argparse.Namespace) -> None:
+    """Dump configuration parameters from one or all motors."""
+    asyncio.run(_run(args))
+
+
+_ACCESS_TAG = {
+    Access.READ_WRITE: "",
+    Access.PROTECTED: "  (protected)",
+    Access.READ_ONLY: "  (read-only)",
+}
+
+
+async def _dump_motor(
+    bus: CanBus, motor_id: int, channel: str, motor_type: str | None, raw: bool
+) -> dict[str, Any] | None:
+    """Dump one motor, printing a table and returning its JSON record."""
+    try:
+        motor = make_driver(bus, motor_id, kt=1.0, motor_type=motor_type)
+    except ValueError as e:
+        print(f"\nmotor-config — {channel}  id={motor_id:#04x}\n")
+        print(f"  ERROR: {e}")
+        print("  Pass --type myactuator|damiao to query an ID outside the known range.")
+        return None
+
+    kind = type(motor).MOTOR_TYPE
+    print(f"\nmotor-config — {channel}  type={kind}  id={motor_id:#04x}\n")
+
+    sweep = motor.PARAM_SWEEP_RANGE if raw else None
+    if raw and sweep is None:
+        print(f"  --raw is not supported for {kind}: its parameter table is complete")
+        return None
+
+    try:
+        values = await motor.dump_config(sweep)
+    except Exception as e:
+        print(f"  ERROR: could not read configuration — {e}")
+        return None
+
+    if not values:
+        print("  no parameters returned")
+        return None
+
+    params: dict[str, float] = {}
+    for index, value in values.items():
+        spec = motor.PARAMS.get(index) if not raw else None
+        if spec is None:
+            print(f"  {int(index):#04x}{'':<26} {value:>14.4f}")
+            params[f"{int(index):#04x}"] = value
+            continue
+        shown = f"{value:>14.0f}" if spec.integer else f"{value:>14.4f}"
+        print(
+            f"  {index.name:<30} {shown} {spec.unit:<7}{_ACCESS_TAG[spec.access]}".rstrip()
+        )
+        params[index.name] = value
+
+    return {"motor_id": motor_id, "type": kind, "raw": raw, "params": params}
+
+
+async def _run(args: argparse.Namespace) -> None:
+    channel = "can_alm_axol_l" if args.l else "can_alm_axol_r"
+    motor_ids = [args.id] if args.id is not None else list(range(1, 9))
+
+    motors: list[dict[str, Any]] = []
+    async with CanBus(channel) as bus:
+        for motor_id in motor_ids:
+            record = await _dump_motor(bus, motor_id, channel, args.type, args.raw)
+            if record is not None:
+                motors.append(record)
+
+    if args.out is None:
+        return
+    if not motors:
+        print("\nnothing to save — no motor answered")
+        return
+
+    args.out.write_text(
+        json.dumps({"channel": channel, "motors": motors}, indent=2) + "\n"
+    )
+    print(f"\nsaved {len(motors)} motor(s) to {args.out}")

--- a/almond_axol/cli/motor/dump_config.py
+++ b/almond_axol/cli/motor/dump_config.py
@@ -26,6 +26,7 @@ from typing import Any
 from ...motor.bus import CanBus
 from ...motor.config import Access
 from ...motor.motor import make_driver
+from . import add_side_and_channel_arguments, resolve_channel
 
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
@@ -36,9 +37,7 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description=__doc__,
     )
-    side = p.add_mutually_exclusive_group(required=True)
-    side.add_argument("--l", action="store_true", help="Left arm (can_alm_axol_l)")
-    side.add_argument("--r", action="store_true", help="Right arm (can_alm_axol_r)")
+    add_side_and_channel_arguments(p)
     p.add_argument(
         "--id",
         default=None,
@@ -129,7 +128,7 @@ async def _dump_motor(
 
 
 async def _run(args: argparse.Namespace) -> None:
-    channel = "can_alm_axol_l" if args.l else "can_alm_axol_r"
+    channel = resolve_channel(args)
     motor_ids = [args.id] if args.id is not None else list(range(1, 9))
 
     motors: list[dict[str, Any]] = []

--- a/almond_axol/cli/motor/flash.py
+++ b/almond_axol/cli/motor/flash.py
@@ -1,0 +1,137 @@
+"""
+axol motor.flash
+
+Flash a firmware image to a single MyActuator motor over CAN.
+
+The motor reboots into its bootloader and the image is streamed to it as a
+YMODEM-1K transfer (see ``almond_axol.motor.firmware``). Nothing else may talk
+to the motor while this runs, so power the arm but leave it idle.
+
+Interrupting a flash leaves the motor sitting in its bootloader with a partially
+written image: it will not answer normal commands, but re-running this command
+recovers it, so do not power-cycle and assume the motor is lost.
+
+Examples:
+    axol motor.flash --l --id 0x01 ./RMD-X6-V4.4.bin
+    axol motor.flash --r --id 0x03 ./firmware.bin --yes
+"""
+
+import argparse
+import asyncio
+import sys
+import time
+from pathlib import Path
+
+from ...motor.bus import CanBus
+from ...motor.firmware import FirmwareUpdater
+
+# Guards against handing the tool a .zip/.hex or the wrong file entirely; the
+# vendor images are tens to a few hundred KiB.
+_MAX_REASONABLE_BYTES = 4 * 1024 * 1024
+
+
+def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    """Register the ``motor.flash`` subcommand."""
+    p = subparsers.add_parser(
+        "motor.flash",
+        help="Flash a firmware .bin to a MyActuator motor over CAN.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=__doc__,
+    )
+    side = p.add_mutually_exclusive_group(required=True)
+    side.add_argument("--l", action="store_true", help="Left arm (can_alm_axol_l)")
+    side.add_argument("--r", action="store_true", help="Right arm (can_alm_axol_r)")
+    p.add_argument(
+        "firmware",
+        type=Path,
+        help="Path to the firmware image (.bin)",
+    )
+    p.add_argument(
+        "--id",
+        required=True,
+        type=lambda x: int(x, 0),
+        metavar="ID",
+        help="CAN ID of the motor to flash (hex or decimal, e.g. 0x01 or 1)",
+    )
+    p.add_argument(
+        "--frame-delay",
+        type=float,
+        default=0.0,
+        metavar="SECONDS",
+        help="Pause between CAN frames; raise if the adapter's TX queue overruns "
+        "(default: 0, matching the vendor tool)",
+    )
+    p.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip the confirmation prompt",
+    )
+    p.set_defaults(func=run)
+
+
+def run(args: argparse.Namespace) -> None:
+    """Flash a firmware image to one motor."""
+    asyncio.run(_run(args))
+
+
+def _load_image(path: Path) -> bytes:
+    if not path.is_file():
+        raise SystemExit(f"error: {path} is not a file")
+    image = path.read_bytes()
+    if not image:
+        raise SystemExit(f"error: {path} is empty")
+    if len(image) > _MAX_REASONABLE_BYTES:
+        raise SystemExit(
+            f"error: {path} is {len(image) / 1024:.0f} KiB, which does not look "
+            f"like an RMD firmware image — refusing to flash it"
+        )
+    if path.suffix.lower() != ".bin":
+        print(f"  warning: {path.name} is not a .bin — flashing it anyway")
+    return image
+
+
+def _confirm(channel: str, motor_id: int, path: Path, size: int) -> None:
+    print(
+        "\n  This overwrites the motor's firmware. A failed or interrupted flash\n"
+        "  leaves it in the bootloader until you re-run this command.\n"
+    )
+    answer = input(
+        f"  Flash {path.name} ({size} B) to {motor_id:#04x} on {channel}? [y/N] "
+    )
+    if answer.strip().lower() not in ("y", "yes"):
+        raise SystemExit("aborted")
+
+
+async def _run(args: argparse.Namespace) -> None:
+    channel = "can_alm_axol_l" if args.l else "can_alm_axol_r"
+    path: Path = args.firmware
+    image = _load_image(path)
+
+    print(f"\nflash — {channel}  motor {args.id:#04x}")
+    print(f"  image:  {path}  ({len(image)} B)")
+
+    if not args.yes:
+        _confirm(channel, args.id, path, len(image))
+
+    started = time.monotonic()
+    last_pct = -1
+
+    def on_progress(sent: int, total: int) -> None:
+        nonlocal last_pct
+        pct = sent * 100 // total
+        if pct != last_pct:
+            last_pct = pct
+            print(f"\r  writing: {pct:3d}%  ({sent}/{total} B)", end="", flush=True)
+
+    async with CanBus(channel) as bus:
+        updater = FirmwareUpdater(bus, args.id)
+        print("  entering bootloader ...")
+        await updater.flash(
+            image,
+            name=path.name,
+            frame_delay=args.frame_delay,
+            on_progress=on_progress,
+        )
+
+    print(f"\n  done in {time.monotonic() - started:.1f}s — power-cycle the motor")
+    sys.stdout.flush()

--- a/almond_axol/cli/motor/flash.py
+++ b/almond_axol/cli/motor/flash.py
@@ -24,6 +24,7 @@ from pathlib import Path
 
 from ...motor.bus import CanBus
 from ...motor.firmware import FirmwareUpdater
+from . import add_side_and_channel_arguments, resolve_channel
 
 # Guards against handing the tool a .zip/.hex or the wrong file entirely; the
 # vendor images are tens to a few hundred KiB.
@@ -38,9 +39,7 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description=__doc__,
     )
-    side = p.add_mutually_exclusive_group(required=True)
-    side.add_argument("--l", action="store_true", help="Left arm (can_alm_axol_l)")
-    side.add_argument("--r", action="store_true", help="Right arm (can_alm_axol_r)")
+    add_side_and_channel_arguments(p)
     p.add_argument(
         "firmware",
         type=Path,
@@ -103,7 +102,7 @@ def _confirm(channel: str, motor_id: int, path: Path, size: int) -> None:
 
 
 async def _run(args: argparse.Namespace) -> None:
-    channel = "can_alm_axol_l" if args.l else "can_alm_axol_r"
+    channel = resolve_channel(args)
     path: Path = args.firmware
     image = _load_image(path)
 

--- a/almond_axol/cli/motor/restore_config.py
+++ b/almond_axol/cli/motor/restore_config.py
@@ -1,0 +1,164 @@
+"""
+axol motor.restore-config
+
+Write a JSON snapshot produced by ``axol motor.dump-config`` back to the motors
+it came from, returning them to a known-good configuration. Works for both
+motor families; each snapshot record carries the motor type it was taken from.
+
+Parameters already holding the saved value are skipped, so restoring onto a
+matching motor writes nothing. Read-only parameters are always skipped, and
+protected ones — factory calibration, CAN IDs, baud rate — unless
+``--include-protected`` is passed, since rewriting those can leave a motor
+unable to commutate or unreachable on the bus.
+
+Examples:
+    axol motor.restore-config --l arm-left.json
+    axol motor.restore-config --l --id 0x01 arm-left.json
+"""
+
+import argparse
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+from ...motor.bus import CanBus
+from ...motor.config import MotorParam
+from ...motor.driver import MotorDriver
+from ...motor.errors import MotorError
+from ...motor.motor import make_driver
+
+
+def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    """Register the ``motor.restore-config`` subcommand."""
+    p = subparsers.add_parser(
+        "motor.restore-config",
+        help="Write a saved configuration snapshot back to motors.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=__doc__,
+    )
+    side = p.add_mutually_exclusive_group(required=True)
+    side.add_argument("--l", action="store_true", help="Left arm (can_alm_axol_l)")
+    side.add_argument("--r", action="store_true", help="Right arm (can_alm_axol_r)")
+    p.add_argument("snapshot", type=Path, help="JSON file from motor.dump-config")
+    p.add_argument(
+        "--id",
+        default=None,
+        type=lambda x: int(x, 0),
+        metavar="ID",
+        help="Restore only this motor CAN ID (hex or decimal). "
+        "If omitted, every motor in the snapshot is restored.",
+    )
+    p.add_argument(
+        "--include-protected",
+        action="store_true",
+        help="Also write protected parameters — factory calibration, CAN IDs, "
+        "baud rate (dangerous)",
+    )
+    p.add_argument("--yes", action="store_true", help="Skip the confirmation prompt")
+    p.set_defaults(func=run)
+
+
+def run(args: argparse.Namespace) -> None:
+    """Restore configuration parameters to one or all motors in a snapshot."""
+    asyncio.run(_run(args))
+
+
+def _parse_params(
+    record: dict[str, Any], motor: MotorDriver
+) -> dict[MotorParam, float]:
+    """Resolve a snapshot record's parameter names against this motor's table.
+
+    Raw sweeps are rejected rather than partially applied: their keys are bare
+    indices with no known meaning, so writing them back could hit anything.
+    """
+    if record.get("raw"):
+        raise ValueError(
+            "snapshot was taken with --raw; raw index dumps cannot be restored"
+        )
+    params: dict[MotorParam, float] = {}
+    for name, value in record.get("params", {}).items():
+        try:
+            params[type(motor).resolve_param(name)] = float(value)
+        except MotorError:
+            print(f"    skipping unknown parameter {name!r}")
+    return params
+
+
+def _confirm(motor_ids: list[int], channel: str, include_protected: bool) -> bool:
+    ids = ", ".join(f"{i:#04x}" for i in motor_ids)
+    extra = " including PROTECTED parameters" if include_protected else ""
+    reply = input(f"  Restore config to {ids} on {channel}{extra}? [y/N] ")
+    return reply.strip().lower() in ("y", "yes")
+
+
+async def _restore_motor(
+    bus: CanBus, record: dict[str, Any], include_protected: bool
+) -> None:
+    """Restore one motor from its snapshot record."""
+    motor_id = int(record["motor_id"])
+    print(f"\n  motor {motor_id:#04x}")
+    try:
+        motor = make_driver(bus, motor_id, kt=1.0, motor_type=record.get("type"))
+    except ValueError as e:
+        print(f"    ERROR: {e}")
+        return
+
+    try:
+        params = _parse_params(record, motor)
+    except ValueError as e:
+        print(f"    ERROR: {e}")
+        return
+    if not params:
+        print("    nothing to restore")
+        return
+
+    try:
+        written = await motor.restore_config(
+            params, include_protected=include_protected
+        )
+    except Exception as e:
+        print(f"    ERROR: could not restore — {e}")
+        return
+
+    if not written:
+        print("    already matches the snapshot")
+        return
+    for param in written:
+        spec = motor.PARAMS[param]
+        shown = f"{params[param]:.0f}" if spec.integer else f"{params[param]:.4f}"
+        print(f"    wrote {param.name:<30} {shown:>14} {spec.unit}".rstrip())
+    print(f"    persisted {len(written)} parameter(s)")
+
+
+async def _run(args: argparse.Namespace) -> None:
+    channel = "can_alm_axol_l" if args.l else "can_alm_axol_r"
+
+    try:
+        snapshot = json.loads(args.snapshot.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"could not read {args.snapshot}: {e}")
+        return
+
+    records = [
+        r
+        for r in snapshot.get("motors", [])
+        if args.id is None or int(r["motor_id"]) == args.id
+    ]
+    if not records:
+        print(f"no matching motors in {args.snapshot}")
+        return
+
+    saved_channel = snapshot.get("channel")
+    if saved_channel and saved_channel != channel:
+        print(f"note: snapshot was taken on {saved_channel}, restoring to {channel}")
+
+    if not args.yes and not _confirm(
+        [int(r["motor_id"]) for r in records], channel, args.include_protected
+    ):
+        print("aborted")
+        return
+
+    async with CanBus(channel) as bus:
+        for record in records:
+            await _restore_motor(bus, record, args.include_protected)

--- a/almond_axol/cli/motor/restore_config.py
+++ b/almond_axol/cli/motor/restore_config.py
@@ -27,6 +27,7 @@ from ...motor.config import MotorParam
 from ...motor.driver import MotorDriver
 from ...motor.errors import MotorError
 from ...motor.motor import make_driver
+from . import add_side_and_channel_arguments, resolve_channel
 
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
@@ -37,9 +38,7 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description=__doc__,
     )
-    side = p.add_mutually_exclusive_group(required=True)
-    side.add_argument("--l", action="store_true", help="Left arm (can_alm_axol_l)")
-    side.add_argument("--r", action="store_true", help="Right arm (can_alm_axol_r)")
+    add_side_and_channel_arguments(p)
     p.add_argument("snapshot", type=Path, help="JSON file from motor.dump-config")
     p.add_argument(
         "--id",
@@ -132,7 +131,7 @@ async def _restore_motor(
 
 
 async def _run(args: argparse.Namespace) -> None:
-    channel = "can_alm_axol_l" if args.l else "can_alm_axol_r"
+    channel = resolve_channel(args)
 
     try:
         snapshot = json.loads(args.snapshot.read_text())

--- a/almond_axol/cli/motor/set_config.py
+++ b/almond_axol/cli/motor/set_config.py
@@ -1,0 +1,147 @@
+"""
+axol motor.set-config
+
+Read or write a single configuration parameter on either motor family —
+MyActuator's 0xC0 parameters or Damiao's 0x7FF registers. The type is inferred
+from the CAN ID, and parameter names are unique across families.
+
+With ``--value`` the parameter is written and persisted; without it the current
+value is just read back. Use ``axol motor.dump-config`` to see everything at
+once.
+
+Read-only parameters (firmware versions, measured winding constants) are always
+refused. Protected ones — factory calibration, CAN IDs, baud rate — need
+``--force-protected``, since getting one wrong can leave a motor unable to
+commutate or unreachable on the bus.
+
+Damiao's CAN timeout is handled in milliseconds here; the underlying register
+counts 50 us ticks, and the conversion is applied for you.
+
+Examples:
+    axol motor.set-config --l --id 0x01 --param LOW_VOLTAGE
+    axol motor.set-config --l --id 0x01 --param LOW_VOLTAGE --value -2.0
+    axol motor.set-config --r --id 0x07 --param TIMEOUT --value 1000
+"""
+
+import argparse
+import asyncio
+
+from ...motor.bus import CanBus
+from ...motor.config import ALL_PARAM_NAMES, Access
+from ...motor.errors import MotorError
+from ...motor.motor import make_driver
+
+
+def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+    """Register the ``motor.set-config`` subcommand."""
+    p = subparsers.add_parser(
+        "motor.set-config",
+        help="Read or write one motor configuration parameter.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=__doc__,
+    )
+    side = p.add_mutually_exclusive_group(required=True)
+    side.add_argument("--l", action="store_true", help="Left arm (can_alm_axol_l)")
+    side.add_argument("--r", action="store_true", help="Right arm (can_alm_axol_r)")
+    p.add_argument(
+        "--id",
+        required=True,
+        type=lambda x: int(x, 0),
+        metavar="ID",
+        help="CAN ID of the motor (hex or decimal, e.g. 0x01 or 1)",
+    )
+    p.add_argument(
+        "--param",
+        required=True,
+        choices=ALL_PARAM_NAMES,
+        help="Parameter to read or write",
+    )
+    p.add_argument(
+        "--value",
+        type=float,
+        default=None,
+        help="New value; omit to read the current value without writing",
+    )
+    p.add_argument(
+        "--type",
+        choices=["myactuator", "damiao"],
+        default=None,
+        help="Motor driver type (inferred from ID if omitted)",
+    )
+    p.add_argument(
+        "--force-protected",
+        action="store_true",
+        help="Allow writing a protected parameter (calibration, CAN ID, baud)",
+    )
+    p.add_argument("--yes", action="store_true", help="Skip the confirmation prompt")
+    p.set_defaults(func=run)
+
+
+def run(args: argparse.Namespace) -> None:
+    """Read or write one configuration parameter."""
+    asyncio.run(_run(args))
+
+
+async def _run(args: argparse.Namespace) -> None:
+    channel = "can_alm_axol_l" if args.l else "can_alm_axol_r"
+
+    async with CanBus(channel) as bus:
+        try:
+            motor = make_driver(bus, args.id, kt=1.0, motor_type=args.type)
+        except ValueError as e:
+            print(f"error: {e}")
+            raise SystemExit(1) from e
+
+        kind = type(motor).MOTOR_TYPE
+        try:
+            param = type(motor).resolve_param(args.param)
+        except MotorError as e:
+            print(f"error: {e}")
+            print(f"  ({args.param} belongs to the other motor family)")
+            raise SystemExit(1) from e
+
+        spec = motor.PARAMS[param]
+        unit = f" {spec.unit}" if spec.unit else ""
+        fmt = "{:.0f}" if spec.integer else "{:.4f}"
+        print(
+            f"\nmotor-config — {channel}  type={kind}  id={args.id:#04x}  "
+            f"{param.name} ({int(param):#04x})"
+        )
+
+        if args.value is not None:
+            if spec.access is Access.READ_ONLY:
+                print(f"\n  {param.name} is read-only and cannot be written.")
+                raise SystemExit("aborted")
+            if spec.access is Access.PROTECTED and not args.force_protected:
+                print(
+                    f"\n  {param.name} is a protected parameter (factory calibration,\n"
+                    "  CAN identity, or baud rate). Changing it can leave the motor\n"
+                    "  unable to commutate or unreachable on the bus. Pass\n"
+                    "  --force-protected if you really mean to change it."
+                )
+                raise SystemExit("aborted")
+
+        current = await motor.read_config(param)
+        print(f"  current: {fmt.format(current)}{unit}")
+
+        if args.value is None:
+            return
+        if current == args.value:
+            print("  already at the requested value — nothing written")
+            return
+
+        if not args.yes:
+            answer = input(
+                f"  Set {param.name} to {fmt.format(args.value)}{unit}? [y/N] "
+            )
+            if answer.strip().lower() not in ("y", "yes"):
+                raise SystemExit("aborted")
+
+        await motor.write_config(param, args.value)
+        readback = await motor.read_config(param)
+        print(f"  wrote:   {fmt.format(readback)}{unit}  (persisted)")
+        if readback != args.value:
+            print(
+                f"  warning: motor stored {fmt.format(readback)}{unit}, not "
+                f"{fmt.format(args.value)}{unit} — it may clamp this parameter"
+            )

--- a/almond_axol/cli/motor/set_config.py
+++ b/almond_axol/cli/motor/set_config.py
@@ -30,6 +30,7 @@ from ...motor.bus import CanBus
 from ...motor.config import ALL_PARAM_NAMES, Access
 from ...motor.errors import MotorError
 from ...motor.motor import make_driver
+from . import add_side_and_channel_arguments, resolve_channel
 
 
 def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
@@ -40,9 +41,7 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description=__doc__,
     )
-    side = p.add_mutually_exclusive_group(required=True)
-    side.add_argument("--l", action="store_true", help="Left arm (can_alm_axol_l)")
-    side.add_argument("--r", action="store_true", help="Right arm (can_alm_axol_r)")
+    add_side_and_channel_arguments(p)
     p.add_argument(
         "--id",
         required=True,
@@ -83,7 +82,7 @@ def run(args: argparse.Namespace) -> None:
 
 
 async def _run(args: argparse.Namespace) -> None:
-    channel = "can_alm_axol_l" if args.l else "can_alm_axol_r"
+    channel = resolve_channel(args)
 
     async with CanBus(channel) as bus:
         try:

--- a/almond_axol/motor/config.py
+++ b/almond_axol/motor/config.py
@@ -1,0 +1,253 @@
+"""Configuration parameter tables for both motor families.
+
+Each driver owns its own table. The two enums must never share a dict: both
+are :class:`enum.IntEnum`, so they hash as plain ints, and their value ranges
+overlap (Damiao registers run 0-36, MyActuator indices 0x1C-0x55) — merged,
+they would silently alias one another.
+
+MyActuator
+    Reached through the undocumented 0xC0 command; see :class:`MyActuatorParam`.
+
+Damiao
+    Reached through the documented 0x7FF register protocol (0x33 read, 0x55
+    write, 0xAA store), which the driver already implements.
+"""
+
+from dataclasses import dataclass
+from enum import IntEnum
+
+
+class Access(IntEnum):
+    """How freely a parameter may be written."""
+
+    READ_WRITE = 0
+    """Ordinary setting: written by a restore, shown as editable."""
+
+    PROTECTED = 1
+    """Writable, but not casually.
+
+    Covers factory/calibration values (pole pairs, encoder calibration, phase
+    order) and identity/comm settings (CAN IDs, baud rate). Getting one wrong
+    can leave a motor unable to commutate or unreachable on the bus, and the
+    identity ones would change the address mid-conversation, so a restore
+    skips them unless explicitly told otherwise.
+    """
+
+    READ_ONLY = 2
+    """Reported by the motor but not writable — firmware versions, serial
+    number, measured winding constants. Always skipped by a write."""
+
+
+@dataclass(frozen=True)
+class ParamSpec:
+    """Display and safety metadata for one configuration parameter."""
+
+    unit: str
+    """Unit of the *displayed* value; empty for unitless flags and codes."""
+
+    access: Access = Access.READ_WRITE
+
+    integer: bool = False
+    """Whether the value is a whole number, so it is shown without decimals."""
+
+    scale: float = 1.0
+    """Multiplier from the motor's raw units to the displayed unit.
+
+    Only Damiao's timeout needs this today: the register counts 50 µs ticks,
+    which is a needless footgun to expose, so it is shown and set in ms.
+    """
+
+
+# ---------------------------------------------------------------------------
+# MyActuator — 0xC0 parameter indices
+# ---------------------------------------------------------------------------
+
+# Index range worth sweeping in a raw dump. The vendor software never addresses
+# anything above 0x55, so this covers its whole parameter space.
+PARAM_SWEEP_RANGE = range(0x00, 0x60)
+
+
+class MyActuatorParam(IntEnum):
+    """Parameter index carried in byte 2 of a 0xC0 frame.
+
+    None of these appear in MyActuator's published protocol (V4.4). The command
+    and the index assignments were recovered from the vendor setup software,
+    whose entire "advanced parameter" UI is built on 0xC0 — 158 of the ~180 CAN
+    calls in that binary are 0xC0, with 0xC1 committing batches to ROM.
+
+    Indices were recovered by matching each 0xC0 call site to the field it
+    loads from or stores into, then aligning those fields against the parameter
+    list the GUI renders. The fields form one contiguous run, and four of them
+    (:attr:`ENCODER_CALIBRATION_VALUE`, :attr:`OVER_VOLTAGE`,
+    :attr:`LOW_VOLTAGE`, :attr:`STALL_TIME_LIMIT`) were confirmed directly,
+    which pins the alignment for the rest.
+
+    Parameters the GUI shows past the end of this run — stall current, shutdown
+    and resume temperature, max and nominal speed — are deliberately absent:
+    their call sites could not be resolved, so their indices are unknown.
+    Reading an unknown index is harmless, so use ``dump_config(raw_range=...)``
+    to identify them against a motor rather than guessing here. "Motor Position
+    Zero" is likewise omitted because two candidate indices fit it equally well;
+    the documented 0x64 command already sets the zero position.
+    """
+
+    POWERDOWN_SAVE_MULTITURN = 0x1C
+    POLE_PAIRS = 0x1D
+    SINGLE_TURN_RESOLUTION = 0x1F
+    CALIBRATION_CURRENT = 0x20
+    EXCHANGE_PHASE = 0x21
+    EBRAKE_HOLD_DUTY = 0x22
+    BRAKE_MODE = 0x23
+    MAX_POSITIVE_POSITION = 0x24
+    MIN_NEGATIVE_POSITION = 0x25
+    POSITION_PLAN_MAX_ACC = 0x26
+    POSITION_PLAN_MAX_DEC = 0x27
+    POSITION_PLAN_MAX_SPEED = 0x28
+    SPEED_PLAN_MAX_ACC = 0x29
+    SPEED_PLAN_MAX_DEC = 0x3C
+    CHANGE_MOTOR_DIRECTION = 0x3E
+    ENCODER_CALIBRATION_VALUE = 0x46
+    STALL_TIME_LIMIT = 0x47
+    EBRAKE_START_DUTY = 0x48
+    CURRENT_SAMPLE_RES = 0x49
+    OVER_VOLTAGE = 0x54
+    LOW_VOLTAGE = 0x55
+
+
+_RW = Access.READ_WRITE
+_PROT = Access.PROTECTED
+_RO = Access.READ_ONLY
+
+MYACTUATOR_PARAMS: dict[MyActuatorParam, ParamSpec] = {
+    MyActuatorParam.POWERDOWN_SAVE_MULTITURN: ParamSpec(""),
+    MyActuatorParam.POLE_PAIRS: ParamSpec("", _PROT),
+    MyActuatorParam.SINGLE_TURN_RESOLUTION: ParamSpec("pulses", _PROT),
+    MyActuatorParam.CALIBRATION_CURRENT: ParamSpec("A", _PROT),
+    MyActuatorParam.EXCHANGE_PHASE: ParamSpec("", _PROT),
+    MyActuatorParam.EBRAKE_HOLD_DUTY: ParamSpec("%"),
+    MyActuatorParam.BRAKE_MODE: ParamSpec(""),
+    MyActuatorParam.MAX_POSITIVE_POSITION: ParamSpec("deg"),
+    MyActuatorParam.MIN_NEGATIVE_POSITION: ParamSpec("deg"),
+    MyActuatorParam.POSITION_PLAN_MAX_ACC: ParamSpec("dps/s"),
+    MyActuatorParam.POSITION_PLAN_MAX_DEC: ParamSpec("dps/s"),
+    MyActuatorParam.POSITION_PLAN_MAX_SPEED: ParamSpec("rpm"),
+    MyActuatorParam.SPEED_PLAN_MAX_ACC: ParamSpec("dps/s"),
+    MyActuatorParam.SPEED_PLAN_MAX_DEC: ParamSpec("dps/s"),
+    MyActuatorParam.CHANGE_MOTOR_DIRECTION: ParamSpec("", _PROT),
+    MyActuatorParam.ENCODER_CALIBRATION_VALUE: ParamSpec("", _PROT),
+    MyActuatorParam.STALL_TIME_LIMIT: ParamSpec("s"),
+    MyActuatorParam.EBRAKE_START_DUTY: ParamSpec("%"),
+    MyActuatorParam.CURRENT_SAMPLE_RES: ParamSpec("mOhm", _PROT),
+    MyActuatorParam.OVER_VOLTAGE: ParamSpec("V"),
+    MyActuatorParam.LOW_VOLTAGE: ParamSpec("V"),
+}
+
+
+# ---------------------------------------------------------------------------
+# Damiao — 0x7FF register IDs
+# ---------------------------------------------------------------------------
+
+
+class DamiaoParam(IntEnum):
+    """Damiao register ID (RID), carried in byte 3 of a 0x7FF frame.
+
+    This table is published by Damiao and matches the register list embedded in
+    the DMTool setup software, where the fields appear in RID order. It is
+    corroborated by the driver's own ``_DM_UINT32_REGS``: every register this
+    table types as an integer is exactly one the driver already packs as
+    uint32.
+    """
+
+    UV_VALUE = 0  # undervoltage threshold
+    KT_VALUE = 1  # torque constant
+    OT_VALUE = 2  # overtemperature threshold
+    OC_VALUE = 3  # overcurrent threshold
+    ACC = 4
+    DEC = 5
+    MAX_SPD = 6
+    MST_ID = 7  # feedback CAN ID
+    ESC_ID = 8  # receive CAN ID
+    TIMEOUT = 9  # CAN loss-of-comms alarm time
+    CTRL_MODE = 10  # 1=MIT, 2=POS_VEL, 3=VEL, 4=FORCE_POS
+    DAMP = 11
+    INERTIA = 12
+    HW_VER = 13
+    SW_VER = 14
+    SN = 15
+    NPP = 16  # pole pairs
+    RS = 17  # phase resistance
+    LS = 18  # phase inductance
+    FLUX = 19
+    GR = 20  # gear ratio
+    PMAX = 21  # position scaling for the MIT protocol
+    VMAX = 22  # velocity scaling for the MIT protocol
+    TMAX = 23  # torque scaling for the MIT protocol
+    I_BW = 24  # current loop bandwidth
+    KP_ASR = 25  # speed loop Kp
+    KI_ASR = 26  # speed loop Ki
+    KP_APR = 27  # position loop Kp
+    KI_APR = 28  # position loop Ki
+    OV_VALUE = 29  # overvoltage threshold
+    GREF = 30
+    DETA = 31
+    V_BW = 32  # velocity loop bandwidth
+    IQ_CL = 33
+    VL_CL = 34
+    CAN_BR = 35  # CAN baud rate code (0-4)
+    SUB_VER = 36
+
+
+# The register counts 50 µs ticks; ms is the unit every human uses for it.
+DAMIAO_TIMEOUT_MS_PER_UNIT = 0.05
+
+DAMIAO_PARAMS: dict[DamiaoParam, ParamSpec] = {
+    DamiaoParam.UV_VALUE: ParamSpec("V"),
+    DamiaoParam.KT_VALUE: ParamSpec("Nm/A"),
+    DamiaoParam.OT_VALUE: ParamSpec("C"),
+    DamiaoParam.OC_VALUE: ParamSpec("A"),
+    DamiaoParam.ACC: ParamSpec("rad/s^2"),
+    DamiaoParam.DEC: ParamSpec("rad/s^2"),
+    DamiaoParam.MAX_SPD: ParamSpec("rad/s"),
+    DamiaoParam.MST_ID: ParamSpec("", _PROT, integer=True),
+    DamiaoParam.ESC_ID: ParamSpec("", _PROT, integer=True),
+    DamiaoParam.TIMEOUT: ParamSpec(
+        "ms", _RW, integer=False, scale=DAMIAO_TIMEOUT_MS_PER_UNIT
+    ),
+    DamiaoParam.CTRL_MODE: ParamSpec("", _RW, integer=True),
+    DamiaoParam.DAMP: ParamSpec("", _RO),
+    DamiaoParam.INERTIA: ParamSpec("kg*m^2", _RO),
+    DamiaoParam.HW_VER: ParamSpec("", _RO, integer=True),
+    DamiaoParam.SW_VER: ParamSpec("", _RO, integer=True),
+    DamiaoParam.SN: ParamSpec("", _RO, integer=True),
+    DamiaoParam.NPP: ParamSpec("", _RO, integer=True),
+    DamiaoParam.RS: ParamSpec("mOhm", _RO),
+    DamiaoParam.LS: ParamSpec("uH", _RO),
+    DamiaoParam.FLUX: ParamSpec("Wb", _RO),
+    DamiaoParam.GR: ParamSpec("", _RO),
+    DamiaoParam.PMAX: ParamSpec("rad"),
+    DamiaoParam.VMAX: ParamSpec("rad/s"),
+    DamiaoParam.TMAX: ParamSpec("Nm"),
+    DamiaoParam.I_BW: ParamSpec("Hz"),
+    DamiaoParam.KP_ASR: ParamSpec(""),
+    DamiaoParam.KI_ASR: ParamSpec(""),
+    DamiaoParam.KP_APR: ParamSpec(""),
+    DamiaoParam.KI_APR: ParamSpec(""),
+    DamiaoParam.OV_VALUE: ParamSpec("V"),
+    DamiaoParam.GREF: ParamSpec(""),
+    DamiaoParam.DETA: ParamSpec(""),
+    DamiaoParam.V_BW: ParamSpec("Hz"),
+    DamiaoParam.IQ_CL: ParamSpec(""),
+    DamiaoParam.VL_CL: ParamSpec(""),
+    DamiaoParam.CAN_BR: ParamSpec("", _PROT, integer=True),
+    DamiaoParam.SUB_VER: ParamSpec("", _RO, integer=True),
+}
+
+
+MotorParam = MyActuatorParam | DamiaoParam
+
+# Union of every parameter name, for CLI/UI dropdowns. Names are unique across
+# the two families, so a name resolves to at most one parameter; the driver
+# still validates that the name belongs to *its* table.
+ALL_PARAM_NAMES: list[str] = [p.name for p in MyActuatorParam] + [
+    p.name for p in DamiaoParam
+]

--- a/almond_axol/motor/damiao.py
+++ b/almond_axol/motor/damiao.py
@@ -277,16 +277,38 @@ class DamiaoMotor(MotorDriver):
             raise MotorError(f"CAN timeout must not be negative, got {milliseconds}")
         await self.write_config(DamiaoParam.TIMEOUT, milliseconds)
 
-    async def _request_feedback(self, timeout: float = 0.1) -> _MotorFeedback:
+    async def _request_feedback(
+        self, timeout: float = 0.1, attempts: int = 5
+    ) -> _MotorFeedback:
+        """Request a feedback frame, re-sending the request if a reply is missed.
+
+        Like the parameter-read reply (see :meth:`_read_register`), the 0xCC
+        feedback reply is a single unacknowledged CAN frame that is most often
+        dropped in the enable burst — e.g. the ``get_position`` that opens
+        gripper calibration, issued right after every motor on both arms has
+        cleared errors and read its registers at once. One dropped frame must
+        not abort the whole enable, so each attempt re-sends the request.
+        """
         loop = asyncio.get_running_loop()
-        fut: asyncio.Future[_MotorFeedback] = loop.create_future()
-        self._feedback_waiters.append(fut)
         canid_l, canid_h = self._canid_bytes()
-        await self._bus._send(0x7FF, bytes([canid_l, canid_h, 0xCC, 0, 0, 0, 0, 0]))
-        try:
-            return await asyncio.wait_for(fut, timeout)
-        except asyncio.TimeoutError:
-            raise MotorError(f"Damiao motor {self._motor_id:#04x} feedback timed out")
+        last_exc: asyncio.TimeoutError | None = None
+        for _ in range(attempts):
+            fut: asyncio.Future[_MotorFeedback] = loop.create_future()
+            self._feedback_waiters.append(fut)
+            await self._bus._send(0x7FF, bytes([canid_l, canid_h, 0xCC, 0, 0, 0, 0, 0]))
+            try:
+                return await asyncio.wait_for(fut, timeout)
+            except asyncio.TimeoutError as exc:
+                last_exc = exc
+            finally:
+                # Drop our waiter unless a feedback frame already resolved it,
+                # so a late reply can't resolve a future from a previous attempt.
+                if fut in self._feedback_waiters:
+                    self._feedback_waiters.remove(fut)
+        raise MotorError(
+            f"Damiao motor {self._motor_id:#04x} feedback timed out "
+            f"after {attempts} attempts"
+        ) from last_exc
 
     async def _send_cmd(
         self,
@@ -352,7 +374,8 @@ class DamiaoMotor(MotorDriver):
             await self._raw_send(bytes([0xFF] * 7 + [0xFD]))
             await asyncio.sleep(0.01)
             try:
-                feedback = await self._request_feedback()
+                # attempts=1: this loop already re-sends on a missed reply.
+                feedback = await self._request_feedback(attempts=1)
                 if feedback.status == _DamiaoStatus.DISABLED:
                     return
             except MotorError:

--- a/almond_axol/motor/damiao.py
+++ b/almond_axol/motor/damiao.py
@@ -13,6 +13,7 @@ from typing import Callable
 import can
 
 from .bus import CanBus
+from .config import DAMIAO_PARAMS, DamiaoParam
 from .driver import MotorDriver
 from .errors import MotorError
 from .types import ControlMode, MotorGains, MotorStatus
@@ -85,6 +86,11 @@ def _uint_to_float(x_int: int, x_min: float, x_max: float, bits: int) -> float:
 
 class DamiaoMotor(MotorDriver):
     """MotorDriver implementation for Damiao motors using the MIT/position-force protocol."""
+
+    MOTOR_TYPE = "damiao"
+    PARAMS = DAMIAO_PARAMS
+    # Damiao publishes the whole register table, so a sweep has nothing to find.
+    PARAM_SWEEP_RANGE = None
 
     def __init__(self, bus: CanBus, motor_id: int, feedback_id: int) -> None:
         """Construct a Damiao driver.
@@ -243,6 +249,33 @@ class DamiaoMotor(MotorDriver):
         """Persist all RAM register values to flash (0xAA command)."""
         canid_l, canid_h = self._canid_bytes()
         await self._bus._send(0x7FF, bytes([canid_l, canid_h, 0xAA, 0x01, 0, 0, 0, 0]))
+
+    async def _config_read(self, index: int) -> float:
+        return float(await self._read_register(index))
+
+    async def _config_write(self, index: int, value: float) -> None:
+        await self._write_register(index, value)
+
+    async def _config_commit(self) -> None:
+        await self._store_parameters()
+
+    async def get_can_timeout(self) -> float:
+        """Return the loss-of-comms alarm time in milliseconds.
+
+        The motor raises :attr:`MotorStatus.LOST_COMM` when it goes this long
+        without a command. Zero disables the alarm.
+        """
+        return await self.read_config(DamiaoParam.TIMEOUT)
+
+    async def set_can_timeout(self, milliseconds: float) -> None:
+        """Set the loss-of-comms alarm time in milliseconds and persist it.
+
+        Pass 0 to disable the alarm. The register itself counts 50 µs ticks;
+        the conversion is handled by the parameter's scale.
+        """
+        if milliseconds < 0:
+            raise MotorError(f"CAN timeout must not be negative, got {milliseconds}")
+        await self.write_config(DamiaoParam.TIMEOUT, milliseconds)
 
     async def _request_feedback(self, timeout: float = 0.1) -> _MotorFeedback:
         loop = asyncio.get_running_loop()

--- a/almond_axol/motor/driver.py
+++ b/almond_axol/motor/driver.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import math
 from abc import ABC, abstractmethod
-from typing import Callable
+from typing import Callable, Mapping
 
+from .config import Access, MotorParam, ParamSpec
 from .errors import MotorError
 from .types import ControlMode, MotorGains, MotorStatus
 
@@ -106,6 +108,157 @@ class MotorDriver(ABC):
     async def get_error_code(self) -> MotorStatus:
         """Return the current motor status / error code."""
         ...
+
+    async def get_low_voltage_threshold(self) -> float:
+        """Return the undervoltage protection threshold in Volts.
+
+        Below this bus voltage the motor latches a level-2 undervoltage fault
+        (:attr:`MotorStatus.UNDER_VOLTAGE`). Only supported by MyActuator
+        motors; raises MotorError on Damiao.
+        """
+        raise MotorError(
+            f"get_low_voltage_threshold is not supported by {type(self).__name__}"
+        )
+
+    async def set_low_voltage_threshold(self, volts: float) -> None:
+        """Set the undervoltage protection threshold and persist it to ROM.
+
+        Only supported by MyActuator motors; raises MotorError on Damiao.
+        MyActuator applies this on every ``enable()`` — see
+        ``_MA_LOW_VOLTAGE_THRESHOLD_V`` in ``myactuator.py``.
+
+        Args:
+            volts: Threshold in Volts. A negative value can never be reached,
+                   which suppresses the undervoltage fault entirely.
+        """
+        raise MotorError(
+            f"set_low_voltage_threshold is not supported by {type(self).__name__}"
+        )
+
+    #: Canonical name of this motor family, as accepted by ``make_driver``'s
+    #: ``motor_type``. Config snapshots persist it and feed it back on restore,
+    #: so it must be a declared identity rather than anything derived from the
+    #: class name.
+    MOTOR_TYPE: str = ""
+
+    #: This driver's configuration parameter table, keyed by its own parameter
+    #: enum. Empty for drivers with no configuration surface.
+    PARAMS: Mapping[MotorParam, ParamSpec] = {}
+
+    @classmethod
+    def resolve_param(cls, name: str) -> MotorParam:
+        """Look a parameter up by name in *this* driver's table.
+
+        Names are unique across motor families, so naming a Damiao register
+        while talking to a MyActuator motor is a mistake worth reporting rather
+        than silently matching some same-valued index in the other table.
+        """
+        for param in cls.PARAMS:
+            if param.name == name:
+                return param
+        raise MotorError(f"{cls.__name__} has no configuration parameter {name!r}")
+
+    #: Bare indices a raw dump may sweep, for families whose table is still
+    #: incomplete. ``None`` where every parameter is already known, so there is
+    #: nothing a sweep could discover.
+    PARAM_SWEEP_RANGE: range | None = None
+
+    async def get_can_timeout(self) -> float:
+        """Return the CAN loss-of-comms alarm time in milliseconds.
+
+        Only supported by Damiao motors; raises MotorError on MyActuator.
+        """
+        raise MotorError(f"get_can_timeout is not supported by {type(self).__name__}")
+
+    async def set_can_timeout(self, milliseconds: float) -> None:
+        """Set the CAN loss-of-comms alarm time in ms and persist it.
+
+        The motor faults with :attr:`MotorStatus.LOST_COMM` when it goes this
+        long without a command; 0 disables the alarm. Only supported by Damiao
+        motors; raises MotorError on MyActuator.
+        """
+        raise MotorError(f"set_can_timeout is not supported by {type(self).__name__}")
+
+    async def _config_read(self, index: int) -> float:
+        """Read one parameter by raw index, in the motor's own units."""
+        raise MotorError(f"config access is not supported by {type(self).__name__}")
+
+    async def _config_write(self, index: int, value: float) -> None:
+        """Write one parameter by raw index without persisting it."""
+        raise MotorError(f"config access is not supported by {type(self).__name__}")
+
+    async def _config_commit(self) -> None:
+        """Persist every deferred config write to flash/ROM."""
+        raise MotorError(f"config access is not supported by {type(self).__name__}")
+
+    async def read_config(self, param: MotorParam) -> float:
+        """Read one configuration parameter, in the unit its spec names."""
+        raw = await self._config_read(int(param))
+        return raw * self.PARAMS[param].scale
+
+    async def write_config(self, param: MotorParam, value: float) -> None:
+        """Write one configuration parameter and persist it to flash/ROM.
+
+        Refuses read-only parameters; protected ones are allowed here because
+        naming a single parameter is already deliberate. Bulk restores gate
+        them behind ``include_protected`` instead.
+        """
+        spec = self.PARAMS[param]
+        if spec.access is Access.READ_ONLY:
+            raise MotorError(f"{param.name} is read-only")
+        await self._config_write(int(param), value / spec.scale)
+        await self._config_commit()
+
+    async def dump_config(
+        self, raw_range: range | None = None
+    ) -> dict[MotorParam | int, float]:
+        """Read every known configuration parameter.
+
+        Pass ``raw_range`` to sweep bare indices instead of the known table —
+        the way to pin down parameters a vendor GUI exposes but whose indices
+        are still unidentified. Indices the motor rejects are left out rather
+        than reported as an error, since a sweep is expected to hit gaps.
+        """
+        if not self.PARAMS:
+            raise MotorError(f"dump_config is not supported by {type(self).__name__}")
+        if raw_range is not None:
+            values: dict[MotorParam | int, float] = {}
+            for index in raw_range:
+                try:
+                    values[index] = await self._config_read(index)
+                except MotorError:
+                    continue
+            return values
+        return {param: await self.read_config(param) for param in self.PARAMS}
+
+    async def restore_config(
+        self, values: Mapping[MotorParam, float], *, include_protected: bool = False
+    ) -> list[MotorParam]:
+        """Write ``values`` back to the motor and return the ones that changed.
+
+        Parameters already holding the requested value are skipped so a restore
+        onto a matching motor costs no flash writes, and the whole batch shares
+        a single commit. Read-only parameters are always skipped, and protected
+        ones unless ``include_protected`` is set — see :class:`Access`.
+        """
+        if not self.PARAMS:
+            raise MotorError(
+                f"restore_config is not supported by {type(self).__name__}"
+            )
+        written: list[MotorParam] = []
+        for param, value in values.items():
+            spec = self.PARAMS.get(param)
+            if spec is None or spec.access is Access.READ_ONLY:
+                continue
+            if spec.access is Access.PROTECTED and not include_protected:
+                continue
+            if math.isclose(await self.read_config(param), value, rel_tol=1e-6):
+                continue
+            await self._config_write(int(param), value / spec.scale)
+            written.append(param)
+        if written:
+            await self._config_commit()
+        return written
 
     @abstractmethod
     async def set_position_velocity(self, position: float, max_speed: float) -> None:

--- a/almond_axol/motor/firmware.py
+++ b/almond_axol/motor/firmware.py
@@ -1,0 +1,318 @@
+"""MyActuator firmware update over CAN.
+
+The RMD bootloader is absent from MyActuator's published protocol (V4.4); the
+sequence here was recovered from the vendor setup software. It is a YMODEM-1K
+transfer tunnelled over three CAN IDs derived from the motor's ID:
+
+    trigger  ((id & 0x1F) << 6) | 0x28   host  -> motor, reboot into bootloader
+    data     ((id & 0x1F) << 6) | 0x3E   host  -> motor, YMODEM byte stream
+    reply    ((id & 0x1F) << 6) | 0x14   motor -> host, YMODEM control bytes
+
+Note these are unrelated to the 0x140-series IDs the normal protocol uses, so a
+flash in progress does not collide with regular motor traffic — but nothing
+else may talk to the target motor while it is in the bootloader.
+
+A YMODEM packet is ``header, block, ~block, payload, crc_hi, crc_lo`` with a
+CRC-16/XMODEM over the payload only. It is split across CAN frames 8 bytes at a
+time; DLC is the only framing, so a packet simply spans ceil(n / 8) frames.
+The handshake is stock YMODEM: the bootloader sends ``C`` to open the transfer,
+block 0 carries ``filename\\0size``, and every block is answered with ACK.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Callable
+
+import can
+
+from .bus import CanBus
+from .errors import MotorError
+
+_logger = logging.getLogger(__name__)
+
+# Sub-function codes OR-ed into (motor_id << 6) to form each channel's 11-bit ID.
+_FW_TRIGGER_SUB = 0x28
+_FW_DATA_SUB = 0x3E
+_FW_REPLY_SUB = 0x14
+_FW_ID_MASK = 0x1F  # the bootloader addresses motors with 5 bits of ID
+
+# Sent on the trigger ID to make a running motor jump into its bootloader.
+_FW_ENTER_BOOTLOADER = bytes([0xF0, 0xF1, 0xF2, 0xF3, 0xF4, 0xF5, 0xF6, 0xF7])
+
+# YMODEM control bytes.
+_SOH = 0x01  # header for a 128-byte payload
+_STX = 0x02  # header for a 1024-byte payload
+_EOT = 0x04
+_ACK = 0x06
+_NAK = 0x15
+_CANCEL = 0x18  # two in a row aborts the transfer
+_CRC_REQ = 0x43  # "C" — receiver asks for a CRC-mode transfer
+_PAD = 0x1A  # fills the tail of a short final block
+
+_SHORT_BLOCK = 128
+_LONG_BLOCK = 1024
+
+# The vendor tool waits 7 s for every handshake byte; a flash erase before the
+# first "C" is the slowest step and stays well inside that.
+_FW_REPLY_TIMEOUT_S = 7.0
+
+# Blocks rejected with NAK are retransmitted this many times before giving up.
+_FW_BLOCK_RETRIES = 5
+
+
+def _make_crc16_table() -> tuple[int, ...]:
+    table = []
+    for i in range(256):
+        crc = i << 8
+        for _ in range(8):
+            crc = (
+                ((crc << 1) ^ 0x1021) & 0xFFFF if crc & 0x8000 else (crc << 1) & 0xFFFF
+            )
+        table.append(crc)
+    return tuple(table)
+
+
+_CRC16_TABLE = _make_crc16_table()
+
+
+def _crc16(data: bytes) -> int:
+    """CRC-16/XMODEM (poly 0x1021, zero seed) over ``data``."""
+    crc = 0
+    for byte in data:
+        crc = ((crc << 8) ^ _CRC16_TABLE[((crc >> 8) ^ byte) & 0xFF]) & 0xFFFF
+    return crc
+
+
+class _TransferNak(Exception):
+    """The bootloader NAK-ed a block; the caller should retransmit it."""
+
+
+class FirmwareUpdater:
+    """Flashes a firmware image to one MyActuator motor over CAN.
+
+    The motor must be powered, idle, and the only thing being addressed on the
+    bus for the duration — the bootloader does not answer normal 0x140-series
+    commands, and a half-finished transfer leaves the motor in the bootloader
+    (recoverable by re-running the flash, since the trigger frame is not needed
+    once it is already there).
+
+        async with CanBus("can_alm_axol_l") as bus:
+            await FirmwareUpdater(bus, 0x01).flash(image, name="RMD-X6.bin")
+    """
+
+    def __init__(self, bus: CanBus, motor_id: int) -> None:
+        """Bind an updater to one motor.
+
+        Args:
+            bus:      Shared CAN bus, already started.
+            motor_id: Target motor's CAN ID. Only the low 5 bits address the
+                      bootloader, so IDs above 0x1F cannot be flashed.
+        """
+        if not 0 < motor_id <= _FW_ID_MASK:
+            raise ValueError(
+                f"motor_id must be in [0x01, {_FW_ID_MASK:#04x}] to reach the "
+                f"bootloader, got {motor_id:#04x}"
+            )
+        self._bus = bus
+        self._motor_id = motor_id
+        base = (motor_id & _FW_ID_MASK) << 6
+        self._trigger_id = base | _FW_TRIGGER_SUB
+        self._data_id = base | _FW_DATA_SUB
+        self._reply_id = base | _FW_REPLY_SUB
+        self._replies: asyncio.Queue[bytes] = asyncio.Queue()
+        bus._add_listener(self._on_message)
+
+    # ------------------------------------------------------------------ #
+    # Reply channel                                                        #
+    # ------------------------------------------------------------------ #
+
+    def _on_message(self, msg: can.Message) -> None:
+        if msg.arbitration_id == self._reply_id:
+            self._replies.put_nowait(bytes(msg.data[: msg.dlc]))
+
+    def _drain(self) -> None:
+        """Discard replies buffered before the current step."""
+        while not self._replies.empty():
+            self._replies.get_nowait()
+
+    async def _await_reply(self, expected: bytes, timeout: float, step: str) -> None:
+        """Block until the bootloader answers with exactly ``expected``.
+
+        Frames that are neither the expected reply nor a protocol control byte
+        are ignored — a retransmitted ACK from the previous step can still be
+        in flight. Raises :class:`_TransferNak` on NAK so the caller can resend.
+        """
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        cancels = 0
+        while True:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                raise MotorError(
+                    f"MyActuator motor {self._motor_id:#04x}: no response to {step} "
+                    f"within {timeout:g}s (expected {expected.hex()})"
+                )
+            try:
+                reply = await asyncio.wait_for(self._replies.get(), remaining)
+            except asyncio.TimeoutError:
+                continue
+            if reply == expected:
+                return
+            if reply[:1] == bytes([_NAK]):
+                raise _TransferNak()
+            if reply[:1] == bytes([_CANCEL]) or reply == bytes([_CANCEL, _CANCEL]):
+                cancels += 2 if len(reply) > 1 else 1
+                if cancels >= 2:
+                    raise MotorError(
+                        f"MyActuator motor {self._motor_id:#04x}: bootloader "
+                        f"aborted the transfer during {step}"
+                    )
+                continue
+            _logger.debug(
+                "motor %#04x: ignoring %s during %s",
+                self._motor_id,
+                reply.hex(),
+                step,
+            )
+
+    # ------------------------------------------------------------------ #
+    # Transmit                                                             #
+    # ------------------------------------------------------------------ #
+
+    async def _send_stream(self, payload: bytes, frame_delay: float) -> None:
+        """Push raw bytes down the data channel, 8 per CAN frame."""
+        for off in range(0, len(payload), 8):
+            await self._bus._send(self._data_id, payload[off : off + 8])
+            if frame_delay:
+                await asyncio.sleep(frame_delay)
+
+    @staticmethod
+    def _packet(header: int, block: int, payload: bytes) -> bytes:
+        crc = _crc16(payload)
+        return (
+            bytes([header, block & 0xFF, ~block & 0xFF])
+            + payload
+            + bytes([crc >> 8, crc & 0xFF])
+        )
+
+    async def _send_block(
+        self, block: int, payload: bytes, frame_delay: float, step: str
+    ) -> None:
+        """Send one YMODEM block and wait for its ACK, retrying on NAK."""
+        header = _SOH if len(payload) == _SHORT_BLOCK else _STX
+        packet = self._packet(header, block, payload)
+        for attempt in range(1, _FW_BLOCK_RETRIES + 1):
+            self._drain()
+            await self._send_stream(packet, frame_delay)
+            try:
+                await self._await_reply(bytes([_ACK]), _FW_REPLY_TIMEOUT_S, step)
+                return
+            except _TransferNak:
+                if attempt == _FW_BLOCK_RETRIES:
+                    raise MotorError(
+                        f"MyActuator motor {self._motor_id:#04x}: bootloader "
+                        f"rejected {step} after {_FW_BLOCK_RETRIES} attempts"
+                    )
+                _logger.warning(
+                    "motor %#04x: NAK on %s, retrying (%d/%d)",
+                    self._motor_id,
+                    step,
+                    attempt,
+                    _FW_BLOCK_RETRIES,
+                )
+
+    # ------------------------------------------------------------------ #
+    # Public API                                                           #
+    # ------------------------------------------------------------------ #
+
+    async def enter_bootloader(self) -> None:
+        """Send the magic frame that reboots the motor into its bootloader.
+
+        Unacknowledged by design — the motor resets immediately. A motor that is
+        already in the bootloader ignores it.
+        """
+        await self._bus._send(self._trigger_id, _FW_ENTER_BOOTLOADER)
+
+    async def flash(
+        self,
+        firmware: bytes,
+        *,
+        name: str = "firmware.bin",
+        frame_delay: float = 0.0,
+        on_progress: Callable[[int, int], None] | None = None,
+    ) -> None:
+        """Write ``firmware`` to the motor and wait for the bootloader to accept it.
+
+        Args:
+            firmware:    Raw image, exactly as it would be flashed by the vendor
+                         tool (a ``.bin``, not Intel hex or an archive).
+            name:        Filename advertised in YMODEM block 0. The bootloader
+                         keys off the size rather than the name, but the vendor
+                         tool sends the real basename so this mirrors it.
+            frame_delay: Seconds to pause between consecutive CAN frames. ``0``
+                         matches the vendor tool; raise it if the adapter's TX
+                         queue overruns on long blocks.
+            on_progress: Called as ``(bytes_sent, total_bytes)`` after each
+                         acknowledged block.
+
+        Raises:
+            MotorError: The bootloader did not answer, NAK-ed a block too many
+                        times, or aborted the transfer.
+        """
+        if not firmware:
+            raise ValueError("firmware image is empty")
+
+        total = len(firmware)
+        self._drain()
+
+        await self.enter_bootloader()
+        await self._await_reply(
+            bytes([_CRC_REQ]), _FW_REPLY_TIMEOUT_S, "bootloader handshake"
+        )
+
+        header = name.encode("ascii", errors="replace") + b"\x00" + str(total).encode()
+        if len(header) > _SHORT_BLOCK:
+            raise ValueError(f"firmware name {name!r} is too long for YMODEM block 0")
+        await self._send_header_block(header, frame_delay)
+
+        sent = 0
+        block = 1
+        while sent < total:
+            chunk = firmware[sent : sent + _LONG_BLOCK]
+            # The vendor tool reads 1 KiB at a time and drops to a 128-byte
+            # block only when the remainder fits, padding either with 0x1A.
+            size = _SHORT_BLOCK if len(chunk) <= _SHORT_BLOCK else _LONG_BLOCK
+            payload = chunk[:size].ljust(size, bytes([_PAD]))
+            await self._send_block(
+                block, payload, frame_delay, f"block {block} ({sent}/{total} B)"
+            )
+            sent += len(chunk)
+            block = (block + 1) & 0xFF
+            if on_progress is not None:
+                on_progress(min(sent, total), total)
+
+        self._drain()
+        await self._bus._send(self._data_id, bytes([_EOT]))
+        await self._await_reply(bytes([_ACK]), _FW_REPLY_TIMEOUT_S, "end of transfer")
+
+    async def _send_header_block(self, header: bytes, frame_delay: float) -> None:
+        """Send YMODEM block 0 and consume the ACK + "C" that follows it."""
+        payload = header.ljust(_SHORT_BLOCK, b"\x00")
+        packet = self._packet(_SOH, 0, payload)
+        for attempt in range(1, _FW_BLOCK_RETRIES + 1):
+            self._drain()
+            await self._send_stream(packet, frame_delay)
+            try:
+                # Block 0 is answered with ACK and a fresh "C" in one frame.
+                await self._await_reply(
+                    bytes([_ACK, _CRC_REQ]), _FW_REPLY_TIMEOUT_S, "header block"
+                )
+                return
+            except _TransferNak:
+                if attempt == _FW_BLOCK_RETRIES:
+                    raise MotorError(
+                        f"MyActuator motor {self._motor_id:#04x}: bootloader "
+                        f"rejected the header block"
+                    )

--- a/almond_axol/motor/motor.py
+++ b/almond_axol/motor/motor.py
@@ -11,9 +11,11 @@ from __future__ import annotations
 import asyncio
 from dataclasses import dataclass
 from enum import Enum
+from typing import Mapping
 
 from ..constants import Joint
 from .bus import CanBus
+from .config import MotorParam
 from .damiao import DamiaoMotor
 from .driver import MotorDriver
 from .errors import MotorError
@@ -22,10 +24,14 @@ from .types import ControlMode, MotorGains, MotorStatus
 
 
 class _MotorType(Enum):
-    """Identifies which vendor protocol a joint's motor speaks."""
+    """Identifies which vendor protocol a joint's motor speaks.
 
-    MYACTUATOR = "myactuator"
-    DAMIAO = "damiao"
+    Values come from the drivers so the CLI, config snapshots, and this
+    mapping cannot drift apart.
+    """
+
+    MYACTUATOR = MyActuatorMotor.MOTOR_TYPE
+    DAMIAO = DamiaoMotor.MOTOR_TYPE
 
 
 @dataclass(frozen=True)
@@ -275,6 +281,61 @@ class Motor:
     async def get_voltage(self) -> float:
         """Return bus voltage in Volts."""
         return await self._driver.get_voltage()
+
+    async def get_low_voltage_threshold(self) -> float:
+        """Return the undervoltage protection threshold in Volts.
+
+        MyActuator only; raises MotorError on Damiao.
+        """
+        return await self._driver.get_low_voltage_threshold()
+
+    async def set_low_voltage_threshold(self, volts: float) -> None:
+        """Set the undervoltage protection threshold (V) and persist it to ROM.
+
+        MyActuator only; raises MotorError on Damiao. MyActuator motors already
+        apply the project-wide threshold on ``enable()``.
+        """
+        await self._driver.set_low_voltage_threshold(volts)
+
+    def resolve_config_param(self, name: str) -> MotorParam:
+        """Look a configuration parameter up by name for this motor's family."""
+        return type(self._driver).resolve_param(name)
+
+    async def read_config(self, param: MotorParam) -> float:
+        """Read one configuration parameter, in the unit its spec names."""
+        return await self._driver.read_config(param)
+
+    async def write_config(self, param: MotorParam, value: float) -> None:
+        """Write one configuration parameter and persist it to flash/ROM."""
+        await self._driver.write_config(param, value)
+
+    async def dump_config(
+        self, raw_range: range | None = None
+    ) -> dict[MotorParam | int, float]:
+        """Read every known configuration parameter."""
+        return await self._driver.dump_config(raw_range)
+
+    async def restore_config(
+        self, values: Mapping[MotorParam, float], *, include_protected: bool = False
+    ) -> list[MotorParam]:
+        """Write a saved configuration back and return the parameters changed."""
+        return await self._driver.restore_config(
+            values, include_protected=include_protected
+        )
+
+    async def get_can_timeout(self) -> float:
+        """Return the CAN loss-of-comms alarm time in milliseconds.
+
+        Damiao only; raises MotorError on MyActuator.
+        """
+        return await self._driver.get_can_timeout()
+
+    async def set_can_timeout(self, milliseconds: float) -> None:
+        """Set the CAN loss-of-comms alarm time in ms and persist it.
+
+        Damiao only; raises MotorError on MyActuator.
+        """
+        await self._driver.set_can_timeout(milliseconds)
 
     async def get_error_code(self) -> MotorStatus:
         """Return the current motor status / error code."""

--- a/almond_axol/motor/myactuator.py
+++ b/almond_axol/motor/myactuator.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import math
 import re
 import struct
@@ -17,9 +18,12 @@ from typing import Callable
 import can
 
 from .bus import CanBus
+from .config import MYACTUATOR_PARAMS, PARAM_SWEEP_RANGE, MyActuatorParam
 from .driver import MotorDriver
 from .errors import MotorError
 from .types import ControlMode, MotorGains, MotorStatus
+
+_logger = logging.getLogger(__name__)
 
 _MA_REQ = 0x140  # standard command request  → 0x140 + motor_id
 _MA_RESP = 0x240  # standard command response ← 0x240 + motor_id
@@ -44,6 +48,31 @@ _MA_WRITE_GAINS_ROM = (
     0x32  # write all PID gains to ROM (uint8, bulk); persistent by command
 )
 _MA_SET_ACCELERATION = 0x43  # write acceleration to RAM and ROM; persistent by command
+
+# Configuration-parameter access. These two commands are absent from MyActuator's
+# published protocol (V4.4) — they were recovered from the vendor setup software,
+# which uses them for every "advanced" / protection parameter the GUI exposes.
+#
+#   request: [0xC0, 0x00, index, rw, v0, v1, v2, v3]
+#
+# where ``rw`` selects read or write and ``v0..v3`` are a little-endian float32
+# (the value in the parameter's display unit — Volts for the threshold below).
+# A read echoes the frame back with the stored value in bytes 4-7. Writes only
+# land in RAM; 0xC1 commits every parameter written since the last commit to ROM.
+_MA_PARAM_ACCESS = 0xC0
+_MA_PARAM_SAVE = 0xC1  # commit 0xC0 writes to ROM; sent with an empty payload
+_MA_PARAM_READ = 0x01  # byte 3 of a 0xC0 frame
+_MA_PARAM_WRITE = 0x00
+
+# Undervoltage threshold applied to every motor on enable(). Negative, so the
+# bus voltage can never fall below it and the motor never latches the level-2
+# undervoltage fault (status-1 bit 0x0004).
+_MA_LOW_VOLTAGE_THRESHOLD_V = -2.0
+
+# Match tolerance (V) when checking the stored threshold against the target.
+# Only a mismatch triggers a write, so an already-provisioned motor doesn't
+# burn a ROM write cycle on every enable().
+_MA_LOW_VOLTAGE_TOL_V = 0.05
 
 # Seconds to wait after a 0x76 system reset before the motor answers again.
 # Measured reboot time is ~1.12s; 2.0s leaves margin across motors/temperature.
@@ -153,6 +182,11 @@ def _model_max_torque(model: str | None) -> float:
 class MyActuatorMotor(MotorDriver):
     """MotorDriver implementation for MyActuator RMD motors using the 0x140-series protocol."""
 
+    MOTOR_TYPE = "myactuator"
+    PARAMS = MYACTUATOR_PARAMS
+    # The 0xC0 table is still incomplete, so a raw sweep has something to find.
+    PARAM_SWEEP_RANGE = PARAM_SWEEP_RANGE
+
     def __init__(self, bus: CanBus, motor_id: int, kt: float) -> None:
         """Construct a MyActuator driver.
 
@@ -243,6 +277,59 @@ class MyActuatorMotor(MotorDriver):
         chars = raw.split(b"\x00", 1)[0]
         return chars.decode("ascii", errors="ignore")
 
+    async def _read_param(self, index: int) -> float:
+        """Read configuration parameter ``index`` via 0xC0.
+
+        Every parameter shares one response CAN ID and command byte, so
+        concurrent reads on the same motor would race — keep them sequential.
+        """
+        data = bytes([_MA_PARAM_ACCESS, 0x00, index, _MA_PARAM_READ, 0, 0, 0, 0])
+        resp = await self._request(data)
+        return float(struct.unpack_from("<f", resp, 4)[0])
+
+    async def _write_param(
+        self, index: int, value: float, *, commit: bool = True
+    ) -> None:
+        """Write configuration parameter ``index`` via 0xC0.
+
+        A 0xC0 write only lands in RAM. Pass ``commit=False`` to defer the 0xC1
+        that flushes it to ROM, so a batch of writes costs one ROM cycle
+        instead of one per parameter.
+        """
+        data = bytes([_MA_PARAM_ACCESS, 0x00, index, _MA_PARAM_WRITE]) + struct.pack(
+            "<f", value
+        )
+        await self._request(data)
+        if commit:
+            await self._commit_params()
+
+    async def _commit_params(self) -> None:
+        """Commit every 0xC0 write made since the last commit to ROM."""
+        await self._request(self._cmd(_MA_PARAM_SAVE))
+
+    async def _apply_low_voltage_threshold(self) -> None:
+        """Bring the undervoltage threshold to :data:`_MA_LOW_VOLTAGE_THRESHOLD_V`.
+
+        Reads first so an already-provisioned motor is left untouched. A motor
+        that doesn't answer keeps whatever threshold it has — that only costs
+        the (optional) undervoltage suppression, so warn rather than fail the
+        whole enable().
+        """
+        try:
+            current = await self.get_low_voltage_threshold()
+            if math.isclose(
+                current, _MA_LOW_VOLTAGE_THRESHOLD_V, abs_tol=_MA_LOW_VOLTAGE_TOL_V
+            ):
+                return
+            await self.set_low_voltage_threshold(_MA_LOW_VOLTAGE_THRESHOLD_V)
+        except MotorError as exc:
+            _logger.warning(
+                "MyActuator motor %#04x: could not set undervoltage threshold to %.1f V (%s)",
+                self._motor_id,
+                _MA_LOW_VOLTAGE_THRESHOLD_V,
+                exc,
+            )
+
     async def _detect_capabilities(self) -> None:
         """Read firmware version + model once and configure MIT-command ranges.
 
@@ -277,6 +364,7 @@ class MyActuatorMotor(MotorDriver):
             await self._detect_capabilities()
         except MotorError:
             pass
+        await self._apply_low_voltage_threshold()
         await self._request(self._cmd(_MA_RELEASE_BRAKE))
 
     async def get_firmware_version(self) -> int | None:
@@ -350,6 +438,21 @@ class MyActuatorMotor(MotorDriver):
         resp = await self._get_status1()
         raw = struct.unpack_from("<H", resp, 4)[0]
         return raw * 0.1  # 0.1 V/LSB
+
+    async def get_low_voltage_threshold(self) -> float:
+        return await self._read_param(MyActuatorParam.LOW_VOLTAGE)
+
+    async def set_low_voltage_threshold(self, volts: float) -> None:
+        await self._write_param(MyActuatorParam.LOW_VOLTAGE, volts)
+
+    async def _config_read(self, index: int) -> float:
+        return await self._read_param(index)
+
+    async def _config_write(self, index: int, value: float) -> None:
+        await self._write_param(index, value, commit=False)
+
+    async def _config_commit(self) -> None:
+        await self._commit_params()
 
     async def get_error_code(self) -> MotorStatus:
         resp = await self._get_status1()

--- a/almond_axol/serve/commands.py
+++ b/almond_axol/serve/commands.py
@@ -15,6 +15,10 @@ one-off checks (``motor.info`` / ``motor.health``, whose read set the
 dashboard's motor tiles show live), the remote ``inference-server``, and
 ``serve`` itself — stays CLI-only.
 
+``motor.restore-config`` is also CLI-only: it consumes a snapshot file, and a
+browser form can only name a path on the serve host, so the dashboard offers
+the read half (``motor.dump-config``) and single-parameter writes instead.
+
 :data:`COMMANDS` is a registry rather than a fixed table: a package that builds
 on ``almond-axol`` can :func:`register` its own commands before calling
 :func:`~almond_axol.serve.create_app`, and they flow through the API and the
@@ -418,6 +422,42 @@ COMMANDS: dict[str, CommandDef] = {
         "Calibrate",
         "argparse",
         _argparse_loader("..cli.motor.set_can_id"),
+        requires_hardware=True,
+    ),
+    "motor.dump-config": CommandDef(
+        "motor.dump-config",
+        "motor.dump-config",
+        "Dump config",
+        "Read every configuration parameter from one or all motors, MyActuator "
+        "or Damiao. Read-only — the run log is the snapshot to attach to a "
+        "support thread.",
+        "Calibrate",
+        "argparse",
+        _argparse_loader("..cli.motor.dump_config"),
+        requires_hardware=True,
+    ),
+    "motor.set-config": CommandDef(
+        "motor.set-config",
+        "motor.set-config",
+        "Set config parameter",
+        "Read or write a single configuration parameter on either motor family "
+        "— protection thresholds, position limits, motion planning caps, and "
+        "Damiao's CAN timeout.",
+        "Calibrate",
+        "argparse",
+        _argparse_loader("..cli.motor.set_config"),
+        requires_hardware=True,
+    ),
+    "motor.flash": CommandDef(
+        "motor.flash",
+        "motor.flash",
+        "Flash firmware",
+        "Overwrite a MyActuator motor's firmware from a .bin on the robot host. "
+        "Nothing else may use the bus while it runs, and an interrupted flash "
+        "leaves the motor in its bootloader until the flash is re-run.",
+        "Calibrate",
+        "argparse",
+        _argparse_loader("..cli.motor.flash"),
         requires_hardware=True,
     ),
     # -- Setup --------------------------------------------------------------

--- a/web/app/src/routes/Diagnostics.tsx
+++ b/web/app/src/routes/Diagnostics.tsx
@@ -1,5 +1,16 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { Activity, Cable, Crosshair, Loader2, Radio, Tag, Wrench } from "lucide-react"
+import {
+  Activity,
+  Cable,
+  Crosshair,
+  ClipboardList,
+  Loader2,
+  Radio,
+  SlidersHorizontal,
+  Tag,
+  Upload,
+  Wrench,
+} from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { SiteNav } from "@/components/site-nav"
@@ -76,7 +87,15 @@ const STATE_BADGE: Record<
 // tools. Used to recognise an already-running session and adopt it (see the
 // adoption effect) so its Stop button shows on any browser, not just the tab
 // that started it.
-const PAGE_COMMAND_IDS = ["can.setup", "can.enable", "motor.set-can-id", "motor.set-zero-pos"]
+const PAGE_COMMAND_IDS = [
+  "can.setup",
+  "can.enable",
+  "motor.set-can-id",
+  "motor.set-zero-pos",
+  "motor.dump-config",
+  "motor.set-config",
+  "motor.flash",
+]
 
 // The Axol hub adapter's persistent interface names (created by can.setup).
 // A configured channel equal to its hub default is omitted from launches so
@@ -452,15 +471,18 @@ export default function Diagnostics() {
     }
   }, [serverOk, activeRun, diagCommands])
 
-  // Motor calibration tools surfaced as buttons in the Motors header. Zeroing
-  // is one button whose dialog tabs between "specific motor" and the guided
-  // walk of every joint (both back motor.set-zero-pos via presets).
+  // Per-motor service tools surfaced as buttons in the Motors header: CAN ID,
+  // zeroing, configuration parameters, and firmware. A tool with modes tabs
+  // between presets of one command — zeroing between "specific motor" and the
+  // guided walk of every joint, config between reading and writing.
   const MOTOR_TOOLS: {
     key: string
     command: string
     label: string
     icon: typeof Tag
     description?: string
+    presetArgs?: Record<string, FormValue>
+    hideKeys?: string[]
     modes?: ActionMode[]
     /** Restrict the `--joints` picker's choices for this tool's dialog. */
     pickerJoints?: readonly JointName[]
@@ -498,6 +520,58 @@ export default function Diagnostics() {
           hideKeys: ["id", "type"],
         },
       ],
+    },
+    {
+      key: "dump-config",
+      command: "motor.dump-config",
+      label: "Dump config",
+      icon: ClipboardList,
+      description:
+        "Read every configuration parameter from one motor, or all of them when the " +
+        "CAN ID is left blank. Works for MyActuator and Damiao alike. Read-only — the " +
+        "run log is kept in the history below, so this is what to capture before " +
+        "changing anything.",
+    },
+    {
+      key: "set-config",
+      command: "motor.set-config",
+      label: "Set config",
+      icon: SlidersHorizontal,
+      modes: [
+        {
+          key: "read",
+          label: "Read",
+          description:
+            "Read one configuration parameter without writing anything. Parameter " +
+            "names cover both motor families, including Damiao's CAN timeout.",
+          hideKeys: ["value", "force_protected", "yes"],
+        },
+        {
+          key: "write",
+          label: "Write",
+          description:
+            "Write one configuration parameter and persist it. Damiao's CAN timeout " +
+            "is in milliseconds. Protected parameters — factory calibration, CAN IDs, " +
+            "baud rate — need the override, since changing those can leave the motor " +
+            "unable to commutate or unreachable on the bus.",
+          // Running the dialog is the confirmation; the CLI prompt would other-
+          // wise block the session waiting on stdin.
+          presetArgs: { yes: true },
+        },
+      ],
+    },
+    {
+      key: "flash",
+      command: "motor.flash",
+      label: "Flash firmware",
+      icon: Upload,
+      description:
+        "Overwrite one motor's firmware from a .bin file on the robot host. Leave " +
+        "the arm powered and idle — nothing else may use the bus. An interrupted " +
+        "flash leaves the motor in its bootloader until you run this again.",
+      // Running the dialog is the confirmation; the CLI prompt would otherwise
+      // block the session waiting on stdin.
+      presetArgs: { yes: true },
     },
   ]
   const [motorTool, setMotorTool] = useState<string | null>(null)
@@ -772,12 +846,14 @@ export default function Diagnostics() {
         <RunHistory runs={runs} loading={runsLoading} onRefresh={refreshRuns} onClear={clearRuns} />
       </main>
 
-      {/* Motor calibration tool dialog (Set CAN ID / Set zero position) */}
+      {/* Per-motor service tool dialog (CAN ID / zero / config / firmware) */}
       {openTool && openToolSpec && (
         <ActionDialog
           spec={openToolSpec}
           title={openTool.label}
           description={openTool.description}
+          presetArgs={openTool.presetArgs}
+          hideKeys={openTool.hideKeys}
           modes={openTool.modes}
           pickerJoints={openTool.pickerJoints}
           // The adapter mapping decides the interface (injected at launch);

--- a/web/app/src/routes/Diagnostics.tsx
+++ b/web/app/src/routes/Diagnostics.tsx
@@ -852,14 +852,17 @@ export default function Diagnostics() {
           spec={openToolSpec}
           title={openTool.label}
           description={openTool.description}
-          presetArgs={openTool.presetArgs}
-          hideKeys={openTool.hideKeys}
           modes={openTool.modes}
           pickerJoints={openTool.pickerJoints}
           // The adapter mapping decides the interface (injected at launch);
-          // a single-arm config also decides the arm.
-          hideKeys={configHiddenKeys}
-          presetArgs={onlySide ? { arm: onlySide } : undefined}
+          // a single-arm config also decides the arm. The tool's own presets
+          // (e.g. skipping a CLI confirmation the dialog already covers) and
+          // hidden fields stack on top.
+          hideKeys={[...configHiddenKeys, ...(openTool.hideKeys ?? [])]}
+          presetArgs={{
+            ...(onlySide ? { arm: onlySide } : {}),
+            ...(openTool.presetArgs ?? {}),
+          }}
           running={activeRun?.command === openTool.command}
           blocked={activeRun != null && activeRun.command !== openTool.command}
           busy={launchBusy}


### PR DESCRIPTION
## Summary

Recovering a misbehaving motor currently means walking a remote customer through MyActuator's Windows setup software or Damiao's DMTool, which we can't do over a support call. This adds the pieces we actually reach for, driven over CAN from the SDK.

- **MyActuator undervoltage threshold** is forced to -2V on `enable()`, so a motor that shipped with a positive threshold stops faulting when the bus sags. A failure to apply it warns rather than blocking startup.
- **Firmware updates over CAN** (`axol motor.flash <image.bin>`), using the YMODEM-1K transfer the setup software performs against the undocumented `0xC0`/`0xC1` bootloader commands.
- **Named configuration parameters for both motor families** — MyActuator's `0xC0` parameters and Damiao's `0x7FF` registers — with `motor.dump-config`, `motor.restore-config`, and single-parameter `motor.set-config`. Each parameter carries a unit and an access level, so a restore won't overwrite CAN IDs or baud rates unless `--include-protected` is passed, and read-only values are never written.
- **Damiao's CAN timeout** is exposed in milliseconds instead of its raw 50 µs register units.

Flash and the config commands are available from the diagnostics dashboard. `motor.restore-config` stays CLI-only: it consumes a snapshot file, and a browser form can only name a path on the serve host, so the dashboard offers the read half plus single-parameter writes instead.

The parameter tables and the flash protocol were recovered by disassembling the vendor tools; the shared read/write/dump/restore logic lives in `MotorDriver` with per-family `_config_read`/`_config_write`/`_config_commit` hooks.

The second commit is rebase follow-up: these commands predate non-Axol-hub CAN adapter support (#151) and had hardcoded the hub interface names, so they now use the shared arm/channel arguments like the other motor commands.

## Test plan

No hardware in this environment, so everything below was exercised against simulated motors and a simulated bootloader.

- [x] Damiao `TIMEOUT` round-trips through the ms↔50 µs conversion (1000 ms stores 20000 units); `0` disables the alarm and negatives are rejected
- [x] Read-only registers (`SW_VER`, `NPP`, `GR`) are refused; protected ones (`ESC_ID`) are skipped on restore unless `--include-protected`
- [x] `dump_config` covers all 37 Damiao registers and 21 MyActuator parameters; MyActuator raw index sweep still works
- [x] End-to-end CLI dump → set → restore on a mixed MyActuator/Damiao bus, including the cross-family parameter-name guard
- [x] Firmware flash against a simulated YMODEM bootloader
- [x] Serve catalog loads and all three new commands introspect their flags (including the new `channel` field)
- [x] `pre-commit run --all-files` passes; `web` builds (`tsc -b && vite build`); `eslint` shows no new problems versus `origin/main`
- [ ] Flash a real MyActuator and confirm the version reports correctly afterward
- [ ] Confirm the -2V threshold on real hardware clears the undervoltage faults we've seen

Made with [Cursor](https://cursor.com)