### PR TITLE
Pluggable IK backends: pink-qp default, swivel-circle elbow conditioning, offline solver bench

### DIFF
--- a/almond_axol/kinematics/__init__.py
+++ b/almond_axol/kinematics/__init__.py
@@ -1,6 +1,32 @@
-"""Public re-exports for almond_axol.kinematics."""
+"""Public re-exports for almond_axol.kinematics.
 
+``KinematicsSolver`` (the original pyroki Levenberg-Marquardt solver) is
+imported lazily: the teleop IK path now goes through the pluggable backend
+factory (:func:`create_backend`), and eagerly importing the solver would pull
+JAX in even when a non-JAX backend is selected.
+"""
+
+from typing import TYPE_CHECKING, Any
+
+from .backends import BACKEND_NAMES, create_backend
+from .base import IKBackend
 from .config import KinematicsConfig
-from .solver import KinematicsSolver
 
-__all__ = ["KinematicsConfig", "KinematicsSolver"]
+if TYPE_CHECKING:
+    from .solver import KinematicsSolver
+
+__all__ = [
+    "BACKEND_NAMES",
+    "IKBackend",
+    "KinematicsConfig",
+    "KinematicsSolver",
+    "create_backend",
+]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "KinematicsSolver":
+        from .solver import KinematicsSolver
+
+        return KinematicsSolver
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/almond_axol/kinematics/backends/__init__.py
+++ b/almond_axol/kinematics/backends/__init__.py
@@ -1,0 +1,62 @@
+"""IK backend registry + factory.
+
+``pink-qp`` won the 2026-07 offline solver bake-off (see ``bench.py``) and is
+the default; the other candidates are kept for on-hardware A/B comparison
+(``axol teleop --kinematics.backend=...``). Backends are imported lazily so
+selecting one never pays the import cost (or requires the dependencies) of
+the others — e.g. ``mink-qp`` works without JAX warm-up, and ``pyroki-lm``
+works without mink/pink installed.
+"""
+
+from __future__ import annotations
+
+from ..base import IKBackend
+from ..config import KinematicsConfig
+
+BACKEND_NAMES: tuple[str, ...] = (
+    "pink-qp",
+    "pyroki-lm",
+    "pyroki-diff",
+    "mink-qp",
+    "dls",
+)
+
+
+def create_backend(config: KinematicsConfig, dt: float) -> IKBackend:
+    """Instantiate the IK backend selected by ``config.backend``.
+
+    Args:
+        config: Solver parameters (including the ``backend`` selector).
+        dt: Integration timestep in seconds — the interval between
+            consecutive :meth:`IKBackend.ik` calls (the teleop IK rate).
+
+    Returns:
+        A ready (warmed-up) backend instance.
+    """
+    name = config.backend
+    if name == "pink-qp":
+        from .pink_qp import PinkBackend
+
+        return PinkBackend(config, dt)
+    if name == "pyroki-lm":
+        from .pyroki_lm import PyrokiLMBackend
+
+        return PyrokiLMBackend(config)
+    if name == "pyroki-diff":
+        from .pyroki_diff import PyrokiDiffBackend
+
+        return PyrokiDiffBackend(config, dt)
+    if name == "mink-qp":
+        from .mink_qp import MinkBackend
+
+        return MinkBackend(config, dt)
+    if name == "dls":
+        from .dls import DLSBackend
+
+        return DLSBackend(config, dt)
+    raise ValueError(
+        f"Unknown IK backend {name!r}; expected one of {list(BACKEND_NAMES)}"
+    )
+
+
+__all__ = ["BACKEND_NAMES", "create_backend", "IKBackend"]

--- a/almond_axol/kinematics/backends/dls.py
+++ b/almond_axol/kinematics/backends/dls.py
@@ -1,0 +1,212 @@
+"""``dls`` backend: custom damped-least-squares differential IK in NumPy.
+
+Fully self-contained velocity-level solver with zero new dependencies:
+MuJoCo (already a core dependency) provides forward kinematics and geometric
+Jacobians; the solve itself is a weighted damped least squares with
+
+- **SVD-adaptive damping**: the damping factor grows as the smallest task-
+  space singular value approaches zero, so joint velocities stay bounded
+  through singularities (Nakamura & Hanafusa's classic scheme),
+- **null-space posture**: the preferred-posture attractor acts through the
+  projector ``N = I - J⁺J`` so it can never disturb tracking,
+- **joint-limit velocity damper + hard clip**: motion toward a limit slows
+  linearly inside an influence zone and is clipped at the bound, so limits
+  behave like a smooth detent instead of a soft cost the solver can fight.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import mujoco
+import numpy as np
+from scipy.spatial.transform import Rotation
+
+from ..base import CANONICAL_JOINT_NAMES, FKFrames, IKBackend, frame_body_names
+from ..config import KinematicsConfig
+from ..mujoco_model import load_mj_model
+
+_logger = logging.getLogger(__name__)
+
+_LIMIT_INFLUENCE = 0.15
+"""Joint-limit velocity-damper influence zone (rad)."""
+
+_SIGMA_TH_SCALE = 0.02
+"""Singular-value threshold as a fraction of the position task weight."""
+
+
+class DLSBackend(IKBackend):
+    """Adaptive damped least squares with null-space posture, in NumPy."""
+
+    name = "dls"
+
+    def __init__(self, config: KinematicsConfig, dt: float) -> None:
+        self._config = config
+        self._dt = dt
+
+        model = load_mj_model(with_meshes=False)
+        self._model = model
+        self._data = mujoco.MjData(model)
+
+        qidx: list[int] = []
+        didx: list[int] = []
+        for name in CANONICAL_JOINT_NAMES:
+            jid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, name)
+            if jid < 0:
+                raise RuntimeError(f"Joint {name!r} not found in MuJoCo model")
+            qidx.append(int(model.jnt_qposadr[jid]))
+            didx.append(int(model.jnt_dofadr[jid]))
+        self._qidx = np.array(qidx, dtype=np.int64)
+        self._didx = np.array(didx, dtype=np.int64)
+
+        jnt_ids = [
+            mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, n)
+            for n in CANONICAL_JOINT_NAMES
+        ]
+        self._lower = model.jnt_range[jnt_ids, 0].astype(np.float64)
+        self._upper = model.jnt_range[jnt_ids, 1].astype(np.float64)
+
+        names = frame_body_names()
+        self._bids = {
+            key: mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, name)
+            for key, name in names.items()
+        }
+
+        self._posture = np.zeros(self.num_joints, dtype=np.float64)
+
+        self._fk(np.zeros(self.num_joints, dtype=np.float32))
+        self.left_shoulder_pos = np.asarray(
+            self._data.xpos[self._bids["left_shoulder"]], dtype=np.float32
+        ).copy()
+        self.right_shoulder_pos = np.asarray(
+            self._data.xpos[self._bids["right_shoulder"]], dtype=np.float32
+        ).copy()
+        _logger.info("dls backend ready.")
+
+    # -- Internal helpers -----------------------------------------------------
+
+    def _fk(self, q_canonical: np.ndarray) -> None:
+        self._data.qpos[:] = 0.0
+        self._data.qpos[self._qidx] = np.asarray(q_canonical, dtype=np.float64)
+        mujoco.mj_kinematics(self._model, self._data)
+        mujoco.mj_comPos(self._model, self._data)
+
+    def _body_jac(self, bid: int) -> tuple[np.ndarray, np.ndarray]:
+        nv = self._model.nv
+        jacp = np.zeros((3, nv))
+        jacr = np.zeros((3, nv))
+        mujoco.mj_jacBody(self._model, self._data, jacp, jacr, bid)
+        return jacp[:, self._didx], jacr[:, self._didx]
+
+    def _pose(self, key: str) -> tuple[np.ndarray, np.ndarray]:
+        bid = self._bids[key]
+        pos = np.asarray(self._data.xpos[bid], dtype=np.float64)
+        rot = np.asarray(self._data.xmat[bid].reshape(3, 3), dtype=np.float64)
+        return pos, rot
+
+    # -- IKBackend interface ----------------------------------------------------
+
+    def ik(
+        self,
+        q_current: np.ndarray,
+        left_pose: tuple[np.ndarray, np.ndarray] | None = None,
+        right_pose: tuple[np.ndarray, np.ndarray] | None = None,
+        left_elbow_pos: np.ndarray | None = None,
+        right_elbow_pos: np.ndarray | None = None,
+    ) -> np.ndarray:
+        if left_pose is None and right_pose is None:
+            return np.asarray(q_current, dtype=np.float32).copy()
+
+        cfg = self._config
+        n = self.num_joints
+        n_iters = max(1, cfg.diff_iters)
+        sub_dt = self._dt / n_iters
+        max_step = cfg.diff_max_joint_vel * sub_dt
+
+        q = np.asarray(q_current, dtype=np.float64).copy()
+        for _ in range(n_iters):
+            self._fk(q)
+
+            rows: list[np.ndarray] = []
+            errs: list[np.ndarray] = []
+
+            def add_pose_task(key: str, target: tuple[np.ndarray, np.ndarray]) -> None:
+                pos, rot = self._pose(key)
+                jacp, jacr = self._body_jac(self._bids[key])
+                t_pos = np.asarray(target[0], dtype=np.float64)
+                t_rot = np.asarray(target[1], dtype=np.float64)
+                rows.append(cfg.diff_position_cost * jacp)
+                errs.append(cfg.diff_position_cost * (t_pos - pos))
+                rot_err = Rotation.from_matrix(t_rot @ rot.T).as_rotvec()
+                rows.append(cfg.diff_orientation_cost * jacr)
+                errs.append(cfg.diff_orientation_cost * rot_err)
+
+            def add_point_task(key: str, target: np.ndarray) -> None:
+                pos, _ = self._pose(key)
+                jacp, _ = self._body_jac(self._bids[key])
+                t = np.asarray(target, dtype=np.float64)
+                rows.append(cfg.diff_elbow_cost * jacp)
+                errs.append(cfg.diff_elbow_cost * (t - pos))
+
+            if left_pose is not None:
+                add_pose_task("left_ee", left_pose)
+            if right_pose is not None:
+                add_pose_task("right_ee", right_pose)
+            if left_elbow_pos is not None:
+                add_point_task("left_elbow", left_elbow_pos)
+            if right_elbow_pos is not None:
+                add_point_task("right_elbow", right_elbow_pos)
+
+            J = np.vstack(rows)
+            e = np.concatenate(errs)
+
+            # SVD-adaptive damping: raise damping as the smallest singular
+            # value approaches zero (Nakamura & Hanafusa).
+            U, S, Vt = np.linalg.svd(J, full_matrices=False)
+            sigma_th = _SIGMA_TH_SCALE * cfg.diff_position_cost
+            lam_max = 0.5 * sigma_th
+            s_min = S[-1]
+            lam2 = cfg.diff_damping
+            if s_min < sigma_th:
+                lam2 = lam2 + (1.0 - (s_min / sigma_th) ** 2) * lam_max**2
+            gains = S / (S**2 + lam2)
+            dq = Vt.T @ (gains * (U.T @ e))
+
+            # Null-space posture attractor: project through N = I - J⁺J so it
+            # cannot disturb the task.
+            jjp = Vt.T @ np.diag(S**2 / (S**2 + lam2)) @ Vt
+            nullspace = np.eye(n) - jjp
+            v_post = cfg.diff_posture_cost * (self._posture - q)
+            dq = dq + nullspace @ (v_post * sub_dt)
+
+            # Joint-limit velocity damper: scale motion toward a limit down
+            # linearly inside the influence zone, then hard-clip at the bound.
+            dist_up = np.maximum(self._upper - q, 0.0)
+            dist_lo = np.maximum(q - self._lower, 0.0)
+            up_scale = np.minimum(dist_up / _LIMIT_INFLUENCE, 1.0)
+            lo_scale = np.minimum(dist_lo / _LIMIT_INFLUENCE, 1.0)
+            dq = np.where(dq > 0, dq * up_scale, dq * lo_scale)
+
+            dq = np.clip(dq, -max_step, max_step)
+            q = np.clip(q + dq, self._lower, self._upper)
+
+        return q.astype(np.float32)
+
+    def fk_frames(self, q: np.ndarray) -> FKFrames:
+        self._fk(q)
+
+        def _cast(pose: tuple[np.ndarray, np.ndarray]) -> tuple[np.ndarray, np.ndarray]:
+            return (
+                pose[0].astype(np.float32).copy(),
+                pose[1].astype(np.float32).copy(),
+            )
+
+        return FKFrames(
+            left_ee=_cast(self._pose("left_ee")),
+            right_ee=_cast(self._pose("right_ee")),
+            left_elbow=self._pose("left_elbow")[0].astype(np.float32).copy(),
+            right_elbow=self._pose("right_elbow")[0].astype(np.float32).copy(),
+        )
+
+    def set_posture_pose(self, q: np.ndarray) -> None:
+        self._posture = np.asarray(q, dtype=np.float64).copy()

--- a/almond_axol/kinematics/backends/mink_qp.py
+++ b/almond_axol/kinematics/backends/mink_qp.py
@@ -1,0 +1,219 @@
+"""``mink-qp`` backend: MuJoCo QP differential IK (the OpenArm reference stack).
+
+Velocity-level IK solved as one quadratic program per tick: end-effector /
+elbow / posture tasks in the objective, joint position limits and joint
+velocity limits as *hard* inequality constraints, plus an optional
+arm<->torso collision-clearance constraint (off by default — the coarse STL
+convex hulls overlap the nominal workspace, and the bake-off showed the
+constraint chattering against them; see
+``KinematicsConfig.diff_collision_margin``). Integrating the solved velocity
+from the current configuration makes the output inherently smooth — there is
+no trust region to reject steps (no freeze/lurch) and Tikhonov damping keeps
+behaviour graceful through singularities.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import mink
+import mujoco
+import numpy as np
+
+from ..base import CANONICAL_JOINT_NAMES, FKFrames, IKBackend, frame_body_names
+from ..config import KinematicsConfig
+from ..mujoco_model import arm_torso_geom_pairs, canonical_qpos_indices, load_mj_model
+
+_logger = logging.getLogger(__name__)
+
+_QP_SOLVER = "daqp"
+
+
+class MinkBackend(IKBackend):
+    """Differential IK on MuJoCo via mink, both arms in a single QP."""
+
+    name = "mink-qp"
+
+    def __init__(self, config: KinematicsConfig, dt: float) -> None:
+        self._config = config
+        self._dt = dt
+
+        model = load_mj_model(with_meshes=True)
+        self._model = model
+        self._qidx = canonical_qpos_indices(model)
+        self._configuration = mink.Configuration(model)
+        self._fk_data = mujoco.MjData(model)
+
+        names = frame_body_names()
+        self._body_names = names
+        self._l_ee_task = mink.FrameTask(
+            frame_name=names["left_ee"],
+            frame_type="body",
+            position_cost=config.diff_position_cost,
+            orientation_cost=config.diff_orientation_cost,
+            lm_damping=config.diff_lm_damping,
+        )
+        self._r_ee_task = mink.FrameTask(
+            frame_name=names["right_ee"],
+            frame_type="body",
+            position_cost=config.diff_position_cost,
+            orientation_cost=config.diff_orientation_cost,
+            lm_damping=config.diff_lm_damping,
+        )
+        self._l_elbow_task = mink.FrameTask(
+            frame_name=names["left_elbow"],
+            frame_type="body",
+            position_cost=config.diff_elbow_cost,
+            orientation_cost=0.0,
+            lm_damping=config.diff_lm_damping,
+        )
+        self._r_elbow_task = mink.FrameTask(
+            frame_name=names["right_elbow"],
+            frame_type="body",
+            position_cost=config.diff_elbow_cost,
+            orientation_cost=0.0,
+            lm_damping=config.diff_lm_damping,
+        )
+        self._posture_task = mink.PostureTask(
+            model=model, cost=config.diff_posture_cost
+        )
+        self._tasks = [
+            self._l_ee_task,
+            self._r_ee_task,
+            self._l_elbow_task,
+            self._r_elbow_task,
+            self._posture_task,
+        ]
+
+        limits = [
+            mink.ConfigurationLimit(model),
+            mink.VelocityLimit(
+                model,
+                {n: config.diff_max_joint_vel for n in CANONICAL_JOINT_NAMES},
+            ),
+        ]
+        if config.diff_collision_margin > 0.0:
+            pairs = arm_torso_geom_pairs(model, margin=config.diff_collision_margin)
+            if pairs:
+                limits.append(
+                    mink.CollisionAvoidanceLimit(
+                        model,
+                        geom_pairs=pairs,
+                        minimum_distance_from_collisions=config.diff_collision_margin,
+                        collision_detection_distance=config.diff_collision_margin
+                        + 0.05,
+                    )
+                )
+        self._limits = limits
+
+        mujoco.mj_kinematics(model, self._fk_data)
+        self.left_shoulder_pos = self._body_pos(names["left_shoulder"]).copy()
+        self.right_shoulder_pos = self._body_pos(names["right_shoulder"]).copy()
+
+        self.set_posture_pose(np.zeros(self.num_joints, dtype=np.float32))
+        self._warmup()
+
+    # -- Internal helpers -----------------------------------------------------
+
+    def _body_pos(self, name: str) -> np.ndarray:
+        bid = mujoco.mj_name2id(self._model, mujoco.mjtObj.mjOBJ_BODY, name)
+        return np.asarray(self._fk_data.xpos[bid], dtype=np.float32)
+
+    def _to_mj(self, q_canonical: np.ndarray) -> np.ndarray:
+        q = np.zeros(self._model.nq, dtype=np.float64)
+        q[self._qidx] = np.asarray(q_canonical, dtype=np.float64)
+        return q
+
+    @staticmethod
+    def _se3(pos: np.ndarray, rot: np.ndarray | None) -> mink.SE3:
+        so3 = (
+            mink.SO3.identity()
+            if rot is None
+            else mink.SO3.from_matrix(np.asarray(rot, dtype=np.float64))
+        )
+        return mink.SE3.from_rotation_and_translation(
+            so3, np.asarray(pos, dtype=np.float64)
+        )
+
+    def _warmup(self) -> None:
+        q = np.zeros(self.num_joints, dtype=np.float32)
+        frames = self.fk_frames(q)
+        self.ik(
+            q,
+            left_pose=frames.left_ee,
+            right_pose=frames.right_ee,
+            left_elbow_pos=frames.left_elbow,
+            right_elbow_pos=frames.right_elbow,
+        )
+        _logger.info("mink-qp backend ready.")
+
+    # -- IKBackend interface ----------------------------------------------------
+
+    def ik(
+        self,
+        q_current: np.ndarray,
+        left_pose: tuple[np.ndarray, np.ndarray] | None = None,
+        right_pose: tuple[np.ndarray, np.ndarray] | None = None,
+        left_elbow_pos: np.ndarray | None = None,
+        right_elbow_pos: np.ndarray | None = None,
+    ) -> np.ndarray:
+        if left_pose is None and right_pose is None:
+            return np.asarray(q_current, dtype=np.float32).copy()
+
+        cfg = self._config
+        self._configuration.update(self._to_mj(q_current))
+
+        if left_pose is not None:
+            self._l_ee_task.set_target(self._se3(left_pose[0], left_pose[1]))
+        else:
+            self._l_ee_task.set_target_from_configuration(self._configuration)
+        if right_pose is not None:
+            self._r_ee_task.set_target(self._se3(right_pose[0], right_pose[1]))
+        else:
+            self._r_ee_task.set_target_from_configuration(self._configuration)
+        if left_elbow_pos is not None:
+            self._l_elbow_task.set_target(self._se3(left_elbow_pos, None))
+        else:
+            self._l_elbow_task.set_target_from_configuration(self._configuration)
+        if right_elbow_pos is not None:
+            self._r_elbow_task.set_target(self._se3(right_elbow_pos, None))
+        else:
+            self._r_elbow_task.set_target_from_configuration(self._configuration)
+
+        n_iters = max(1, cfg.diff_iters)
+        sub_dt = self._dt / n_iters
+        for _ in range(n_iters):
+            vel = mink.solve_ik(
+                self._configuration,
+                self._tasks,
+                sub_dt,
+                _QP_SOLVER,
+                damping=cfg.diff_damping,
+                limits=self._limits,
+            )
+            self._configuration.integrate_inplace(vel, sub_dt)
+
+        return np.asarray(self._configuration.q[self._qidx], dtype=np.float32)
+
+    def fk_frames(self, q: np.ndarray) -> FKFrames:
+        self._fk_data.qpos[:] = self._to_mj(q)
+        mujoco.mj_kinematics(self._model, self._fk_data)
+        names = self._body_names
+
+        def _pose(name: str) -> tuple[np.ndarray, np.ndarray]:
+            bid = mujoco.mj_name2id(self._model, mujoco.mjtObj.mjOBJ_BODY, name)
+            pos = np.asarray(self._fk_data.xpos[bid], dtype=np.float32)
+            rot = np.asarray(self._fk_data.xmat[bid].reshape(3, 3), dtype=np.float32)
+            return pos, rot
+
+        l_ee = _pose(names["left_ee"])
+        r_ee = _pose(names["right_ee"])
+        return FKFrames(
+            left_ee=l_ee,
+            right_ee=r_ee,
+            left_elbow=_pose(names["left_elbow"])[0],
+            right_elbow=_pose(names["right_elbow"])[0],
+        )
+
+    def set_posture_pose(self, q: np.ndarray) -> None:
+        self._posture_task.set_target(self._to_mj(q))

--- a/almond_axol/kinematics/backends/pink_qp.py
+++ b/almond_axol/kinematics/backends/pink_qp.py
@@ -1,0 +1,449 @@
+"""``pink-qp`` backend: Pinocchio QP differential IK (bake-off winner).
+
+Velocity-level IK solved as one small QP per tick on the Pinocchio rigid-body
+library: end-effector / elbow / posture tasks in the objective, joint position
+and velocity limits as hard QP inequality constraints, plus an arm<->torso
+self-collision barrier (control-barrier-function inequality on convex pair
+distances; arm links versus base/torso only, never arm<->arm — see
+``KinematicsConfig.diff_collision_margin``).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import pinocchio as pin
+import pink
+from pink.barriers import SelfCollisionBarrier
+from pink.limits import ConfigurationLimit, VelocityLimit
+from pink.tasks import FrameTask, PostureTask
+
+from ...constants import URDF_PATH, Joint, urdf_joint_name
+from ..base import CANONICAL_JOINT_NAMES, FKFrames, IKBackend, frame_body_names
+from ..config import KinematicsConfig
+
+_logger = logging.getLogger(__name__)
+
+_QP_SOLVER = "daqp"
+
+_TORSO_LINKS: tuple[str, ...] = ("base", "s1")
+
+_SHOULDER_SUFFIXES: tuple[str, ...] = ("_s2", "_s3")
+"""Arm links excluded from the barrier: the shoulder clusters orbit the base
+column at ~18-22 mm across the whole joint range (inside any useful margin),
+so a minimum-distance constraint on them wedges permanently and shoves the
+arm's null space; joint limits, not the barrier, keep them safe. Measured:
+with them included the barrier rode ``s3<->base`` at exactly the margin and
+displaced the solution up to 115 deg from the unconstrained one."""
+
+_BARRIER_GAIN = 10.0
+"""CBF gain: max approach speed toward the margin is ``gain * (d - d_min)``.
+
+The gain sets where braking starts, so it trades penetration against how
+much of the workspace the constraint slows down: low gains brake from tens
+of centimetres away and drag on ordinary motion, very high gains brake so
+late that the discrete 120 Hz step overshoots the margin. 10 is the value
+that ran the most real-hardware hours without either a reported contact or
+a complaint attributable to the barrier. Verify the bench ``torso-graze``
+scenario when changing this.
+"""
+
+_PRUNE_THRESHOLD = 0.025
+"""Home-pose clearance (m) a pair needs to stay in the barrier.
+
+Fixed — deliberately *not* derived from the runtime margin. The pair set
+must not change with the margin: deriving the threshold as ``margin +
+buffer`` meant a small margin re-admitted the shoulder-adjacent pairs that
+sit 18-22 mm from the column across their whole joint range (they wedge the
+QP — see ``_SHOULDER_SUFFIXES``), while a large margin silently pruned the
+forearm<->base pairs that provide the actual protection. 0.025 sits between
+the shoulder-cluster clearance (~22 mm) and the forearm rest clearance
+(~27 mm), giving the same pair set at any margin.
+"""
+
+
+def _build_collision_model(
+    model: pin.Model, margin: float, threshold: float | None = None
+) -> pin.GeometryModel | None:
+    """Convex-hull collision model restricted to feasible arm<->torso pairs.
+
+    Mirrors :func:`almond_axol.kinematics.mujoco_model.arm_torso_geom_pairs`:
+    only arm<->torso pairs matter, and pairs already within
+    ``_PRUNE_THRESHOLD`` at the home pose are dropped (close by construction;
+    a hard minimum-distance constraint on them would permanently fight the
+    task). ``margin`` is only logged — the pair set is margin-independent.
+    """
+    urdf = URDF_PATH.read_text().replace(
+        "package://assembly/meshes/", str(URDF_PATH.parent / "meshes") + "/"
+    )
+    geom_model = pin.buildGeomFromUrdfString(model, urdf, pin.GeometryType.COLLISION)
+    for gobj in geom_model.geometryObjects:
+        gobj.geometry.buildConvexRepresentation(False)
+        gobj.geometry = gobj.geometry.convex
+
+    torso_gids: list[int] = []
+    arm_gids: list[int] = []
+    for gid, gobj in enumerate(geom_model.geometryObjects):
+        link = model.frames[gobj.parentFrame].name
+        if link in _TORSO_LINKS:
+            torso_gids.append(gid)
+        elif link.startswith(("left_", "right_")) and not link.endswith(
+            _SHOULDER_SUFFIXES
+        ):
+            arm_gids.append(gid)
+    for a in arm_gids:
+        for t in torso_gids:
+            geom_model.addCollisionPair(pin.CollisionPair(a, t))
+
+    data = model.createData()
+    geom_data = pin.GeometryData(geom_model)
+    pin.computeDistances(model, data, geom_model, geom_data, np.zeros(model.nq))
+    threshold = _PRUNE_THRESHOLD if threshold is None else threshold
+    keep = [
+        k
+        for k in range(len(geom_model.collisionPairs))
+        if geom_data.distanceResults[k].min_distance > threshold
+    ]
+    pruned = len(geom_model.collisionPairs) - len(keep)
+    for k in sorted(
+        set(range(len(geom_model.collisionPairs))) - set(keep), reverse=True
+    ):
+        geom_model.removeCollisionPair(geom_model.collisionPairs[k])
+    _logger.info(
+        "pink collision: %d active arm<->torso pairs (%d pruned at home, "
+        "margin %.0f mm).",
+        len(geom_model.collisionPairs),
+        pruned,
+        margin * 1e3,
+    )
+    if not geom_model.collisionPairs:
+        return None
+    return geom_model
+
+
+class _ArmTorsoBarrier(SelfCollisionBarrier):
+    """``SelfCollisionBarrier`` with a fast Jacobian for arm<->torso pairs.
+
+    The stock implementation costs ~2.5 ms per call here: a Python loop with
+    ~20 small-array numpy ops per pair (each a few microseconds on this ARM
+    CPU), an ``np.allclose`` per pair, closest-pair re-sorting, and a full
+    two-body Jacobian even though our torso geoms sit on fixed links whose
+    Jacobian is identically zero. This override produces bit-identical rows
+    vectorised across pairs — one wrench-matrix product per moving joint —
+    and skips fixed links.
+    """
+
+    def compute_barrier(self, configuration: pink.Configuration) -> np.ndarray:
+        results = configuration.collision_data.distanceResults
+        return np.array([results[k].min_distance - self.d_min for k in range(self.dim)])
+
+    def compute_jacobian(self, configuration: pink.Configuration) -> np.ndarray:
+        model = configuration.model
+        data = configuration.data
+        cm = configuration.collision_model
+        cd = configuration.collision_data
+
+        # Static structure (the collision model never changes after
+        # construction): the moving joint of each pair's arm-side geometry,
+        # remapped to a compact list of unique joints. The torso-side
+        # geometries all sit on fixed links (parentJoint 0, zero Jacobian),
+        # so only the arm-side term of the distance gradient survives.
+        maps = getattr(self, "_pair_maps", None)
+        if maps is None:
+            pair_jids = []
+            for cp in cm.collisionPairs:
+                jids = [
+                    cm.geometryObjects[gid].parentJoint for gid in (cp.first, cp.second)
+                ]
+                moving = [j for j in jids if j != 0]
+                if len(moving) != 1 or cm.geometryObjects[cp.second].parentJoint != 0:
+                    raise RuntimeError(
+                        "_ArmTorsoBarrier expects pairs of (moving arm geom, "
+                        "fixed torso geom)."
+                    )
+                pair_jids.append(moving[0])
+            unique = sorted(set(pair_jids))
+            maps = (unique, np.array([unique.index(j) for j in pair_jids]))
+            self._pair_maps = maps
+        unique_jids, pair_to_unique = maps
+
+        K = self.dim
+        w1 = np.empty((K, 3))
+        w2 = np.empty((K, 3))
+        for k in range(K):
+            dr = cd.distanceResults[k]
+            w1[k] = dr.getNearestPoint1()
+            w2[k] = dr.getNearestPoint2()
+        sep = w1 - w2
+        dist = np.linalg.norm(sep, axis=1)
+        # Touching pairs (distance ~0) have an undefined gradient; their
+        # normal is zeroed so the row stays zero (matches the stock code).
+        n = np.where((dist > 1e-9)[:, None], sep / np.maximum(dist, 1e-9)[:, None], 0.0)
+
+        jacs = np.stack(
+            [
+                pin.getJointJacobian(
+                    model, data, jid, pin.ReferenceFrame.LOCAL_WORLD_ALIGNED
+                )
+                for jid in unique_jids
+            ]
+        )
+        origins = np.stack([data.oMi[jid].translation for jid in unique_jids])
+        r = w1 - origins[pair_to_unique]
+        wrench = np.hstack([n, np.cross(r, n)])
+        return np.einsum("kf,kfv->kv", wrench, jacs[pair_to_unique])
+
+
+class PinkBackend(IKBackend):
+    """Differential IK on Pinocchio via pink, both arms in a single QP."""
+
+    name = "pink-qp"
+
+    def __init__(self, config: KinematicsConfig, dt: float) -> None:
+        self._config = config
+        self._dt = dt
+
+        model = pin.buildModelFromUrdf(str(URDF_PATH))
+        # The URDF's 30 rad/s placeholder velocity limits are far beyond the
+        # hardware; enforce the configured teleop limit instead.
+        model.velocityLimit[:] = config.diff_max_joint_vel
+        # Shoulder yaw/roll get half the global limit. They are the arm's
+        # internal-reconfiguration pair: near the singular shoulder
+        # (|shoulder_2| ~ 90 deg, crossed by every reach above shoulder
+        # height) the swivel self-motion collapses onto an s1/s3
+        # counter-rotation whose gain diverges, and the solver answers a
+        # slowly moving hand with a violent whole-arm unwind at whatever
+        # speed it is allowed — measured 300+ deg/s on captured sessions
+        # while the hand crawled at 0.15 m/s. Ordinary teleop keeps these
+        # joints under 135 deg/s (p99 across captured sessions), so pi rad/s
+        # slows only the pathological reconfigurations, spreading them over
+        # time instead of snapping.
+        for joint in (Joint.SHOULDER_1, Joint.SHOULDER_3):
+            for is_left in (True, False):
+                jid = model.getJointId(urdf_joint_name(joint, is_left=is_left))
+                model.velocityLimit[model.joints[jid].idx_v] = min(
+                    config.diff_max_joint_vel, np.pi
+                )
+        self._model = model
+        self._qidx = np.array(
+            [model.joints[model.getJointId(n)].idx_q for n in CANONICAL_JOINT_NAMES],
+            dtype=np.int64,
+        )
+        self._fk_data = model.createData()
+
+        names = frame_body_names()
+        self._body_names = names
+        self._frame_ids = {key: model.getFrameId(frame) for key, frame in names.items()}
+
+        self._barriers: list[SelfCollisionBarrier] = []
+        collision_model = (
+            _build_collision_model(model, config.diff_collision_margin)
+            if config.diff_collision_margin > 0.0
+            else None
+        )
+        if collision_model is not None:
+            self._configuration = pink.Configuration(
+                model,
+                model.createData(),
+                np.zeros(model.nq),
+                collision_model=collision_model,
+                collision_data=pin.GeometryData(collision_model),
+            )
+            self._barriers.append(
+                _ArmTorsoBarrier(
+                    n_collision_pairs=len(collision_model.collisionPairs),
+                    gain=_BARRIER_GAIN,
+                    safe_displacement_gain=0.0,
+                    d_min=config.diff_collision_margin,
+                )
+            )
+        else:
+            self._configuration = pink.Configuration(
+                model, model.createData(), np.zeros(model.nq)
+            )
+        self._l_ee_task = FrameTask(
+            names["left_ee"],
+            position_cost=config.diff_position_cost,
+            orientation_cost=config.diff_orientation_cost,
+            lm_damping=config.diff_lm_damping,
+        )
+        self._r_ee_task = FrameTask(
+            names["right_ee"],
+            position_cost=config.diff_position_cost,
+            orientation_cost=config.diff_orientation_cost,
+            lm_damping=config.diff_lm_damping,
+        )
+        self._l_elbow_task = FrameTask(
+            names["left_elbow"],
+            position_cost=config.diff_elbow_cost,
+            orientation_cost=0.0,
+            lm_damping=config.diff_lm_damping,
+        )
+        self._r_elbow_task = FrameTask(
+            names["right_elbow"],
+            position_cost=config.diff_elbow_cost,
+            orientation_cost=0.0,
+            lm_damping=config.diff_lm_damping,
+        )
+        # Canonical indices of the two shoulder_2 joints, whose angle is the
+        # conditioning of the swivel null space (see _gate_elbow_tasks).
+        self._l_s2_idx = CANONICAL_JOINT_NAMES.index(
+            urdf_joint_name(Joint.SHOULDER_2, is_left=True)
+        )
+        self._r_s2_idx = CANONICAL_JOINT_NAMES.index(
+            urdf_joint_name(Joint.SHOULDER_2, is_left=False)
+        )
+        self._posture_task = PostureTask(cost=config.diff_posture_cost)
+        self._tasks = [
+            self._l_ee_task,
+            self._r_ee_task,
+            self._posture_task,
+        ]
+        # With the elbow weight at zero the tasks would only add rows of
+        # zeros to the QP; keep them out entirely.
+        if config.diff_elbow_cost > 0.0:
+            self._tasks[2:2] = [self._l_elbow_task, self._r_elbow_task]
+        self._limits = [ConfigurationLimit(model), VelocityLimit(model)]
+
+        frames = self.fk_frames(np.zeros(self.num_joints, dtype=np.float32))
+        pin.framesForwardKinematics(model, self._fk_data, np.zeros(model.nq))
+        self.left_shoulder_pos = np.asarray(
+            self._fk_data.oMf[self._frame_ids["left_shoulder"]].translation,
+            dtype=np.float32,
+        )
+        self.right_shoulder_pos = np.asarray(
+            self._fk_data.oMf[self._frame_ids["right_shoulder"]].translation,
+            dtype=np.float32,
+        )
+
+        self.set_posture_pose(np.zeros(self.num_joints, dtype=np.float32))
+        # Warm-up solve (builds the QP once).
+        self.ik(
+            np.zeros(self.num_joints, dtype=np.float32),
+            left_pose=frames.left_ee,
+            right_pose=frames.right_ee,
+        )
+        _logger.info("pink-qp backend ready.")
+
+    # -- Internal helpers -----------------------------------------------------
+
+    def _to_pin(self, q_canonical: np.ndarray) -> np.ndarray:
+        q = np.zeros(self._model.nq, dtype=np.float64)
+        q[self._qidx] = np.asarray(q_canonical, dtype=np.float64)
+        return q
+
+    @staticmethod
+    def _se3(pos: np.ndarray, rot: np.ndarray | None) -> pin.SE3:
+        R = np.eye(3) if rot is None else np.asarray(rot, dtype=np.float64)
+        return pin.SE3(R, np.asarray(pos, dtype=np.float64))
+
+    def _gate_elbow_tasks(self, q_current: np.ndarray) -> None:
+        """Fade each elbow task with its shoulder's conditioning.
+
+        The elbow reference only ever asks for a swivel — the arm's single
+        self-motion — and near ``shoulder_2 = +/-90 deg`` that self-motion is a
+        shoulder_1/shoulder_3 counter-rotation whose joint gain diverges (the
+        shoulder's contribution to end-effector pose is exactly rank-deficient
+        there, measured ``sigma_min = 0``). A full-strength elbow task at that
+        point answers a centimetre of swivel error with hundreds of deg/s of
+        shoulder rotation — it saturates the velocity limit, and the operator
+        sees the shoulder snap round while the hand barely moves. Every reach
+        above shoulder height crosses this configuration, so it cannot be
+        avoided, only handled.
+
+        Scaling the task's weight by the conditioning makes it *singularity
+        consistent*: full authority where the swivel is cheap to move (so the
+        posture actually tracks), fading to none where it is not (so the arm
+        coasts through holding whatever swivel it arrived with, which is also
+        the swivel it leaves with — no branch flip on the way back down).
+        ``|cos(shoulder_2)|`` is the conditioning: measured against the true
+        singular value it tracks it within 7% over the whole range.
+        """
+        q = np.asarray(q_current, dtype=np.float64)
+        for task, idx, cost in (
+            (self._l_elbow_task, self._l_s2_idx, self._config.diff_elbow_cost),
+            (self._r_elbow_task, self._r_s2_idx, self._config.diff_elbow_cost),
+        ):
+            task.set_position_cost(cost * abs(float(np.cos(q[idx]))))
+
+    # -- IKBackend interface ----------------------------------------------------
+
+    def ik(
+        self,
+        q_current: np.ndarray,
+        left_pose: tuple[np.ndarray, np.ndarray] | None = None,
+        right_pose: tuple[np.ndarray, np.ndarray] | None = None,
+        left_elbow_pos: np.ndarray | None = None,
+        right_elbow_pos: np.ndarray | None = None,
+    ) -> np.ndarray:
+        if left_pose is None and right_pose is None:
+            return np.asarray(q_current, dtype=np.float32).copy()
+
+        cfg = self._config
+        self._configuration.update(self._to_pin(q_current))
+
+        if left_pose is not None:
+            self._l_ee_task.set_target(self._se3(left_pose[0], left_pose[1]))
+        else:
+            self._l_ee_task.set_target_from_configuration(self._configuration)
+        if right_pose is not None:
+            self._r_ee_task.set_target(self._se3(right_pose[0], right_pose[1]))
+        else:
+            self._r_ee_task.set_target_from_configuration(self._configuration)
+        if cfg.diff_elbow_cost > 0.0:
+            if left_elbow_pos is not None:
+                self._l_elbow_task.set_target(self._se3(left_elbow_pos, None))
+            else:
+                self._l_elbow_task.set_target_from_configuration(self._configuration)
+            if right_elbow_pos is not None:
+                self._r_elbow_task.set_target(self._se3(right_elbow_pos, None))
+            else:
+                self._r_elbow_task.set_target_from_configuration(self._configuration)
+            self._gate_elbow_tasks(q_current)
+
+        n_iters = max(1, cfg.diff_iters)
+        sub_dt = self._dt / n_iters
+        for _ in range(n_iters):
+            try:
+                vel = pink.solve_ik(
+                    self._configuration,
+                    self._tasks,
+                    sub_dt,
+                    solver=_QP_SOLVER,
+                    damping=cfg.diff_damping,
+                    limits=self._limits,
+                    barriers=self._barriers,
+                    safety_break=False,
+                )
+            except pink.exceptions.NoSolutionFound:
+                # Infeasible QP (possible when the collision barrier is
+                # enabled and wedged against the task): hold the current
+                # configuration for this tick instead of crashing teleop.
+                _logger.warning("pink QP infeasible; holding configuration.")
+                return np.asarray(q_current, dtype=np.float32).copy()
+            self._configuration.integrate_inplace(vel, sub_dt)
+
+        return np.asarray(self._configuration.q[self._qidx], dtype=np.float32)
+
+    def fk_frames(self, q: np.ndarray) -> FKFrames:
+        pin.framesForwardKinematics(self._model, self._fk_data, self._to_pin(q))
+
+        def _pose(key: str) -> tuple[np.ndarray, np.ndarray]:
+            M = self._fk_data.oMf[self._frame_ids[key]]
+            return (
+                np.asarray(M.translation, dtype=np.float32),
+                np.asarray(M.rotation, dtype=np.float32),
+            )
+
+        l_ee = _pose("left_ee")
+        r_ee = _pose("right_ee")
+        return FKFrames(
+            left_ee=l_ee,
+            right_ee=r_ee,
+            left_elbow=_pose("left_elbow")[0],
+            right_elbow=_pose("right_elbow")[0],
+        )
+
+    def set_posture_pose(self, q: np.ndarray) -> None:
+        self._posture_task.set_target(self._to_pin(q))

--- a/almond_axol/kinematics/backends/pyroki_diff.py
+++ b/almond_axol/kinematics/backends/pyroki_diff.py
@@ -1,0 +1,220 @@
+"""``pyroki-diff`` backend: single damped Gauss-Newton step per tick.
+
+Keeps the existing pyroki/JAX kinematic model but replaces the per-frame
+Levenberg-Marquardt run-to-convergence solve (whose trust region can reject
+steps and freeze the output) with a fixed damped Gauss-Newton step per tick:
+
+    dq = -(J^T J + λI)^{-1} J^T r,   clamped to ±v_max·dt, then joint limits.
+
+There is no accept/reject logic, so the output can never freeze; the damping
+λ bounds joint velocities through singularities, and the per-joint clamp +
+hard limit clip replace the soft limit costs. This is the lowest-churn
+differential candidate (same model and dependencies as today).
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+
+import jax
+import jax.numpy as jnp
+import jaxlie
+import numpy as np
+import pyroki as pk
+
+from ..base import FKFrames, IKBackend, frame_body_names
+from ..config import KinematicsConfig
+from ..jax_cache import enable_persistent_compilation_cache
+from ..pyroki_model import canonical_to_pyroki, load_pyroki_model
+
+_logger = logging.getLogger(__name__)
+
+
+@functools.partial(jax.jit, static_argnames=("l_ee", "r_ee", "l_el", "r_el"))
+def _gn_step(
+    robot: pk.Robot,
+    q: jax.Array,
+    l_ee: int,
+    r_ee: int,
+    l_el: int,
+    r_el: int,
+    target_l: jax.Array,
+    target_r: jax.Array,
+    elbow_l: jax.Array,
+    elbow_r: jax.Array,
+    posture: jax.Array,
+    w_pos: float,
+    w_ori: float,
+    w_elbow: float,
+    w_posture: float,
+    damping: float,
+    max_step: jax.Array,
+    lower: jax.Array,
+    upper: jax.Array,
+) -> jax.Array:
+    """One damped Gauss-Newton step toward the targets (all in pyroki order)."""
+
+    def residual(q_: jax.Array) -> jax.Array:
+        fk = robot.forward_kinematics(q_)
+
+        def pose_err(idx: int, target: jax.Array) -> jax.Array:
+            T = jaxlie.SE3(fk[idx])
+            T_t = jaxlie.SE3(target)
+            p = w_pos * (T.translation() - T_t.translation())
+            r = w_ori * (T_t.rotation().inverse() @ T.rotation()).log()
+            return jnp.concatenate([p, r])
+
+        def elbow_err(idx: int, target: jax.Array) -> jax.Array:
+            return w_elbow * (jaxlie.SE3(fk[idx]).translation() - target)
+
+        return jnp.concatenate(
+            [
+                pose_err(l_ee, target_l),
+                pose_err(r_ee, target_r),
+                elbow_err(l_el, elbow_l),
+                elbow_err(r_el, elbow_r),
+                w_posture * (q_ - posture),
+            ]
+        )
+
+    r = residual(q)
+    J = jax.jacfwd(residual)(q)
+    n = q.shape[0]
+    H = J.T @ J + damping * jnp.eye(n)
+    dq = -jnp.linalg.solve(H, J.T @ r)
+    dq = jnp.clip(dq, -max_step, max_step)
+    return jnp.clip(q + dq, lower, upper)
+
+
+class PyrokiDiffBackend(IKBackend):
+    """Velocity-level differential IK on the existing pyroki/JAX model."""
+
+    name = "pyroki-diff"
+
+    def __init__(self, config: KinematicsConfig, dt: float) -> None:
+        self._config = config
+        self._dt = dt
+
+        enable_persistent_compilation_cache()
+        _, robot, _ = load_pyroki_model()
+        self._robot = robot
+        self._perm = canonical_to_pyroki(robot)
+
+        names = frame_body_names()
+        link_names = robot.links.names
+        self._l_ee_idx = link_names.index(names["left_ee"])
+        self._r_ee_idx = link_names.index(names["right_ee"])
+        self._l_elbow_idx = link_names.index(names["left_elbow"])
+        self._r_elbow_idx = link_names.index(names["right_elbow"])
+        l_sh_idx = link_names.index(names["left_shoulder"])
+        r_sh_idx = link_names.index(names["right_shoulder"])
+
+        self._lower = jnp.asarray(robot.joints.lower_limits)
+        self._upper = jnp.asarray(robot.joints.upper_limits)
+        n_iters = max(1, config.diff_iters)
+        self._n_iters = n_iters
+        self._max_step = jnp.full(
+            robot.joints.num_actuated_joints,
+            config.diff_max_joint_vel * dt / n_iters,
+        )
+
+        fk0 = robot.forward_kinematics(jnp.zeros(robot.joints.num_actuated_joints))
+        self.left_shoulder_pos = np.asarray(
+            jaxlie.SE3(fk0[l_sh_idx]).translation(), dtype=np.float32
+        )
+        self.right_shoulder_pos = np.asarray(
+            jaxlie.SE3(fk0[r_sh_idx]).translation(), dtype=np.float32
+        )
+
+        self._posture = jnp.zeros(robot.joints.num_actuated_joints)
+
+        # Warm-up solve (compiles the jitted step).
+        q0 = np.zeros(self.num_joints, dtype=np.float32)
+        frames = self.fk_frames(q0)
+        self.ik(q0, left_pose=frames.left_ee, right_pose=frames.right_ee)
+        _logger.info("pyroki-diff backend ready.")
+
+    # -- Internal helpers -----------------------------------------------------
+
+    def _to_pk(self, q_canonical: np.ndarray) -> np.ndarray:
+        q = np.empty_like(np.asarray(q_canonical, dtype=np.float32))
+        q[self._perm] = np.asarray(q_canonical, dtype=np.float32)
+        return q
+
+    @staticmethod
+    def _wxyz_xyz(pos: np.ndarray, rot: np.ndarray) -> jax.Array:
+        se3 = jaxlie.SE3.from_rotation_and_translation(
+            jaxlie.SO3.from_matrix(jnp.asarray(rot, dtype=jnp.float32)),
+            jnp.asarray(pos, dtype=jnp.float32),
+        )
+        return se3.wxyz_xyz
+
+    # -- IKBackend interface ----------------------------------------------------
+
+    def ik(
+        self,
+        q_current: np.ndarray,
+        left_pose: tuple[np.ndarray, np.ndarray] | None = None,
+        right_pose: tuple[np.ndarray, np.ndarray] | None = None,
+        left_elbow_pos: np.ndarray | None = None,
+        right_elbow_pos: np.ndarray | None = None,
+    ) -> np.ndarray:
+        if left_pose is None and right_pose is None:
+            return np.asarray(q_current, dtype=np.float32).copy()
+
+        cfg = self._config
+        frames = self.fk_frames(q_current)
+        lp, lr = left_pose if left_pose is not None else frames.left_ee
+        rp, rr = right_pose if right_pose is not None else frames.right_ee
+        el = left_elbow_pos if left_elbow_pos is not None else frames.left_elbow
+        er = right_elbow_pos if right_elbow_pos is not None else frames.right_elbow
+
+        target_l = self._wxyz_xyz(lp, lr)
+        target_r = self._wxyz_xyz(rp, rr)
+        q = jnp.asarray(self._to_pk(q_current))
+        for _ in range(self._n_iters):
+            q = _gn_step(
+                self._robot,
+                q,
+                self._l_ee_idx,
+                self._r_ee_idx,
+                self._l_elbow_idx,
+                self._r_elbow_idx,
+                target_l,
+                target_r,
+                jnp.asarray(el, dtype=jnp.float32),
+                jnp.asarray(er, dtype=jnp.float32),
+                self._posture,
+                cfg.diff_position_cost,
+                cfg.diff_orientation_cost,
+                cfg.diff_elbow_cost,
+                cfg.diff_posture_cost,
+                cfg.diff_damping,
+                self._max_step,
+                self._lower,
+                self._upper,
+            )
+
+        q_pk = np.asarray(q, dtype=np.float32)
+        return q_pk[self._perm]
+
+    def fk_frames(self, q: np.ndarray) -> FKFrames:
+        fk = self._robot.forward_kinematics(jnp.asarray(self._to_pk(q)))
+
+        def _pose(idx: int) -> tuple[np.ndarray, np.ndarray]:
+            T = jaxlie.SE3(fk[idx])
+            return (
+                np.asarray(T.translation(), dtype=np.float32),
+                np.asarray(T.rotation().as_matrix(), dtype=np.float32),
+            )
+
+        return FKFrames(
+            left_ee=_pose(self._l_ee_idx),
+            right_ee=_pose(self._r_ee_idx),
+            left_elbow=_pose(self._l_elbow_idx)[0],
+            right_elbow=_pose(self._r_elbow_idx)[0],
+        )
+
+    def set_posture_pose(self, q: np.ndarray) -> None:
+        self._posture = jnp.asarray(self._to_pk(q))

--- a/almond_axol/kinematics/backends/pyroki_lm.py
+++ b/almond_axol/kinematics/backends/pyroki_lm.py
@@ -1,0 +1,103 @@
+"""``pyroki-lm`` backend: the original per-frame Levenberg-Marquardt solver.
+
+Thin adapter over :class:`almond_axol.kinematics.solver.KinematicsSolver`
+that translates between the canonical joint order and pyroki's internal
+(topologically sorted) actuated order. This is the bake-off baseline.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import jaxlie
+import numpy as np
+
+from ..base import FKFrames, IKBackend
+from ..config import KinematicsConfig
+from ..pyroki_model import canonical_to_pyroki, to_canonical_order, to_pyroki_order
+from ..solver import KinematicsSolver
+
+
+class PyrokiLMBackend(IKBackend):
+    """Adapter exposing :class:`KinematicsSolver` through the backend interface."""
+
+    name = "pyroki-lm"
+
+    def __init__(self, config: KinematicsConfig) -> None:
+        self._solver = KinematicsSolver(config)
+        self._perm = canonical_to_pyroki(self._solver.robot)
+        self.left_shoulder_pos = self._solver._left_shoulder_pos.copy()
+        self.right_shoulder_pos = self._solver._right_shoulder_pos.copy()
+
+    def ik(
+        self,
+        q_current: np.ndarray,
+        left_pose: tuple[np.ndarray, np.ndarray] | None = None,
+        right_pose: tuple[np.ndarray, np.ndarray] | None = None,
+        left_elbow_pos: np.ndarray | None = None,
+        right_elbow_pos: np.ndarray | None = None,
+    ) -> np.ndarray:
+        q_pk = to_pyroki_order(np.asarray(q_current, dtype=np.float32), self._perm)
+        q_new = self._solver.ik(
+            q_pk,
+            left_pose=left_pose,
+            right_pose=right_pose,
+            left_elbow_pos=left_elbow_pos,
+            right_elbow_pos=right_elbow_pos,
+        )
+        return to_canonical_order(q_new, self._perm)
+
+    def fk_frames(self, q: np.ndarray) -> FKFrames:
+        q_pk = to_pyroki_order(np.asarray(q, dtype=np.float32), self._perm)
+        fk = self._solver.robot.forward_kinematics(jnp.asarray(q_pk))
+
+        def _pose(idx: int) -> tuple[np.ndarray, np.ndarray]:
+            T = jaxlie.SE3(fk[idx])
+            return (
+                np.asarray(T.translation(), dtype=np.float32),
+                np.asarray(T.rotation().as_matrix(), dtype=np.float32),
+            )
+
+        def _pos(idx: int) -> np.ndarray:
+            return np.asarray(jaxlie.SE3(fk[idx]).translation(), dtype=np.float32)
+
+        return FKFrames(
+            left_ee=_pose(self._solver.l_ee_idx),
+            right_ee=_pose(self._solver.r_ee_idx),
+            left_elbow=_pos(self._solver.l_elbow_idx),
+            right_elbow=_pos(self._solver.r_elbow_idx),
+        )
+
+    def set_posture_pose(self, q: np.ndarray) -> None:
+        self._solver.set_posture_pose(
+            to_pyroki_order(np.asarray(q, dtype=np.float32), self._perm)
+        )
+
+    def settle_rest_pose(self, q_rest: np.ndarray) -> np.ndarray:
+        """Iterate the full teleop IK to the manipulability-balanced rest pose.
+
+        EE and elbow targets are the configured rest pose's own FK, and posture
+        is pinned to the current iterate, so all costs except manipulability
+        have zero gradient at the starting q. The remaining manipulability
+        gradient drives q in the EE null space until it stops changing — the
+        same conditions the rising-edge posture pin in the teleop worker
+        produces at engage time.
+        """
+        max_iterations, tol = 200, 1e-5
+        q = np.asarray(q_rest, dtype=np.float32).copy()
+        frames = self.fk_frames(q)
+        l_pose, r_pose = frames.left_ee, frames.right_ee
+        l_elbow, r_elbow = frames.left_elbow, frames.right_elbow
+
+        for _ in range(max_iterations):
+            self.set_posture_pose(q)
+            q_new = self.ik(
+                q,
+                left_pose=l_pose,
+                right_pose=r_pose,
+                left_elbow_pos=l_elbow,
+                right_elbow_pos=r_elbow,
+            )
+            if float(np.max(np.abs(q_new - q))) < tol:
+                return q_new
+            q = q_new
+        return q

--- a/almond_axol/kinematics/base.py
+++ b/almond_axol/kinematics/base.py
@@ -1,0 +1,129 @@
+"""IK backend interface.
+
+Every solver backend (pink-qp, pyroki-lm, pyroki-diff, mink-qp, dls) exposes
+the same joint-vector convention and call signature so
+:class:`almond_axol.teleop.worker.IKWorker` (and the offline benchmark) can
+swap them freely.
+
+Canonical joint order
+---------------------
+All ``q`` vectors crossing the backend boundary are ``(14,)`` arrays in
+**canonical order**: the 7 left-arm joints in ``ARM_JOINTS`` order
+(shoulder_1 … wrist_3) followed by the 7 right-arm joints. Backends whose
+underlying model orders joints differently (pyroki sorts topologically)
+permute internally.
+"""
+
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass
+
+import numpy as np
+
+from ..constants import Joint, urdf_arm_joint_names, urdf_body_name
+
+CANONICAL_JOINT_NAMES: tuple[str, ...] = tuple(
+    urdf_arm_joint_names(is_left=True) + urdf_arm_joint_names(is_left=False)
+)
+"""URDF joint names in canonical order (left arm then right arm)."""
+
+
+def frame_body_names() -> dict[str, str]:
+    """URDF body names for the frames the teleop layer tracks."""
+    return {
+        "left_ee": urdf_body_name(Joint.GRIPPER, is_left=True),
+        "right_ee": urdf_body_name(Joint.GRIPPER, is_left=False),
+        "left_elbow": urdf_body_name(Joint.ELBOW, is_left=True),
+        "right_elbow": urdf_body_name(Joint.ELBOW, is_left=False),
+        "left_shoulder": urdf_body_name(Joint.SHOULDER_1, is_left=True),
+        "right_shoulder": urdf_body_name(Joint.SHOULDER_1, is_left=False),
+    }
+
+
+NUM_JOINTS: int = len(CANONICAL_JOINT_NAMES)
+
+LEFT_INDICES: list[int] = list(range(7))
+RIGHT_INDICES: list[int] = list(range(7, 14))
+
+
+@dataclass
+class FKFrames:
+    """Poses of the frames the teleop layer cares about, in world frame (FLU).
+
+    Attributes:
+        left_ee / right_ee: ``(pos_3, rot_3x3)`` gripper poses.
+        left_elbow / right_elbow: ``(3,)`` elbow (forearm-root) positions.
+    """
+
+    left_ee: tuple[np.ndarray, np.ndarray]
+    right_ee: tuple[np.ndarray, np.ndarray]
+    left_elbow: np.ndarray
+    right_elbow: np.ndarray
+
+
+class IKBackend(abc.ABC):
+    """Common interface every teleop IK solver implements.
+
+    Attributes:
+        left_indices / right_indices: Per-arm indices into the canonical
+            ``(14,)`` joint vector, in ``ARM_JOINTS`` order. Constant across
+            backends (``0..6`` / ``7..13``) but kept as attributes because the
+            teleop handshake ships them to the control process.
+        left_shoulder_pos / right_shoulder_pos: Fixed world-frame shoulder
+            positions (m), used by the target-conditioning layer.
+    """
+
+    name: str = ""
+
+    left_indices: list[int] = LEFT_INDICES
+    right_indices: list[int] = RIGHT_INDICES
+
+    left_shoulder_pos: np.ndarray
+    right_shoulder_pos: np.ndarray
+
+    @property
+    def num_joints(self) -> int:
+        """Length of the canonical joint vector (14)."""
+        return NUM_JOINTS
+
+    @abc.abstractmethod
+    def ik(
+        self,
+        q_current: np.ndarray,
+        left_pose: tuple[np.ndarray, np.ndarray] | None = None,
+        right_pose: tuple[np.ndarray, np.ndarray] | None = None,
+        left_elbow_pos: np.ndarray | None = None,
+        right_elbow_pos: np.ndarray | None = None,
+    ) -> np.ndarray:
+        """Advance the joint solution one tick toward the Cartesian targets.
+
+        Args:
+            q_current: Canonical ``(14,)`` joint vector (radians), the seed /
+                integration state.
+            left_pose: ``(pos_3, rot_3x3)`` world-frame target for the left
+                gripper, or ``None`` to leave that arm unconstrained.
+            right_pose: Same for the right gripper.
+            left_elbow_pos: Optional ``(3,)`` world-frame elbow position hint.
+            right_elbow_pos: Same for the right elbow.
+
+        Returns:
+            Updated canonical ``(14,)`` joint vector.
+        """
+
+    @abc.abstractmethod
+    def fk_frames(self, q: np.ndarray) -> FKFrames:
+        """Compute gripper poses + elbow positions for a canonical ``q``."""
+
+    @abc.abstractmethod
+    def set_posture_pose(self, q: np.ndarray) -> None:
+        """Set the preferred-posture attractor (canonical ``(14,)``, radians)."""
+
+    def settle_rest_pose(self, q_rest: np.ndarray) -> np.ndarray:
+        """Return the solver's fixed point nearest to ``q_rest``.
+
+        Differential backends are already at a fixed point when posture ==
+        rest, so the default is the identity. The pyroki-LM backend overrides
+        this to bake in its manipulability-cost null-space settling.
+        """
+        return np.asarray(q_rest, dtype=np.float32).copy()

--- a/almond_axol/kinematics/bench.py
+++ b/almond_axol/kinematics/bench.py
@@ -1,0 +1,746 @@
+"""Offline IK backend benchmark for the teleop bake-off.
+
+Replays scripted (or captured) ``VRFrame`` streams through the full
+:class:`almond_axol.teleop.worker.IKWorker` step path — filters, engage snap,
+target conditioning, and the selected IK backend — and scores each backend on
+the failure modes reported from real teleop sessions:
+
+- ``figure8``       nominal pick-place-speed motion (baseline tracking/smoothness)
+- ``fast-jitter``   fast multi-frequency hand motion + tracking noise (jitter)
+- ``singularity``   sweep through full arm extension and back (lockups)
+- ``bounds``        targets far past reach and wrists rolled past limits (bounds)
+- ``shelf``         high wrist + raised elbow, the elbow-up shelf/box pose (swivel)
+- ``torso-graze``   hands sweeping close across the torso (collision freezes)
+
+Metrics per backend per scenario: EE tracking RMSE / max error, joint jerk
+RMS, >3 Hz spectral power fraction of the joint velocities, freeze events
+(unchanged q while the target keeps moving), joint-limit and collision-margin
+violations, achieved elbow rise, and solve-time p50/p99.
+
+Usage::
+
+    python -m almond_axol.kinematics.bench                       # all backends
+    python -m almond_axol.kinematics.bench --backends pink-qp
+    python -m almond_axol.kinematics.bench --scenarios shelf --json out.json
+    python -m almond_axol.kinematics.bench --replay session.jsonl
+
+Synthetic scenarios are defined as world-frame EE/elbow displacement
+trajectories relative to the rest pose and converted *exactly* into VR
+controller streams by inverting the worker's relative-target mapping, so what
+the bench commands is what a headset would have commanded.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import math
+import time
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+
+import mujoco
+import numpy as np
+from scipy.spatial.transform import Rotation
+
+from ..teleop.config import VRTeleopConfig
+from ..teleop.worker import IKWorker
+from ..vr.models import VRFrame, VRPose, VRPosition, VRQuaternion
+from .base import CANONICAL_JOINT_NAMES, FKFrames, frame_body_names
+from .config import KinematicsConfig
+from .mujoco_model import arm_torso_geom_pairs, canonical_qpos_indices, load_mj_model
+
+_logger = logging.getLogger(__name__)
+
+# Base VR controller positions at engage (headset frame: X=Down, Y=Left,
+# Z=Forward). Arbitrary — the worker's mapping is relative to the engage snap.
+_L_CTRL0 = np.array([0.0, 0.2, 0.3])
+_R_CTRL0 = np.array([0.0, -0.2, 0.3])
+# Elbows hang below and behind the wrists at engage.
+_L_ELBOW0 = _L_CTRL0 + np.array([0.25, 0.0, -0.2])
+_R_ELBOW0 = _R_CTRL0 + np.array([0.25, 0.0, -0.2])
+
+# Axis-permutation matrices of the worker's coordinate plumbing, used to
+# invert it exactly:
+# - ``_D`` maps VR axes (X=Down, Y=Left, Z=Forward) to FLU: the worker's
+#   ``_vr_to_flu_np`` rotation conversion is ``A_flu = D @ m @ D.T``.
+# - ``_C`` relates the FLU-converted controller rotation ``A`` (relative to
+#   its engage snap) to the world-frame rotation delta applied to the EE
+#   target: ``R_delta = C @ A @ C`` (C is symmetric and involutive).
+# A commanded world rotation delta therefore requires the VR quaternion of
+# ``m = D.T @ (C @ R_delta @ C) @ D``.
+_C = np.array([[0.0, 0.0, 1.0], [0.0, -1.0, 0.0], [1.0, 0.0, 0.0]])
+_D = np.array([[0.0, 0.0, 1.0], [0.0, 1.0, 0.0], [-1.0, 0.0, 0.0]])
+
+_FREEZE_EPS_RAD = 1e-6
+_FREEZE_TARGET_DRIFT_M = 0.005
+_HF_CUTOFF_HZ = 3.0
+
+
+@dataclass
+class ArmCmd:
+    """World-frame command for one arm at time ``t``, relative to rest FK.
+
+    Attributes:
+        dpos:   ``(3,)`` EE displacement (m) from the rest EE position.
+        drot:   Optional ``(3,3)`` EE rotation delta (about the rest EE
+                orientation); identity when ``None``.
+        delbow: ``(3,)`` elbow displacement (m) from the rest elbow position.
+    """
+
+    dpos: np.ndarray
+    drot: np.ndarray | None = None
+    delbow: np.ndarray = field(default_factory=lambda: np.zeros(3))
+
+
+ScenarioFn = Callable[[float], tuple[ArmCmd, ArmCmd]]
+"""t (seconds since engage) -> (left command, right command)."""
+
+
+# ---------------------------------------------------------------------------
+# Scenarios
+# ---------------------------------------------------------------------------
+
+
+def _mirror(dpos: np.ndarray) -> np.ndarray:
+    """Mirror a left-arm displacement for the right arm (lateral axis flips)."""
+    return np.array([-dpos[0], dpos[1], dpos[2]])
+
+
+def _scn_figure8(t: float) -> tuple[ArmCmd, ArmCmd]:
+    """Nominal pick-place: 0.4 Hz figure-eight, 20 cm wide, elbows following.
+
+    Centred 10 cm *above* rest — the rest pose is close to full downward
+    extension, so motion below it is unreachable by construction.
+    """
+    w = 2 * math.pi * 0.4
+    d = np.array(
+        [
+            0.10 * math.sin(w * t),
+            0.08 * math.sin(2 * w * t),
+            0.10 - 0.10 * math.cos(w * t),
+        ]
+    )
+    left = ArmCmd(dpos=d, delbow=0.5 * d)
+    return left, ArmCmd(dpos=_mirror(d), delbow=0.5 * _mirror(d))
+
+
+def _tracking_noise(t: float, phase: float) -> np.ndarray:
+    """Deterministic ~1.5 mm pseudo-noise (same stream for every backend)."""
+    return 0.0015 * np.array(
+        [
+            math.sin(2 * math.pi * 8.7 * t + phase),
+            math.sin(2 * math.pi * 11.3 * t + 2.1 + phase),
+            math.sin(2 * math.pi * 9.9 * t + 4.2 + phase),
+        ]
+    )
+
+
+def _scn_fast_jitter(t: float) -> tuple[ArmCmd, ArmCmd]:
+    """Fast multi-frequency hand motion plus millimetre tracking noise."""
+    d = np.array(
+        [
+            0.12 * math.sin(2 * math.pi * 1.1 * t)
+            + 0.05 * math.sin(2 * math.pi * 2.3 * t + 1.0),
+            0.10 * math.sin(2 * math.pi * 0.9 * t + 0.5)
+            + 0.04 * math.sin(2 * math.pi * 2.7 * t),
+            0.10 * math.sin(2 * math.pi * 1.4 * t + 2.0)
+            + 0.04 * math.sin(2 * math.pi * 2.1 * t + 0.7),
+        ]
+    )
+    left = ArmCmd(dpos=d + _tracking_noise(t, 0.0), delbow=0.5 * d)
+    d_r = _mirror(d) + _tracking_noise(t, 1.0)
+    return left, ArmCmd(dpos=d_r, delbow=0.5 * _mirror(d))
+
+
+def _scn_singularity(t: float) -> tuple[ArmCmd, ArmCmd]:
+    """Sweep to full extension (straight-arm singularity) and back, twice.
+
+    The commanded EE runs 45 cm outward-down-forward from rest — past full
+    extension — holds, and returns. Solvers without damping lock up or spin
+    the wrist at the straight-arm boundary.
+    """
+    s = 0.45 * 0.5 * (1 - math.cos(2 * math.pi * t / 5.0))  # 0->0.45->0 per 5 s
+    d = s * np.array([0.4, 0.5, -0.75])
+    left = ArmCmd(dpos=d, delbow=0.6 * d)
+    return left, ArmCmd(dpos=_mirror(d), delbow=0.6 * _mirror(d))
+
+
+def _scn_bounds(t: float) -> tuple[ArmCmd, ArmCmd]:
+    """Push far past reach while rolling the wrists past their joint limits."""
+    s = 0.5 * (1 - math.cos(2 * math.pi * t / 6.0))
+    d = s * np.array([0.2, 0.7, 0.4])  # ~0.85 m past rest at peak
+    roll = s * 2.4  # past the ±1.57 wrist limits
+    drot = Rotation.from_rotvec([0.0, 0.0, roll]).as_matrix()
+    left = ArmCmd(dpos=d, drot=drot, delbow=0.5 * d)
+    right = ArmCmd(
+        dpos=_mirror(d),
+        drot=Rotation.from_rotvec([0.0, 0.0, -roll]).as_matrix(),
+        delbow=0.5 * _mirror(d),
+    )
+    return left, right
+
+
+def _scn_shelf(t: float) -> tuple[ArmCmd, ArmCmd]:
+    """Shelf/box pose: wrists high in front, elbows raised to shoulder level.
+
+    Ramps up over 2 s, holds with a small placing motion. The elbow command
+    rises ~45 cm — an elbow-up swivel the raw-position elbow tracking could
+    never reach. Scores the achieved elbow rise.
+    """
+    ramp = min(t / 2.0, 1.0)
+    ramp = ramp * ramp * (3 - 2 * ramp)  # smoothstep
+    place = 0.03 * math.sin(2 * math.pi * 0.5 * max(t - 2.0, 0.0))
+    d = ramp * np.array([0.05, 0.30, 0.55]) + np.array([0.0, place, 0.0])
+    delbow = ramp * np.array([0.10, 0.15, 0.45])
+    left = ArmCmd(dpos=d, delbow=delbow)
+    return left, ArmCmd(dpos=_mirror(d), delbow=_mirror(delbow))
+
+
+def _scn_torso_graze(t: float) -> tuple[ArmCmd, ArmCmd]:
+    """Sweep the hands inward toward the torso, grazing the collision margin."""
+    s = math.sin(2 * math.pi * t / 4.0)
+    # Inward (toward the torso mid-plane, stopping short of the far arm's
+    # half) and slightly forward/up.
+    d = np.array([-0.18 * max(s, 0.0), 0.10, 0.15 * max(s, 0.0)])
+    left = ArmCmd(dpos=d, delbow=0.5 * d)
+    return left, ArmCmd(dpos=_mirror(d), delbow=0.5 * _mirror(d))
+
+
+SCENARIOS: dict[str, tuple[ScenarioFn, float]] = {
+    "figure8": (_scn_figure8, 8.0),
+    "fast-jitter": (_scn_fast_jitter, 8.0),
+    "singularity": (_scn_singularity, 10.0),
+    "bounds": (_scn_bounds, 6.0),
+    "shelf": (_scn_shelf, 8.0),
+    "torso-graze": (_scn_torso_graze, 8.0),
+}
+
+
+# ---------------------------------------------------------------------------
+# VRFrame synthesis (exact inverse of the worker's relative-target mapping)
+# ---------------------------------------------------------------------------
+
+
+def _vr_pose(pos: np.ndarray, quat_xyzw: np.ndarray) -> VRPose:
+    return VRPose(
+        position=VRPosition(x=float(pos[0]), y=float(pos[1]), z=float(pos[2])),
+        quaternion=VRQuaternion(
+            x=float(quat_xyzw[0]),
+            y=float(quat_xyzw[1]),
+            z=float(quat_xyzw[2]),
+            w=float(quat_xyzw[3]),
+        ),
+    )
+
+
+class FrameSynth:
+    """Convert world-frame arm commands into the VR stream a headset would send.
+
+    The worker maps controller deltas through the engage-snapshot FK frame
+    (see ``_relative_target_np``); this class inverts that mapping so a
+    commanded world displacement/rotation lands exactly on the intended EE
+    target. Rest FK orientation columns come from the backend under test at
+    the engage pose, which the worker also uses — so the inversion is exact.
+    """
+
+    def __init__(self, rest_frames: FKFrames, position_multiplier: float) -> None:
+        self._rot_fk = {
+            "left": np.asarray(rest_frames.left_ee[1], dtype=np.float64),
+            "right": np.asarray(rest_frames.right_ee[1], dtype=np.float64),
+        }
+        self._mult = position_multiplier
+
+    def _ctrl_delta(self, side: str, dpos_world: np.ndarray) -> np.ndarray:
+        """VR-frame controller displacement producing ``dpos_world`` at the EE."""
+        R = self._rot_fk[side]
+        w = np.asarray(dpos_world, dtype=np.float64) / self._mult
+        # Worker: new_t = fk0*d[2] - fk1*d[1] + fk2*d[0] with d the FLU
+        # controller delta (orthonormal columns => project), and the FLU
+        # delta of a VR delta (dx, dy, dz) is (dz, dy, -dx).
+        d_flu = np.array([w @ R[:, 2], -(w @ R[:, 1]), w @ R[:, 0]])
+        return np.array([-d_flu[2], d_flu[1], d_flu[0]])
+
+    def _ctrl_rot(self, side: str, drot_world: np.ndarray | None) -> np.ndarray:
+        """Controller quaternion (xyzw) producing ``drot_world`` about the snap."""
+        if drot_world is None:
+            return np.array([0.0, 0.0, 0.0, 1.0])
+        A = _C @ np.asarray(drot_world, dtype=np.float64) @ _C
+        m = _D.T @ A @ _D
+        return Rotation.from_matrix(m).as_quat()
+
+    @staticmethod
+    def _elbow_delta(dpos_world: np.ndarray) -> np.ndarray:
+        """VR-frame elbow displacement for a world displacement (FLU inverse)."""
+        f = np.asarray(dpos_world, dtype=np.float64)
+        return np.array([-f[2], f[1], f[0]])
+
+    def frame(self, left: ArmCmd, right: ArmCmd, lock: bool = True) -> VRFrame:
+        lq = self._ctrl_rot("left", left.drot)
+        rq = self._ctrl_rot("right", right.drot)
+        return VRFrame(
+            l_ee=_vr_pose(_L_CTRL0 + self._ctrl_delta("left", left.dpos), lq),
+            r_ee=_vr_pose(_R_CTRL0 + self._ctrl_delta("right", right.dpos), rq),
+            l_elbow=VRPosition(
+                x=float(_L_ELBOW0[0] + self._elbow_delta(left.delbow)[0]),
+                y=float(_L_ELBOW0[1] + self._elbow_delta(left.delbow)[1]),
+                z=float(_L_ELBOW0[2] + self._elbow_delta(left.delbow)[2]),
+            ),
+            r_elbow=VRPosition(
+                x=float(_R_ELBOW0[0] + self._elbow_delta(right.delbow)[0]),
+                y=float(_R_ELBOW0[1] + self._elbow_delta(right.delbow)[1]),
+                z=float(_R_ELBOW0[2] + self._elbow_delta(right.delbow)[2]),
+            ),
+            l_lock=lock,
+            r_lock=lock,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Reference model for metrics (backend-independent)
+# ---------------------------------------------------------------------------
+
+
+class MetricModel:
+    """Backend-independent FK + limit/collision measurement on MuJoCo."""
+
+    def __init__(self) -> None:
+        model = load_mj_model(with_meshes=True)
+        self._model = model
+        self._data = mujoco.MjData(model)
+        self._qidx = canonical_qpos_indices(model)
+        names = frame_body_names()
+        self._bids = {
+            k: mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, v)
+            for k, v in names.items()
+        }
+        jnt_ids = [
+            mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, n)
+            for n in CANONICAL_JOINT_NAMES
+        ]
+        self.lower = model.jnt_range[jnt_ids, 0].copy()
+        self.upper = model.jnt_range[jnt_ids, 1].copy()
+        # Measurement pair set: every arm<->torso pair that is separable at
+        # home (buffer 0) — a superset of any backend's constraint pairs.
+        self._pairs = [
+            (p[0][0], p[1][0])
+            for p in arm_torso_geom_pairs(model, margin=0.0, threshold=0.0)
+        ]
+
+    def _set(self, q: np.ndarray) -> None:
+        self._data.qpos[:] = 0.0
+        self._data.qpos[self._qidx] = np.asarray(q, dtype=np.float64)
+        mujoco.mj_kinematics(self._model, self._data)
+
+    def ee_and_elbow(
+        self, q: np.ndarray
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """(left EE pos, right EE pos, left elbow pos, right elbow pos)."""
+        self._set(q)
+        return (
+            self._data.xpos[self._bids["left_ee"]].copy(),
+            self._data.xpos[self._bids["right_ee"]].copy(),
+            self._data.xpos[self._bids["left_elbow"]].copy(),
+            self._data.xpos[self._bids["right_elbow"]].copy(),
+        )
+
+    def min_clearance(self, q: np.ndarray) -> float:
+        """Minimum arm<->torso separation (m); negative when penetrating."""
+        self._set(q)
+        fromto = np.empty(6)
+        best = np.inf
+        for g, t in self._pairs:
+            d = mujoco.mj_geomDistance(self._model, self._data, g, t, 0.2, fromto)
+            best = min(best, d)
+        return float(best)
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RunResult:
+    """Metrics for one backend on one scenario."""
+
+    backend: str
+    scenario: str
+    rmse_mm: float
+    max_err_mm: float
+    jerk_rms: float
+    hf_frac: float
+    freezes: int
+    limit_viol_ticks: int
+    min_clearance_mm: float
+    penetration_ticks: int
+    elbow_rise_cm: float
+    solve_ms_p50: float
+    solve_ms_p99: float
+
+    def row(self) -> list[str]:
+        return [
+            self.backend,
+            f"{self.rmse_mm:.1f}",
+            f"{self.max_err_mm:.0f}",
+            f"{self.jerk_rms:.0f}",
+            f"{self.hf_frac * 100:.1f}%",
+            str(self.freezes),
+            str(self.limit_viol_ticks),
+            f"{self.min_clearance_mm:.0f}",
+            str(self.penetration_ticks),
+            f"{self.elbow_rise_cm:.1f}",
+            f"{self.solve_ms_p50:.2f}",
+            f"{self.solve_ms_p99:.2f}",
+        ]
+
+
+_HEADER = [
+    "backend",
+    "rmse_mm",
+    "max_mm",
+    "jerk",
+    "hf>3Hz",
+    "freezes",
+    "lim_viol",
+    "clear_mm",
+    "penetr",
+    "elbow_cm",
+    "p50_ms",
+    "p99_ms",
+]
+
+
+def _make_worker(backend: str, frequency: float) -> tuple[IKWorker, VRTeleopConfig]:
+    cfg = VRTeleopConfig(frequency=frequency)
+    kin = KinematicsConfig(backend=backend)
+    return IKWorker(cfg, kin), cfg
+
+
+def _metrics_from_run(
+    backend: str,
+    scenario: str,
+    dt: float,
+    qs: np.ndarray,
+    targets_l: np.ndarray,
+    targets_r: np.ndarray,
+    solve_ms: np.ndarray,
+    metric_model: MetricModel,
+    rest_elbow_z: float,
+) -> RunResult:
+    """Score one recorded run (T ticks of q, targets, and solve times)."""
+    T = qs.shape[0]
+    ee_l = np.zeros((T, 3))
+    ee_r = np.zeros((T, 3))
+    elb_l = np.zeros((T, 3))
+    clearance = np.full(T, np.inf)
+    for i in range(T):
+        pl, pr, pel, _ = metric_model.ee_and_elbow(qs[i])
+        ee_l[i], ee_r[i], elb_l[i] = pl, pr, pel
+        if i % 2 == 0:
+            clearance[i] = metric_model.min_clearance(qs[i])
+
+    err = np.concatenate(
+        [
+            np.linalg.norm(ee_l - targets_l, axis=1),
+            np.linalg.norm(ee_r - targets_r, axis=1),
+        ]
+    )
+    rmse_mm = float(np.sqrt(np.mean(err**2)) * 1e3)
+    max_err_mm = float(np.max(err) * 1e3)
+
+    dq = np.diff(qs, axis=0) / dt
+    jerk = np.diff(qs, n=3, axis=0) / dt**3
+    jerk_rms = float(np.sqrt(np.mean(jerk**2)))
+
+    # Fraction of joint-velocity spectral power above the cutoff.
+    spec = np.abs(np.fft.rfft(dq, axis=0)) ** 2
+    freqs = np.fft.rfftfreq(dq.shape[0], d=dt)
+    total = float(np.sum(spec))
+    hf_frac = float(np.sum(spec[freqs > _HF_CUTOFF_HZ])) / total if total > 0 else 0.0
+
+    # Freeze events: runs of bit-identical q during which the commanded target
+    # kept moving by more than the threshold.
+    freezes = 0
+    run_start: int | None = None
+    for i in range(1, T):
+        if np.max(np.abs(qs[i] - qs[i - 1])) < _FREEZE_EPS_RAD:
+            if run_start is None:
+                run_start = i - 1
+        elif run_start is not None:
+            drift = max(
+                float(np.linalg.norm(targets_l[i - 1] - targets_l[run_start])),
+                float(np.linalg.norm(targets_r[i - 1] - targets_r[run_start])),
+            )
+            if drift > _FREEZE_TARGET_DRIFT_M:
+                freezes += 1
+            run_start = None
+    if run_start is not None:
+        drift = max(
+            float(np.linalg.norm(targets_l[-1] - targets_l[run_start])),
+            float(np.linalg.norm(targets_r[-1] - targets_r[run_start])),
+        )
+        if drift > _FREEZE_TARGET_DRIFT_M:
+            freezes += 1
+
+    limit_viol = int(
+        np.sum(
+            np.any(
+                (qs < metric_model.lower - 1e-4) | (qs > metric_model.upper + 1e-4),
+                axis=1,
+            )
+        )
+    )
+
+    measured = clearance[np.isfinite(clearance)]
+    min_clearance_mm = float(np.min(measured) * 1e3) if measured.size else float("nan")
+    penetration_ticks = int(np.sum(measured < 0.0))
+
+    elbow_rise_cm = float((np.max(elb_l[:, 2]) - rest_elbow_z) * 1e2)
+
+    return RunResult(
+        backend=backend,
+        scenario=scenario,
+        rmse_mm=rmse_mm,
+        max_err_mm=max_err_mm,
+        jerk_rms=jerk_rms,
+        hf_frac=hf_frac,
+        freezes=freezes,
+        limit_viol_ticks=limit_viol,
+        min_clearance_mm=min_clearance_mm,
+        penetration_ticks=penetration_ticks,
+        elbow_rise_cm=elbow_rise_cm,
+        solve_ms_p50=float(np.percentile(solve_ms, 50)),
+        solve_ms_p99=float(np.percentile(solve_ms, 99)),
+    )
+
+
+def run_scenario(
+    backend: str,
+    scenario: str,
+    metric_model: MetricModel,
+    frequency: float = 120.0,
+    worker: IKWorker | None = None,
+) -> RunResult:
+    """Run one synthetic scenario through the full worker path for one backend."""
+    fn, duration = SCENARIOS[scenario]
+    dt = 1.0 / frequency
+    if worker is None:
+        worker, _ = _make_worker(backend, frequency)
+
+    q = worker.get_rest_q()
+    rest_frames = worker._backend.fk_frames(q)
+    synth = FrameSynth(rest_frames, worker._config.position_multiplier)
+    rest_l = np.asarray(rest_frames.left_ee[0], dtype=np.float64)
+    rest_r = np.asarray(rest_frames.right_ee[0], dtype=np.float64)
+    rest_elbow_z = float(rest_frames.left_elbow[2])
+
+    # Engage at the scenario's t=0 command so there is no initial jump.
+    l0, r0 = fn(0.0)
+    q = worker.step(synth.frame(l0, r0), q)
+
+    n_ticks = int(duration * frequency)
+    qs = np.zeros((n_ticks, worker._backend.num_joints), dtype=np.float32)
+    targets_l = np.zeros((n_ticks, 3))
+    targets_r = np.zeros((n_ticks, 3))
+    solve_ms = np.zeros(n_ticks)
+    for i in range(n_ticks):
+        t = (i + 1) * dt
+        left, right = fn(t)
+        frame = synth.frame(left, right)
+        t0 = time.perf_counter()
+        q = worker.step(frame, q)
+        solve_ms[i] = (time.perf_counter() - t0) * 1e3
+        qs[i] = q
+        targets_l[i] = rest_l + left.dpos
+        targets_r[i] = rest_r + right.dpos
+
+    worker.reset()
+    return _metrics_from_run(
+        backend,
+        scenario,
+        dt,
+        qs,
+        targets_l,
+        targets_r,
+        solve_ms,
+        metric_model,
+        rest_elbow_z,
+    )
+
+
+def _latch_engage(frames: list[VRFrame]) -> list[VRFrame]:
+    """Rewrite a raw capture's lock flags with the live engage-toggle state.
+
+    A capture stores the *raw* grip-button levels, which are only held for the
+    ~0.2 s of the engage press. Live, ``VRTeleopCore.update_engage`` latches
+    those presses into a toggle (both grips together → enable, either alone →
+    disable) and rewrites the frame locks before the worker sees them; without
+    mirroring that here the worker ignores everything after the press and a
+    replay of a real session is a no-op.
+    """
+    out: list[VRFrame] = []
+    enabled = prev_both = prev_either = False
+    for frame in frames:
+        both = frame.l_lock and frame.r_lock
+        either = frame.l_lock or frame.r_lock
+        if not enabled:
+            if both and not prev_both:
+                enabled = True
+        elif either and not prev_either:
+            enabled = False
+        prev_both = both
+        prev_either = either
+        out.append(frame.model_copy(update={"l_lock": enabled, "r_lock": enabled}))
+    return out
+
+
+def run_replay(
+    backend: str,
+    frames: list[VRFrame],
+    metric_model: MetricModel,
+    frequency: float = 120.0,
+) -> RunResult:
+    """Replay a captured VRFrame session through one backend.
+
+    A capture has no ground-truth EE targets, so the tracking-error columns
+    are scored against the achieved EE positions (i.e. reported as ~0);
+    jerk, freeze, limit, collision, and solve-time metrics are fully valid.
+    """
+    worker, _ = _make_worker(backend, frequency)
+    q = worker.get_rest_q()
+    qs_list: list[np.ndarray] = []
+    solve_list: list[float] = []
+    for frame in _latch_engage(frames):
+        t0 = time.perf_counter()
+        q = worker.step(frame, q)
+        solve_list.append((time.perf_counter() - t0) * 1e3)
+        qs_list.append(q.copy())
+    qs = np.asarray(qs_list, dtype=np.float32)
+    T = qs.shape[0]
+    # No ground-truth targets in a capture: reuse achieved EE so rmse == 0.
+    ee_l = np.zeros((T, 3))
+    ee_r = np.zeros((T, 3))
+    for i in range(T):
+        pl, pr, _, _ = metric_model.ee_and_elbow(qs[i])
+        ee_l[i], ee_r[i] = pl, pr
+    rest_frames = worker._backend.fk_frames(worker.get_rest_q())
+    return _metrics_from_run(
+        backend,
+        "replay",
+        1.0 / frequency,
+        qs,
+        ee_l,
+        ee_r,
+        np.asarray(solve_list),
+        metric_model,
+        float(rest_frames.left_elbow[2]),
+    )
+
+
+def load_capture(path: str) -> list[VRFrame]:
+    """Load a JSONL VRFrame capture (see ``VRServerConfig.capture_path``)."""
+    frames: list[VRFrame] = []
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            obj = json.loads(line)
+            obj.pop("recv_t", None)
+            frames.append(VRFrame.model_validate(obj))
+    return frames
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _print_table(scenario: str, results: Iterable[RunResult]) -> None:
+    rows = [_HEADER] + [r.row() for r in results]
+    widths = [max(len(row[c]) for row in rows) for c in range(len(_HEADER))]
+    print(f"\n=== {scenario} ===")
+    for i, row in enumerate(rows):
+        print("  ".join(cell.ljust(widths[c]) for c, cell in enumerate(row)))
+        if i == 0:
+            print("  ".join("-" * widths[c] for c in range(len(_HEADER))))
+
+
+def main(argv: list[str] | None = None) -> None:
+    from .backends import BACKEND_NAMES
+
+    parser = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    parser.add_argument(
+        "--backends",
+        default=",".join(BACKEND_NAMES),
+        help="Comma-separated backend names (default: all).",
+    )
+    parser.add_argument(
+        "--scenarios",
+        default=",".join(SCENARIOS),
+        help="Comma-separated scenario names (default: all).",
+    )
+    parser.add_argument("--frequency", type=float, default=120.0)
+    parser.add_argument("--json", default=None, help="Write results JSON here.")
+    parser.add_argument(
+        "--replay", default=None, help="Replay a captured VRFrame JSONL session."
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.WARNING, force=True)
+    backends = [b.strip() for b in args.backends.split(",") if b.strip()]
+    scenarios = [s.strip() for s in args.scenarios.split(",") if s.strip()]
+    for s in scenarios:
+        if s not in SCENARIOS:
+            parser.error(f"unknown scenario {s!r}; choose from {list(SCENARIOS)}")
+
+    metric_model = MetricModel()
+    all_results: list[RunResult] = []
+
+    if args.replay is not None:
+        frames = load_capture(args.replay)
+        print(f"Replaying {len(frames)} captured frames.")
+        results = []
+        for backend in backends:
+            try:
+                results.append(
+                    run_replay(backend, frames, metric_model, args.frequency)
+                )
+            except Exception as exc:  # noqa: BLE001 - missing optional dep
+                print(f"[skip] {backend}: {exc}")
+        _print_table("replay", results)
+        all_results.extend(results)
+    else:
+        # One worker per backend, reused across scenarios (worker.reset()
+        # between runs) — backend construction (JIT compile / model load) is
+        # by far the most expensive part.
+        by_scenario: dict[str, list[RunResult]] = {s: [] for s in scenarios}
+        for backend in backends:
+            try:
+                worker, _ = _make_worker(backend, args.frequency)
+            except Exception as exc:  # noqa: BLE001 - missing optional dep
+                print(f"[skip] {backend}: {exc}")
+                continue
+            for scenario in scenarios:
+                r = run_scenario(
+                    backend,
+                    scenario,
+                    metric_model,
+                    frequency=args.frequency,
+                    worker=worker,
+                )
+                by_scenario[scenario].append(r)
+        for scenario in scenarios:
+            _print_table(scenario, by_scenario[scenario])
+            all_results.extend(by_scenario[scenario])
+
+    if args.json:
+        with open(args.json, "w", encoding="utf-8") as f:
+            json.dump([vars(r) for r in all_results], f, indent=2)
+        print(f"\nWrote {args.json}")
+
+
+if __name__ == "__main__":
+    main()

--- a/almond_axol/kinematics/conditioning.py
+++ b/almond_axol/kinematics/conditioning.py
@@ -1,0 +1,444 @@
+"""Backend-independent target conditioning for teleop IK.
+
+Transforms applied to the raw Cartesian targets before they reach any IK
+backend (see :class:`almond_axol.teleop.worker.IKWorker`):
+
+- :func:`swivel_direction`, :func:`elbow_circle`, :func:`swivel_frame` and
+  :func:`clear_swivel_angle` map the operator's elbow position onto the
+  robot's own swivel circle — the locus of elbow positions consistent with
+  the robot's upper-arm/forearm lengths for a given shoulder->wrist line. The
+  human arm is shorter than the robot's, so tracking the raw (scaled) elbow
+  position biases the solve toward unreachable references (in practice:
+  elbow-down); preserving only the *swivel direction* keeps the intent
+  ("elbow up/out") while making the reference exactly reachable.
+
+  The steps are separate so the caller can smooth the swivel *as an angle*
+  and keep it clear of the robot's own base column. Smoothing matters more
+  than it looks: the swivel is the arm's only self-motion, and where the
+  shoulder is near-singular (``|shoulder_2| ~ 90 deg``, which every
+  reach above shoulder height passes through) that self-motion is a
+  shoulder_1/shoulder_3 counter-rotation of unbounded gain. Reference noise
+  is amplified straight into wild shoulder rotation there, so the reference
+  has to be rate-limited, and it has to be authoritative enough to pin the
+  swivel — otherwise the solver resolves the redundancy arbitrarily and the
+  arm comes back down through a different, drastic configuration.
+
+- :func:`clamp_target_error` caps the pose error between the current
+  end-effector pose and the commanded target (Drake-style feasibility
+  scaling). Out-of-reach or fast-moving targets degrade into a smooth,
+  bounded pull in the commanded direction instead of a large error whose
+  resolution depends on solver internals.
+
+- :func:`clamp_reach` keeps targets inside the annulus the arm can actually
+  reach: outside ``min_reach`` (the folded-arm inner zone around the
+  shoulder, where every solve grinds against joint limits) and inside
+  ``max_reach``.
+
+- :func:`clamp_column_keepout` keeps wrist targets out of the base-column
+  footprint, so a hands-toward-chest motion slides along the column face
+  instead of commanding the forearm through the torso (which the collision
+  barrier must then fight for as long as the pose is held).
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+import numpy as np
+from scipy.spatial.transform import Rotation
+
+_EPS = 1e-9
+
+
+class ColumnKeepout(NamedTuple):
+    """Elliptical-cylinder keep-out around the robot's central base column.
+
+    An ellipse rather than the column's box hull: the clamp has to be
+    continuous in its input, and projecting onto the nearest face of a
+    rectangle is not (it flips across the diagonals). With the operator's
+    hand hovering inside the footprint that discontinuity chattered, measured
+    at 3x the whole-session jerk of the ellipse version.
+
+    Attributes:
+        half_x / half_y: Ellipse semi-axes (m), inflated past the column hull
+            so links stop short of touching it.
+        top_z: Height (m) above which targets are unconstrained.
+    """
+
+    half_x: float
+    half_y: float
+    top_z: float
+
+    def radius(self, points: np.ndarray) -> np.ndarray:
+        """Normalised radial distance of ``(N, 3)`` points from the column axis.
+
+        Ignores height, so it is a smooth "how far outboard" score usable as
+        an objective anywhere in the workspace.
+        """
+        pts = np.atleast_2d(np.asarray(points, dtype=np.float64))
+        return np.hypot(pts[:, 0] / self.half_x, pts[:, 1] / self.half_y)
+
+    def clearance(self, points: np.ndarray) -> np.ndarray:
+        """Normalised radial clearance of ``(N, 3)`` points; ``>= 1`` is clear.
+
+        Points above :attr:`top_z` clear the column regardless of radius.
+        """
+        pts = np.atleast_2d(np.asarray(points, dtype=np.float64))
+        return np.where(pts[:, 2] >= self.top_z, np.inf, self.radius(pts))
+
+
+def swivel_direction(
+    shoulder: np.ndarray,
+    wrist_target: np.ndarray,
+    elbow_raw: np.ndarray,
+) -> np.ndarray | None:
+    """Unit component of an elbow hint perpendicular to the shoulder->wrist axis.
+
+    Args:
+        shoulder: ``(3,)`` world-frame shoulder position (m).
+        wrist_target: ``(3,)`` world-frame wrist/EE target position (m).
+        elbow_raw: ``(3,)`` raw (operator-derived) elbow hint position (m).
+
+    Returns:
+        ``(3,)`` unit direction, or ``None`` when degenerate (wrist at the
+        shoulder, or elbow hint collinear with the arm axis).
+    """
+    shoulder = np.asarray(shoulder, dtype=np.float64)
+    wrist = np.asarray(wrist_target, dtype=np.float64)
+    elbow = np.asarray(elbow_raw, dtype=np.float64)
+
+    axis_vec = wrist - shoulder
+    d = float(np.linalg.norm(axis_vec))
+    if d < _EPS:
+        return None
+    axis = axis_vec / d
+
+    r = elbow - shoulder
+    r_perp = r - float(np.dot(r, axis)) * axis
+    norm = float(np.linalg.norm(r_perp))
+    if norm < 1e-6:
+        return None
+    return (r_perp / norm).astype(np.float64)
+
+
+class ElbowCircle(NamedTuple):
+    """The locus of elbow positions consistent with one wrist target.
+
+    With the shoulder fixed and the wrist at ``center + ...``, the robot's
+    segment lengths put the elbow on a circle around the shoulder->wrist
+    axis. Attributes:
+        center: ``(3,)`` circle centre, on the shoulder->wrist axis (m).
+        radius: Circle radius (m).
+        axis: ``(3,)`` unit shoulder->wrist direction (the circle normal).
+    """
+
+    center: np.ndarray
+    radius: float
+    axis: np.ndarray
+
+    def point(self, swivel_dir: np.ndarray) -> np.ndarray:
+        """Circle point in the (unit, in-plane) direction ``swivel_dir``."""
+        return (self.center + self.radius * swivel_dir).astype(np.float32)
+
+
+def elbow_circle(
+    shoulder: np.ndarray,
+    wrist_target: np.ndarray,
+    upper_arm_len: float,
+    forearm_len: float,
+) -> ElbowCircle | None:
+    """Reachable elbow circle for a wrist target (law of cosines).
+
+    Args:
+        shoulder: ``(3,)`` world-frame shoulder position (m).
+        wrist_target: ``(3,)`` world-frame wrist/EE target position (m).
+        upper_arm_len: Robot shoulder->elbow segment length (m).
+        forearm_len: Robot elbow->wrist segment length (m).
+
+    Returns:
+        The circle, or ``None`` when degenerate (wrist at the shoulder).
+    """
+    shoulder = np.asarray(shoulder, dtype=np.float64)
+    wrist = np.asarray(wrist_target, dtype=np.float64)
+
+    axis_vec = wrist - shoulder
+    d = float(np.linalg.norm(axis_vec))
+    if d < _EPS:
+        return None
+    axis = axis_vec / d
+    # Clamp the shoulder->wrist distance to the annulus the two segments span
+    # so the circle construction below is always well-defined.
+    d = float(
+        np.clip(
+            d,
+            abs(upper_arm_len - forearm_len) + 1e-3,
+            upper_arm_len + forearm_len - 1e-3,
+        )
+    )
+
+    a = (upper_arm_len**2 - forearm_len**2 + d * d) / (2.0 * d)
+    h_sq = upper_arm_len**2 - a * a
+    if h_sq <= 0.0:
+        return None
+    return ElbowCircle(shoulder + a * axis, float(np.sqrt(h_sq)), axis)
+
+
+def swivel_frame(
+    axis: np.ndarray, reference_dir: np.ndarray
+) -> tuple[np.ndarray, np.ndarray] | None:
+    """Orthonormal basis of the swivel plane, with the first axis along a reference.
+
+    Swivel angles are always measured *relative to the previous reference*
+    rather than in a fixed world frame: no world frame is free of a
+    degeneracy on the sphere of arm axes, and one placed anywhere in the
+    reachable workspace would make the angle jump as the arm swept past it.
+    Re-basing on the previous direction (parallel transport) keeps the angle
+    well-conditioned everywhere and makes "no change" exactly angle zero.
+
+    Args:
+        axis: ``(3,)`` unit circle normal (shoulder->wrist direction).
+        reference_dir: ``(3,)`` direction defining the zero angle; only its
+            component perpendicular to ``axis`` is used.
+
+    Returns:
+        ``(e_a, e_b)`` unit vectors spanning the plane, or ``None`` when
+        ``reference_dir`` is collinear with ``axis``.
+    """
+    axis = np.asarray(axis, dtype=np.float64)
+    e_a = np.asarray(reference_dir, dtype=np.float64)
+    e_a = e_a - float(np.dot(e_a, axis)) * axis
+    norm = float(np.linalg.norm(e_a))
+    if norm < 1e-6:
+        return None
+    e_a = e_a / norm
+    return e_a, np.cross(axis, e_a)
+
+
+def _arm_samples(
+    circle: ElbowCircle,
+    e_a: np.ndarray,
+    e_b: np.ndarray,
+    wrist_target: np.ndarray,
+    angles: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Elbow positions and forearm interior points for candidate swivel angles.
+
+    Returns ``(elbows, forearm)`` shaped ``(N, 3)`` and ``(N, 3, 3)``. The
+    upper arm is not sampled: it is anchored at the shoulder, which sits at
+    the column's edge by construction, so no swivel angle can clear it and
+    including it would make every candidate score identically badly.
+    """
+    dirs = np.cos(angles)[:, None] * e_a + np.sin(angles)[:, None] * e_b
+    elbows = circle.center + circle.radius * dirs
+    fractions = np.array([0.25, 0.5, 0.75])
+    reach = np.asarray(wrist_target, dtype=np.float64) - elbows
+    return elbows, elbows[:, None, :] + fractions[None, :, None] * reach[:, None, :]
+
+
+def elevated_swivel_angle(e_a: np.ndarray, e_b: np.ndarray) -> float:
+    """Swivel angle lifting the elbow as high as the circle allows.
+
+    A posture *prior*, and the term that actually makes the elbow rise when
+    the operator reaches out — the reason the elbow otherwise stays down is
+    that the headset's elbow hint is pinned at the bottom of the swivel
+    range. Measured over a captured session, the hint asked for an elbow at
+    the 4th percentile of the elevation the arm could have reached; it is
+    inferred from the head and controller poses rather than measured, and
+    inference biases elbow-down.
+
+    Elevation is the right axis for a prior because it is exactly the
+    operator's stated intent ("elbow up to reach the shelf") and because it
+    is self-limiting: the circle's elevation span is only ~2 cm with the arm
+    hanging (nothing to gain, and the prior degenerates to holding the
+    current swivel) but ~33 cm with the hand above shoulder height, which is
+    precisely where shelf and bin work needs it.
+
+    Args:
+        e_a / e_b: Orthonormal basis of the circle plane (see
+            :func:`swivel_frame`); the returned angle is measured from ``e_a``.
+
+    Returns:
+        The angle, in radians, in ``(-pi, pi]`` relative to ``e_a``. Zero
+        (hold the current swivel) when the circle is horizontal and elevation
+        does not depend on the angle at all.
+    """
+    return float(np.arctan2(e_b[2], e_a[2]))
+
+
+def clear_swivel_angle(
+    circle: ElbowCircle,
+    e_a: np.ndarray,
+    e_b: np.ndarray,
+    wrist_target: np.ndarray,
+    desired: float,
+    keepout: ColumnKeepout,
+    samples: int = 180,
+) -> float:
+    """Swivel angle nearest ``desired`` that keeps the arm clear of the column.
+
+    The elbow reference is free to sit anywhere on the elbow circle, and much
+    of that circle passes through the robot's own base column — the shoulders
+    are mounted at the column's edge, so an inward swivel points straight into
+    it. Commanding such a reference asks the solver for a configuration that
+    does not exist, which it can only answer by grinding against whatever
+    protection is active (measured on a captured session: 13% of ticks
+    referenced an elbow inside the column hull, and the upper arm penetrated
+    it for 24% of ticks). Rotating the reference to the nearest clear angle
+    keeps the operator's intent — swivel is a one-parameter family, so the
+    nearest clear angle is on the same side they asked for — while staying
+    reachable.
+
+    Args:
+        circle: The reachable elbow circle.
+        e_a / e_b: Orthonormal basis of the circle plane (see
+            :func:`swivel_frame`); angles are measured from ``e_a``.
+        wrist_target: ``(3,)`` wrist target, the far end of the forearm (m).
+        desired: Requested swivel angle (radians, measured from ``e_a``).
+        keepout: Column keep-out region.
+        samples: Angular resolution of the search (180 -> 2 degrees).
+
+    Returns:
+        The clear angle nearest ``desired``, or ``desired`` itself when no
+        sampled angle is clear (fully boxed in — let the solver do its best).
+    """
+    offsets = np.linspace(-np.pi, np.pi, samples, endpoint=False)
+    angles = desired + offsets
+    elbows, forearm = _arm_samples(circle, e_a, e_b, wrist_target, angles)
+
+    clear = keepout.clearance(elbows) >= 1.0
+    clear &= (
+        keepout.clearance(forearm.reshape(-1, 3)).reshape(samples, -1) >= 1.0
+    ).all(axis=1)
+    if not clear.any():
+        return float(desired)
+    idx = np.flatnonzero(clear)
+    return float(angles[idx[np.argmin(np.abs(offsets[idx]))]])
+
+
+def clamp_target_error(
+    cur_pos: np.ndarray,
+    cur_rot: np.ndarray,
+    target_pos: np.ndarray,
+    target_rot: np.ndarray,
+    max_lin: float,
+    max_ang: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Cap the pose error between the current pose and the target.
+
+    Scales the position and orientation error *jointly* (one factor for both)
+    so the commanded direction in SE(3) is preserved — the same feasibility
+    scaling Drake's differential IK applies to infeasible velocity commands.
+
+    Args:
+        cur_pos / cur_rot: Current EE pose (``(3,)``, ``(3,3)``).
+        target_pos / target_rot: Desired EE pose.
+        max_lin: Maximum allowed position error (m).
+        max_ang: Maximum allowed orientation error (radians).
+
+    Returns:
+        ``(pos, rot_3x3)`` — the target, pulled toward the current pose when
+        the error exceeded the caps, unchanged otherwise.
+    """
+    cur_pos = np.asarray(cur_pos, dtype=np.float64)
+    target_pos = np.asarray(target_pos, dtype=np.float64)
+    dp = target_pos - cur_pos
+    lin = float(np.linalg.norm(dp))
+
+    cur_rot = np.asarray(cur_rot, dtype=np.float64)
+    target_rot = np.asarray(target_rot, dtype=np.float64)
+    rotvec = Rotation.from_matrix(cur_rot.T @ target_rot).as_rotvec()
+    ang = float(np.linalg.norm(rotvec))
+
+    scale = min(
+        1.0,
+        max_lin / lin if lin > _EPS else 1.0,
+        max_ang / ang if ang > _EPS else 1.0,
+    )
+    if scale >= 1.0:
+        return (
+            target_pos.astype(np.float32),
+            target_rot.astype(np.float32),
+        )
+    pos = cur_pos + scale * dp
+    rot = cur_rot @ Rotation.from_rotvec(scale * rotvec).as_matrix()
+    return pos.astype(np.float32), rot.astype(np.float32)
+
+
+def clamp_reach(
+    pos: np.ndarray,
+    center: np.ndarray,
+    max_reach: float,
+    min_reach: float = 0.0,
+) -> np.ndarray:
+    """Clamp a target position to the annulus ``[min_reach, max_reach]`` of ``center``.
+
+    The inner clamp keeps the wrist target out of the folded-arm zone right
+    around the shoulder, where no feasible configuration exists and the solve
+    degenerates into grinding against joint limits (jerky on hardware).
+    Targets closer than ``min_reach`` are pushed radially outward; a target
+    exactly at the centre is left unchanged (no meaningful direction).
+    """
+    pos = np.asarray(pos, dtype=np.float32)
+    d = pos - np.asarray(center, dtype=np.float32)
+    dist = float(np.linalg.norm(d))
+    if dist > max_reach:
+        return (center + d * (max_reach / dist)).astype(np.float32)
+    if dist < min_reach and dist > _EPS:
+        return (center + d * (min_reach / dist)).astype(np.float32)
+    return pos
+
+
+def clamp_column_keepout(
+    pos: np.ndarray,
+    rot: np.ndarray,
+    keepout: ColumnKeepout,
+    hand_offsets: tuple[float, ...] = (0.0,),
+    iterations: int = 3,
+) -> np.ndarray:
+    """Push an end-effector target out until its whole hand clears the column.
+
+    The engage-relative mapping happily places wrist targets *inside* the
+    base column (the rest EE hangs level with the column face, so any
+    hand-toward-chest motion crosses it). Such a target is unreachable by
+    construction; without this clamp the solve can only answer by grinding
+    against whatever protection is active for as long as the operator holds
+    the pose — measured as jitter and "the arm is stuck" on hardware.
+
+    It is not enough to clamp the gripper point: the hand and wrist assembly
+    extends from 145 mm ahead of the gripper frame to 230 mm behind it, and
+    on a captured session those links reached 67 mm inside the column while
+    the commanded point itself sat legally on the boundary. ``hand_offsets``
+    are therefore sampled along the gripper frame's own axis, and the target
+    is pushed radially until the worst of them clears. Clamping this way
+    turns the conflict into a smooth slide along the column face, exactly as
+    ``clamp_reach`` does at the workspace boundary.
+
+    Args:
+        pos: ``(3,)`` commanded end-effector position (m).
+        rot: ``(3, 3)`` commanded end-effector rotation; its third column is
+            the hand axis along which ``hand_offsets`` are measured.
+        keepout: Column keep-out region.
+        hand_offsets: Signed distances (m) along the hand axis to test.
+            Negative is ahead of the gripper frame (the fingers).
+        iterations: Fixed-point refinements. Each push moves every sample by
+            the same vector, so one pass can expose a different worst sample;
+            a few passes converge (the region is convex).
+
+    Returns:
+        The pushed target, or ``pos`` unchanged when the hand already clears.
+    """
+    pos = np.asarray(pos, dtype=np.float32)
+    axis = np.asarray(rot, dtype=np.float64)[:, 2]
+    offsets = np.asarray(hand_offsets, dtype=np.float64)
+    out = pos.astype(np.float64)
+    for _ in range(iterations):
+        points = out + offsets[:, None] * axis
+        radii = keepout.radius(points)
+        # Only points inside the column's height band can be pushed usefully.
+        radii = np.where(points[:, 2] < keepout.top_z, radii, np.inf)
+        worst = int(np.argmin(radii))
+        r = float(radii[worst])
+        if r >= 1.0 or r < _EPS:
+            break
+        out[:2] += points[worst, :2] * (1.0 / r - 1.0)
+    return out.astype(np.float32)

--- a/almond_axol/kinematics/config.py
+++ b/almond_axol/kinematics/config.py
@@ -8,12 +8,27 @@ from dataclasses import dataclass
 
 @dataclass
 class KinematicsConfig:
-    """Cost weights and solver parameters for :class:`KinematicsSolver`.
+    """Cost weights and solver parameters for the teleop IK backends.
+
+    The ``backend`` field selects the solver implementation; the ``pos_weight``
+    … ``max_reach`` block parametrises the original pyroki Levenberg-Marquardt
+    solver (``pyroki-lm``), the ``diff_*`` block parametrises the differential
+    (velocity-level) backends, and the ``elbow_swivel`` / ``max_target_err_*``
+    fields tune the backend-independent target conditioning.
 
     All weights are unitless scale factors passed directly to pyroki cost
     functions. Higher values make the solver prioritise that term more strongly.
 
     Attributes:
+        backend: IK solver implementation. ``pink-qp`` (default) is Pinocchio
+            QP differential IK with hard joint/velocity limits — the winner of
+            the 2026-07 offline solver bake-off (see ``bench.py``). The other
+            candidates are kept for on-hardware A/B comparison: ``pyroki-lm``
+            (the original per-frame Levenberg-Marquardt full solve),
+            ``pyroki-diff`` (single damped Gauss-Newton step per tick on the
+            pyroki/JAX model), ``mink-qp`` (MuJoCo QP differential IK, same
+            structure as pink-qp), and ``dls`` (custom NumPy damped least
+            squares with null-space posture and limit clamping).
         pos_weight: Weight on end-effector position error.
         ori_weight: Weight on end-effector orientation error.
         elbow_weight: Weight on elbow position hints (position only, no orientation).
@@ -55,8 +70,85 @@ class KinematicsConfig:
             accumulated target error finally made a full step acceptable. 10.0
             spans the useful damping range within the iteration budget.
         max_joint_delta: Maximum joint change per :meth:`KinematicsSolver.ik` call, in radians.
-        max_reach: Maximum allowed distance (m) from shoulder to end-effector target.
+        max_reach: Maximum allowed distance (m) from shoulder to end-effector
+            target. The worker additionally caps this at the arm's physical
+            extension minus a small margin (see ``_MAX_REACH_MARGIN_M``), so
+            the effective limit is ~0.70 m: this arm fully extends at
+            ~0.73 m, and a value beyond that (like this 0.8 default on its
+            own) would let operators command past full extension and grind
+            the straight-elbow singularity.
+        diff_position_cost: Differential backends — weight on end-effector
+            position error (per metre).
+        diff_orientation_cost: Differential backends — weight on end-effector
+            orientation error (per radian).
+        diff_elbow_cost: Differential backends — weight on the elbow (swivel)
+            reference, per metre. Position only, and below the EE position
+            cost so end-effector tracking always wins. **Default 0.0 — the
+            elbow task is off**, on direct operator feedback: every reference
+            tried (the headset's inferred elbow raw, gated and smoothed, and
+            an elevation prior with a singularity-gated weight) felt worse on
+            hardware than leaving the swivel to the solver's damping and
+            posture pull, because any elbow pull strong enough to matter
+            competes with hand tracking in exactly the poses (reaches above
+            the shoulder) where the shoulder is nearly singular. The swivel
+            conditioning machinery stays available: setting a positive cost
+            re-enables it (see ``elbow_swivel``).
+        diff_posture_cost: Differential backends — weight of the preferred-
+            posture attractor. Acts purely in the task null space when small.
+            Must stay well below ``diff_elbow_cost``: the attractor pulls the
+            swivel back toward the rest pose (elbow-down) and at 0.5 it wins
+            outright — the same sweep showed the elbow pinned near the rest
+            swivel (~89 deg mean error) regardless of the operator's hint.
+        diff_damping: Tikhonov regularisation added to the QP Hessian.
+            The primary singularity-robustness knob: larger values slow the
+            solution near singular configurations instead of letting joint
+            velocities blow up. 1.0 cuts jerk ~30x at the reach boundary
+            (bench ``singularity`` scenario) with no measurable tracking cost
+            on nominal motion.
+        diff_lm_damping: Levenberg-Marquardt damping scaled by task error
+            (pink ``lm_damping``). Stabilises far-from-target steps; tuned
+            together with ``diff_damping`` on the bench.
+        diff_max_joint_vel: Hard per-joint velocity limit (rad/s) enforced by
+            the differential backends (QP inequality / DLS clamp). Do not
+            lower it to make constraints better behaved: halving it to pi was
+            tried and made the whole arm lag fast operator motion (a wrist
+            flip alone wants 3-6 rad/s), which reads as the robot being
+            "messed up" long before any constraint does.
+        diff_iters: Integration sub-steps per :meth:`ik` call. More sub-steps
+            converge closer to the target per tick at proportional CPU cost.
+        diff_collision_margin: Minimum arm<->torso clearance (m) enforced as a
+            hard constraint by ``pink-qp`` (collision barrier) and ``mink-qp``
+            (collision-avoidance limit); ``pyroki-diff`` and ``dls`` have no
+            collision support. Pairs are arm links versus the base column and
+            torso yoke only — never arm<->arm. The URDF collision meshes are
+            tight boxes (the base is a 0.26 x 0.12 x 0.80 m column), so the
+            constraint only activates on genuine near-contact; the arms hang
+            ~27 mm from the column at rest, which bounds how large the margin
+            plus prune buffer can be before the forearm pairs get pruned as
+            "close by construction" (see ``_PRUNE_THRESHOLD`` in the pink
+            backend; the pair set is fixed and does not change with the
+            margin). The margin trades protection against how often ordinary
+            motion rides the constraint, and riding is what operators report
+            as jitter and "the arm fighting me": on a captured session,
+            0.02 produced 2.8x the whole-run jerk of 0.01 with no difference
+            in penetration (both zero — the hulls the barrier acts on are
+            already conservative convex boxes). Set to 0.0 to disable
+            entirely; on the same session that meant ~11% of ticks in
+            contact with the column hulls, i.e. real metal contact.
+        elbow_swivel: When true, re-project the operator's elbow hint onto the
+            robot's own upper-arm/forearm geometry (the swivel circle around
+            the shoulder->wrist axis) so the hint is always reachable. Fixes
+            the elbow-down bias of tracking the human elbow position directly.
+        max_target_err_lin: Cap (m) on the position error between the current
+            end-effector pose and the commanded target fed to the solver. The
+            target direction is preserved (Drake-style feasibility scaling),
+            so an out-of-reach or lagging target degrades into a smooth,
+            bounded pull instead of a solver-dependent lurch.
+        max_target_err_ang: Cap (radians) on the orientation error fed to the
+            solver, scaled jointly with ``max_target_err_lin``.
     """
+
+    backend: str = "pink-qp"
 
     pos_weight: float = 50.0
     ori_weight: float = 10.0
@@ -73,3 +165,20 @@ class KinematicsConfig:
     lambda_factor: float = 10.0
     max_joint_delta: float = 0.0055 * 2 * math.pi
     max_reach: float = 0.8
+
+    # Differential (velocity-level) backend parameters: pink-qp, mink-qp,
+    # pyroki-diff, dls. Damping values are tuned for pink-qp (the default).
+    diff_position_cost: float = 50.0
+    diff_orientation_cost: float = 10.0
+    diff_elbow_cost: float = 0.0
+    diff_posture_cost: float = 0.1
+    diff_damping: float = 1.0
+    diff_lm_damping: float = 4.0
+    diff_max_joint_vel: float = 2 * math.pi
+    diff_iters: int = 2
+    diff_collision_margin: float = 0.01
+
+    # Backend-independent target conditioning (applied in IKWorker).
+    elbow_swivel: bool = True
+    max_target_err_lin: float = 0.20
+    max_target_err_ang: float = 1.5

--- a/almond_axol/kinematics/mujoco_model.py
+++ b/almond_axol/kinematics/mujoco_model.py
@@ -1,0 +1,149 @@
+"""Shared MuJoCo model of the Axol URDF for the mink / dls IK backends.
+
+Loads the bundled URDF into an :class:`mujoco.MjModel`, rewriting the
+``package://`` mesh URIs so MuJoCo can resolve the STL collision meshes
+(needed by mink's collision-avoidance limit and the bench's clearance
+metrics). The gravity compensator keeps its own stripped-mesh loader; this
+one is cached separately because the IK backends need the collision geoms.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+import re
+
+import mujoco
+import numpy as np
+
+from ..constants import URDF_PATH
+from .base import CANONICAL_JOINT_NAMES
+
+_logger = logging.getLogger(__name__)
+
+_TORSO_BODIES: tuple[str, ...] = ("base", "s1")
+"""Static torso bodies; arm<->torso is the only self-collision that matters
+(see :mod:`almond_axol.kinematics.pyroki_model`)."""
+
+
+@functools.lru_cache(maxsize=2)
+def load_mj_model(with_meshes: bool = True) -> mujoco.MjModel:
+    """Load the Axol URDF into MuJoCo (cached per process).
+
+    Args:
+        with_meshes: Keep the STL collision meshes (required for collision
+            avoidance). ``False`` strips all geoms for a lighter kinematics-only
+            model.
+
+    Returns:
+        The compiled model. Joint (qpos/dof) order matches the canonical
+        left-then-right ``ARM_JOINTS`` order, but callers should still index
+        via :func:`canonical_qpos_indices` rather than assume it.
+    """
+    text = URDF_PATH.read_text()
+    if with_meshes:
+        mesh_dir = str((URDF_PATH.parent / "meshes").resolve())
+        text = text.replace("package://assembly/meshes/", "")
+        compiler = (
+            f'<mujoco><compiler meshdir="{mesh_dir}" balanceinertia="true" '
+            'discardvisual="true" fusestatic="false"/></mujoco>'
+        )
+    else:
+        text = re.sub(r"<visual>.*?</visual>", "", text, flags=re.DOTALL)
+        text = re.sub(r"<collision>.*?</collision>", "", text, flags=re.DOTALL)
+        compiler = (
+            '<mujoco><compiler balanceinertia="true" fusestatic="false"/></mujoco>'
+        )
+    text = re.sub(r"(<robot[^>]*>)", r"\1" + compiler, text, count=1)
+    model = mujoco.MjModel.from_xml_string(text)
+    _logger.info(
+        "MuJoCo model loaded: %d joints, %d geoms (meshes=%s).",
+        model.njnt,
+        model.ngeom,
+        with_meshes,
+    )
+    return model
+
+
+def canonical_qpos_indices(model: mujoco.MjModel) -> np.ndarray:
+    """qpos (== dof, all hinges) index for each canonical joint name."""
+    idx = []
+    for name in CANONICAL_JOINT_NAMES:
+        jid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, name)
+        if jid < 0:
+            raise RuntimeError(f"Joint {name!r} not found in the MuJoCo model")
+        idx.append(int(model.jnt_qposadr[jid]))
+    return np.array(idx, dtype=np.int64)
+
+
+def body_id(model: mujoco.MjModel, name: str) -> int:
+    """Body id by name, raising if absent."""
+    bid = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, name)
+    if bid < 0:
+        raise RuntimeError(f"Body {name!r} not found in the MuJoCo model")
+    return bid
+
+
+def arm_torso_geom_pairs(
+    model: mujoco.MjModel,
+    margin: float,
+    # Fixed home-pose clearance a pair needs to stay active — deliberately
+    # NOT derived from the margin, so the pair set is margin-independent
+    # (mirrors _PRUNE_THRESHOLD in the pink backend: 0.025 sits between the
+    # shoulder-cluster clearance ~22 mm and the forearm rest clearance
+    # ~27 mm).
+    threshold: float = 0.025,
+) -> list[tuple[list[int], list[int]]]:
+    """Geom pairs for arm<->torso collision avoidance, pruned for feasibility.
+
+    Mirrors the pyroki collision model's restriction: only arm<->torso pairs
+    are considered (cross-arm contacts are unreachable, within-arm is
+    constrained by joint limits). The shoulder clusters (``*_s2``/``*_s3``)
+    are excluded outright — they orbit the base column inside any useful
+    margin across the whole joint range, so a hard minimum-distance
+    constraint on them wedges permanently (see ``_SHOULDER_SUFFIXES`` in the
+    pink backend). Any remaining pair whose separation at the home pose is
+    already below ``threshold`` is also dropped as close by construction.
+
+    Args:
+        model: MuJoCo model with collision geoms.
+        margin: The minimum-distance value the caller will enforce (m);
+            logged only — it does not affect the pair set.
+        threshold: Home-pose clearance a pair must have to stay active (m).
+
+    Returns:
+        A list of single-pair ``([arm_geom], [torso_geom])`` tuples.
+    """
+    torso_ids = {body_id(model, n) for n in _TORSO_BODIES}
+    torso_geoms: list[int] = []
+    arm_geoms: list[int] = []
+    data = mujoco.MjData(model)
+    mujoco.mj_forward(model, data)
+    for g in range(model.ngeom):
+        b = int(model.geom_bodyid[g])
+        bname = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_BODY, b) or ""
+        if b in torso_ids:
+            torso_geoms.append(g)
+        elif bname.startswith(("left_", "right_")) and not bname.endswith(
+            ("_s2", "_s3")
+        ):
+            arm_geoms.append(g)
+
+    pairs: list[tuple[list[int], list[int]]] = []
+    pruned = 0
+    fromto = np.empty(6)
+    for g in arm_geoms:
+        for t in torso_geoms:
+            d = mujoco.mj_geomDistance(model, data, g, t, threshold + 0.1, fromto)
+            if d > threshold:
+                pairs.append(([g], [t]))
+            else:
+                pruned += 1
+    _logger.info(
+        "Collision pairs: %d active arm<->torso pairs (%d pruned at home, "
+        "margin %.0f mm).",
+        len(pairs),
+        pruned,
+        margin * 1e3,
+    )
+    return pairs

--- a/almond_axol/kinematics/pyroki_model.py
+++ b/almond_axol/kinematics/pyroki_model.py
@@ -1,0 +1,115 @@
+"""Shared, cached pyroki robot + collision model for the Axol URDF.
+
+One pyroki :class:`~pyroki.Robot` / :class:`~pyroki.collision.RobotCollision`
+pair per process, shared by the pyroki IK backends and the collision-aware
+reset-trajectory planner so the (expensive) URDF parse and capsule fit happen
+once regardless of which IK backend is selected.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+
+import jax.numpy as jnp
+import numpy as np
+import pyroki as pk
+import yourdfpy
+
+from ..constants import URDF_PATH
+from .base import CANONICAL_JOINT_NAMES
+
+_logger = logging.getLogger(__name__)
+
+
+_TORSO_LINKS: tuple[str, ...] = ("base", "s1")
+"""Static body links that the arms must not collide into.
+
+Self-collision on Axol is restricted to ``arm <-> torso`` pairs only.
+"""
+
+
+def build_robot_collision(
+    urdf: yourdfpy.URDF, robot: pk.Robot
+) -> pk.collision.RobotCollision:
+    """Build ``RobotCollision`` with self-collision restricted to torso<->arm pairs.
+
+    Each Axol arm is a serial chain attached to a static torso (``base`` +
+    ``s1``). pyroki's PCA capsule fit produces conservative single-capsule-
+    per-link shapes that always overlap at adjacent-link joint interfaces,
+    so blanket self-collision causes persistent jitter the IK cannot
+    resolve. We restrict the active pair set to the only collisions that
+    actually matter: any link pair where exactly one side is the torso
+    and the other is an arm link. Within-arm, cross-arm, and torso<->torso
+    pairs are filtered out (cross-arm contacts are unreachable, within-arm
+    is constrained by joint limits, and torso<->torso is rigidly fixed).
+
+    A second pass excludes any remaining pair that is already penetrating
+    at the home pose — those are over-conservative capsule fits the IK
+    can never separate (e.g. ``base <-> shoulder`` capsules that overlap
+    by construction because the arms mount onto the torso).
+    """
+    link_names = [link.name for link in urdf.robot.links]
+
+    def is_arm(n: str) -> bool:
+        return n.startswith("left_") or n.startswith("right_")
+
+    def is_torso(n: str) -> bool:
+        return n in _TORSO_LINKS
+
+    ignore: set[tuple[str, str]] = set()
+    for i, a in enumerate(link_names):
+        for b in link_names[i + 1 :]:
+            keep = (is_torso(a) and is_arm(b)) or (is_torso(b) and is_arm(a))
+            if not keep:
+                ignore.add((a, b))
+
+    rc = pk.collision.RobotCollision.from_urdf(urdf, user_ignore_pairs=tuple(ignore))
+    q0 = jnp.zeros(robot.joints.num_actuated_joints)
+    d = np.asarray(rc.compute_self_collision_distance(robot, q0))
+    ai = np.asarray(rc.active_idx_i)
+    aj = np.asarray(rc.active_idx_j)
+    for k in np.where(d < 0.0)[0]:
+        ignore.add((rc.link_names[ai[k]], rc.link_names[aj[k]]))
+
+    rc = pk.collision.RobotCollision.from_urdf(urdf, user_ignore_pairs=tuple(ignore))
+    _logger.info(
+        "RobotCollision: restricted to %d torso<->arm pairs.",
+        len(rc.active_idx_i),
+    )
+    return rc
+
+
+@functools.lru_cache(maxsize=1)
+def load_pyroki_model() -> tuple[yourdfpy.URDF, pk.Robot, pk.collision.RobotCollision]:
+    """Load the bundled Axol URDF into pyroki once per process (cached)."""
+    _logger.info("Loading Axol URDF into pyroki...")
+    urdf = yourdfpy.URDF.load(str(URDF_PATH), mesh_dir=str(URDF_PATH.parent))
+    robot = pk.Robot.from_urdf(urdf)
+    robot_coll = build_robot_collision(urdf, robot)
+    return urdf, robot, robot_coll
+
+
+def canonical_to_pyroki(robot: pk.Robot) -> np.ndarray:
+    """Index array mapping canonical joint order into pyroki's actuated order.
+
+    ``q_pyroki[perm] = q_canonical`` and ``q_canonical = q_pyroki[perm]``
+    do NOT both hold; use the returned ``perm`` as
+    ``q_pyroki = q_canonical[inverse]`` via the helpers below instead.
+
+    Returns ``perm`` such that ``q_canonical[i] == q_pyroki[perm[i]]``.
+    """
+    actuated = list(robot.joints.actuated_names)
+    return np.array([actuated.index(n) for n in CANONICAL_JOINT_NAMES], dtype=np.int64)
+
+
+def to_pyroki_order(q_canonical: np.ndarray, perm: np.ndarray) -> np.ndarray:
+    """Reorder a canonical ``(14,)`` joint vector into pyroki's actuated order."""
+    q_pyroki = np.empty_like(q_canonical)
+    q_pyroki[perm] = q_canonical
+    return q_pyroki
+
+
+def to_canonical_order(q_pyroki: np.ndarray, perm: np.ndarray) -> np.ndarray:
+    """Reorder a pyroki-ordered ``(14,)`` joint vector into canonical order."""
+    return np.asarray(q_pyroki)[perm]

--- a/almond_axol/kinematics/solver.py
+++ b/almond_axol/kinematics/solver.py
@@ -16,76 +16,17 @@ import jaxlie
 import jaxls
 import numpy as np
 import pyroki as pk
-import yourdfpy
 
 from ..constants import (
-    URDF_PATH,
     Joint,
     urdf_arm_joint_names,
     urdf_body_name,
 )
 from .config import KinematicsConfig
 from .jax_cache import enable_persistent_compilation_cache
+from .pyroki_model import load_pyroki_model
 
 _logger = logging.getLogger(__name__)
-
-
-_TORSO_LINKS: tuple[str, ...] = ("base", "s1")
-"""Static body links that the arms must not collide into.
-
-Self-collision on Axol is restricted to ``arm <-> torso`` pairs only.
-"""
-
-
-def _build_robot_collision(
-    urdf: yourdfpy.URDF, robot: pk.Robot
-) -> pk.collision.RobotCollision:
-    """Build ``RobotCollision`` with self-collision restricted to torso<->arm pairs.
-
-    Each Axol arm is a serial chain attached to a static torso (``base`` +
-    ``s1``). pyroki's PCA capsule fit produces conservative single-capsule-
-    per-link shapes that always overlap at adjacent-link joint interfaces,
-    so blanket self-collision causes persistent jitter the IK cannot
-    resolve. We restrict the active pair set to the only collisions that
-    actually matter: any link pair where exactly one side is the torso
-    and the other is an arm link. Within-arm, cross-arm, and torso<->torso
-    pairs are filtered out (cross-arm contacts are unreachable, within-arm
-    is constrained by joint limits, and torso<->torso is rigidly fixed).
-
-    A second pass excludes any remaining pair that is already penetrating
-    at the home pose — those are over-conservative capsule fits the IK
-    can never separate (e.g. ``base <-> shoulder`` capsules that overlap
-    by construction because the arms mount onto the torso).
-    """
-    link_names = [link.name for link in urdf.robot.links]
-
-    def is_arm(n: str) -> bool:
-        return n.startswith("left_") or n.startswith("right_")
-
-    def is_torso(n: str) -> bool:
-        return n in _TORSO_LINKS
-
-    ignore: set[tuple[str, str]] = set()
-    for i, a in enumerate(link_names):
-        for b in link_names[i + 1 :]:
-            keep = (is_torso(a) and is_arm(b)) or (is_torso(b) and is_arm(a))
-            if not keep:
-                ignore.add((a, b))
-
-    rc = pk.collision.RobotCollision.from_urdf(urdf, user_ignore_pairs=tuple(ignore))
-    q0 = jnp.zeros(robot.joints.num_actuated_joints)
-    d = np.asarray(rc.compute_self_collision_distance(robot, q0))
-    ai = np.asarray(rc.active_idx_i)
-    aj = np.asarray(rc.active_idx_j)
-    for k in np.where(d < 0.0)[0]:
-        ignore.add((rc.link_names[ai[k]], rc.link_names[aj[k]]))
-
-    rc = pk.collision.RobotCollision.from_urdf(urdf, user_ignore_pairs=tuple(ignore))
-    _logger.info(
-        "RobotCollision: restricted to %d torso<->arm pairs.",
-        len(rc.active_idx_i),
-    )
-    return rc
 
 
 # Convenience aliases for URDF link / joint names. The single source of
@@ -356,10 +297,7 @@ class KinematicsSolver:
 
         enable_persistent_compilation_cache()
 
-        _logger.info("Loading Axol URDF...")
-        urdf = yourdfpy.URDF.load(str(URDF_PATH), mesh_dir=str(URDF_PATH.parent))
-        self.robot = pk.Robot.from_urdf(urdf)
-        self.robot_coll = _build_robot_collision(urdf, self.robot)
+        _, self.robot, self.robot_coll = load_pyroki_model()
 
         names = self.robot.links.names
         self.l_ee_idx = names.index(_LEFT_EE)

--- a/almond_axol/lerobot/teleop/teleop_vr.py
+++ b/almond_axol/lerobot/teleop/teleop_vr.py
@@ -309,6 +309,13 @@ class AxolVRTeleop(Teleoperator):
 
         if self._parent_conn is not None:
             try:
+                # Drain in-flight worker responses before closing: the dispatch
+                # thread can stop mid solve, and closing a connection with
+                # unread data RSTs the peer — the worker's blocking recv then
+                # dies with ConnectionResetError instead of reading the None
+                # shutdown sentinel.
+                while self._parent_conn.poll(0):
+                    self._parent_conn.recv()
                 self._parent_conn.send(None)
             except Exception:
                 pass

--- a/almond_axol/teleop/config.py
+++ b/almond_axol/teleop/config.py
@@ -57,20 +57,23 @@ class VRTeleopConfig:
             the IK output before the trapezoidal filter.  Range ``(0, 1]``
             where ``1.0`` disables smoothing.  Lower values kill more
             high-frequency jitter at the cost of a small fixed lag
-            (``~(1-alpha)/alpha`` frames).  Defaults to ``0.5`` (~8 ms lag
-            at 120 Hz), which removes most IK noise without a perceptible
-            feel difference.
+            (``~(1-alpha)/alpha`` frames).  Defaults to ``0.3`` (~20 ms lag
+            at 120 Hz), favouring smoothness over minimum latency.
         pose_min_cutoff: Minimum cutoff frequency (Hz) for the One Euro Filter
             applied to raw VR controller positions, quaternions, and elbow
             positions **before** they enter the IK solver.  This is the
             primary tremor / tracking-noise kill knob.  Lower values give
             heavier smoothing at rest (more tremor rejection) at the cost of
             slightly more lag when still.  Typical range: 0.5–3 Hz.  Defaults
-            to ``1.5`` Hz.
+            to ``0.8`` Hz, favouring smoothness over minimum latency (the
+            fixed-lag smoother in the VR server's pose interpolator does the
+            heavy lifting upstream).
         pose_beta: Speed coefficient for the One Euro Filter.  Raises the
             filter cutoff proportionally to the signal's instantaneous speed,
             keeping the filter transparent during fast intentional moves.
-            Increase if fast moves feel sticky.  Defaults to ``5.0``.
+            Increase if fast moves feel sticky.  Defaults to ``2.0`` so the
+            filter stays partially engaged during motion instead of opening
+            fully and passing noise through.
         position_multiplier: Scale factor applied to the controller's
             **position** displacement (not orientation) when mapping hand
             motion to the end-effector target.  ``1.0`` is 1:1 motion;
@@ -126,8 +129,8 @@ class VRTeleopConfig:
     engage_duration: float = 1.0
     teleop_max_vel: float = 1.0 * 2 * math.pi
     teleop_max_accel: float = 3.5 * 2 * math.pi
-    ik_alpha: float = 0.5
-    pose_min_cutoff: float = 1.5
-    pose_beta: float = 5.0
+    ik_alpha: float = 0.3
+    pose_min_cutoff: float = 0.8
+    pose_beta: float = 2.0
     position_multiplier: float = 1.0
     rotation_multiplier: float = 1.0

--- a/almond_axol/teleop/core.py
+++ b/almond_axol/teleop/core.py
@@ -328,6 +328,7 @@ class VRTeleopCore:
         ik_interval = 1.0 / self.config.frequency
         last_frame = None
         recv_timeout_count = 0
+        last_dead_warn = 0.0
 
         while not stop_event.is_set():
             t0 = time.perf_counter()
@@ -368,16 +369,35 @@ class VRTeleopCore:
                 time.sleep(0.001)
                 continue
 
-            frame = get_frame()
+            # Guard the sampling + engage steps: an exception here previously
+            # killed this thread silently, freezing teleop at the last target
+            # with nothing in the logs.
+            try:
+                frame = get_frame()
+            except Exception:
+                self._logger.exception("VR frame sampling failed; keeping last target")
+                self._pace(t0, ik_interval)
+                continue
             if frame is None or frame is last_frame:
                 time.sleep(0.001)
                 continue
             last_frame = frame
 
-            self.update_engage(frame)
+            try:
+                self.update_engage(frame)
+            except Exception:
+                self._logger.exception("Engage update failed; keeping last target")
+                self._pace(t0, ik_interval)
+                continue
 
             if not process_alive():
-                self._logger.warning("IK process is not alive")
+                # Rate-limited: this used to log per iteration (~120 Hz).
+                if t0 - last_dead_warn >= 5.0:
+                    last_dead_warn = t0
+                    self._logger.error(
+                        "IK process is not alive — teleop is holding its last "
+                        "target; restart teleop to recover"
+                    )
                 self._pace(t0, ik_interval)
                 continue
 

--- a/almond_axol/teleop/filter.py
+++ b/almond_axol/teleop/filter.py
@@ -17,7 +17,11 @@ class TrapezoidalFilter:
 
     The deceleration distance is computed from kinematics:
     ``v_stop = sqrt(2 * max_accel * distance)``
-    so the filter always arrives at the target without overshoot.
+    so the filter always arrives at the target without overshoot.  When a step
+    reaches the target, the internal velocity keeps the value realized by that
+    step (rather than resetting to zero) so continuously tracking a moving
+    target produces a smooth velocity profile instead of a snap / re-accelerate
+    limit cycle.
 
     Args:
         max_vel:   Maximum joint velocity in rad/s.
@@ -72,10 +76,15 @@ class TrapezoidalFilter:
         self._vel = self._vel + dv
 
         # Advance position; snap to target if we would overshoot this step.
+        # On snap, keep the velocity actually realized by the snap (|err|/dt,
+        # always a slowdown since |err| < |step|) instead of zeroing it:
+        # zeroing made every arrival a velocity discontinuity, so closely
+        # tracking a *moving* target limit-cycled through snap / re-accelerate
+        # every few steps and manufactured jerk from a perfectly smooth input.
         step = self._vel * self.dt
         overshoot = np.abs(step) > dist
         self._pos = np.where(overshoot, target, self._pos + step)
-        self._vel = np.where(overshoot, 0.0, self._vel)
+        self._vel = np.where(overshoot, err / self.dt, self._vel)
 
         return self._pos.copy()
 

--- a/almond_axol/teleop/teleop.py
+++ b/almond_axol/teleop/teleop.py
@@ -235,6 +235,13 @@ class VRTeleop:
 
         if self._parent_conn is not None:
             try:
+                # Drain in-flight worker responses before closing: the dispatch
+                # thread can stop mid solve, and closing a connection with
+                # unread data RSTs the peer — the worker's blocking recv then
+                # dies with ConnectionResetError instead of reading the None
+                # shutdown sentinel.
+                while self._parent_conn.poll(0):
+                    self._parent_conn.recv()
                 self._parent_conn.send(None)
             except Exception:
                 pass
@@ -358,6 +365,20 @@ class VRTeleop:
                 prev_iter = now
                 loop_times.append(now)
                 if now - last_log >= 1.0 and len(loop_times) > 1:
+                    # Surface silent freeze modes: the control loop keeps
+                    # commanding the last smoothed target when either of these
+                    # dies, which reads as "teleop froze" with no explanation.
+                    if self._ik_process is not None and not self._ik_process.is_alive():
+                        _logger.error(
+                            "IK worker process died (exit code %s) — arms are "
+                            "holding the last target; restart teleop",
+                            self._ik_process.exitcode,
+                        )
+                    elif self._ik_thread is not None and not self._ik_thread.is_alive():
+                        _logger.error(
+                            "IK dispatch thread died — arms are holding the "
+                            "last target; restart teleop"
+                        )
                     total = loop_times[-1] - loop_times[0]
                     rate = (len(loop_times) - 1) / total
                     with self._ik_loop_times_lock:

--- a/almond_axol/teleop/worker.py
+++ b/almond_axol/teleop/worker.py
@@ -1,9 +1,11 @@
 """
 IK subprocess worker for VR teleoperation.
 
-Runs in a separate process to keep JAX off the main asyncio event loop.
-All intermediate computations stay in NumPy; the single JAX boundary is the
-``solver.ik`` call itself (matching the arm-repo pattern).
+Runs in a separate process to keep the solver (JAX / QP) off the main asyncio
+event loop. All intermediate computations stay in NumPy; the solver boundary
+is the :meth:`IKBackend.ik` call itself. The backend implementation is
+selected by ``KinematicsConfig.backend`` (see
+:mod:`almond_axol.kinematics.backends`).
 """
 
 from __future__ import annotations
@@ -15,12 +17,26 @@ import multiprocessing.connection
 import os
 import time
 
-import jax.numpy as jnp
-import jaxlie
 import numpy as np
 
+from ..kinematics.backends import create_backend
+from ..kinematics.conditioning import (
+    ColumnKeepout,
+    clamp_reach,
+    clamp_target_error,
+    clear_swivel_angle,
+    elbow_circle,
+    elevated_swivel_angle,
+    swivel_direction,
+    swivel_frame,
+)
 from ..kinematics.config import KinematicsConfig
-from ..kinematics.solver import KinematicsSolver
+from ..kinematics.pyroki_model import (
+    canonical_to_pyroki,
+    load_pyroki_model,
+    to_canonical_order,
+    to_pyroki_order,
+)
 from ..vr.models import VRFrame
 from .config import VRTeleopConfig
 from .filter import OneEuroFilter
@@ -38,9 +54,66 @@ _FREEZE_WARN_AFTER_S = 0.5
 _FREEZE_MIN_TARGET_DRIFT_M = 0.005
 _FREEZE_REWARN_EVERY_S = 2.0
 
+# Elbow swivel smoothing, per 120 Hz tick, applied to the swivel *angle*
+# relative to the previous reference (see conditioning.swivel_frame). The EMA
+# factor sets the lag toward a new operator swivel; the rate limit caps how
+# fast the reference can move regardless. The rate limit is the important
+# one: the swivel is the arm's only self-motion and near the singular
+# shoulder its gain is unbounded, so reference noise (the inferred elbow
+# whips up to ~22 deg/tick when the wrist target passes near the shoulder)
+# becomes wild shoulder rotation. 2 deg/tick = 240 deg/s still tracks a
+# deliberate 90-degree swivel in under half a second.
+_SWIVEL_BLEND_ALPHA = 0.15
+_SWIVEL_MAX_STEP_RAD = math.radians(2.0)
+
+# How far (radians) the swivel reference may be rotated up from the operator's
+# own elbow toward the highest elbow the arm could reach. The headset infers
+# the operator's elbow rather than measuring it, and that inference sits at the
+# bottom of the swivel range — measured over a captured session it asked for
+# the 4th percentile of reachable elbow elevation, which is why the elbow never
+# rose when the operator reached out. 40 degrees restores the elevation without
+# taking the swivel far enough to fight the end-effector task. 0.0 follows the
+# operator's elbow exactly.
+_SWIVEL_LIFT_LIMIT_RAD = math.radians(40.0)
+
+# Margin (m) added to the theoretical folded-arm distance |upper - forearm|
+# for the inner reach clamp around each shoulder.
+_MIN_REACH_MARGIN_M = 0.05
+
+# Margin (m) subtracted from the arm's full extension (upper + forearm) for
+# the outer reach clamp. Reach is a flat function of elbow angle near the
+# straight arm, so a small radial margin buys a lot of bend: 30 mm keeps the
+# elbow >= ~28 deg from its straight stop.
+_MAX_REACH_MARGIN_M = 0.03
+
+# Keep-out around the base column, used by the (opt-in) elbow-swivel
+# reference so it never asks for an elbow inside the robot's own torso. The
+# column collision hull spans x[-0.13, 0.13], y[-0.06, 0.06] up to z=0.80,
+# with the s1 yoke extending it to z=0.92 (measured from the URDF convex
+# hulls); semi-axes are inflated 45 mm for link thickness.
+_COLUMN_KEEPOUT = ColumnKeepout(half_x=0.13 + 0.045, half_y=0.06 + 0.045, top_z=0.92)
+
+# The headset's elbow positions are *inferred* by a generative body model from
+# the headset + controller poses, not measured; when the model re-localises it
+# teleports (up to 70 mm in a single 8 ms frame in captured sessions — 8+ m/s,
+# physically impossible). The OneEuro pose filter passes fast steps by design,
+# so those teleports must be rejected before it: a per-frame step larger than
+# this (m) keeps the previous sample instead. A real elbow swing measures
+# ~10 mm/frame at 120 Hz, so the gate never engages on genuine motion.
+_ELBOW_JUMP_REJECT_M = 0.04
+# A model flip can be persistent (the new estimate is the one that tracks);
+# after this many consecutive rejected frames (~0.25 s) the new position is
+# accepted so the hint can't stay latched to a stale estimate.
+_ELBOW_JUMP_ACCEPT_AFTER = 30
+
 # ---------------------------------------------------------------------------
 # NumPy-only helpers (no JAX dispatch overhead)
 # ---------------------------------------------------------------------------
+
+
+def _wrap_pi(angle: float) -> float:
+    """Wrap an angle (radians) into ``(-pi, pi]``."""
+    return float((angle + math.pi) % (2.0 * math.pi) - math.pi)
 
 
 def _quat_xyzw_to_matrix(qx: float, qy: float, qz: float, qw: float) -> np.ndarray:
@@ -150,7 +223,7 @@ def _relative_target_np(
 class IKWorker:
     """Self-contained IK controller for the subprocess.
 
-    Snap state is numpy-only. The single JAX boundary is the ``solver.ik``
+    Snap state is numpy-only. The solver boundary is the backend's ``ik``
     call inside :meth:`step`.
     """
 
@@ -159,20 +232,21 @@ class IKWorker:
     ) -> None:
         """Construct the IK worker.
 
-        Instantiates the :class:`KinematicsSolver` (which triggers JAX JIT
-        compilation) and initialises One Euro Filters for all VR pose streams.
+        Instantiates the IK backend selected by ``kinematics_config.backend``
+        and initialises One Euro Filters for all VR pose streams.
 
         Args:
             config:            Teleop session parameters (rest poses, frequency, filter settings).
-            kinematics_config: IK solver cost weights forwarded to :class:`KinematicsSolver`.
+            kinematics_config: IK solver parameters (backend selector + weights).
         """
         self._config = config
-        self._solver = KinematicsSolver(kinematics_config)
+        self._kin = kinematics_config
+        self._backend = create_backend(kinematics_config, dt=1.0 / config.frequency)
 
         self._rest_pose_left = np.asarray(config.rest_pose_left, dtype=np.float32)
         self._rest_pose_right = np.asarray(config.rest_pose_right, dtype=np.float32)
 
-        self._solver.set_posture_pose(self.get_rest_q())
+        self._backend.set_posture_pose(self.get_rest_q())
 
         self._active: bool = False
         # Freeze detection state: when the last solve returned its seed
@@ -199,35 +273,86 @@ class IKWorker:
         self._f_l_elbow = OneEuroFilter(freq, mc, beta)
         self._f_r_elbow = OneEuroFilter(freq, mc, beta)
 
-        # Pre-settle the configured rest pose to the manipulability-balanced
-        # IK fixed point. The configured pose has a non-zero manipulability
-        # gradient, so a first engage there walks q in the EE null space
-        # toward higher manipulability over the next ~10-30 frames. Baking the
-        # settling in at startup means the trajectory ends at the fixed point
-        # and the first engage produces no motion.
-        q_settled = self._settle_rest_pose()
-        self._rest_pose_left = q_settled[self._solver.left_indices].astype(np.float32)
-        self._rest_pose_right = q_settled[self._solver.right_indices].astype(np.float32)
-        self._solver.set_posture_pose(self.get_rest_q())
+        # Pre-settle the configured rest pose to the solver's own fixed point
+        # (identity for the differential backends; the pyroki-lm baseline
+        # settles its manipulability-cost null-space drift). Baking the
+        # settling in at startup means the startup trajectory ends at the
+        # fixed point and the first engage produces no motion.
+        q_settled = self._backend.settle_rest_pose(self.get_rest_q())
+        self._rest_pose_left = q_settled[self._backend.left_indices].astype(np.float32)
+        self._rest_pose_right = q_settled[self._backend.right_indices].astype(
+            np.float32
+        )
+        self._backend.set_posture_pose(self.get_rest_q())
+
+        # Robot arm segment lengths (m) for the elbow swivel projection,
+        # measured at the rest pose (the shoulder->elbow and elbow->EE
+        # distances vary only marginally with wrist configuration).
+        rest_frames = self._backend.fk_frames(self.get_rest_q())
+        self._l_upper = float(
+            np.linalg.norm(rest_frames.left_elbow - self._backend.left_shoulder_pos)
+        )
+        self._l_fore = float(
+            np.linalg.norm(rest_frames.left_ee[0] - rest_frames.left_elbow)
+        )
+        self._r_upper = float(
+            np.linalg.norm(rest_frames.right_elbow - self._backend.right_shoulder_pos)
+        )
+        self._r_fore = float(
+            np.linalg.norm(rest_frames.right_ee[0] - rest_frames.right_elbow)
+        )
+        # Inner reach clamp: closer than the folded-arm distance no feasible
+        # configuration exists (the shoulder-singular region) and the solve
+        # grinds against joint limits.
+        self._l_min_reach = abs(self._l_upper - self._l_fore) + _MIN_REACH_MARGIN_M
+        self._r_min_reach = abs(self._r_upper - self._r_fore) + _MIN_REACH_MARGIN_M
+        # Outer reach clamp: the configured max_reach, additionally capped by
+        # the arm's *physical* extension minus a margin. The config default
+        # (0.8 m) predates this arm's geometry — full extension is only
+        # ~0.73 m from the shoulder, so without the cap the clamp never
+        # engaged and operators could command past full extension, grinding
+        # the straight-elbow singularity and the e1 = 0 travel stop. The
+        # 30 mm margin keeps the elbow at least ~28 deg bent, where the arm
+        # still has authority to track radially.
+        self._l_max_reach = min(
+            kinematics_config.max_reach,
+            self._l_upper + self._l_fore - _MAX_REACH_MARGIN_M,
+        )
+        self._r_max_reach = min(
+            kinematics_config.max_reach,
+            self._r_upper + self._r_fore - _MAX_REACH_MARGIN_M,
+        )
+        # Low-passed elbow swivel direction per arm (see _elbow_reference).
+        self._swivel_dir: dict[str, np.ndarray | None] = {"left": None, "right": None}
+        # Jump-rejection state for the inferred elbow hints (see _gate_elbow).
+        self._elbow_prev_raw: dict[str, np.ndarray | None] = {
+            "left": None,
+            "right": None,
+        }
+        self._elbow_reject_count: dict[str, int] = {"left": 0, "right": 0}
+
+        # Permutation for the pyroki-based reset planner (built lazily so the
+        # non-pyroki backends only pay for it on the first reset/startup plan).
+        self._pk_perm: np.ndarray | None = None
 
     # -- Properties the main process needs ----------------------------------
 
     @property
     def left_indices(self) -> list[int]:
         """Indices of the left arm joints within the full ``(N,)`` joint array, in ARM_JOINTS order."""
-        return self._solver.left_indices
+        return self._backend.left_indices
 
     @property
     def right_indices(self) -> list[int]:
         """Indices of the right arm joints within the full ``(N,)`` joint array, in ARM_JOINTS order."""
-        return self._solver.right_indices
+        return self._backend.right_indices
 
     def get_rest_q(self) -> np.ndarray:
         """Full (N,) rest pose vector in radians."""
-        q = np.zeros(self._solver.num_joints, dtype=np.float32)
-        for i, gi in enumerate(self._solver.left_indices):
+        q = np.zeros(self._backend.num_joints, dtype=np.float32)
+        for i, gi in enumerate(self._backend.left_indices):
             q[gi] = self._rest_pose_left[i]
-        for i, gi in enumerate(self._solver.right_indices):
+        for i, gi in enumerate(self._backend.right_indices):
             q[gi] = self._rest_pose_right[i]
         return q
 
@@ -251,7 +376,7 @@ class IKWorker:
             # fixed point. The default rest-pose attractor would otherwise pull
             # q in the EE null space at every frame, growing with distance from
             # rest; reset() restores the rest-pose attractor.
-            self._solver.set_posture_pose(q_current)
+            self._backend.set_posture_pose(q_current)
 
         # Filter raw VR poses before IK to remove tracking noise / tremor.
         lp = self._f_l_pos.update(
@@ -292,10 +417,14 @@ class IKWorker:
         right_pos, right_rot = _vr_to_flu_np(*rp, *rq)
 
         le = self._f_l_elbow.update(
-            np.array([frame.l_elbow.x, frame.l_elbow.y, frame.l_elbow.z])
+            self._gate_elbow(
+                "left", np.array([frame.l_elbow.x, frame.l_elbow.y, frame.l_elbow.z])
+            )
         )
         re = self._f_r_elbow.update(
-            np.array([frame.r_elbow.x, frame.r_elbow.y, frame.r_elbow.z])
+            self._gate_elbow(
+                "right", np.array([frame.r_elbow.x, frame.r_elbow.y, frame.r_elbow.z])
+            )
         )
         left_e = np.array((le[2], le[1], -le[0]), dtype=np.float32)
         right_e = np.array((re[2], re[1], -re[0]), dtype=np.float32)
@@ -334,7 +463,11 @@ class IKWorker:
             right_e - self._snap_elbow_ctrl["right"]
         )
 
-        q_new = self._solver.ik(
+        (tl_pos, tl_rot), (tr_pos, tr_rot), elbow_l, elbow_r = self._condition_targets(
+            q_current, (tl_pos, tl_rot), (tr_pos, tr_rot), elbow_l, elbow_r
+        )
+
+        q_new = self._backend.ik(
             q_current,
             left_pose=(tl_pos, tl_rot),
             right_pose=(tr_pos, tr_rot),
@@ -343,20 +476,188 @@ class IKWorker:
         )
         self._note_solve(
             bool(np.array_equal(q_new, q_current)),
-            np.concatenate([tl_pos, tr_pos, elbow_l, elbow_r]),
+            np.concatenate(
+                [
+                    tl_pos,
+                    tr_pos,
+                    elbow_l if elbow_l is not None else np.zeros(3, np.float32),
+                    elbow_r if elbow_r is not None else np.zeros(3, np.float32),
+                ]
+            ),
         )
         return q_new
+
+    def _condition_targets(
+        self,
+        q_current: np.ndarray,
+        left_pose: tuple[np.ndarray, np.ndarray],
+        right_pose: tuple[np.ndarray, np.ndarray],
+        elbow_l: np.ndarray,
+        elbow_r: np.ndarray,
+    ) -> tuple[
+        tuple[np.ndarray, np.ndarray],
+        tuple[np.ndarray, np.ndarray],
+        np.ndarray | None,
+        np.ndarray | None,
+    ]:
+        """Backend-independent target conditioning (see kinematics.conditioning).
+
+        1. Reach clamp: EE targets are pulled into the ``[min_reach,
+           max_reach]`` annulus around each shoulder — outside the folded-arm
+           (shoulder-singular) zone, inside the arm's reach.
+        2. Error clamp: the SE(3) error between the current EE pose and its
+           target is capped (jointly for position and orientation), so fast or
+           unreachable targets become a bounded, direction-preserving pull.
+        3. Elbow swivel (only when ``elbow_swivel`` is enabled): the
+           operator's elbow hint keeps only its (smoothed, rate-limited)
+           swivel angle about the shoulder->wrist axis, rotated to the
+           nearest angle that also clears the column; the reference the
+           solver sees lies exactly on the robot's own reachable elbow
+           circle.
+        """
+        kin = self._kin
+        frames = self._backend.fk_frames(q_current)
+
+        tl_pos, tl_rot = left_pose
+        tr_pos, tr_rot = right_pose
+        tl_pos = clamp_reach(
+            tl_pos,
+            self._backend.left_shoulder_pos,
+            self._l_max_reach,
+            self._l_min_reach,
+        )
+        tr_pos = clamp_reach(
+            tr_pos,
+            self._backend.right_shoulder_pos,
+            self._r_max_reach,
+            self._r_min_reach,
+        )
+        tl_pos, tl_rot = clamp_target_error(
+            *frames.left_ee,
+            tl_pos,
+            tl_rot,
+            kin.max_target_err_lin,
+            kin.max_target_err_ang,
+        )
+        tr_pos, tr_rot = clamp_target_error(
+            *frames.right_ee,
+            tr_pos,
+            tr_rot,
+            kin.max_target_err_lin,
+            kin.max_target_err_ang,
+        )
+
+        out_l: np.ndarray | None = elbow_l
+        out_r: np.ndarray | None = elbow_r
+        if kin.elbow_swivel and kin.diff_elbow_cost > 0.0:
+            out_l = self._elbow_reference(
+                "left",
+                self._backend.left_shoulder_pos,
+                tl_pos,
+                elbow_l,
+                frames.left_elbow,
+                self._l_upper,
+                self._l_fore,
+            )
+            out_r = self._elbow_reference(
+                "right",
+                self._backend.right_shoulder_pos,
+                tr_pos,
+                elbow_r,
+                frames.right_elbow,
+                self._r_upper,
+                self._r_fore,
+            )
+        return (tl_pos, tl_rot), (tr_pos, tr_rot), out_l, out_r
+
+    def _elbow_reference(
+        self,
+        side: str,
+        shoulder: np.ndarray,
+        wrist_target: np.ndarray,
+        elbow_raw: np.ndarray,
+        elbow_fk: np.ndarray,
+        upper_len: float,
+        fore_len: float,
+    ) -> np.ndarray | None:
+        """Smoothed, column-clear swivel reference from the operator's elbow hint.
+
+        The swivel angle is measured relative to the reference this method
+        last produced, EMA-blended toward the hint and rate-limited, then
+        rotated to the nearest angle that clears the base column. Working
+        relative to the previous reference keeps the whole chain
+        well-conditioned: "hint unchanged" is exactly angle zero, and a
+        degenerate tick (hint collinear with the arm axis) simply holds the
+        previous swivel rather than dropping the reference, which would leave
+        the arm's only self-motion unconstrained.
+
+        Seeded from the robot's current FK elbow, so the first engaged tick
+        references the swivel the arm is already in and nothing snaps; the
+        rate limit then walks it to the prior over a few tenths of a second.
+        """
+        circle = elbow_circle(shoulder, wrist_target, upper_len, fore_len)
+        if circle is None:
+            return None
+
+        prev = self._swivel_dir[side]
+        if prev is None:
+            prev = swivel_direction(shoulder, wrist_target, elbow_fk)
+            if prev is None:
+                return None
+        basis = swivel_frame(circle.axis, prev)
+        if basis is None:
+            return None
+        e_a, e_b = basis
+
+        # Follow the operator's swivel, then rotate it a bounded amount toward
+        # the highest elbow the circle allows. The operator stays in control —
+        # this only corrects the body model's documented downward bias — and
+        # the bound is what keeps it honest: aiming *at* maximum elevation
+        # instead drove the shoulder to its travel limit for a quarter of a
+        # captured session and cost up to 100 mm of hand-tracking accuracy,
+        # since an extreme swivel competes with the end-effector task.
+        hint = swivel_direction(shoulder, wrist_target, elbow_raw)
+        base = 0.0  # angle zero is "hold the previous swivel"
+        if hint is not None:
+            base = float(np.arctan2(np.dot(hint, e_b), np.dot(hint, e_a)))
+        lift = _wrap_pi(elevated_swivel_angle(e_a, e_b) - base)
+        target = base + float(
+            np.clip(lift, -_SWIVEL_LIFT_LIMIT_RAD, _SWIVEL_LIFT_LIMIT_RAD)
+        )
+        step = float(
+            np.clip(
+                _SWIVEL_BLEND_ALPHA * _wrap_pi(target),
+                -_SWIVEL_MAX_STEP_RAD,
+                _SWIVEL_MAX_STEP_RAD,
+            )
+        )
+
+        angle = clear_swivel_angle(
+            circle, e_a, e_b, wrist_target, step, _COLUMN_KEEPOUT
+        )
+
+        direction = np.cos(angle) * e_a + np.sin(angle) * e_b
+        self._swivel_dir[side] = direction
+        return circle.point(direction)
 
     def compute_reset_trajectory(
         self, q_current: np.ndarray, q_target: np.ndarray
     ) -> list[np.ndarray]:
-        """Collision-aware trajectory. Each item is a full (N,) array in radians."""
+        """Collision-aware trajectory. Each item is a full (N,) array in radians.
+
+        Reset/startup trajectories are offline plans and stay on the shared
+        pyroki model regardless of the selected IK backend; joint vectors are
+        permuted between the canonical and pyroki orders at this boundary.
+        """
         cfg = self._config
-        return plan_collision_aware_trajectory(
-            self._solver.robot,
-            self._solver.robot_coll,
-            q_current,
-            q_target,
+        _, robot, robot_coll = load_pyroki_model()
+        if self._pk_perm is None:
+            self._pk_perm = canonical_to_pyroki(robot)
+        traj = plan_collision_aware_trajectory(
+            robot,
+            robot_coll,
+            to_pyroki_order(np.asarray(q_current, dtype=np.float32), self._pk_perm),
+            to_pyroki_order(np.asarray(q_target, dtype=np.float32), self._pk_perm),
             speed=cfg.reset_speed,
             rate=cfg.frequency,
             min_duration=cfg.reset_min_duration,
@@ -366,6 +667,7 @@ class IKWorker:
             collision_weight=cfg.reset_collision_weight,
             max_iterations=cfg.reset_max_iterations,
         )
+        return [to_canonical_order(q, self._pk_perm) for q in traj]
 
     def reset(self) -> None:
         """Deactivate the engage-toggle state and clear snap poses and filter state.
@@ -379,10 +681,11 @@ class IKWorker:
         self._snap_fk = {}
         self._snap_elbow_ctrl = {}
         self._snap_elbow_fk = {}
+        self._swivel_dir = {"left": None, "right": None}
         self._reset_pose_filters()
         # step() pins posture to q_current on each engage; an explicit reset
         # restores the default rest-pose attractor.
-        self._solver.set_posture_pose(self.get_rest_q())
+        self._backend.set_posture_pose(self.get_rest_q())
 
     # -- Internal -----------------------------------------------------------
 
@@ -429,6 +732,27 @@ class IKWorker:
             )
             self._freeze_next_warn = duration + _FREEZE_REWARN_EVERY_S
 
+    def _gate_elbow(self, side: str, raw: np.ndarray) -> np.ndarray:
+        """Reject single-frame teleports in the inferred elbow position.
+
+        The headset's body model re-localises in discrete jumps that no
+        low-pass filter downstream is allowed to smooth away (OneEuro tracks
+        fast steps by design). A step above ``_ELBOW_JUMP_REJECT_M`` holds the
+        previous sample; a persistent jump (the model settled on a new
+        estimate) is accepted after ``_ELBOW_JUMP_ACCEPT_AFTER`` frames.
+        """
+        prev = self._elbow_prev_raw[side]
+        if (
+            prev is not None
+            and float(np.linalg.norm(raw - prev)) > _ELBOW_JUMP_REJECT_M
+            and self._elbow_reject_count[side] < _ELBOW_JUMP_ACCEPT_AFTER
+        ):
+            self._elbow_reject_count[side] += 1
+            return prev
+        self._elbow_reject_count[side] = 0
+        self._elbow_prev_raw[side] = raw
+        return raw
+
     def _reset_pose_filters(self) -> None:
         """Clear the OneEuroFilter state for every controller and elbow stream."""
         self._f_l_pos.reset()
@@ -437,50 +761,8 @@ class IKWorker:
         self._f_r_quat.reset()
         self._f_l_elbow.reset()
         self._f_r_elbow.reset()
-
-    def _settle_rest_pose(
-        self, max_iterations: int = 200, tol: float = 1e-5
-    ) -> np.ndarray:
-        """Iterate the full teleop IK to the manipulability-balanced rest pose.
-
-        EE and elbow targets are the configured rest pose's own FK, and posture
-        is pinned to the current iterate, so all costs except manipulability
-        have zero gradient at the starting q. The remaining manipulability
-        gradient drives q in the EE null space until it stops changing — the
-        same conditions the rising-edge posture pin in :meth:`step` produces
-        at engage time.
-        """
-        q = self.get_rest_q()
-        fk = self._solver.robot.forward_kinematics(jnp.asarray(q))
-
-        def _pose(idx: int) -> tuple[np.ndarray, np.ndarray]:
-            T = jaxlie.SE3(fk[idx])
-            return (
-                np.asarray(T.translation(), dtype=np.float32),
-                np.asarray(T.rotation().as_matrix(), dtype=np.float32),
-            )
-
-        def _elbow(idx: int) -> np.ndarray:
-            return np.asarray(jaxlie.SE3(fk[idx]).translation(), dtype=np.float32)
-
-        l_pose = _pose(self._solver.l_ee_idx)
-        r_pose = _pose(self._solver.r_ee_idx)
-        l_elbow = _elbow(self._solver.l_elbow_idx)
-        r_elbow = _elbow(self._solver.r_elbow_idx)
-
-        for _ in range(max_iterations):
-            self._solver.set_posture_pose(q)
-            q_new = self._solver.ik(
-                q,
-                left_pose=l_pose,
-                right_pose=r_pose,
-                left_elbow_pos=l_elbow,
-                right_elbow_pos=r_elbow,
-            )
-            if float(np.max(np.abs(q_new - q))) < tol:
-                return q_new
-            q = q_new
-        return q
+        self._elbow_prev_raw = {"left": None, "right": None}
+        self._elbow_reject_count = {"left": 0, "right": 0}
 
     def _engage_snap(
         self,
@@ -497,30 +779,20 @@ class IKWorker:
         These snapshots become the origin against which subsequent controller
         motion is measured to build relative EE and elbow targets in :meth:`step`.
         """
-        fk = self._solver.robot.forward_kinematics(jnp.asarray(q_current))
-
-        def _fk_pos_rot(idx: int) -> tuple[np.ndarray, np.ndarray]:
-            T = jaxlie.SE3(fk[idx])
-            pos = np.asarray(T.translation(), dtype=np.float32)
-            rot = np.asarray(T.rotation().as_matrix(), dtype=np.float32)
-            return pos, rot
+        frames = self._backend.fk_frames(q_current)
 
         self._snap_ctrl = {
             "left": (left_pos, left_rot),
             "right": (right_pos, right_rot),
         }
         self._snap_fk = {
-            "left": _fk_pos_rot(self._solver.l_ee_idx),
-            "right": _fk_pos_rot(self._solver.r_ee_idx),
+            "left": frames.left_ee,
+            "right": frames.right_ee,
         }
         self._snap_elbow_ctrl = {"left": left_e, "right": right_e}
         self._snap_elbow_fk = {
-            "left": np.asarray(
-                jaxlie.SE3(fk[self._solver.l_elbow_idx]).translation(), dtype=np.float32
-            ),
-            "right": np.asarray(
-                jaxlie.SE3(fk[self._solver.r_elbow_idx]).translation(), dtype=np.float32
-            ),
+            "left": frames.left_elbow,
+            "right": frames.right_elbow,
         }
 
 
@@ -612,5 +884,9 @@ def run_ik_worker(
             elif isinstance(msg, VRFrame):
                 q = worker.step(msg, q)
                 conn.send(q.copy())
-        except (EOFError, KeyboardInterrupt):
+        except (EOFError, KeyboardInterrupt, OSError):
+            # OSError covers ConnectionResetError/BrokenPipeError when the
+            # parent end closes abruptly (parent crash, or a shutdown that
+            # left an in-flight response unread — the close then RSTs this
+            # end). Exit cleanly instead of dying with a traceback.
             break

--- a/almond_axol/vr/config.py
+++ b/almond_axol/vr/config.py
@@ -24,6 +24,20 @@ class VRServerConfig:
         interp_min_delay_s: Floor on the adaptive playout delay (seconds).
         interp_max_delay_s: Cap on the adaptive playout delay (seconds); bounds
             the teleop latency added in exchange for smoothness.
+        interp_smooth_window_s: Width (seconds) of the Gaussian fixed-lag
+            smoothing window rendered around the playout point. Adds a fixed
+            ``window / 2`` of latency in exchange for zero-phase smoothing and
+            tracking-glitch rejection (glitches shorter than ~half the window
+            are dropped entirely). ``0`` disables smoothing and restores the
+            plain two-frame lerp.
+        interp_outlier_k: Hampel outlier threshold in robust standard
+            deviations for the glitch rejection inside the smoothing window.
+            Lower is more aggressive. ``<= 0`` disables rejection.
+        capture_path: When set, every validated inbound ``VRFrame`` is appended
+            to this JSONL file (one frame per line, with a server-side
+            ``recv_t`` arrival timestamp) so real headset sessions can be
+            replayed offline through the IK benchmark
+            (``python -m almond_axol.kinematics.bench --replay <file>``).
     """
 
     port: int = VR_PORT
@@ -31,4 +45,7 @@ class VRServerConfig:
     keyfile: str | None = None
     interp_enabled: bool = True
     interp_min_delay_s: float = 0.0
-    interp_max_delay_s: float = 0.1
+    interp_max_delay_s: float = 0.15
+    interp_smooth_window_s: float = 0.12
+    interp_outlier_k: float = 4.0
+    capture_path: str | None = None

--- a/almond_axol/vr/interp.py
+++ b/almond_axol/vr/interp.py
@@ -12,10 +12,48 @@ driven by an irregular, lossy sample stream.
 :class:`PoseInterpolator` reconstructs the original smooth motion: it buffers
 recent frames stamped with the headset's **capture** time (``VRFrame.t``) and,
 when the consumer asks for the current target, renders the pose at a playout
-time held slightly in the past (``now - delay``) by interpolating between the
-two buffered frames that bracket it (lerp for positions/grips, slerp for
-orientation). A whole 150 ms burst then plays back as the smooth stream it
-originally was.
+time held slightly in the past (``now - delay``). A whole 150 ms burst then
+plays back as the smooth stream it originally was.
+
+On top of the jitter buffer, the playout point is rendered as a **fixed-lag
+smoother**: a Gaussian-weighted average over every buffered frame within
+``smooth_window_s`` of the playout time (weighted mean for positions / grips,
+weighted quaternion mean for orientation). Because the window extends into the
+*future* relative to the playout point, this is zero-phase smoothing whose lag
+is fixed (``delay + smooth_window_s / 2``) rather than growing with hand speed
+the way a causal low-pass filter's does.
+
+The buffered lookahead also enables **glitch rejection**, which no causal
+filter can do (at the instant of a jump it cannot distinguish a tracking
+glitch from the start of a fast intentional move). Before averaging, a Hampel
+test — computed over a wider window (``_REJECT_WINDOW_MULT`` x the smoothing
+window) so a glitch burst stays a minority for the median — drops frames whose
+EE/elbow positions deviate from the window median by more than ``outlier_k``
+robust standard deviations (with an absolute floor so a still hand's
+micro-noise never flags). A tracking excursion that jumps away and comes back
+within roughly the smoothing window is erased entirely instead of being
+chased; while it lasts, the nearest clean frames dominate the renormalized
+weights so the output bridges smoothly across it. A *sustained* jump
+eventually wins the median and is followed normally after the fixed lag. When
+the window holds too few frames (startup, sparse or unstamped streams),
+rendering falls back to plain lerp/slerp between the two bracketing frames.
+
+Frames also carry a **per-hand tracked flag** (``VRFrame.l_tracked`` /
+``r_tracked``, from WebXR ``emulatedPosition``): the headset sets it False
+while a controller's position is only inertially dead-reckoned (occluded, out
+of camera view, whipped too fast) — the pose drifts while coasting and snaps
+when optical tracking re-acquires. Unlike the Hampel test, this identifies the
+bad samples *deterministically*, including drifts too long or too gentle for
+the median to out-vote. Untracked frames are excluded from that hand's average
+(each hand is gated independently, so one occluded controller never freezes
+the other arm); if a hand's whole window is untracked, its last cleanly
+tracked pose (EE + elbow) is held until tracking returns, and the downstream
+velocity limits turn the eventual re-acquire step into a bounded catch-up.
+Grip values keep flowing regardless — the trigger is electronic, not
+optically tracked. Streams that never carried a tracked frame (older web
+builds after an upgrade race, or a runtime that always reports emulation)
+pass through un-gated, so the mechanism can only ever engage when real
+tracked/untracked transitions are observed.
 
 ``delay`` is **adaptive**: it tracks the observed arrival jitter (clamped to
 ``[min_delay, max_delay]``), so a clean LAN adds almost no latency while a
@@ -32,12 +70,20 @@ server arrival time, where bursts can't be reconstructed but nothing breaks.
 from __future__ import annotations
 
 import bisect
+import logging
 import threading
 import time
 
 import numpy as np
 
 from .models import VRFrame, VRPose, VRPosition, VRQuaternion
+
+_logger = logging.getLogger(__name__)
+
+# Warn once per hold episode after this long, so an unexpectedly sticky hold
+# (e.g. a controller left face-down on a table while engaged) is explained in
+# the logs rather than looking like a dead arm.
+_HOLD_WARN_AFTER_S = 1.0
 
 
 class PoseInterpolator:
@@ -57,16 +103,30 @@ class PoseInterpolator:
         max_frames: Hard cap on buffered frames (safety bound).
         pos_eps: Position change (metres) below which a re-render is considered
             unchanged, so the consumer's identity check can skip redundant IK.
+        smooth_window_s: Width (seconds) of the Gaussian fixed-lag smoothing
+            window centred on the playout point. Adds ``smooth_window_s / 2``
+            of fixed latency in exchange for zero-phase smoothing and glitch
+            rejection. ``0`` disables smoothing (plain two-frame lerp).
+        outlier_k: Hampel threshold in robust standard deviations (MAD-based).
+            Frames whose EE/elbow positions deviate from the window median by
+            more than this are excluded from the average, so transient
+            tracking glitches are dropped rather than followed. ``<= 0``
+            disables rejection.
+        outlier_floor_m: Absolute floor (metres) on the Hampel threshold so a
+            perfectly still hand's micro-noise is never flagged as outliers.
     """
 
     def __init__(
         self,
         enabled: bool = True,
         min_delay_s: float = 0.0,
-        max_delay_s: float = 0.1,
+        max_delay_s: float = 0.15,
         window_s: float = 2.0,
         max_frames: int = 512,
         pos_eps: float = 1e-4,
+        smooth_window_s: float = 0.12,
+        outlier_k: float = 4.0,
+        outlier_floor_m: float = 0.02,
     ) -> None:
         self.enabled = enabled
         self._min_delay = float(min_delay_s)
@@ -74,11 +134,21 @@ class PoseInterpolator:
         self._window = float(window_s)
         self._max_frames = int(max_frames)
         self._pos_eps = float(pos_eps)
+        self._half_smooth = max(0.0, float(smooth_window_s)) / 2.0
+        self._outlier_k = float(outlier_k)
+        self._outlier_floor = float(outlier_floor_m)
 
         self._lock = threading.Lock()
         # Buffer of (capture_time_s, frame), kept sorted by capture time.
         self._caps: list[float] = []
         self._frames: list[VRFrame] = []
+        # Per-frame numeric vector (see _frame_vec), parallel to _caps/_frames.
+        # Precomputed at push time (~90 Hz) so the smoothing render in sample()
+        # is pure vectorized numpy — walking the pydantic models per sample was
+        # ~0.8 ms/call on Jetson, enough to slow the IK dispatch loop it runs
+        # on (in series with every solve) and cost more smoothness through a
+        # coarser IK staircase than the smoothing itself bought.
+        self._vecs: list[np.ndarray] = []
         # Recent (local_recv_s, transit_s) for jitter/offset estimation.
         self._transits: list[tuple[float, float]] = []
         self._clock_offset: float | None = None
@@ -93,11 +163,23 @@ class PoseInterpolator:
         self._last_out: VRFrame | None = None
         self._last_pos: np.ndarray | None = None
 
+        # Last per-hand pose rendered from optically tracked frames, as a
+        # (10,) vector [ee_pos(3), ee_quat(4), elbow(3)]. Substituted while a
+        # hand's whole rejection window is untracked (WebXR emulatedPosition),
+        # so the arm holds instead of chasing inertial drift. ``None`` until
+        # the stream shows its first tracked frame — see the module docstring
+        # for the pass-through this implies.
+        self._held: dict[str, np.ndarray | None] = {"left": None, "right": None}
+        # Hold-episode bookkeeping for the rate-limited log warning.
+        self._hold_since: dict[str, float | None] = {"left": None, "right": None}
+        self._hold_warned: dict[str, bool] = {"left": False, "right": False}
+
     def reset(self) -> None:
         """Drop all buffered state (e.g. on reconnect)."""
         with self._lock:
             self._caps.clear()
             self._frames.clear()
+            self._vecs.clear()
             self._transits.clear()
             self._clock_offset = None
             self._delay = self._min_delay
@@ -105,6 +187,9 @@ class PoseInterpolator:
             self._latest = None
             self._last_out = None
             self._last_pos = None
+            self._held = {"left": None, "right": None}
+            self._hold_since = {"left": None, "right": None}
+            self._hold_warned = {"left": False, "right": False}
 
     def push(self, frame: VRFrame, now: float | None = None) -> None:
         """Ingest a freshly received frame.
@@ -124,6 +209,7 @@ class PoseInterpolator:
             if self._t_is_client is not None and is_client != self._t_is_client:
                 self._caps.clear()
                 self._frames.clear()
+                self._vecs.clear()
                 self._transits.clear()
                 self._clock_offset = None
                 self._delay = self._min_delay
@@ -153,9 +239,11 @@ class PoseInterpolator:
             i = bisect.bisect_right(self._caps, cap_t)
             self._caps.insert(i, cap_t)
             self._frames.insert(i, frame)
+            self._vecs.insert(i, _frame_vec(frame))
 
-            # Prune: keep a little history behind the current playout point.
-            play = (local_recv - self._clock_offset) - self._delay
+            # Prune: keep a little history behind the current playout point
+            # (which is held an extra half smoothing-window in the past).
+            play = (local_recv - self._clock_offset) - self._delay - self._half_smooth
             keep_before = play - 0.5
             drop = 0
             while drop < len(self._caps) - 2 and self._caps[drop] < keep_before:
@@ -163,13 +251,53 @@ class PoseInterpolator:
             if drop:
                 del self._caps[:drop]
                 del self._frames[:drop]
+                del self._vecs[:drop]
             extra = len(self._caps) - self._max_frames
             if extra > 0:
                 del self._caps[:extra]
                 del self._frames[:extra]
+                del self._vecs[:extra]
+
+    def _update_hold(
+        self,
+        side: str,
+        live: bool,
+        held_prev: np.ndarray | None,
+        out: np.ndarray,
+        now: float,
+    ) -> bool:
+        """Advance one hand's hold bookkeeping after a smoothing render.
+
+        Must be called with the lock held. ``live`` means the hand was rendered
+        from optically tracked frames, so ``out`` becomes the new held pose.
+        Returns True when a hold episode just crossed the warning threshold
+        (the caller logs outside the lock).
+        """
+        if live:
+            self._held[side] = out
+            self._hold_since[side] = None
+            self._hold_warned[side] = False
+            return False
+        if held_prev is None:
+            return False  # pass-through: this stream has never been tracked
+        if self._hold_since[side] is None:
+            self._hold_since[side] = now
+            return False
+        if (
+            not self._hold_warned[side]
+            and now - self._hold_since[side] >= _HOLD_WARN_AFTER_S
+        ):
+            self._hold_warned[side] = True
+            return True
+        return False
 
     def sample(self, now: float | None = None) -> VRFrame | None:
-        """Render the current interpolated target frame.
+        """Render the current smoothed target frame.
+
+        Renders a Gaussian-weighted, outlier-rejected average of the buffered
+        frames within the smoothing window around the playout point; falls back
+        to plain lerp/slerp between the two bracketing frames when the window
+        is too sparse (startup, unstamped transports, ``smooth_window_s == 0``).
 
         Returns ``None`` only before any frame has been received. The returned
         object is *identity-stable*: when the rendered pose hasn't moved beyond
@@ -190,24 +318,79 @@ class PoseInterpolator:
                 self._last_pos = None
                 return latest
 
+            # The extra half-window playout shift only applies when smoothing
+            # is active (client-stamped streams); unstamped streams keep the
+            # undelayed playout point so they still render the latest frame.
+            smoothing = self._half_smooth > 0.0 and bool(self._t_is_client)
             play = (now - self._clock_offset) - self._delay
+            if smoothing:
+                play -= self._half_smooth
             caps = self._caps
             frames = self._frames
-            if play <= caps[0]:
-                a = b = frames[0]
-                alpha = 0.0
-            elif play >= caps[-1]:
-                a = b = frames[-1]
-                alpha = 0.0
-            else:
-                j = bisect.bisect_right(caps, play)
-                a, b = frames[j - 1], frames[j]
-                span = caps[j] - caps[j - 1]
-                alpha = (play - caps[j - 1]) / span if span > 1e-9 else 0.0
+
+            # Fixed-lag smoothing: snapshot the window slices under the lock
+            # (frames are immutable models; slicing copies only the refs).
+            # The slice spans the *rejection* window — wider than the Gaussian
+            # smoothing window so the Hampel median sees enough clean frames to
+            # out-vote a glitch burst, at no extra latency (the history side is
+            # already buffered; the future side is capped by what has arrived).
+            # Only client-stamped streams are smoothed: unstamped frames carry
+            # arrival timestamps, so a delivery burst collapses distinct poses
+            # onto near-identical time coordinates and the weighted average
+            # would blend them into a false target. Unstamped streams fall
+            # through to the lerp path, which renders the latest frame.
+            win_caps: list[float] | None = None
+            win_vecs: list[np.ndarray] | None = None
+            if smoothing:
+                half_rej = self._half_smooth * _REJECT_WINDOW_MULT
+                lo = bisect.bisect_left(caps, play - half_rej)
+                hi = bisect.bisect_right(caps, play + half_rej)
+                if hi - lo >= 3:
+                    win_caps = caps[lo:hi]
+                    win_vecs = self._vecs[lo:hi]
+
+            if win_vecs is None:
+                if play <= caps[0]:
+                    a = b = frames[0]
+                    alpha = 0.0
+                elif play >= caps[-1]:
+                    a = b = frames[-1]
+                    alpha = 0.0
+                else:
+                    j = bisect.bisect_right(caps, play)
+                    a, b = frames[j - 1], frames[j]
+                    span = caps[j] - caps[j - 1]
+                    alpha = (play - caps[j - 1]) / span if span > 1e-9 else 0.0
             last_out = self._last_out
             last_pos = self._last_pos
+            held_l = self._held["left"]
+            held_r = self._held["right"]
 
-        rendered, pos = _interpolate(a, b, alpha, latest)
+        if win_vecs is not None and win_caps is not None:
+            rendered, pos, l_out, l_live, r_out, r_live = _smooth_window(
+                win_vecs,
+                win_caps,
+                play,
+                self._half_smooth,
+                self._outlier_k,
+                self._outlier_floor,
+                latest,
+                held_l,
+                held_r,
+            )
+            with self._lock:
+                warn_l = self._update_hold("left", l_live, held_l, l_out, now)
+                warn_r = self._update_hold("right", r_live, held_r, r_out, now)
+            for side, warn in (("left", warn_l), ("right", warn_r)):
+                if warn:
+                    _logger.warning(
+                        "%s controller position untracked for %.1fs — holding "
+                        "its last optically-tracked pose until tracking returns",
+                        side,
+                        _HOLD_WARN_AFTER_S,
+                    )
+        else:
+            rendered, pos = _interpolate(a, b, alpha, latest)
 
         # Identity-stable: reuse the previous object when nothing moved and the
         # control state matches, so the consumer's `is` check skips the solve.
@@ -257,6 +440,230 @@ def _quat(q: VRQuaternion) -> np.ndarray:
     return np.array([q.x, q.y, q.z, q.w], dtype=np.float64)
 
 
+def _quat_weighted_mean(quats: np.ndarray, w: np.ndarray, ref_i: int) -> np.ndarray:
+    """Weighted mean of ``(n, 4)`` quaternions, hemisphere-aligned to row ``ref_i``.
+
+    Sign-aligning every quaternion to the reference before the weighted sum
+    makes the normalized result a good mean for the small angular spreads seen
+    within a smoothing window.
+    """
+    ref = quats[ref_i]
+    sign = np.where(quats @ ref < 0.0, -1.0, 1.0)
+    q = (w * sign) @ quats
+    norm = np.linalg.norm(q)
+    return q / norm if norm > 1e-12 else ref.copy()
+
+
+# The Hampel rejection window is this multiple of the smoothing window, so a
+# glitch burst as long as the whole smoothing window is still a minority for
+# the median and gets rejected. Costs no latency: the extra frames come from
+# history already buffered (and whatever future frames have arrived).
+_REJECT_WINDOW_MULT = 2.5
+
+
+# _frame_vec layout: 4 position streams, 2 quaternions, 2 grips, 2 tracked flags.
+_VEC_LEE = slice(0, 3)
+_VEC_REE = slice(3, 6)
+_VEC_LEL = slice(6, 9)
+_VEC_REL = slice(9, 12)
+_VEC_LQ = slice(12, 16)
+_VEC_RQ = slice(16, 20)
+_VEC_LGRIP = 20
+_VEC_RGRIP = 21
+_VEC_LTRK = 22
+_VEC_RTRK = 23
+
+
+def _frame_vec(f: VRFrame) -> np.ndarray:
+    """Flatten a frame's motion fields into a (24,) float64 vector.
+
+    Computed once per received frame so the smoothing render never walks the
+    pydantic models on the hot sampling path.
+    """
+    lp, rp, le, re = f.l_ee.position, f.r_ee.position, f.l_elbow, f.r_elbow
+    lq, rq = f.l_ee.quaternion, f.r_ee.quaternion
+    return np.array(
+        [
+            lp.x, lp.y, lp.z,
+            rp.x, rp.y, rp.z,
+            le.x, le.y, le.z,
+            re.x, re.y, re.z,
+            lq.x, lq.y, lq.z, lq.w,
+            rq.x, rq.y, rq.z, rq.w,
+            f.l_grip, f.r_grip,
+            1.0 if f.l_tracked else 0.0,
+            1.0 if f.r_tracked else 0.0,
+        ],
+        dtype=np.float64,
+    )  # fmt: skip
+
+
+def _hampel_mean(
+    Vt: np.ndarray,
+    gt: np.ndarray,
+    ee_sl: slice,
+    q_sl: slice,
+    el_sl: slice,
+    outlier_k: float,
+    outlier_floor: float,
+) -> np.ndarray:
+    """Hampel-rejected Gaussian mean of one hand's streams over ``Vt``.
+
+    Returns the (10,) vector ``[ee_pos(3), ee_quat(4), elbow(3)]``.
+    """
+    m = len(Vt)
+    inlier = np.ones(m, dtype=bool)
+    if outlier_k > 0.0 and m >= 3:
+        # (m, 2, 3): this hand's EE + elbow position streams. Medians use
+        # np.partition (upper median for even m) — np.median's generality is
+        # ~10x the cost on windows this small, and robust statistics don't
+        # care about the midpoint averaging.
+        P = np.stack((Vt[:, ee_sl], Vt[:, el_sl]), axis=1)
+        mid = m // 2
+        med = np.partition(P, mid, axis=0)[mid]  # (2, 3)
+        diff = P - med
+        d = np.sqrt(np.einsum("ijk,ijk->ij", diff, diff))  # (m, 2)
+        mad = np.partition(d, mid, axis=0)[mid]  # (2,)
+        thresh = np.maximum(outlier_k * 1.4826 * mad, outlier_floor)
+        inlier = np.all(d <= thresh, axis=1)
+        if int(inlier.sum()) < 2:
+            # Degenerate (e.g. bimodal window mid-jump): rejecting almost
+            # everything would leave a meaningless average, so keep all frames.
+            inlier[:] = True
+
+    w = gt * inlier
+    w = w / w.sum()
+    ref_i = int(np.argmax(w))
+    out = np.empty(10)
+    out[0:3] = w @ Vt[:, ee_sl]
+    out[3:7] = _quat_weighted_mean(Vt[:, q_sl], w, ref_i)
+    out[7:10] = w @ Vt[:, el_sl]
+    return out
+
+
+def _hand_mean(
+    V: np.ndarray,
+    g: np.ndarray,
+    trk: np.ndarray,
+    ee_sl: slice,
+    q_sl: slice,
+    el_sl: slice,
+    outlier_k: float,
+    outlier_floor: float,
+    held: np.ndarray | None,
+) -> tuple[np.ndarray, bool]:
+    """Weighted mean of one hand's streams over its tracked, inlier frames.
+
+    Returns ``(out, live)`` where ``out`` is the (10,) vector
+    ``[ee_pos(3), ee_quat(4), elbow(3)]`` rendered for this hand:
+
+      - some frames tracked: Hampel-rejected Gaussian mean over the tracked
+        frames only, ``live=True``;
+      - none tracked, held pose available: the held pose, ``live=False`` —
+        the arm holds instead of chasing inertial dead-reckoning drift;
+      - none tracked, nothing held (the stream has never carried a tracked
+        frame, e.g. a runtime that always reports emulated positions): the
+        same Hampel-rejected mean over all frames, ``live=False`` — exactly
+        the pre-gating behaviour rather than freezing teleop.
+    """
+    if not bool(trk.any()):
+        if held is not None:
+            return held, False
+        return _hampel_mean(V, g, ee_sl, q_sl, el_sl, outlier_k, outlier_floor), False
+
+    all_tracked = bool(trk.all())
+    Vt = V if all_tracked else V[trk]
+    gt = g if all_tracked else g[trk]
+    return _hampel_mean(Vt, gt, ee_sl, q_sl, el_sl, outlier_k, outlier_floor), True
+
+
+def _smooth_window(
+    vecs: list[np.ndarray],
+    caps: list[float],
+    play: float,
+    half_window: float,
+    outlier_k: float,
+    outlier_floor: float,
+    latest: VRFrame,
+    held_l: np.ndarray | None,
+    held_r: np.ndarray | None,
+) -> tuple[VRFrame, np.ndarray, np.ndarray, bool, np.ndarray, bool]:
+    """Render the Gaussian-weighted, outlier-rejected mean pose of a window.
+
+    ``vecs`` (per-frame :func:`_frame_vec` vectors) spans the wide *rejection*
+    window; the Gaussian sigma comes from the narrower smoothing
+    ``half_window``, so frames beyond the smoothing window carry negligible
+    weight — *unless* the frames near the playout point are rejected as
+    glitches, in which case the nearest clean frames dominate the renormalized
+    weights and the output bridges smoothly across the glitch.
+
+    Each hand is rendered independently by :func:`_hand_mean`: frames the
+    headset marked untracked (inertially dead-reckoned) are excluded outright,
+    then Hampel rejection drops statistical outliers among the tracked frames
+    — a frame whose EE or elbow position deviates from the tracked median by
+    more than ``outlier_k * 1.4826 * MAD`` (floored at ``outlier_floor``
+    metres) is excluded entirely, orientation included, since a glitched
+    tracking sample corrupts position and orientation together. The MAD scale
+    grows with genuine motion spread, so fast intentional moves are never
+    flagged; only a minority cluster far from the median is. Grips are
+    electronic reads, valid regardless of optical tracking, and are averaged
+    over every frame. Control state comes from ``latest``, exactly like
+    :func:`_interpolate`.
+
+    Returns ``(frame, pos_vector, l_out, l_live, r_out, r_live)`` where
+    ``l_out`` / ``r_out`` are each hand's rendered (10,) vectors and ``l_live``
+    / ``r_live`` flag whether that hand was rendered from tracked frames (the
+    caller adopts it as the new held pose) rather than held or passed through.
+    """
+    V = np.stack(vecs)  # (n, 24)
+    t = np.array(caps, dtype=np.float64)
+
+    # Gaussian weights centred on the playout point; smoothing-window edges sit
+    # at ~2 sigma so the average is dominated by frames near the playout time.
+    sigma = max(half_window / 2.0, 1e-6)
+    g = np.exp(-0.5 * ((t - play) / sigma) ** 2)
+    w_all = g / g.sum()
+
+    l_grip = float(w_all @ V[:, _VEC_LGRIP])
+    r_grip = float(w_all @ V[:, _VEC_RGRIP])
+
+    l_out, l_live = _hand_mean(
+        V,
+        g,
+        V[:, _VEC_LTRK] > 0.5,
+        _VEC_LEE,
+        _VEC_LQ,
+        _VEC_LEL,
+        outlier_k,
+        outlier_floor,
+        held_l,
+    )
+    r_out, r_live = _hand_mean(
+        V,
+        g,
+        V[:, _VEC_RTRK] > 0.5,
+        _VEC_REE,
+        _VEC_RQ,
+        _VEC_REL,
+        outlier_k,
+        outlier_floor,
+        held_r,
+    )
+
+    frame, pos = _build_frame(
+        l_out[0:3],
+        l_out[3:7],
+        r_out[0:3],
+        r_out[3:7],
+        l_out[7:10],
+        r_out[7:10],
+        l_grip,
+        r_grip,
+        latest,
+    )
+    return frame, pos, l_out, l_live, r_out, r_live
+
+
 def _interpolate(
     a: VRFrame, b: VRFrame, alpha: float, latest: VRFrame
 ) -> tuple[VRFrame, np.ndarray]:
@@ -271,20 +678,61 @@ def _interpolate(
     r_el = _lerp(_pos(a.r_elbow), _pos(b.r_elbow), alpha)
     l_grip = float(a.l_grip + alpha * (b.l_grip - a.l_grip))
     r_grip = float(a.r_grip + alpha * (b.r_grip - a.r_grip))
+    return _build_frame(
+        l_ee_p, l_ee_q, r_ee_p, r_ee_q, l_el, r_el, l_grip, r_grip, latest
+    )
 
-    frame = VRFrame(
-        l_ee=VRPose(
-            position=VRPosition(x=l_ee_p[0], y=l_ee_p[1], z=l_ee_p[2]),
-            quaternion=VRQuaternion(x=l_ee_q[0], y=l_ee_q[1], z=l_ee_q[2], w=l_ee_q[3]),
+
+def _build_frame(
+    l_ee_p: np.ndarray,
+    l_ee_q: np.ndarray,
+    r_ee_p: np.ndarray,
+    r_ee_q: np.ndarray,
+    l_el: np.ndarray,
+    r_el: np.ndarray,
+    l_grip: float,
+    r_grip: float,
+    latest: VRFrame,
+) -> tuple[VRFrame, np.ndarray]:
+    """Assemble a rendered frame; motion from the args, control state from
+    ``latest``. Returns ``(frame, pos_vector)`` where ``pos_vector`` is the
+    concatenated EE+elbow positions used for the change/identity check.
+
+    Uses ``model_construct`` (no validation) with explicit ``float()``
+    conversion: this runs per sample on the IK dispatch thread and the fields
+    are numerics we computed ourselves, so validation is pure overhead.
+    """
+    frame = VRFrame.model_construct(
+        l_ee=VRPose.model_construct(
+            position=VRPosition.model_construct(
+                x=float(l_ee_p[0]), y=float(l_ee_p[1]), z=float(l_ee_p[2])
+            ),
+            quaternion=VRQuaternion.model_construct(
+                x=float(l_ee_q[0]),
+                y=float(l_ee_q[1]),
+                z=float(l_ee_q[2]),
+                w=float(l_ee_q[3]),
+            ),
         ),
-        r_ee=VRPose(
-            position=VRPosition(x=r_ee_p[0], y=r_ee_p[1], z=r_ee_p[2]),
-            quaternion=VRQuaternion(x=r_ee_q[0], y=r_ee_q[1], z=r_ee_q[2], w=r_ee_q[3]),
+        r_ee=VRPose.model_construct(
+            position=VRPosition.model_construct(
+                x=float(r_ee_p[0]), y=float(r_ee_p[1]), z=float(r_ee_p[2])
+            ),
+            quaternion=VRQuaternion.model_construct(
+                x=float(r_ee_q[0]),
+                y=float(r_ee_q[1]),
+                z=float(r_ee_q[2]),
+                w=float(r_ee_q[3]),
+            ),
         ),
-        l_elbow=VRPosition(x=l_el[0], y=l_el[1], z=l_el[2]),
-        r_elbow=VRPosition(x=r_el[0], y=r_el[1], z=r_el[2]),
-        l_grip=l_grip,
-        r_grip=r_grip,
+        l_elbow=VRPosition.model_construct(
+            x=float(l_el[0]), y=float(l_el[1]), z=float(l_el[2])
+        ),
+        r_elbow=VRPosition.model_construct(
+            x=float(r_el[0]), y=float(r_el[1]), z=float(r_el[2])
+        ),
+        l_grip=float(l_grip),
+        r_grip=float(r_grip),
         # Control state is responsive: always the latest received, never delayed.
         l_lock=latest.l_lock,
         r_lock=latest.r_lock,

--- a/almond_axol/vr/models.py
+++ b/almond_axol/vr/models.py
@@ -81,6 +81,15 @@ class VRFrame(BaseModel):
             and network transports; the server processes each logical frame
             exactly once, via whichever transport delivers it first. ``None``
             for senders that don't set it (then no cross-transport de-duplication).
+        l_tracked: True while the left controller's position is optically
+            tracked. ``False`` means the headset lost sight of the controller
+            (occlusion, edge of camera FOV, very fast motion) and the reported
+            position is inertially dead-reckoned (WebXR ``emulatedPosition``) —
+            it drifts while coasting and snaps when tracking re-acquires, so
+            the server's pose smoother excludes these frames and holds the last
+            clean pose instead. Defaults to True so older web builds (which
+            omit the field) keep the previous always-trusted behaviour.
+        r_tracked: Same as ``l_tracked`` for the right controller.
         l_stick_x: Left thumbstick x, [-1, 1], right = +1. With ``l_stick_y``
             it drives the powered cart's translation when one is configured
             (see :class:`almond_axol.robot.cart.Cart`). Neutral defaults keep
@@ -105,6 +114,8 @@ class VRFrame(BaseModel):
     state: VRState = VRState.TELEOP
     t: float | None = None
     seq: int | None = None
+    l_tracked: bool = True
+    r_tracked: bool = True
     l_stick_x: float = 0.0
     l_stick_y: float = 0.0
     r_stick_x: float = 0.0

--- a/almond_axol/vr/server.py
+++ b/almond_axol/vr/server.py
@@ -34,6 +34,7 @@ import json
 import logging
 import os
 import socket
+import time
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
@@ -53,6 +54,12 @@ if TYPE_CHECKING:
     from ..video.video import WebRTCManager
 
 _logger = logging.getLogger(__name__)
+
+# Pose-frame arrival gap (s) above which the transport is considered stalled
+# (the headset streams at ~120 Hz, so 50 ms means ~6 consecutive frames are
+# stuck in flight) and minimum spacing (s) between stall warnings.
+_STALL_GAP_S = 0.05
+_STALL_LOG_EVERY_S = 5.0
 
 
 class VRServer:
@@ -118,6 +125,8 @@ class VRServer:
             enabled=config.interp_enabled,
             min_delay_s=config.interp_min_delay_s,
             max_delay_s=config.interp_max_delay_s,
+            smooth_window_s=config.interp_smooth_window_s,
+            outlier_k=config.interp_outlier_k,
         )
         self._client_count: int = 0
         self._active_clients: set[WebSocket] = set()
@@ -125,6 +134,18 @@ class VRServer:
         self._uvicorn_server: uvicorn.Server | None = None
         self._listen_socket: socket.socket | None = None
         self._webrtc: WebRTCManager | Any | None = None
+
+        # Optional JSONL capture of every validated inbound frame, so real
+        # headset sessions can be replayed through the offline IK benchmark
+        # (``--vr_server.capture_path session.jsonl``). Opened lazily on the
+        # first frame; append mode so restarts extend the same session file.
+        self._capture_path = config.capture_path
+        self._capture_file: Any | None = None
+        # Transport stall detection state (see _note_arrival).
+        self._last_arrival_t: float | None = None
+        self._last_stall_log_t: float = 0.0
+        self._stall_count: int = 0
+        self._worst_stall_s: float = 0.0
         # Dedicated pose data channel (low-latency control transport). Always
         # available — independent of whether any cameras are streaming.
         self._control = ControlChannelManager(self._ingest_pose_text)
@@ -326,8 +347,17 @@ class VRServer:
         self._client_count = 0
         self._active_clients.clear()
         # Fresh session next enable(): don't gate a reloaded headset's restarted
-        # seq counter against a stale high-water mark.
+        # seq counter against a stale high-water mark, and don't count the
+        # inter-session silence as a transport stall.
         self._last_seq = None
+        self._last_arrival_t = None
+
+        if self._capture_file is not None:
+            try:
+                self._capture_file.close()
+            except OSError:
+                pass
+            self._capture_file = None
 
     # ------------------------------------------------------------------
     # Async context manager
@@ -388,9 +418,60 @@ class VRServer:
             self._last_seq = seq
 
         self._latest_frame = frame
+        self._note_arrival()
         self._interp.push(frame)
+        self._capture(frame)
         if self._on_frame is not None:
             self._on_frame(frame)
+
+    def _note_arrival(self) -> None:
+        """Track pose-frame arrival gaps and surface transport stalls.
+
+        The headset produces frames at a steady ~120 Hz; long silences are a
+        transport problem (WiFi scan pauses, relayed-path bufferbloat) that no
+        amount of downstream filtering can hide — the arm holds, then lurches
+        through the motion captured during the gap. Field sessions showed
+        ~150 ms silences every ~10 s wrecking otherwise-fine IK, so make the
+        stalls visible: WARN with a running count, rate-limited to one log per
+        ``_STALL_LOG_EVERY_S``.
+        """
+        now = time.perf_counter()
+        prev = self._last_arrival_t
+        self._last_arrival_t = now
+        if prev is None:
+            return
+        gap = now - prev
+        if gap < _STALL_GAP_S:
+            return
+        self._stall_count += 1
+        self._worst_stall_s = max(self._worst_stall_s, gap)
+        if now - self._last_stall_log_t >= _STALL_LOG_EVERY_S:
+            self._last_stall_log_t = now
+            _logger.warning(
+                "VR pose stream stalled %.0f ms (%d stalls > %.0f ms this "
+                "session, worst %.0f ms) — teleop will hold then catch up; "
+                "check the headset WiFi link or use the USB tether.",
+                gap * 1e3,
+                self._stall_count,
+                _STALL_GAP_S * 1e3,
+                self._worst_stall_s * 1e3,
+            )
+
+    def _capture(self, frame: VRFrame) -> None:
+        """Append ``frame`` to the JSONL capture file when capture is enabled."""
+        if self._capture_path is None:
+            return
+        try:
+            if self._capture_file is None:
+                self._capture_file = open(  # noqa: SIM115 - held for the session
+                    self._capture_path, "a", encoding="utf-8"
+                )
+            record = frame.model_dump(mode="json")
+            record["recv_t"] = time.time()
+            self._capture_file.write(json.dumps(record) + "\n")
+        except Exception as exc:  # noqa: BLE001 - capture is best-effort
+            _logger.warning("VRFrame capture disabled: %s", exc)
+            self._capture_path = None
 
     def _ingest_pose_text(self, data: str) -> None:
         """Ingest a pose frame from the control data channel (text message).
@@ -560,6 +641,7 @@ class VRServer:
                 if server._client_count == 0:
                     server._latest_frame = None
                     server._last_seq = None
+                    server._last_arrival_t = None
                     server._interp.reset()
 
         return app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,14 @@ dependencies = [
     "fastapi>=0.135.2",
     "jax>=0.9.2",
     "jaxlie>=1.5.0",
+    "mink>=0.0.5,<1.2", # MuJoCo QP IK: the mink-qp teleop backend (1.2 forces mujoco>=3.11)
     "mujoco>=3.8.0",
+    "pin>=2.7", # Pinocchio: kinematics for the pink-qp teleop IK backend
+    "pin-pink>=3.0",
     "pydantic>=2.12.5",
     "pyroki",
     "python-can>=4.6.1",
+    "qpsolvers[daqp]>=4.0",
     "scipy>=1.17.1",
     "uvicorn[standard]>=0.42.0",
     "yourdfpy>=0.0.60",

--- a/uv.lock
+++ b/uv.lock
@@ -167,11 +167,15 @@ dependencies = [
     { name = "fastapi" },
     { name = "jax" },
     { name = "jaxlie" },
+    { name = "mink" },
     { name = "mujoco" },
     { name = "opencv-python-headless" },
+    { name = "pin" },
+    { name = "pin-pink" },
     { name = "pydantic" },
     { name = "pyroki" },
     { name = "python-can" },
+    { name = "qpsolvers", extra = ["daqp"] },
     { name = "scipy" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "yourdfpy" },
@@ -196,12 +200,16 @@ requires-dist = [
     { name = "jax", specifier = ">=0.9.2" },
     { name = "jaxlie", specifier = ">=1.5.0" },
     { name = "lerobot", extras = ["dataset", "viz", "async"], marker = "extra == 'lerobot'", git = "https://github.com/huggingface/lerobot.git?rev=b5f65e533270015f33dc2f5f570b27dada96fbb1" },
+    { name = "mink", specifier = ">=0.0.5,<1.2" },
     { name = "mujoco", specifier = ">=3.8.0" },
     { name = "opencv-python-headless", specifier = ">=4.13.0.92" },
+    { name = "pin", specifier = ">=2.7" },
+    { name = "pin-pink", specifier = ">=3.0" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pygame", marker = "extra == 'gamepad'", specifier = ">=2.6" },
     { name = "pyroki", git = "https://github.com/chungmin99/pyroki.git?rev=388e43e1fc0d0ee382968d3dd72970fd62a0450c" },
     { name = "python-can", specifier = ">=4.6.1" },
+    { name = "qpsolvers", extras = ["daqp"], specifier = ">=4.0" },
     { name = "scipy", specifier = ">=1.17.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.42.0" },
     { name = "viser", marker = "extra == 'sim'", specifier = ">=1.0.24" },
@@ -436,6 +444,190 @@ wheels = [
 ]
 
 [[package]]
+name = "cmeel"
+version = "0.60.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/46/ddc7df697e49cae32b1a97b3e1a3b47b815238f9059312f987bc62a2e756/cmeel-0.60.1.tar.gz", hash = "sha256:3e0b92eb933a3693ad3f1da8aae31defcbee5f25969daaf20e59c57d6a9474cf", size = 14972, upload-time = "2026-05-11T17:13:57.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/39/f2db2ff475d42222c70fe25c737028aeaafdd9c0aeba04e6b2dc66e7f93f/cmeel-0.60.1-py3-none-any.whl", hash = "sha256:3f92b68353a58b4d6b5a664ea96bf58a3fef0891a8ed570d3c153361bbbb94b7", size = 20612, upload-time = "2026-05-11T17:13:55.812Z" },
+]
+
+[[package]]
+name = "cmeel-assimp"
+version = "6.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cmeel" },
+    { name = "cmeel-zlib" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/57/444bedd35567a8d6b61850b03aadf6b0d2d20737ee79c620c0e40f9a56dc/cmeel_assimp-6.0.5-0-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:840ab4bd398abbec5a612a731bb6f7fdc4e21b2708ae0dc0f99d7ff6d9992624", size = 10057855, upload-time = "2026-05-20T16:36:19.775Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/96/d4d128e074f59b79e90c78b8379127bd8953c72d1ad8a65229c23a09814f/cmeel_assimp-6.0.5-0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:6d81f913e9efc8526a335900325906b85dc57891eeb7ece463714a107f14f63f", size = 9216472, upload-time = "2026-05-20T16:36:22.369Z" },
+    { url = "https://files.pythonhosted.org/packages/77/37/11de8f263a5cde3cde4796e344ff034674bdbb7a2381f6b5303d49b24def/cmeel_assimp-6.0.5-0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:db6fe58f8bd633cb05ab9f390c576a4e774927ed8c343083fad4f939e834bf6e", size = 13709230, upload-time = "2026-05-20T16:36:25.497Z" },
+    { url = "https://files.pythonhosted.org/packages/62/66/7f12b2f003671828a46ab35964aed0a34632fcba5638b4049bdd918cf342/cmeel_assimp-6.0.5-0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:7b5ee36f3027de9b1bd73bd4294b60fed1bbc6c1524f94f64f69f38c5a49bf03", size = 14840275, upload-time = "2026-05-20T16:36:28.311Z" },
+]
+
+[[package]]
+name = "cmeel-boost"
+version = "1.90.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cmeel" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/01/ab2ea5b1ceae6283eb68be8beac529f294c70ac49d40b7873b0b639a7784/cmeel_boost-1.90.0.tar.gz", hash = "sha256:747d6d932838df26f50cdcb5983fa7532cad1d9ccce46c9f9d8b27b20a115981", size = 4085, upload-time = "2026-05-20T15:19:13.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a2/1298a943326a2676fb01315580097afdbb4ed7713eec8a43501ea734afad/cmeel_boost-1.90.0-0-cp313-cp313-macosx_10_9_x86_64.whl", hash = "sha256:32eb2faf91bf7fcd1858a7a1adddb3b92d7c65d305b4800fc41e0a8a53d29534", size = 30801906, upload-time = "2026-05-20T15:18:31.541Z" },
+    { url = "https://files.pythonhosted.org/packages/be/54/d6eb64585a9ad92699ad43a035f0eccff3d6ab0df9938232329bc710c645/cmeel_boost-1.90.0-0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4c4fb3a1e0b04a2c4c871f0e72b55f6f381b14b110002505276a7831be24d348", size = 30695070, upload-time = "2026-05-20T15:18:36.371Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/a6/948afc3ad0eed1b1f0f482191293b4ea57e6da853842121cb6bdb36538bc/cmeel_boost-1.90.0-0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:83efcb881da48f3645d4eae4ddb2bde6e2ae241b3b0a9c9abae6bdfcc0ca4ae6", size = 35830386, upload-time = "2026-05-20T15:18:42.294Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f0/a153892d8d8f5624eed29a933779d6ff00c144dd9dc6f70b41f98377f39a/cmeel_boost-1.90.0-0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:deeefeae790e4a9ac200ece07c935faf415e48933ccffd7a692682f7f4c3f524", size = 36167733, upload-time = "2026-05-20T15:18:47.775Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/e9/533f21bacafc50cb13ad9e305992910b3719d105e1a303508eb09338f4ef/cmeel_boost-1.90.0-0-cp314-cp314-macosx_10_9_x86_64.whl", hash = "sha256:022a3e3b059921e5147fd6f2b47f4ee787a83210157c6d70443b65190dcdfd5f", size = 30804533, upload-time = "2026-05-20T15:18:53.572Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/fcfbec49b9cbbb3814d1df8638aa4af75a2134578417f11e9dfaedb00a20/cmeel_boost-1.90.0-0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec217d419adbdc486af7deab664bccd6aa5d4d69878ce7df374c29482b10d731", size = 30695643, upload-time = "2026-05-20T15:18:58.999Z" },
+    { url = "https://files.pythonhosted.org/packages/33/98/98c56099e55ad4532d539613bb8f4acbf61b3ece2d8964738ee721d6a73c/cmeel_boost-1.90.0-0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:7527de3b45851da92fca44c61fb5f6562fd61e15d7f1dc071c63f55d672becc4", size = 35836813, upload-time = "2026-05-20T15:19:04.464Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ea/cdc8fe9402b6ef844e87c7aaedd411a63a827e1f332cdf590c8d8d3c929d/cmeel_boost-1.90.0-0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:5fda3fb51276d3ec95d9e035af69b3c2c4032b681ff10d67918109043296b8e9", size = 36174146, upload-time = "2026-05-20T15:19:09.696Z" },
+]
+
+[[package]]
+name = "cmeel-console-bridge"
+version = "1.0.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cmeel" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/13/2e9e9d23db8548aef975564055bdb4fb6da8a397a1e7df8cb61f5afebefb/cmeel_console_bridge-1.0.2.3.tar.gz", hash = "sha256:3b2837da7ab408e9d1a775c83c0a7772356062b3a3672e4ce247f2da71a8ecd9", size = 262061, upload-time = "2025-03-19T18:22:06.845Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/a7/527fa060e5881acb3b0a07bf1d803ccb831cb87739abb62b6bcd14f5aed3/cmeel_console_bridge-1.0.2.3-0-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:7aa19b2d006073a1fad55d32968c7d0c7136749e06f98405f4f73a71038a5c41", size = 21341, upload-time = "2025-03-19T18:21:56.834Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/db/f8643a8766e8909e0dbfcda6191ca92454cf9a3fadd89be417db261601a1/cmeel_console_bridge-1.0.2.3-0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c47d8c97cb120feed1c01f30845d16c67e4e8205941e3977951018972b9b8721", size = 21286, upload-time = "2025-03-19T18:21:57.984Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/b4/9c79177152a220ab2e4ffa0140722165035f6a5c2abbed2912352bd7e7b9/cmeel_console_bridge-1.0.2.3-0-py3-none-manylinux_2_17_i686.whl", hash = "sha256:cad9723ac44ab563cd23bf361b604733623d11847c4edf2a2b4ebd1d984ade09", size = 23740, upload-time = "2025-03-19T18:21:59.683Z" },
+    { url = "https://files.pythonhosted.org/packages/92/65/5741de6f550fe701d0780546d97b283306676315a3e1f379a6038e8c0ab0/cmeel_console_bridge-1.0.2.3-0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:372942e9c44f681bfff377fba25b348801283aa6f3826a00e4195089bda9737a", size = 25762, upload-time = "2025-03-19T18:22:01.055Z" },
+    { url = "https://files.pythonhosted.org/packages/50/a5/70e23c5570506bb39b56aa4d0f3a4a414e38082ddb33e86a48b546620121/cmeel_console_bridge-1.0.2.3-0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:5bb1115ed38441b2396e732e10ec63d1e68445674f9f5d321f7985eb10e9aeef", size = 24477, upload-time = "2025-03-19T18:22:02.091Z" },
+    { url = "https://files.pythonhosted.org/packages/47/36/bfd5a255348902e39243ccc6eba693bce714b891cd3be5603a9bd50c6de5/cmeel_console_bridge-1.0.2.3-0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:2b8d084b797f592942208c2040b08e06b82f8832aa6c5e582ba6f1a4a653505b", size = 24970, upload-time = "2025-03-19T18:22:03.075Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/02/3ae074e9acb9e150a4d5d97f341c2064573cd5fe9e5af20ab58bf8c0020a/cmeel_console_bridge-1.0.2.3-0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:fb6753a9864217d969c4965389d66a476ac978136c03eadf1063b1619c359220", size = 24689, upload-time = "2025-03-19T18:22:04.084Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d0/321f74b7d4167a6c59bb7714a6899ba402d9fad611f62573b9d646107320/cmeel_console_bridge-1.0.2.3-0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9d446c0fc541413d8d2ceea3c1cfb9cbfd57938d6659c113121eca6c245caafe", size = 24404, upload-time = "2025-03-19T18:22:05.232Z" },
+]
+
+[[package]]
+name = "cmeel-octomap"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cmeel" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/89/ab/2fed2dbee13e4b39949591685419f1dbb691295e32a6bbbaf87edc005922/cmeel_octomap-1.10.0.tar.gz", hash = "sha256:bd79d1d17adede534de242e42e13ef0d9f04bdd27daf7d56c57f7c43670c9b05", size = 1694189, upload-time = "2025-01-06T17:57:05.477Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/22/ea67d35df31ec4bb2ed6e594b173c572c72dbd2a87e96906eac67b4af930/cmeel_octomap-1.10.0-4-py3-none-macosx_14_0_arm64.whl", hash = "sha256:c116eb151920d26ee2b2c1f656cd7526862006739817205f11f9366ab0ef6cb4", size = 639956, upload-time = "2025-01-06T17:56:56.826Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/da/07725a8c11224881f536ad252e97a3d9801b48e5e776017d5f00fb39b17f/cmeel_octomap-1.10.0-4-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:76cc42553f54bae97584aaf0c7bc33753ff287e2738aa2ecac4820121101dd46", size = 1044402, upload-time = "2025-01-06T17:56:58.553Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/15/9617b7039afd6d17d3148f6f970d953f5e265d7736f8fdbca09c86e976a0/cmeel_octomap-1.10.0-4-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:5fdb04546fff3accac5f8626c3fc15c3b99e94ab887793565e0b92cedaf96468", size = 1105037, upload-time = "2025-01-06T17:57:01.287Z" },
+    { url = "https://files.pythonhosted.org/packages/51/69/88c1d1eca1abf2387ee8263ac7e12708c8b1b5b70b46a0bd9f43b485165b/cmeel_octomap-1.10.0-4-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:84a7376cfced954bb7e3e347afbd02bdc1c83066b995afbdd0fb1e2d9f57ebec", size = 1108359, upload-time = "2025-01-06T17:57:04.085Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/59/57b3b38cf7a382855902b9d24266c283c29d977706438e6b7af62df74e2b/cmeel_octomap-1.10.0-5-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:042b4a21b5e5e19ee78a9a7db78e1b06fb8a287c832031788aec0d3fcabbfecd", size = 748832, upload-time = "2025-02-12T11:57:34.252Z" },
+    { url = "https://files.pythonhosted.org/packages/55/8b/f5ec7676808a48c0185e216c0da700e34cb13ba233f13a4557a5ec56324a/cmeel_octomap-1.10.0-5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:79c15a0ece5ca3746170088ef2a377dfb3df8326fafde9bdba688852219758b9", size = 706924, upload-time = "2025-02-12T11:57:35.846Z" },
+    { url = "https://files.pythonhosted.org/packages/09/50/56de5a4d9f8ca58100146f16f42c4e2fbb49c0957bfe40d3fd2bc910afe4/cmeel_octomap-1.10.0-5-py3-none-manylinux_2_17_i686.whl", hash = "sha256:e2923bf593ebdafed86b6f3890a122c62fbd9cc9f325d60dbecb72b6b60d78fb", size = 1073973, upload-time = "2025-02-12T11:57:37.914Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f5/8dddf5cdd31176288acd85cc8bf0262b7c3de81d5cb2cb33aa6646f44eb1/cmeel_octomap-1.10.0-5-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:d9e6f9c826905e8de632e9df8cc20e59ce2eb5d1e0b368d8d4abbbc5c0829c1a", size = 1044533, upload-time = "2025-02-12T11:57:39.672Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/14/b85bd33bb05c9bb7e87b9ac8401793c12a80a6d594b3ca4bcb5e971a24b7/cmeel_octomap-1.10.0-5-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:b0b54fac180dce4f483afe7029c29cc55f6f2b21be8413e8e2275845b0c204d7", size = 1105199, upload-time = "2025-02-12T11:57:41.286Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ee/fe3360441159974ebdbb4c013a92ad0425d5f8bf414868d5161060e40660/cmeel_octomap-1.10.0-5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:c8691e665bab7c12b6f51e6c5fbbb83ee6f91dce9d15d9d0387553950e7fb5ee", size = 1092962, upload-time = "2025-02-12T11:57:43.297Z" },
+    { url = "https://files.pythonhosted.org/packages/82/a6/074166544cc0ce3a5d7844f97dfd13d1b3ec7bff6a6e2cfb18d66a671a7f/cmeel_octomap-1.10.0-5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:735c0ad84dacbbcc8c4237f127c57244c236b7d6c7500b5c45a4c225e19daac1", size = 1083321, upload-time = "2025-02-12T11:57:46.121Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/a3/b19ea0d30837369091141b248936b0757ee17f58b809007399bad0b398e4/cmeel_octomap-1.10.0-5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5f86a83f6bd60de290cd327f0374d525328369e76591e3ab2ad1bc0b183678c4", size = 1109207, upload-time = "2025-02-12T11:57:48.709Z" },
+]
+
+[[package]]
+name = "cmeel-qhull"
+version = "8.0.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cmeel" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/dd/8d0bcfb18771b2ea02bf85dfbbc587c97b274496fb5419b72134eb69430b/cmeel_qhull-8.0.2.1.tar.gz", hash = "sha256:68e8d41d95f61830f2d460af1e4d760f0dbe4d46413d7c736f0ed701153ebe52", size = 1308055, upload-time = "2023-11-17T14:21:06.003Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/b4/d72ebd5e9ee711b68ad466e7bd4c0edcb45b0c2c8a358fdcdb64b092666a/cmeel_qhull-8.0.2.1-0-py3-none-macosx_12_0_arm64.whl", hash = "sha256:39f5183a6e026754c3c043239bac005bf1825240d72e1d8fdf090a0f3ea27307", size = 2804225, upload-time = "2023-11-17T14:15:39.958Z" },
+    { url = "https://files.pythonhosted.org/packages/29/dc/4bfb8d51a09401cf740e66d10bdb388eacd7c73bae12ef78149cbbc93e83/cmeel_qhull-8.0.2.1-0-py3-none-macosx_12_0_x86_64.whl", hash = "sha256:f135c5a4f4c8ed53f061bc86b794aaca2c0c34761c9269c06b71329c9da56f82", size = 2972481, upload-time = "2023-11-17T14:20:58.418Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/7c/74b5c781cbfc8e4a9bb73b71659cc595bc0163223fd700b18133dbcf2831/cmeel_qhull-8.0.2.1-0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:17f519106df79aed9fc5ec92833d4958d132d23021f02a78a9564cdf83a36c7c", size = 3078962, upload-time = "2023-11-17T14:21:00.183Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/16/ef7b6201835ba2492753c9c91b266d047b6664507be42ec858e2b24673b5/cmeel_qhull-8.0.2.1-0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:c513abafa40e2b8eb7cd3640e3f92d5391fbd6ec0f4182dbf9536934d8a8ea3e", size = 3194917, upload-time = "2023-11-17T14:21:01.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/ae/200bdf257507e2c95d0656bf02278cd666d49f0a9e2e6d281ea76d7d085c/cmeel_qhull-8.0.2.1-0-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:20a69cb34b6250aee1f018412989734c9ddcad6ff66717a7c5516fc19f55d5ff", size = 3290068, upload-time = "2023-11-17T14:21:03.828Z" },
+    { url = "https://files.pythonhosted.org/packages/01/1b/de3fa6091ef58ab40f02653e777c8943acf7cec486184d6007885123571d/cmeel_qhull-8.0.2.1-1-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:b5d47b113c1cb8f519bc813cf015d0d01f8ce5b08912733a24a6018f7caa6e96", size = 2902499, upload-time = "2025-02-12T11:51:16.999Z" },
+    { url = "https://files.pythonhosted.org/packages/05/0c/5e5d9a033c683eb272508ccf560c03ac6bf5d397b038fe05f896a2283eaf/cmeel_qhull-8.0.2.1-1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:33a0169f4ee37d093c450195b0ef73d4fe0d9d62abb7899ebe79f778b36e1f36", size = 2773563, upload-time = "2025-02-12T11:51:19.893Z" },
+    { url = "https://files.pythonhosted.org/packages/52/9b/00c73069348e60fbbdf6a5a10de046083f7d1ad36844958bbf12163ac688/cmeel_qhull-8.0.2.1-1-py3-none-manylinux_2_17_i686.whl", hash = "sha256:a577e76ac94d128f2966b137ead9f088749513df63749728e2b588f4564b7fdf", size = 3228684, upload-time = "2025-02-12T11:51:21.888Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/4a/81b8c88b444935a64d8c83b41e662f696c36dd5937c3ca687113ac4778d0/cmeel_qhull-8.0.2.1-1-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:fd0b2d4ce749b102c3cdead4588249befd34f1a660628f6bfc090ce942925aac", size = 3156051, upload-time = "2025-02-12T11:51:24.594Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c1/44874cd8bfc1e3f7cb15678c836c7a1d5537f34f5a727a0207e01f395598/cmeel_qhull-8.0.2.1-1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:2371a7c80a14f3e874876359ae3e3094861f081fcdd7a03987c3e880d14e07b9", size = 3262508, upload-time = "2025-02-12T11:51:27.147Z" },
+    { url = "https://files.pythonhosted.org/packages/54/0e/425d9ce1f2a831025d39fa5b6479b856bd4d73614c9caa690ac72bbfca04/cmeel_qhull-8.0.2.1-1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:197c14c2006dbeba8f5a5771700a7afea72c1a441aab7cdeaaf10b4ed8c1137d", size = 3172646, upload-time = "2025-02-12T11:51:28.967Z" },
+    { url = "https://files.pythonhosted.org/packages/00/c1/e973e287a7d793911b8e6497b17586e601a678f2379ba2c615f72bd76480/cmeel_qhull-8.0.2.1-1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:886d1be24b31842286ae42755af5c312a43a4199632826e4110185ec36dc5c6a", size = 3530837, upload-time = "2025-02-12T11:51:31.651Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/65/c6cd54f04b5fcaa4ec52f5b57692c1dcef812ff9ee86545e5607369d365e/cmeel_qhull-8.0.2.1-1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1a49ce7f8492c9a8b49f930e34cce75b5e9b9843b015033dd0a25421441159fc", size = 3301908, upload-time = "2025-02-12T11:51:34.53Z" },
+]
+
+[[package]]
+name = "cmeel-tinyxml2"
+version = "11.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cmeel" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/96/4311533fee0a364bb605b585762f04c249f47857b33548a8ea837a7eb860/cmeel_tinyxml2-11.0.0.tar.gz", hash = "sha256:85d9c7680b3369af4c6b40a0dce70bbd84aa67832755622e57eb260cd95abe40", size = 645900, upload-time = "2026-05-21T11:49:32.652Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/f0/90c1640c53b623359d75ab1c70bdf19dc0afe82722bc5df57d09f8eaf83a/cmeel_tinyxml2-11.0.0-0-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:b0bd974e549b8c444626671a8e645897603ebf5225734cbe04a9dd3461477754", size = 111719, upload-time = "2026-05-21T11:49:25.999Z" },
+    { url = "https://files.pythonhosted.org/packages/56/40/166447150a31bc3b794ffb493d5a634f67ffbc75dd8b4c46373701b7ef15/cmeel_tinyxml2-11.0.0-0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:9a1406f408262c37ae7c4566b1d67801c4b10c4980903fb1ef0ba45fa4407072", size = 109146, upload-time = "2026-05-21T11:49:27.829Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ca/3cc665afe2d76999f15454bb3b2f7c05f0088ad7de35718648291a536fd9/cmeel_tinyxml2-11.0.0-0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:6f830007917c3e36f26b27d170ce84a619a62f46104d3cce435dff0125dd665f", size = 157109, upload-time = "2026-05-21T11:49:29.358Z" },
+    { url = "https://files.pythonhosted.org/packages/87/4e/dcc0d9756d93be734d824e2a570cc9ac68909a1d7d3b6fc87c2fb32726c0/cmeel_tinyxml2-11.0.0-0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:18674156bd41f3993dc1d5199da04fa496674358daa6588090fb9f86c71917b0", size = 148825, upload-time = "2026-05-21T11:49:31.035Z" },
+]
+
+[[package]]
+name = "cmeel-urdfdom"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cmeel" },
+    { name = "cmeel-console-bridge" },
+    { name = "cmeel-tinyxml2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/75/4e8aff079e98582aeeb8e752805081da0c2dea405e79bafeefb555defe9f/cmeel_urdfdom-6.0.0.tar.gz", hash = "sha256:65c0fdc6021300fc55b2d0c03ab64dedc328034a74e40498e671bc894bb1dcf7", size = 303688, upload-time = "2026-05-21T12:08:56.663Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/40/51ba667135f01631179eee1614557193f8453740f248302d1b8b7f9f693e/cmeel_urdfdom-6.0.0-0-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:53d55cebb137a6e4dac6c16fa53f2dc2b7b9b5cda644bd1637a5bb849cd96e52", size = 381501, upload-time = "2026-05-21T12:08:48.758Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d1/2b49a8c940fa75abc13df9842c14e577e6a82d5854b6d52597ce3bb04894/cmeel_urdfdom-6.0.0-0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:0ef424735bd30f4afa4d1b4ddca9b297498c43005ddd775c080e55f62e9e0466", size = 377159, upload-time = "2026-05-21T12:08:50.485Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ac/0efde3a48220b55707bafb6d2e2dcca562f99dcd5c2c15311f7696eeacce/cmeel_urdfdom-6.0.0-0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:0436f5230f1484c8e583284ef48c7291b230ada3dc5fb2937941f582e72409ec", size = 506000, upload-time = "2026-05-21T12:08:52.273Z" },
+    { url = "https://files.pythonhosted.org/packages/32/d4/dfd617e598100e4e53ae3d228a968facff80bae53038fb18e2dccb1ab03a/cmeel_urdfdom-6.0.0-0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:7ab1be680a8ec866d5422c617b641d1f0e38774061df28b8b426fb26edce6337", size = 530049, upload-time = "2026-05-21T12:08:54.224Z" },
+]
+
+[[package]]
+name = "cmeel-zlib"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cmeel" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/85/9c6b77d5c49b363b17ba974271d58730bd26cbe00b1c576596339bb624ea/cmeel_zlib-1.3.2.tar.gz", hash = "sha256:6e31f2956c334de9a7e19a4e4f8eed030ed8c8016c841ea57226ce8bed443712", size = 3200, upload-time = "2026-05-20T16:24:37.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/e7/c60533fb6f638fe92d56b79edbcff70ed74a7f19b3ace981532efab5c3dd/cmeel_zlib-1.3.2-0-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:88a89882340391aa263ed1f7448fe0177e6fb9b93740cad381228437879f16a9", size = 1035696, upload-time = "2026-05-20T16:24:28.538Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/dfcc8b9c2989e7342aaac1781d147b06b31197337d1968029216be26ee43/cmeel_zlib-1.3.2-0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:94a2f1adcc811617eab849b5771e608fa20e2fc44fb8cbd2e56a3e4d496461c1", size = 957505, upload-time = "2026-05-20T16:24:30.151Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/e9/6a3d6732e23fcf7072973f9ca8251eaef3e6738e46d6846064dd92e13331/cmeel_zlib-1.3.2-0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:3b07fb7e28aaa917e6accb59a29dd0f5c1d272d42988f32ba2c232f5f455be4c", size = 1055975, upload-time = "2026-05-20T16:24:31.561Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a4/d345605b6f8c9d665baa1dd2f839ad6aee0d771e174be12c81fdd53067ed/cmeel_zlib-1.3.2-0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:4658000c5531273d14ca8f0250abcd2a2ad85b336f10a273a77ecb38611a5f5a", size = 1052274, upload-time = "2026-05-20T16:24:33.078Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/9d/83737c38cc106e1b4959393da7744d5180b9ab5eac0369fc6ba0ea6c6428/cmeel_zlib-1.3.2-0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:06cbf60a361ca18e8a4c46a238149cebcaf955047a60830705e130aa397b5116", size = 1057248, upload-time = "2026-05-20T16:24:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/28/b378182b0f33ed9e9c091b3d1e8d86a6f2d69add107087b2e09adcb12137/cmeel_zlib-1.3.2-0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:2a3425a65a0adf0ddbb48d41204a0d9c13197bd693f7821d1450e8a969d77352", size = 1055409, upload-time = "2026-05-20T16:24:36.219Z" },
+]
+
+[[package]]
+name = "coal"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cmeel" },
+    { name = "cmeel-assimp" },
+    { name = "cmeel-boost" },
+    { name = "cmeel-octomap" },
+    { name = "cmeel-qhull" },
+    { name = "eigenpy" },
+    { name = "libcoal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/14/8cb072a3e5fb85cac4d8d1234351ca3eb4ecf100b87901ab912ec7e5135e/coal-3.0.3.tar.gz", hash = "sha256:18660bde4021af496343646fa0a0d1bcf0be392f432641e772dc423be5075f64", size = 1464421, upload-time = "2026-05-21T12:30:20.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/37/69680aa3b0d6f1cf6309177326d625fe8afe49b440952ee36735c4e6be2b/coal-3.0.3-0-cp313-cp313-macosx_10_9_x86_64.whl", hash = "sha256:cf489028d1123293fe4b0598fdd21ab2c0a7c6f69d8e61a0a849712b47aba885", size = 1626799, upload-time = "2026-05-21T12:30:06.298Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/72/c3b7d84682868252e43f0dc3dfcec5a5d754a383fb20db17863a55d10f2b/coal-3.0.3-0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7dc81cf507301d145b2c0085072effb3744bf3034669092f7d95c49d7318aba5", size = 1516481, upload-time = "2026-05-21T12:30:07.985Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/d9/f0dd708b923368e4628fb760fe2ce2a3f2cd026e2effbad186c076fadb9c/coal-3.0.3-0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:691da7cd15683d23a28cdea81906a6e614cffbeab92523494ea493ede5d433e8", size = 2190073, upload-time = "2026-05-21T12:30:10.137Z" },
+    { url = "https://files.pythonhosted.org/packages/51/76/5ca02caa98c238bf336ce0387464669c29b6f57c3daab441f047a9e65cc1/coal-3.0.3-0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:80cba8b0c3166a024deacfc801b0c6a06337d230af434c379f693887d5c4e458", size = 2201651, upload-time = "2026-05-21T12:30:12.057Z" },
+    { url = "https://files.pythonhosted.org/packages/18/aa/9b0a3560f86c586aa2ddde57c08f7b6d4c9dc622e82104300da5a1781e25/coal-3.0.3-0-cp314-cp314-macosx_10_9_x86_64.whl", hash = "sha256:5888efaa97a1d6160e07503c5463fa55180120d7219aec1cbe0a1efe1d84449b", size = 1628179, upload-time = "2026-05-21T12:30:13.707Z" },
+    { url = "https://files.pythonhosted.org/packages/98/a2/f90b450da22e69922c3ed36bb8e84376fac56a95d1c864ab477a5a77a951/coal-3.0.3-0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dfc85277f55495da5a15cf9a1d86530004c6225986803935cab6e6c90638002f", size = 1516891, upload-time = "2026-05-21T12:30:15.763Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ca/0172d8558f1231c9542b875854101616dfd4227bd540ad095e257596e8bf/coal-3.0.3-0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:e3f46e2030a4a6f91704d5c8e310c80032e979e1d4bb491265a8beb4358a7998", size = 2197024, upload-time = "2026-05-21T12:30:17.562Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/f2/f79c90ec7289f5f80481a1b60bde05a385d247f4a6269fc64b04e8714054/coal-3.0.3-0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:4553a8e088fddf46c48229686e9b66df7e38d09bbd26fa32c411fb5cf86ac3f0", size = 2204048, upload-time = "2026-05-21T12:30:19.398Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -566,7 +758,7 @@ name = "cuda-bindings"
 version = "12.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/63/56/e465c31dc9111be3441a9ba7df1941fe98f4aa6e71e8788a3fb4534ce24d/cuda_bindings-12.9.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:32bdc5a76906be4c61eb98f546a6786c5773a881f3b166486449b5d141e4a39f", size = 11906628, upload-time = "2025-10-21T14:51:49.905Z" },
@@ -590,6 +782,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615, upload-time = "2023-10-07T05:32:18.335Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321, upload-time = "2023-10-07T05:32:16.783Z" },
+]
+
+[[package]]
+name = "daqp"
+version = "0.8.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/2d/fd713bbd3660d5c5306599dd138a341ff70cff246c7ccffc7a8d586e7004/daqp-0.8.7.tar.gz", hash = "sha256:62cfd3208a9841ffb6a87d145bce930a0e87ecea802a5ffed5d0146c4b133a54", size = 37292, upload-time = "2026-05-19T17:21:44.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/a4/fb804633fe8193de24e0f6dd5070dafc7b2ce3850a5277adb6352eb03add/daqp-0.8.7-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2a2cd5a3f2609ab1f692acd1712f38c130b964741b97203984924f03d8cb6f91", size = 158977, upload-time = "2026-05-19T17:34:24.754Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/24/88577290eb87f331dd3170ac2023b0926ddb6011a6ea3566a640ea04414c/daqp-0.8.7-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:22d2f1a912d049a0d9173419feebaa6202e1943316c7f53b5c478e28e2fe039d", size = 151453, upload-time = "2026-05-19T17:34:25.669Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f1/e30d095b2cc703f4b869940e50e73925f7fa20bbd39d1f12b97af8e48348/daqp-0.8.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8bcbd715471aca5112bbe424be2daf56e88251ddc3c2100d5f56f6b837fc47d0", size = 864949, upload-time = "2026-05-19T17:21:36.567Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ed/5df76b2d180220dc05a89e518698c71a1fac6580c7932af48a45dfd935dc/daqp-0.8.7-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c65d557011f36afdfc0671750816603ca9fc07070ab3a4c20c89c9a26fc2f0b3", size = 791258, upload-time = "2026-05-19T18:15:27.738Z" },
+    { url = "https://files.pythonhosted.org/packages/de/28/7d241f2ef246dda6519d19bbeb73454d2b30e3a3a42668818aa80cb488a9/daqp-0.8.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e4a3de6ca168f02286d9626a19e813c72e8ba774143a08eed608c7cdd4f130d7", size = 811424, upload-time = "2026-05-19T18:15:29.564Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ff/52ce7fd66f2e90fd00b2656c9652ecc9492bab92025e8c1704d4a50c7d4d/daqp-0.8.7-cp313-cp313-win32.whl", hash = "sha256:f5bfb79f6f5a1e43d2f4a6e8008caab1754ecff7f816da40e73cd518f2bf0878", size = 108343, upload-time = "2026-05-19T17:29:05.732Z" },
+    { url = "https://files.pythonhosted.org/packages/23/b6/3afd961db3be4a6b95607463f07784eff5650f7db8b05a5a1462314b0381/daqp-0.8.7-cp313-cp313-win_amd64.whl", hash = "sha256:b4f727815a3a878ffb5fb14d653d5e1c49f0c7aa261d7d6aef5e512db9d5fb9a", size = 131701, upload-time = "2026-05-19T17:29:06.674Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a0/958cbc79b84e6c2895ed9ec2bac957f88cb76d8972472c71485f4960b203/daqp-0.8.7-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e6b8fc906d826538819d7ad296cdd45f52354bc0c76e6b4f5ac1754f16f65e0e", size = 159924, upload-time = "2026-05-19T17:34:27.002Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/69/35d960a4f623b76009076793496f49d1e490a51f649259e5714384e1dd1e/daqp-0.8.7-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:404cda6fb82381aa6dac9442c9e3d982c442babada9aeb0ad5ffd94e7fd5c06b", size = 152661, upload-time = "2026-05-19T17:34:27.967Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/d3/cef77ce55a426ccbad23b1a9ef1ec1fe15b379fb6d34160d42386fe029a3/daqp-0.8.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b3f6235e59a87c17e77512be0ab766a66a82c8436f92883e32530eeccadd2002", size = 856320, upload-time = "2026-05-19T17:21:38.022Z" },
+    { url = "https://files.pythonhosted.org/packages/96/89/2d885f8df3642be3597e2699fd3c592698b99b9aa25685d84ff5eac8bcd5/daqp-0.8.7-cp314-cp314-win32.whl", hash = "sha256:7205f2927c38216eb32cdddc07fa51bf6bb7055304d570e762189581ce21ac02", size = 111718, upload-time = "2026-05-19T17:29:07.625Z" },
+    { url = "https://files.pythonhosted.org/packages/be/e5/04c773c37c6fff01bf374628b9e696eeeb1e66ca99a057b3c448e442d3fa/daqp-0.8.7-cp314-cp314-win_amd64.whl", hash = "sha256:32086d721b37ba3a09b2d56f921f334408795c18cdbcede322e46bd57e541064", size = 135270, upload-time = "2026-05-19T17:29:08.857Z" },
+    { url = "https://files.pythonhosted.org/packages/35/4c/79a0358cf660d6c701998003b069e8aaf6c09221b984b09549a70dc496e3/daqp-0.8.7-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:ffa05f443ec0b452952cc03ae5a79df6dbf8176fa7a9e5820965ef66f1d84439", size = 167425, upload-time = "2026-05-19T17:34:29.365Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2b/bf47b4881e21c3af7621233fe17d28c68e88b989db56dd95712c49035fb5/daqp-0.8.7-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:81bdd7f5b1b9400b8cb217207882bd2854de15ee3ff0c209ac35b43a455ff5df", size = 161065, upload-time = "2026-05-19T17:34:30.51Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/33/c5c35a1ed74e7d8d3c2ba8f259835bd2fa8f26af3f3e6c7cab0df587f0e6/daqp-0.8.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:39986b1c80eda2d1a03ea12f8d93f559386cca3db751323bc16278d79c1a1d85", size = 834214, upload-time = "2026-05-19T17:21:39.436Z" },
+    { url = "https://files.pythonhosted.org/packages/84/be/9142dd82f49366d90cb226c5612764a99d84e409b6101df22857e014d638/daqp-0.8.7-cp314-cp314t-win32.whl", hash = "sha256:b2daf4cd45f54b208076e69734477c6720051c0573d6b879a116acd35c4d4dd6", size = 124846, upload-time = "2026-05-19T17:29:09.936Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/30/06855fdc2128fc6de9d1ac6ccbfb100dd4de1ae7bff73dcf64d8f246406e/daqp-0.8.7-cp314-cp314t-win_amd64.whl", hash = "sha256:085a352ab1ca33ce2ed40d897ea3502d9c2d59454994990de8b65a6d7298ce2f", size = 154918, upload-time = "2026-05-19T17:29:10.903Z" },
 ]
 
 [[package]]
@@ -661,6 +878,26 @@ wheels = [
 ]
 
 [[package]]
+name = "eigenpy"
+version = "3.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cmeel" },
+    { name = "cmeel-boost" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6e/04/15aadcaf4141c791217724c3edc103cd66c5444987cb897a2e7112bb94ee/eigenpy-3.13.0.tar.gz", hash = "sha256:49d3cb46b85696baf5445ac707b48aade07c21579c188dfc1c8ad2f92e05fab5", size = 229750, upload-time = "2026-05-21T11:01:28.805Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/35/0e2aadbae4d70bfbc4db0196be399bc949c246391c6bbcbd674fc1aa42af/eigenpy-3.13.0-0-cp313-cp313-macosx_10_9_x86_64.whl", hash = "sha256:0818e204858c0345e38dd18c0f0aa20082f176ce26e57cc72d9b0d1ef0df5c4e", size = 5485486, upload-time = "2026-05-21T11:01:12.154Z" },
+    { url = "https://files.pythonhosted.org/packages/96/a4/3cdd0a7e0ee83ac6a914e527b0e5adf18b383ea8132ad31eab00143666ec/eigenpy-3.13.0-0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bc6de29029d6ccfcf30dae12e272727982585dd67fd923d7c55fa8690948a9a1", size = 4261376, upload-time = "2026-05-21T11:01:14.157Z" },
+    { url = "https://files.pythonhosted.org/packages/14/12/414f3c31d51928e9c7160e3db196f79419ca81fa01dec6283c64a67bc776/eigenpy-3.13.0-0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:caff6dbf5f063dee474ae2aba0bcdd3cb6b18566397339e4ee6386e7c5adedb1", size = 6230831, upload-time = "2026-05-21T11:01:16.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8b/439c4f16f8b6bc341137dc5ee75d896a9d032cd8dc9eedb0464eaad81f20/eigenpy-3.13.0-0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:041df9317cd2a88b2c77a7f459bba8359015540b3bb704118c150a9dea1c3d9b", size = 6068320, upload-time = "2026-05-21T11:01:18.234Z" },
+    { url = "https://files.pythonhosted.org/packages/84/fb/199ef9f6b78b8e51bfc27acc29de8610d648c37704da1b0ed261cf250581/eigenpy-3.13.0-0-cp314-cp314-macosx_10_9_x86_64.whl", hash = "sha256:2f99da9a17768340a0b0cff5cb3ab39458fcd7b44b8e7ab5c749f84751b9c9b4", size = 5488262, upload-time = "2026-05-21T11:01:20.253Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/0d/a657817bcd640f6e806e2fddb80b99a512669225d5b578d766a59fdfda09/eigenpy-3.13.0-0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0d8459fcde1fa501ee13587ef85faa07229e1c9030f392253f4f4c7fb31c5585", size = 4271730, upload-time = "2026-05-21T11:01:22.198Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/5d/4d096eb4b6ec78de2c59320454608db462de8c1b4f0bc73f59b6e8ea5543/eigenpy-3.13.0-0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:cbff5fb6902e2de7b2436864149141b47246babc2ab6ee035b5666662e495552", size = 6238730, upload-time = "2026-05-21T11:01:24.374Z" },
+    { url = "https://files.pythonhosted.org/packages/db/57/2dacd8dbdce012e8ce41329c07352803220a219cb108a3f482a680696249/eigenpy-3.13.0-0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:facffa9dde8a8d123de8e6766a3611362d2969433d8a9e83377b0c03c099044c", size = 6086683, upload-time = "2026-05-21T11:01:26.888Z" },
+]
+
+[[package]]
 name = "einops"
 version = "0.8.2"
 source = { registry = "https://pypi.org/simple" }
@@ -674,7 +911,7 @@ name = "embreex"
 version = "2.17.7.post7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "platform_machine == 'x86_64'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/1a/e6d80ab0104ba947e1e5a0c5251021a4bf374cfe3b0d88e2be62b150170d/embreex-2.17.7.post7-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:377888d4f61b6d523e91b835aea3bd74193bd2b5fee9212adfe5fa0d5b80671b", size = 10734165, upload-time = "2025-10-22T20:07:36.707Z" },
@@ -1368,6 +1605,43 @@ viz = [
 ]
 
 [[package]]
+name = "libcoal"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cmeel" },
+    { name = "cmeel-assimp" },
+    { name = "cmeel-boost" },
+    { name = "cmeel-octomap" },
+    { name = "cmeel-qhull" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/44/d59b10af87165def48bf55fcb3f0591274a39322d48cb92d608d17ed86b5/libcoal-3.0.3.tar.gz", hash = "sha256:fd0f887682c73ef2d429caa09721993acb596b9e529c4f37761fe34faa7675ed", size = 1464501, upload-time = "2026-05-21T08:41:47.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/35/853c33314d1dcb50ff8c1d832cbe1533dd4d0cf6be685b96bbb1d5219d35/libcoal-3.0.3-0-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:c1b3a0c4d10a690c61fb47eb42aee32bad827846bc7413238364ab340b1faf84", size = 1683905, upload-time = "2026-05-21T08:41:39.006Z" },
+    { url = "https://files.pythonhosted.org/packages/14/bb/c2288420bd28f563ff6557f17d330fa07d6e5c5198b130da7efee9e53b86/libcoal-3.0.3-0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c09ff80ff486f00bdcde1fbde14a143933d20c2c46f8567d6f95817339242fbf", size = 1484193, upload-time = "2026-05-21T08:41:40.917Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/60/d8ef12e6a3a21d40d146ccea38fc29e547d884ebd9f531105902b5408092/libcoal-3.0.3-0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:18e203ed53da8b96b192a74c4c041fe33f98b0249bb7ec27a3b67397ce1ecc4d", size = 2257010, upload-time = "2026-05-21T08:41:42.922Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/a1/062d7d444eb9260244cdced41384933f8cdf5b383ab9ed2810d048720bd3/libcoal-3.0.3-0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:28fa1473d80728994f7275b8c8797858959ab77a643f07f2222feb6de155bb8e", size = 2285044, upload-time = "2026-05-21T08:41:45.03Z" },
+]
+
+[[package]]
+name = "libpinocchio"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cmeel" },
+    { name = "cmeel-boost" },
+    { name = "cmeel-urdfdom" },
+    { name = "libcoal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/28/1b46cc98bba7411a57cb20c7a7c2fdf959dceb31d2c5131a29bd3fc649e9/libpinocchio-4.1.0.tar.gz", hash = "sha256:968bb7dff8aa7c25b1f879c0d9808b3e7686a1140eeb6372c003aba0d423772e", size = 4441987, upload-time = "2026-07-08T12:53:02.806Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/e8/914fe63d3e927209cdbbe97ae62f5ef0a7b661e686da3ec446db853ee260/libpinocchio-4.1.0-0-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:9dedf374365ac78e48b9c3c2d7dd159552a3ff0c4346c03a3f66385706980e4b", size = 3697109, upload-time = "2026-07-08T12:52:54.253Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/9a/f8707dc94f25c9f1468b5cf220cb564036bf33fd4471e03d897df18e4122/libpinocchio-4.1.0-0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d23fdd8dc47049f38ec1305742a13b1cfdfaee703c7a49a4fde08086d095dbf2", size = 3135460, upload-time = "2026-07-08T12:52:56.712Z" },
+    { url = "https://files.pythonhosted.org/packages/44/36/ad9187c147527682304e5b6ec0c9b07c350f1e9c2fbebc49715d392e3cf0/libpinocchio-4.1.0-0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:6cdc1e0f0068b50ed9e63b9f0d7e1c6387086316219157831d32bf7116700585", size = 3655853, upload-time = "2026-07-08T12:52:58.437Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/e4/7985df544d60d7b1b569834d8dcfbc469de37e6e3fae4a6510d77653bf72/libpinocchio-4.1.0-0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:dbcc81e9e302ae57700775af0b86ed353effe47b5d33fa12aff9936ac33c0ae0", size = 3823272, upload-time = "2026-07-08T12:53:00.864Z" },
+]
+
+[[package]]
 name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1378,6 +1652,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
+]
+
+[[package]]
+name = "loop-rate-limiters"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/dc/ebbe468e7a71073879b322968a02e37594343ca2cc4b3ba65baf4db60adb/loop_rate_limiters-1.2.0.tar.gz", hash = "sha256:7187ec1f76f282ee7166d85c8e29eb13dd850422577decaf7e6bfc803173b421", size = 35581, upload-time = "2025-08-13T12:46:29.235Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/6d/d56be57340baf2e6f6361386f4c21b8b5e001251c64af954787f8d01ec78/loop_rate_limiters-1.2.0-py3-none-any.whl", hash = "sha256:482f720f409e05dfca8b7b63df180217afa9a51564def681853cb7370a020b74", size = 10917, upload-time = "2025-08-13T12:46:26.7Z" },
 ]
 
 [[package]]
@@ -1447,7 +1730,7 @@ name = "manifold3d"
 version = "3.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
+    { name = "numpy", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b0/fd/4dfc246e076e3912c45a821764f4de8b6c8117fa36fc67f8e44bf9dfe59b/manifold3d-3.4.1.tar.gz", hash = "sha256:b517927e2c15dc52169fff0cd12e1949eceb4ca49f3a5b8c0568b1116a561ab1", size = 269275, upload-time = "2026-03-24T06:22:40.062Z" }
 wheels = [
@@ -1638,6 +1921,27 @@ wheels = [
 ]
 
 [[package]]
+name = "mink"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mujoco" },
+    { name = "qpsolvers", extra = ["daqp"] },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2b/3a/9766856ff5194a73c0e57a8dbdacb5368c796879f7bd8c0af43bee452df9/mink-1.1.1.tar.gz", hash = "sha256:26788965a37b26d3e571a89d48fe4ce22ec00dfdc5ce6550f0164aca742b6ca2", size = 52318, upload-time = "2026-05-15T16:37:20.136Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/95/038f0246adefeeea0b8b040da8ca2ed561eab31d3bdd0eb46d8b1f938714/mink-1.1.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ba96a3b11c378cc5530300249b6cdd3a39db2ea46863f6fc26e8071c15721696", size = 69390, upload-time = "2026-05-15T16:37:10.016Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/94/7ce44f8d35d55836c967119fdaad038f8ed5c4a79d51f9c9fae8f87031a2/mink-1.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:02dbd684bfdc164716d5c139602bd0fe6a45928e4476b77af7616529ba2cacb9", size = 67966, upload-time = "2026-05-15T16:37:11.173Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/f5/10416d26e472c869a86df58f5577fe5e9b04324d6551627f82ee6256ac17/mink-1.1.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:325aaf098a1ead4afc3913855ee94e3ce9c5e5ac03d6413fd6709d5e349e8cf0", size = 70668, upload-time = "2026-05-15T16:37:12.425Z" },
+    { url = "https://files.pythonhosted.org/packages/57/f5/e8d2c1d2cff1aebc6ccb888b9a2a1e84f77bef45e5200cc24c5ff39dcb9a/mink-1.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6907c5c0cea7586e364b4dc8c411e269f1008e29c82acc1ece3b4b4e729acfaa", size = 69814, upload-time = "2026-05-15T16:37:13.664Z" },
+    { url = "https://files.pythonhosted.org/packages/37/bf/b8a7619e196ea4bce165f7677a805f4b8db71b4cc43d30407750c1c600a7/mink-1.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:858e9203f1c2fe2b60cffc65a71c1ebcf08463cff58f9c2e9c625cd0faf27581", size = 69802, upload-time = "2026-05-15T16:37:14.821Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f8/6b8809e5c2e23537bd20a8f64b52075c45dfa987969d3f26a024faa074fe/mink-1.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c16dcc1a3841ca2d65bc8d66118c53e5904752ec7952de17dfa0dccee7114b12", size = 70849, upload-time = "2026-05-15T16:37:15.936Z" },
+    { url = "https://files.pythonhosted.org/packages/31/db/faead105ef9ec195c5167531d664848001e6362d2be28fe864bb79b0ea91/mink-1.1.1-cp313-cp313-win32.whl", hash = "sha256:646a54447de6656d2a8c97b1f58856c28f306fb9ec0e8fcf3111561951cdd8d4", size = 71746, upload-time = "2026-05-15T16:37:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/6e/b9ddcbff1f85e835dbe4c14db2778d26923ba2236ae418349ce09b345cb8/mink-1.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:7fa49dcc72eb06998ee4b6cce737af0e72977cad40333e75f4f7d9774f49b30d", size = 72513, upload-time = "2026-05-15T16:37:18.505Z" },
+]
+
+[[package]]
 name = "ml-dtypes"
 version = "0.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1711,7 +2015,7 @@ wheels = [
 
 [[package]]
 name = "mujoco"
-version = "3.8.0"
+version = "3.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "absl-py" },
@@ -1720,18 +2024,20 @@ dependencies = [
     { name = "numpy" },
     { name = "pyopengl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e2/d8/9aae1a021b6e15ee69d805d893e01dda71cbaae1c75d5f8ec8e12916cb7c/mujoco-3.8.0.tar.gz", hash = "sha256:250afe57458d6881b2d7659fa0029a128cb57cbbb620268d95647fb9ad742183", size = 918250, upload-time = "2026-04-24T22:59:07.531Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/2d/290f3f4062eec1c0d5246de0a75f1b18b59a1961081f49ddc97333fc8263/mujoco-3.11.0.tar.gz", hash = "sha256:390856102af9547dfd87cb2791eb105a3d2e00a37323fe9a12ed17e512aff1a6", size = 1139880, upload-time = "2026-07-28T01:23:32.252Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/7d/41c73ebe93565ed196ec5ad012232138e3d10850e841ccd77d459afc4383/mujoco-3.8.0-cp313-cp313-macosx_10_16_x86_64.whl", hash = "sha256:d4a080aab0be4d02162e6fe3bcd7163c01cc751638f5a84ba05477b512d95cc0", size = 7265494, upload-time = "2026-04-24T22:58:45.119Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/05/d21b43c31c5d9179c2d33e0d38896775b262a9d78729b760717927a02e28/mujoco-3.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5aa987e70a6601ebf02d123d9842f2d1b8f8057163feec1f0a5a049de1cbe252", size = 7205049, upload-time = "2026-04-24T22:58:46.874Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/9c/af181776d0ffb70ad6a4365f0613529f268782850dedab0569c6cce83fcc/mujoco-3.8.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8bd33b7e2382605012dfe41c00a8d3bb358153e5b019d920a52c31664472ce20", size = 6743578, upload-time = "2026-04-24T22:58:48.862Z" },
-    { url = "https://files.pythonhosted.org/packages/89/8a/c9b28784a7e51926d609b70842e16b85e286df87ad861dbbb26c4e49cacf/mujoco-3.8.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f2b3de0c9fed950c5080ea4b3ff1fb5c89f88e22798f1e1693ec8dbbd36de00b", size = 7226464, upload-time = "2026-04-24T22:58:51.039Z" },
-    { url = "https://files.pythonhosted.org/packages/50/3f/0a72c74dd766524b9f1b79f0d6d327b9a797d87b44fe62b3068b44123b54/mujoco-3.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:de03d173f4d9c7341b5dcc10a8eddb36bb19989df68f24369dc7c782dc053f11", size = 5813265, upload-time = "2026-04-24T22:58:53.316Z" },
-    { url = "https://files.pythonhosted.org/packages/81/f7/afdbcb4ad50786ed7500205f29ffb5c3a5ef9d42e6b3ad8f9636c4911687/mujoco-3.8.0-cp314-cp314-macosx_10_16_x86_64.whl", hash = "sha256:09c27fc6ce1560912e920789bc121290e4c84919ae30f7b54da5efed4cd2804a", size = 7320672, upload-time = "2026-04-24T22:58:55.469Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/8a/6299f6209084dda9469374461c77adad5d63041427b9b9bd4fadaf0c35b0/mujoco-3.8.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5fc4e930cd1414f965381ac97ec054a001539e7aa462836145f6a3201b0dfe88", size = 7249791, upload-time = "2026-04-24T22:58:57.126Z" },
-    { url = "https://files.pythonhosted.org/packages/df/3c/a74d169b7725aee971962238d2aee767f64496ede1367cd558361c97d5ca/mujoco-3.8.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:14c32992267906d422ed2127e99aa9ad036a62324139da2a3bd25df1e928d0ee", size = 6754009, upload-time = "2026-04-24T22:59:00.375Z" },
-    { url = "https://files.pythonhosted.org/packages/66/36/f3610724bb35f6cfb2ffebe9d8d315975e5fa9722146ad58298df442da7e/mujoco-3.8.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1373c4744a3424f1aa224d2ad5201497ea150c4698beb9aaeb8c3560efa60fdb", size = 7227764, upload-time = "2026-04-24T22:59:02.722Z" },
-    { url = "https://files.pythonhosted.org/packages/92/5a/80f5347c322300e4402b08df74e7489756e9af060bb8b8d342086dd5b41c/mujoco-3.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:f8da8fc4a2861f9d1eef64d83adcd783bfe5c02bdc78af2d963d942d097dfdce", size = 6144239, upload-time = "2026-04-24T22:59:05.329Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/16/4b822d608cb4bc5aafe910b6f6947c73ecd467470935408e4ad0d207023e/mujoco-3.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dd282aae46dc7350472bd4a81dd789ea011ff961c00fd60c9434e67bfd0519a3", size = 17511474, upload-time = "2026-07-28T01:22:57.111Z" },
+    { url = "https://files.pythonhosted.org/packages/47/73/4cbe741986ed86f13e86ad92a11de870bdec4979eaafcbc7ef3164680260/mujoco-3.11.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b1ea2ed1d20b7cca55fc1e0257f2d4f6ab6e83855f669530fb3f55c85da80aac", size = 17704381, upload-time = "2026-07-28T01:23:00.158Z" },
+    { url = "https://files.pythonhosted.org/packages/90/2e/843071e21831fa5ef4029de6874789f9fd32f340d42fced383757c484bdd/mujoco-3.11.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3379c36b508474127b08e51e77942c493c2f1d7215b425e3b95de08dcba662e0", size = 18868301, upload-time = "2026-07-28T01:23:03.054Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/25/2a518a33b359b0798a9e8b55f30a4c9ab0cadd0cab8d85872ff9da6ca309/mujoco-3.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:d48b4a18d409ce4c746f32b3b402a8419b7450d9a89de68b81d73a3ef333d0e4", size = 15792231, upload-time = "2026-07-28T01:23:05.798Z" },
+    { url = "https://files.pythonhosted.org/packages/36/56/1d434ab8e072a6ca9074a27951cc08770db50daa4f2908fc51c8fe1c73dd/mujoco-3.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d0f031b5b747a96c07938a47305f46079b75697282723e3ae1864c089bb56c02", size = 17525650, upload-time = "2026-07-28T01:23:08.562Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5a/f2fce0b815a51a3cb87d62e0fb3647f8d10330b30a8e7d381b733773263e/mujoco-3.11.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eeb372621f885a0ad16ef879c91ff74d47b3b9533babdc16e07303836a23d27e", size = 17720735, upload-time = "2026-07-28T01:23:11.205Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/98/fad81239c7b827a64a472206a6bff5346e3fa949e6ce4945595329d3fdc7/mujoco-3.11.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:06af29af1fa40156126165f2634481ef7c0f8dabb9f07892c5af30039c5a59dc", size = 18866078, upload-time = "2026-07-28T01:23:13.982Z" },
+    { url = "https://files.pythonhosted.org/packages/81/33/93ba5542249502ab9d7c1d1f3e38cd915a0259bc4c8cd124c05dbe17e7bb/mujoco-3.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:2a9bf53284604397b7cd041cecb22c8f6b10afdddb4c723d5ff493f9f6b630d7", size = 16436726, upload-time = "2026-07-28T01:23:29.6Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/b8/bc0835e43ed36ab465b4c3b1f6f8324c025207acc4d1e9c24ffaa4ebfb87/mujoco-3.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b2be7535332976a82ec69a118cdeb3db3580aba19e3d82bca91c95a416e2a9ce", size = 17696886, upload-time = "2026-07-28T01:23:17.225Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a4/8444786ee44588a02842069eeaca31fc1a25357ac9b5ef03d96e424dc8fd/mujoco-3.11.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:80cf42c0153d8dac61fb56724ba3fd8b0e0fb7093c013d57ae9e51f894262338", size = 17952805, upload-time = "2026-07-28T01:23:20.432Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/bd/46a43763dac53e840a9ce1f204f9d80fb07fc7c2a6805cb023fdc35a0986/mujoco-3.11.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8205329fce598bc3aede8ef530da6a70c529c8f4a91efdc79933614ba3f126fb", size = 19029401, upload-time = "2026-07-28T01:23:23.656Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d8/10200a2c1dc65738bc21375b23fe986e4bf435be045ea91eaf698e86cfd7/mujoco-3.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0804a70ccd9b669ed36e1ede45781d0d707f2940d560ed756647cc8d9ade847c", size = 16460526, upload-time = "2026-07-28T01:23:26.81Z" },
 ]
 
 [[package]]
@@ -1915,7 +2221,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -1926,7 +2232,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -1953,9 +2259,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -1966,7 +2272,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -2144,6 +2450,45 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/01/4a/9202e8d11714c1fc5951f2e1ef362f2d7fbc595e1f6717971d5dd750e969/pillow-12.1.1-cp314-cp314t-win32.whl", hash = "sha256:d2912fd8114fc5545aa3a4b5576512f64c55a03f3ebcca4c10194d593d43ea36", size = 6438736, upload-time = "2026-02-11T04:22:46.347Z" },
     { url = "https://files.pythonhosted.org/packages/f3/ca/cbce2327eb9885476b3957b2e82eb12c866a8b16ad77392864ad601022ce/pillow-12.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:4ceb838d4bd9dab43e06c363cab2eebf63846d6a4aeaea283bbdfd8f1a8ed58b", size = 7182894, upload-time = "2026-02-11T04:22:48.114Z" },
     { url = "https://files.pythonhosted.org/packages/ec/d2/de599c95ba0a973b94410477f8bf0b6f0b5e67360eb89bcb1ad365258beb/pillow-12.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:7b03048319bfc6170e93bd60728a1af51d3dd7704935feb228c4d4faab35d334", size = 2546446, upload-time = "2026-02-11T04:22:50.342Z" },
+]
+
+[[package]]
+name = "pin"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cmeel" },
+    { name = "cmeel-boost" },
+    { name = "cmeel-urdfdom" },
+    { name = "coal" },
+    { name = "libpinocchio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/e0/db25edcac11b2bf2664c5160b56287c5ec386e772c3a2a1ea40faa51afaf/pin-4.1.0.tar.gz", hash = "sha256:f59681eb1dc08d9e959c172ff2e7a34efbc464dfd38af30f1af2874a9800ee5d", size = 4441202, upload-time = "2026-07-08T14:12:12.892Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/97/78059baa247b931a2e3c5739d5d7c2d56afa368de2649d99e857d1c0aaf9/pin-4.1.0-0-cp313-cp313-macosx_10_9_x86_64.whl", hash = "sha256:ebe103811917407e3c219e9ca224d6941030929ba9abe7507b909432c5855698", size = 7468943, upload-time = "2026-07-08T14:11:56.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/e5/d960e7c184cab1ae6f31bf845e2c32a154b48804b4a77da0b4bf6d55c9a8/pin-4.1.0-0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:548a0d69694a459d007a4de07caba2530bffbd5e1be3d6519d61bc610d63dbed", size = 7182700, upload-time = "2026-07-08T14:11:58.454Z" },
+    { url = "https://files.pythonhosted.org/packages/06/7f/15d0474aa87548a0e8db441fe59394efcbb47914f9f4eca75438aa719352/pin-4.1.0-0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:eba314c2ed7fe793341f705c97a9c45aa8f6caf98998e675ed46e8ca12e9a89c", size = 9722017, upload-time = "2026-07-08T14:12:01.454Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c2/ea64851bbf2d4ab0ea17c84610c2016fd178ee436db31bd3f6c64cfcc676/pin-4.1.0-0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:374b54282668518bf34c05752bea80e9c9dc51eb42c20a06612f80c5fa6dc782", size = 9940518, upload-time = "2026-07-08T14:12:03.57Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/10/61640dd5c6ded9ffc19fe056d34cedb2957766f18f301342c0fbd61709c8/pin-4.1.0-0-cp314-cp314-macosx_10_9_x86_64.whl", hash = "sha256:a5359cda5350b20a266fafc0229eabb895bb5512c1e92db2b1952bdf1ac7fdcf", size = 7488996, upload-time = "2026-07-08T14:12:05.646Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/21/206c2857f49e1efe62272f4edd5b7423bf6777abfb43e0c057957f2824ef/pin-4.1.0-0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8459574d26ffc705e2c24830cb12ffd80f66515353b9937bc43e866a3d27a066", size = 7207689, upload-time = "2026-07-08T14:12:07.414Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/81/4b2dbb2956139ec96876d98fbaa3e287562af06b30688c36d188d4416338/pin-4.1.0-0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:d3e27fa5190d0ceb6b27048e3be9a4ba2295cb9b62f051913027a183039b786c", size = 9757301, upload-time = "2026-07-08T14:12:08.96Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/76/53c244f60e6f89ebaa34188fffed5ee6854b85ded18c85e62a7239e8495a/pin-4.1.0-0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:4f9ae5cd6738b86719a4e9877c874005cf08f988a402f0c7d5b991711a064289", size = 9956649, upload-time = "2026-07-08T14:12:10.937Z" },
+]
+
+[[package]]
+name = "pin-pink"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "loop-rate-limiters" },
+    { name = "numpy" },
+    { name = "pin" },
+    { name = "qpsolvers" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/5b/0bfab6a426c051215753995c65f0e2859e038e49e75510b64ce60a9712c1/pin_pink-4.3.0.tar.gz", hash = "sha256:65964e4a2e125d9f5f927f37ee8b85dcf57e125b4845fe6be034fa64c6ed3379", size = 52854, upload-time = "2026-07-15T18:58:20.819Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/dc/863a1cbc36fcb269ebdaa0e42c4e31f1c9d28f6aa0bdbacbd923cf6b16cc/pin_pink-4.3.0-py3-none-any.whl", hash = "sha256:6a38c07e0f01a754f827166242acb2b9f0b03e726712a078d2e243fdbdbf6f6a", size = 64305, upload-time = "2026-07-15T18:58:19.173Z" },
 ]
 
 [[package]]
@@ -2563,6 +2908,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7f/be/2d07ad85e3d593d69640876a8686eae2c533db8cb7bf298d25c421b4d2d5/pyyaml-include-1.4.1.tar.gz", hash = "sha256:1a96e33a99a3e56235f5221273832464025f02ff3d8539309a3bf00dec624471", size = 20592, upload-time = "2024-03-25T14:56:43.748Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/ca/6a2cc3a73170d10b5af1f1613baa2ed1f8f46f62dd0bfab2bffd2c2fe260/pyyaml_include-1.4.1-py3-none-any.whl", hash = "sha256:323c7f3a19c82fbc4d73abbaab7ef4f793e146a13383866831631b26ccc7fb00", size = 19079, upload-time = "2024-03-25T14:56:41.274Z" },
+]
+
+[[package]]
+name = "qpsolvers"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/aa/4d60a7065de30f07d7ead935eed364cf94fb0ad5607ddf1461f2bdf7ba17/qpsolvers-4.13.0.tar.gz", hash = "sha256:e86c4c16bf7c16fdbb8e6c0e4050bc1bfef72a25755211be66a492ac4c939a1c", size = 77317, upload-time = "2026-07-19T07:46:03.087Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/d0/f234961cb3ffbe381c3d82cd9c40fc7e67200c9f6b62a0f60235e74134b3/qpsolvers-4.13.0-py3-none-any.whl", hash = "sha256:7f23759a3d8835fa14b2c9eb4ba971188fde0c1460589f45897b00a75776eef7", size = 107113, upload-time = "2026-07-19T07:46:01.321Z" },
+]
+
+[package.optional-dependencies]
+daqp = [
+    { name = "daqp" },
 ]
 
 [[package]]

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1822,6 +1822,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1839,6 +1840,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1856,6 +1858,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1873,6 +1876,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1890,6 +1894,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1907,6 +1912,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1924,6 +1930,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1941,6 +1948,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1958,6 +1966,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1975,6 +1984,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1992,6 +2002,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -2009,6 +2020,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }

--- a/web/packages/axol-vr-client/src/AxolVRClient.tsx
+++ b/web/packages/axol-vr-client/src/AxolVRClient.tsx
@@ -351,8 +351,16 @@ export function AxolVRClient({
       if (!pose) return null
       const { position: p, orientation: o } = pose.transform
       return {
-        position: { x: p.x, y: p.y, z: p.z },
-        quaternion: { x: o.x, y: o.y, z: o.z, w: o.w },
+        pose: {
+          position: { x: p.x, y: p.y, z: p.z },
+          quaternion: { x: o.x, y: o.y, z: o.z, w: o.w },
+        },
+        // WebXR sets emulatedPosition while the controller's position is only
+        // inertially dead-reckoned (occluded / out of camera view): it drifts
+        // while coasting and snaps when optical tracking re-acquires. Ship the
+        // flag so the server holds the last clean pose instead of chasing the
+        // glitch. `!== true` keeps runtimes that omit the field as tracked.
+        tracked: pose.emulatedPosition !== true,
       }
     }
 
@@ -364,14 +372,16 @@ export function AxolVRClient({
       return { x: p.x, y: p.y, z: p.z }
     }
 
-    const l_ee = getPose(leftSource?.targetRaySpace)
-    const r_ee = getPose(rightSource?.targetRaySpace)
+    const l_hand = getPose(leftSource?.targetRaySpace)
+    const r_hand = getPose(rightSource?.targetRaySpace)
 
-    if (!l_ee || !r_ee) {
+    if (!l_hand || !r_hand) {
       // Lost controller tracking — can't ship a pose frame; leave XR anyway.
       if (yEdge) onExit?.()
       return
     }
+    const l_ee = l_hand.pose
+    const r_ee = r_hand.pose
 
     const body = (frame as XRFrame & { body?: XRBody }).body
     const l_elbow = getPosition(body?.get(L_ELBOW_JOINT))
@@ -408,6 +418,10 @@ export function AxolVRClient({
       r_lock,
       l_grip,
       r_grip,
+      // Per-hand optical-tracking state (see getPose): the server holds a
+      // hand's last tracked pose while its flag is false.
+      l_tracked: l_hand.tracked,
+      r_tracked: r_hand.tracked,
       reset,
       state: stateRef.current,
       l_stick_x,


### PR DESCRIPTION
## Summary

- **IK backend interface + five implementations** (`pink-qp`, `pyroki-lm`, `pyroki-diff`, `mink-qp`, `dls`) behind one canonical joint order and call signature. `pink-qp` (Pinocchio + QP via qpsolvers/daqp) won the 2026-07 offline bake-off and is the default; the others remain selectable with `--kinematics.backend=...` for on-hardware A/B. Lazy imports keep unselected backends' dependencies out of the hot path.
- **Swivel-circle elbow conditioning** (backend-independent): the operator's elbow maps onto the robot's own swivel circle — exactly reachable by construction — smoothed and rate-limited as an angle and kept clear of the base column. This preserves the "elbow up/out" intent while preventing the unbounded-gain swivel noise amplification near the shoulder singularity that previously swung the arm through drastic reconfigurations.
- **Offline bake-off bench** (`python -m almond_axol.kinematics.bench`): replays scripted or captured `VRFrame` streams through the full `IKWorker` path across six scenario families (figure-8, fast jitter, extension singularity, out-of-bounds, elbow-up shelf, torso graze), scoring tracking error, jerk, >3 Hz spectral power, freezes, limit/collision violations, elbow rise, and solve-time p50/p99. The VR server can capture real sessions to JSONL (`--vr_server.capture_path`) for replay through the same bench.
- Carries the hardware-validated teleop smoothing/robustness set: fixed-lag pose smoothing with Hampel glitch rejection, WebXR `emulatedPosition` tracking-loss gating, trapezoid velocity-zeroing fix, IK dispatch exception guards, and drain-before-close worker shutdown.
- New dependencies: `pin`, `pin-pink`, `mink`, `qpsolvers[daqp]`.

Note: overlaps with #165 on the teleop/VR smoothing files (this branch is based on an older main); whichever lands second will need a small rebase/reconciliation.

## Test plan

- [x] Offline bake-off across all five backends and six scenarios
- [x] Backends + worker import cleanly with lazy dependency isolation; ruff clean at the pinned version
- [ ] On-robot teleop session on `pink-qp` (nominal, shelf-height, and close-to-body work)
- [ ] On-hardware A/B vs `pyroki-lm` via `--kinematics.backend`
- [ ] Capture a real session (`--vr_server.capture_path`) and verify bench replay matches on-robot feel

Made with [Cursor](https://cursor.com)