### PR TITLE
Reconnect to a torqued-on robot without dropping the arms

### DIFF
--- a/almond_axol/motor/bus.py
+++ b/almond_axol/motor/bus.py
@@ -39,7 +39,15 @@ class CanBus:
         self._reader_task: asyncio.Task | None = None
 
     async def start(self) -> None:
-        """Start the background frame-dispatch loop."""
+        """Start the background frame-dispatch loop. Idempotent.
+
+        A second call while the loop is already running is a no-op, so flows
+        that compose bus-starting steps (``Axol.connect`` querying state and
+        then delegating to ``attach``/``enable``) don't spawn duplicate
+        reader tasks.
+        """
+        if self._reader_task is not None and not self._reader_task.done():
+            return
         self._reader_task = asyncio.create_task(
             self._reader_loop(),
             name=f"can_reader:{self._bus.channel_info}",

--- a/almond_axol/motor/damiao.py
+++ b/almond_axol/motor/damiao.py
@@ -387,6 +387,10 @@ class DamiaoMotor(MotorDriver):
                 f"for a full bring-up"
             )
 
+    async def is_holding(self) -> bool:
+        feedback = await self._request_feedback()
+        return feedback.status == _DamiaoStatus.ENABLED
+
     async def disable(self) -> None:
         max_attempts = 10
         for _ in range(max_attempts):

--- a/almond_axol/motor/damiao.py
+++ b/almond_axol/motor/damiao.py
@@ -352,12 +352,8 @@ class DamiaoMotor(MotorDriver):
             data = struct.pack("<fHH", target_position, v_scaled, i_scaled)
             await self._raw_send(data, arb_id=0x300 + self._motor_id)
 
-    # ------------------------------------------------------------------ #
-    # Public API (implements MotorDriver)                                  #
-    # ------------------------------------------------------------------ #
-
-    async def enable(self) -> None:
-        await self.clear_errors()
+    async def _read_limits(self) -> None:
+        """Read the position/velocity/torque ranges used to scale MIT frames."""
         pmax, vmax, tmax = await asyncio.gather(
             self._read_register(_DM_REG_PMAX),
             self._read_register(_DM_REG_VMAX),
@@ -366,7 +362,30 @@ class DamiaoMotor(MotorDriver):
         self._p_max = float(pmax)
         self._v_max = float(vmax)
         self._t_max = float(tmax)
+
+    # ------------------------------------------------------------------ #
+    # Public API (implements MotorDriver)                                  #
+    # ------------------------------------------------------------------ #
+
+    async def enable(self) -> None:
+        await self.clear_errors()
+        await self._read_limits()
         await self._raw_send(bytes([0xFF] * 7 + [0xFC]))
+
+    async def attach(self) -> None:
+        # Reads only: limit registers for command/feedback scaling, then one
+        # feedback frame to confirm the motor is still enabled and holding.
+        # No clear-errors and no 0xFC enable — a fault or a disabled state
+        # means torque was already lost, and re-enabling here would mask that.
+        await self._read_limits()
+        feedback = await self._request_feedback()
+        if feedback.status != _DamiaoStatus.ENABLED:
+            status = _DM_STATUS_MAP.get(feedback.status, MotorStatus.UNKNOWN)
+            raise MotorError(
+                f"Damiao motor {self._motor_id:#04x} is {status.value}, not "
+                f"enabled and holding — attach is not possible; use enable() "
+                f"for a full bring-up"
+            )
 
     async def disable(self) -> None:
         max_attempts = 10

--- a/almond_axol/motor/driver.py
+++ b/almond_axol/motor/driver.py
@@ -49,6 +49,24 @@ class MotorDriver(ABC):
         ...
 
     @abstractmethod
+    async def attach(self) -> None:
+        """Prepare to command an already-enabled motor without disturbing it.
+
+        The reconnect counterpart to :meth:`enable`, for when a previous
+        process left the motor enabled and holding (e.g. it died mid-session).
+        Re-reads whatever state the driver needs for correct command scaling
+        (limit registers, firmware capabilities) and verifies the motor is
+        enabled and fault-free — but sends no reset, brake, enable, or motion
+        command, so a motor that is holding position keeps holding it
+        throughout.
+
+        Raises MotorError if the motor is unreachable, disabled, or faulted:
+        attaching is only valid while the motor is still up, and anything else
+        needs a full :meth:`enable` bring-up.
+        """
+        ...
+
+    @abstractmethod
     async def disable(self) -> None:
         """Disable the motor and engage the brake."""
         ...

--- a/almond_axol/motor/driver.py
+++ b/almond_axol/motor/driver.py
@@ -72,6 +72,23 @@ class MotorDriver(ABC):
         ...
 
     @abstractmethod
+    async def is_holding(self) -> bool:
+        """Return True if the motor is enabled and holding torque. Read-only.
+
+        The state probe behind the idempotent ``Axol.enable()``: a holding
+        motor must not be reset (it is attached to instead), while a motor
+        reporting False holds nothing and can take the full bring-up.
+
+        Damiao: feedback status is ENABLED. Note this cannot distinguish an
+        actively-holding motor from one that was enabled but never commanded
+        (which holds no torque) — such a motor conservatively reports True.
+        MyActuator: the status-1 running byte is set and no fault is latched;
+        on fleet firmware the running byte reads 1 only while the motor is
+        actively executing commands, so this matches "holding" exactly.
+        """
+        ...
+
+    @abstractmethod
     async def clear_errors(self) -> None:
         """Clear any latched motor error flags."""
         ...

--- a/almond_axol/motor/motor.py
+++ b/almond_axol/motor/motor.py
@@ -132,6 +132,36 @@ class Motor:
         """Enable the motor and release the brake."""
         await self._driver.enable()
 
+    async def attach(self, mode: ControlMode) -> None:
+        """Attach to an already-enabled motor without disturbing its torque state.
+
+        The reconnect counterpart to :meth:`enable` + :meth:`set_control_mode`,
+        for when a previous process left the motor enabled and holding (e.g.
+        it died mid-session). Re-reads the state needed for correct command
+        scaling and verifies the motor is enabled, fault-free, and — where the
+        hardware exposes a mode register (Damiao) — already in ``mode``. No
+        reset, brake, enable, or motion command is sent, so a motor holding
+        position keeps holding it throughout. In contrast,
+        :meth:`set_control_mode` reboots MyActuator motors, dropping torque
+        for ~2 s.
+
+        Args:
+            mode: Control mode the motor is expected to already be in.
+
+        Raises:
+            MotorError: If the motor is unreachable, disabled, faulted, or in
+                a different hardware control mode. Recover with a full
+                :meth:`enable` bring-up.
+        """
+        await self._driver.attach()
+        hw_mode = await self._driver.get_control_mode()
+        if hw_mode is not None and hw_mode != mode:
+            raise MotorError(
+                f"{self.joint} is in {hw_mode.name} mode, expected {mode.name} "
+                f"— attach is not possible; use enable() for a full bring-up"
+            )
+        self.mode = mode
+
     async def disable(self) -> None:
         """Disable the motor and engage the brake."""
         await self._driver.disable()

--- a/almond_axol/motor/motor.py
+++ b/almond_axol/motor/motor.py
@@ -199,6 +199,11 @@ class Motor:
         MyActuator: resets the motor (no persistent mode register; mode is
         determined per-command).
 
+        WARNING: the MyActuator reset drops torque for ~2 s — never switch
+        modes while the motor is holding a load (the joint falls). Bring the
+        arm to rest first, or use ``enable(hold=False)`` in flows that manage
+        modes themselves.
+
         Args:
             mode: Desired control mode.
         """

--- a/almond_axol/motor/motor.py
+++ b/almond_axol/motor/motor.py
@@ -166,6 +166,20 @@ class Motor:
         """Disable the motor and engage the brake."""
         await self._driver.disable()
 
+    async def is_holding(self) -> bool:
+        """Return True if the motor is enabled and holding torque. Read-only.
+
+        Damiao: feedback status is ENABLED — note an enabled motor that was
+        never sent a command holds no torque but still reports True.
+        MyActuator: the status-1 running byte is set and no fault is latched
+        (on fleet firmware the byte is 1 only while actively executing
+        commands).
+
+        This is the per-motor probe behind the idempotent
+        :meth:`Axol.enable`'s keep-holding-or-bring-up decision.
+        """
+        return await self._driver.is_holding()
+
     async def clear_errors(self) -> None:
         """Clear any latched motor error flags."""
         await self._driver.clear_errors()

--- a/almond_axol/motor/myactuator.py
+++ b/almond_axol/motor/myactuator.py
@@ -367,6 +367,29 @@ class MyActuatorMotor(MotorDriver):
         await self._apply_low_voltage_threshold()
         await self._request(self._cmd(_MA_RELEASE_BRAKE))
 
+    async def attach(self) -> None:
+        # Reads only. The capability detection must succeed here (unlike
+        # enable(), which tolerates a silent motor still booting): a motor
+        # that doesn't answer can't be verified as holding. Crucially there
+        # is no 0x76 reset (that reboots the motor, killing torque for ~2 s)
+        # and no 0x77 brake release (that would drop an arm parked on its
+        # brake) — the whole point of attach is to leave torque untouched.
+        await self._detect_capabilities()
+        resp = await self._get_status1()
+        error_bits = struct.unpack_from("<H", resp, 6)[0]
+        if error_bits:
+            raise MotorError(
+                f"MyActuator motor {self._motor_id:#04x} has a latched fault "
+                f"({_ma_error_to_status(error_bits).value}) — attach is not "
+                f"possible; use enable() for a full bring-up"
+            )
+        if resp[3] != 0x01:  # status-1 byte 3: brake state, 1 = released
+            raise MotorError(
+                f"MyActuator motor {self._motor_id:#04x} brake is engaged "
+                f"(motor not enabled and holding) — attach is not possible; "
+                f"use enable() for a full bring-up"
+            )
+
     async def get_firmware_version(self) -> int | None:
         return await self._read_firmware_version()
 

--- a/almond_axol/motor/myactuator.py
+++ b/almond_axol/motor/myactuator.py
@@ -255,6 +255,20 @@ class MyActuatorMotor(MotorDriver):
         """Request status frame 1 (temperature, voltage, error flags)."""
         return await self._request(self._cmd(_MA_READ_STATUS1))
 
+    async def _running_state(self) -> tuple[bool, int]:
+        """Return ``(running, error_bits)`` from a status-1 read.
+
+        ``running`` is status-1 byte 3. The protocol labels it the brake
+        release state; observed on fleet firmware (2025070202) it reads 1
+        only while the motor is actively executing commands — 0 when
+        disabled, freshly enabled but never commanded, or just reset — which
+        makes it exactly the "enabled and holding" signal attach/is_holding
+        need.
+        """
+        resp = await self._get_status1()
+        error_bits = struct.unpack_from("<H", resp, 6)[0]
+        return resp[3] == 0x01, int(error_bits)
+
     async def _get_status2(self) -> bytes:
         """Request status frame 2 (temperature, current, velocity, encoder)."""
         return await self._request(self._cmd(_MA_MOTOR_STATUS_2))
@@ -375,20 +389,23 @@ class MyActuatorMotor(MotorDriver):
         # and no 0x77 brake release (that would drop an arm parked on its
         # brake) — the whole point of attach is to leave torque untouched.
         await self._detect_capabilities()
-        resp = await self._get_status1()
-        error_bits = struct.unpack_from("<H", resp, 6)[0]
+        running, error_bits = await self._running_state()
         if error_bits:
             raise MotorError(
                 f"MyActuator motor {self._motor_id:#04x} has a latched fault "
                 f"({_ma_error_to_status(error_bits).value}) — attach is not "
                 f"possible; use enable() for a full bring-up"
             )
-        if resp[3] != 0x01:  # status-1 byte 3: brake state, 1 = released
+        if not running:
             raise MotorError(
-                f"MyActuator motor {self._motor_id:#04x} brake is engaged "
-                f"(motor not enabled and holding) — attach is not possible; "
+                f"MyActuator motor {self._motor_id:#04x} is not running "
+                f"(not enabled and holding) — attach is not possible; "
                 f"use enable() for a full bring-up"
             )
+
+    async def is_holding(self) -> bool:
+        running, error_bits = await self._running_state()
+        return running and not error_bits
 
     async def get_firmware_version(self) -> int | None:
         return await self._read_firmware_version()

--- a/almond_axol/robot/axol.py
+++ b/almond_axol/robot/axol.py
@@ -7,8 +7,11 @@ Provides :class:`AxolArm` (single-arm CAN bus controller) and :class:`Axol`
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import math
+import time
+from pathlib import Path
 
 import numpy as np
 
@@ -57,6 +60,59 @@ _GRIPPER_CALIB_MAX_STEPS = math.ceil(GRIPPER_TRAVEL / _GRIPPER_CALIB_STEP)
 # Impedance gains used only during gripper open-stop calibration.
 _GRIPPER_CALIB_KP = 50.0
 _GRIPPER_CALIB_KD = 1.0
+
+# The gripper open position varies per unit and is measured at runtime by
+# ``_calibrate_gripper()``. It is persisted here so ``attach()`` can restore
+# it without re-running the sweep (which physically forces the jaw open —
+# dropping anything held — and is the reason attach must not recalibrate).
+_GRIPPER_CALIB_PATH = Path.home() / ".almond" / "gripper_calibration.json"
+
+# Tolerance (rad) around the calibrated travel range when validating a
+# persisted calibration against the gripper's current position on attach().
+# A shaft position outside the range means the calibration no longer matches
+# the encoder (motor re-zeroed or power-cycled) and must not be trusted.
+_GRIPPER_CALIB_MARGIN = 0.35
+
+
+def _save_gripper_calibration(is_left: bool, open_pos: float) -> None:
+    """Persist one gripper's calibrated open position (raw motor rad).
+
+    A write failure only costs the ability to ``attach()`` later, so it is
+    logged rather than failing the enable that produced the calibration.
+    """
+    side = "left" if is_left else "right"
+    try:
+        data: dict = {}
+        if _GRIPPER_CALIB_PATH.exists():
+            data = json.loads(_GRIPPER_CALIB_PATH.read_text())
+        data[side] = {"open_pos": open_pos, "saved_at": time.time()}
+        _GRIPPER_CALIB_PATH.parent.mkdir(parents=True, exist_ok=True)
+        _GRIPPER_CALIB_PATH.write_text(json.dumps(data, indent=2))
+    except (OSError, ValueError) as exc:
+        _logger.warning(
+            "Could not persist %s gripper calibration to %s: %s",
+            side,
+            _GRIPPER_CALIB_PATH,
+            exc,
+        )
+
+
+def _load_gripper_calibration(is_left: bool) -> float:
+    """Return the persisted open position (raw motor rad) for one gripper.
+
+    Raises:
+        MotorError: If no calibration has been persisted for this arm.
+    """
+    side = "left" if is_left else "right"
+    try:
+        data = json.loads(_GRIPPER_CALIB_PATH.read_text())
+        return float(data[side]["open_pos"])
+    except (OSError, ValueError, KeyError, TypeError) as exc:
+        raise MotorError(
+            f"No persisted gripper calibration for the {side} arm in "
+            f"{_GRIPPER_CALIB_PATH} — run enable() once to calibrate before "
+            f"attach() can be used"
+        ) from exc
 
 
 def arm_limits(joint: Joint, is_left: bool) -> tuple[float, float]:
@@ -300,7 +356,9 @@ class AxolArm:
         Steps the gripper motor incrementally toward open until the torque
         magnitude drops to ``_GRIPPER_TORQUE_THRESHOLD`` (the open hard-stop).
         Updates ``_limits_lo[gripper_idx]`` (open) and ``_limits_hi[gripper_idx]``
-        (close) which are used for normalization and clipping.
+        (close) which are used for normalization and clipping, and persists the
+        open position so a later :meth:`attach` can restore it without moving
+        the gripper.
 
         Must be called with the gripper motor already enabled and in IMPEDANCE mode.
         """
@@ -317,14 +375,12 @@ class AxolArm:
             await asyncio.sleep(_GRIPPER_CALIB_SETTLE)
             torque = await motor.get_torque()
             if abs(torque) >= _GRIPPER_TORQUE_THRESHOLD:
-                open_pos = await motor.get_position()
-                self._limits_lo[gripper_i] = open_pos
-                self._limits_hi[gripper_i] = open_pos + GRIPPER_TRAVEL
-                return
+                break
 
         open_pos = await motor.get_position()
         self._limits_lo[gripper_i] = open_pos
         self._limits_hi[gripper_i] = open_pos + GRIPPER_TRAVEL
+        _save_gripper_calibration(self._is_left, open_pos)
 
     async def enable(self) -> None:
         """Enable all arm motors in IMPEDANCE mode and the gripper in POSITION_FORCE mode.
@@ -341,6 +397,67 @@ class AxolArm:
             await self.motors[Joint.GRIPPER].set_control_mode(
                 ControlMode.POSITION_FORCE
             )
+
+    async def attach(self) -> None:
+        """Reattach to an already-enabled arm without disturbing its torque state.
+
+        The reconnect counterpart to :meth:`enable`, for when a controlling
+        process died (or exited via :meth:`Axol.detach`) while the motors were
+        torqued on and holding. :meth:`enable` would drop the arm — its mode
+        switch reboots the MyActuator motors, and its gripper calibration
+        sweep forces the jaw open. This instead verifies every motor is
+        enabled, fault-free, and in the expected control mode, re-reads the
+        state needed for correct command scaling, and restores the gripper
+        calibration persisted by the last :meth:`enable` — all with reads
+        only, so the arm keeps holding its pose throughout.
+
+        The command history is seeded from the measured pose, so the
+        ``max_step_rad`` safety check applies to the very first
+        :meth:`motion_control` after attaching: resume commanding from the
+        arm's current positions, not from a stale or default target.
+
+        Raises:
+            MotorError: If any motor is unreachable, disabled, faulted, or in
+                an unexpected control mode, or if the persisted gripper
+                calibration is missing or no longer matches the encoder. The
+                arm is not in a cleanly-holding state; recover with a full
+                :meth:`enable` bring-up.
+        """
+        await asyncio.gather(
+            *[
+                m.attach(
+                    ControlMode.POSITION_FORCE
+                    if j == Joint.GRIPPER
+                    else ControlMode.IMPEDANCE
+                )
+                for j, m in self.motors.items()
+            ]
+        )
+
+        if self._has_gripper:
+            open_pos = _load_gripper_calibration(self._is_left)
+            current = await self.motors[Joint.GRIPPER].get_position()
+            if not (
+                open_pos - _GRIPPER_CALIB_MARGIN
+                <= current
+                <= open_pos + GRIPPER_TRAVEL + _GRIPPER_CALIB_MARGIN
+            ):
+                side = "left" if self._is_left else "right"
+                raise MotorError(
+                    f"Persisted {side} gripper calibration does not match the "
+                    f"motor: current position {current:.2f} rad is outside the "
+                    f"calibrated range [{open_pos:.2f}, "
+                    f"{open_pos + GRIPPER_TRAVEL:.2f}] rad (motor re-zeroed or "
+                    f"power-cycled?) — run enable() to recalibrate"
+                )
+            gripper_i = self._gripper_i
+            self._limits_lo[gripper_i] = open_pos
+            self._limits_hi[gripper_i] = open_pos + GRIPPER_TRAVEL
+
+        # Seed the max-step safety check from the held pose so the first
+        # motion_control cannot command a violent jump away from it. Only the
+        # arm-joint elements are compared (the gripper slot is masked out).
+        self._last_q_commanded = (await self.get_positions()).astype(float)
 
     async def disable(self) -> None:
         """Disable all motors and engage brakes."""
@@ -798,6 +915,17 @@ class Axol(RobotBase):
 
             await axol.motion_control(left=np.array([0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.0]))
 
+    To reconnect to a robot that is already torqued on and holding (e.g. the
+    previous process died mid-session), use :meth:`attach` / :meth:`detach`
+    instead of ``enable()`` / ``disable()`` — ``enable()`` reboots the motors
+    and recalibrates the grippers, dropping the arms and anything held:
+
+        axol = Axol()
+        await axol.attach()  # arms keep holding throughout
+        pos_l, pos_r = await axol.get_positions()
+        # ... resume motion_control from the measured pose ...
+        await axol.detach()  # exit, leaving the robot holding
+
     Attributes:
         left:  AxolArm for the left arm.
         right: AxolArm for the right arm.
@@ -916,6 +1044,68 @@ class Axol(RobotBase):
         if self.right is not None:
             motor_tasks.append(self.right.enable())
         await asyncio.gather(*motor_tasks)
+
+    async def attach(self) -> None:
+        """Reconnect to an already-enabled robot without interrupting torque.
+
+        The recovery path for "the process died while the robot was torqued
+        on and holding": calling :meth:`enable` there would drop the arms —
+        its mode switch reboots the MyActuator motors (torque off for ~2 s)
+        and its gripper calibration sweep forces the jaws open. This instead
+        starts the CAN buses and re-verifies/restores per-motor state with
+        reads only, so the arms keep holding their pose. See
+        :meth:`AxolArm.attach` for the per-arm details.
+
+        After attaching, resume control from the robot's *measured* positions
+        (:meth:`get_positions`) — the first :meth:`motion_control` is checked
+        against the held pose, so a stale or default target is rejected
+        instead of yanking the arms.
+
+        Use :meth:`detach` (not :meth:`disable`) to end the session with the
+        robot still holding.
+
+        Raises:
+            MotorError: If any motor is unreachable, disabled, faulted, in an
+                unexpected control mode, or missing persisted gripper
+                calibration — i.e. the robot is not in a cleanly-holding
+                state. Recover with a full :meth:`enable` bring-up on a fresh
+                :class:`Axol` instance.
+        """
+        bus_tasks = []
+        if self.left is not None:
+            bus_tasks.append(self._left_bus.start())
+        if self.right is not None:
+            bus_tasks.append(self._right_bus.start())
+        await asyncio.gather(*bus_tasks)
+
+        arm_tasks = []
+        if self.left is not None:
+            arm_tasks.append(self.left.attach())
+        if self.right is not None:
+            arm_tasks.append(self.right.attach())
+        await asyncio.gather(*arm_tasks)
+
+    async def detach(self) -> None:
+        """Close the CAN buses, leaving all motors enabled and holding.
+
+        The counterpart to :meth:`attach` — ends this process's session
+        without torquing off, so the arms keep holding their pose and a later
+        process can :meth:`attach` again. Telemetry is stopped first.
+        """
+        tasks = []
+        if self.left is not None:
+            tasks.append(self.left.stop_telemetry())
+        if self.right is not None:
+            tasks.append(self.right.stop_telemetry())
+        try:
+            await asyncio.gather(*tasks)
+        finally:
+            close_tasks = []
+            if self.left is not None:
+                close_tasks.append(self._left_bus.close())
+            if self.right is not None:
+                close_tasks.append(self._right_bus.close())
+            await asyncio.gather(*close_tasks)
 
     async def disable(self) -> None:
         """Disable all motors and close CAN buses."""

--- a/almond_axol/robot/axol.py
+++ b/almond_axol/robot/axol.py
@@ -81,14 +81,20 @@ def _save_gripper_calibration(is_left: bool, open_pos: float) -> None:
     logged rather than failing the enable that produced the calibration.
     """
     side = "left" if is_left else "right"
+    data: dict = {}
     try:
-        data: dict = {}
-        if _GRIPPER_CALIB_PATH.exists():
-            data = json.loads(_GRIPPER_CALIB_PATH.read_text())
-        data[side] = {"open_pos": open_pos, "saved_at": time.time()}
+        existing = json.loads(_GRIPPER_CALIB_PATH.read_text())
+        if isinstance(existing, dict):
+            data = existing
+    except (OSError, ValueError):
+        # Missing or corrupt file — overwrite it with a fresh calibration
+        # rather than losing the one we just measured.
+        pass
+    data[side] = {"open_pos": open_pos, "saved_at": time.time()}
+    try:
         _GRIPPER_CALIB_PATH.parent.mkdir(parents=True, exist_ok=True)
         _GRIPPER_CALIB_PATH.write_text(json.dumps(data, indent=2))
-    except (OSError, ValueError) as exc:
+    except OSError as exc:
         _logger.warning(
             "Could not persist %s gripper calibration to %s: %s",
             side,
@@ -385,31 +391,80 @@ class AxolArm:
     async def enable(self) -> None:
         """Enable all arm motors in IMPEDANCE mode and the gripper in POSITION_FORCE mode.
 
+        Idempotent per motor: joints that are already enabled and holding
+        torque (a previous session died or disconnected while live) are
+        attached to with reads only — never reset, so they keep holding their
+        pose — while the rest get the full bring-up (the mode switch reboots
+        MyActuator motors, which is why it must never reach a holding joint).
+        A holding gripper keeps its grasp: its open-stop calibration is
+        restored from the values persisted by the last full bring-up instead
+        of being re-measured (the calibration sweep would force the jaw
+        open). To force a fresh bring-up of a live robot, call
+        :meth:`disable` first.
+
+        A motor only counts as holding once it has received a motion command;
+        a freshly-enabled-but-never-commanded motor holds no torque, so it
+        goes through the full bring-up again — there is nothing to drop.
+
+        When any joint was kept holding, the command history is seeded from
+        the measured pose so the ``max_step_rad`` safety check applies to the
+        very first :meth:`motion_control` — resume commanding from the
+        measured positions, not from a stale or default target.
+
         On the gripperless SKU the gripper calibration and mode switch are
         skipped (there is no gripper motor).
+
+        Raises:
+            MotorError: If a holding motor is unreachable or in an unexpected
+                control mode, or if a holding gripper has no valid persisted
+                calibration (re-measuring would drop whatever it grips —
+                empty the gripper, then :meth:`disable` and re-enable).
         """
-        await asyncio.gather(*[m.enable() for m in self.motors.values()])
+        flags = dict(zip(self.motors.keys(), await self.get_holding()))
+        held = [j for j, holding in flags.items() if holding]
+        cold = [j for j, holding in flags.items() if not holding]
+
         await asyncio.gather(
-            *[m.set_control_mode(ControlMode.IMPEDANCE) for m in self.motors.values()]
+            *[
+                self.motors[j].attach(
+                    ControlMode.POSITION_FORCE
+                    if j == Joint.GRIPPER
+                    else ControlMode.IMPEDANCE
+                )
+                for j in held
+            ],
+            *[self.motors[j].enable() for j in cold],
         )
+        await asyncio.gather(
+            *[self.motors[j].set_control_mode(ControlMode.IMPEDANCE) for j in cold]
+        )
+
         if self._has_gripper:
-            await self._calibrate_gripper()
-            await self.motors[Joint.GRIPPER].set_control_mode(
-                ControlMode.POSITION_FORCE
-            )
+            if Joint.GRIPPER in held:
+                await self._restore_gripper_calibration()
+            else:
+                await self._calibrate_gripper()
+                await self.motors[Joint.GRIPPER].set_control_mode(
+                    ControlMode.POSITION_FORCE
+                )
+
+        if held:
+            # Seed the max-step safety check from the measured pose so the
+            # first motion_control cannot yank the joints that kept holding.
+            self._last_q_commanded = (await self.get_positions()).astype(float)
 
     async def attach(self) -> None:
         """Reattach to an already-enabled arm without disturbing its torque state.
 
-        The reconnect counterpart to :meth:`enable`, for when a controlling
-        process died (or exited via :meth:`Axol.detach`) while the motors were
-        torqued on and holding. :meth:`enable` would drop the arm — its mode
-        switch reboots the MyActuator motors, and its gripper calibration
-        sweep forces the jaw open. This instead verifies every motor is
-        enabled, fault-free, and in the expected control mode, re-reads the
-        state needed for correct command scaling, and restores the gripper
-        calibration persisted by the last :meth:`enable` — all with reads
-        only, so the arm keeps holding its pose throughout.
+        The strict reconnect primitive: unlike the idempotent :meth:`enable`
+        (which brings up whatever isn't holding), this never actuates
+        anything and fails unless the *whole arm* is already live — for when
+        a controlling process died (or exited via :meth:`Axol.disconnect`)
+        while the motors were torqued on and holding. Every motor is verified
+        to be enabled, fault-free, and in the expected control mode; the
+        state needed for correct command scaling is re-read; and the gripper
+        calibration persisted by the last full bring-up is restored — all
+        with reads only, so the arm keeps holding its pose throughout.
 
         The command history is seeded from the measured pose, so the
         ``max_step_rad`` safety check applies to the very first
@@ -420,8 +475,8 @@ class AxolArm:
             MotorError: If any motor is unreachable, disabled, faulted, or in
                 an unexpected control mode, or if the persisted gripper
                 calibration is missing or no longer matches the encoder. The
-                arm is not in a cleanly-holding state; recover with a full
-                :meth:`enable` bring-up.
+                arm is not in a cleanly-holding state; recover with
+                :meth:`enable`.
         """
         await asyncio.gather(
             *[
@@ -435,29 +490,44 @@ class AxolArm:
         )
 
         if self._has_gripper:
-            open_pos = _load_gripper_calibration(self._is_left)
-            current = await self.motors[Joint.GRIPPER].get_position()
-            if not (
-                open_pos - _GRIPPER_CALIB_MARGIN
-                <= current
-                <= open_pos + GRIPPER_TRAVEL + _GRIPPER_CALIB_MARGIN
-            ):
-                side = "left" if self._is_left else "right"
-                raise MotorError(
-                    f"Persisted {side} gripper calibration does not match the "
-                    f"motor: current position {current:.2f} rad is outside the "
-                    f"calibrated range [{open_pos:.2f}, "
-                    f"{open_pos + GRIPPER_TRAVEL:.2f}] rad (motor re-zeroed or "
-                    f"power-cycled?) — run enable() to recalibrate"
-                )
-            gripper_i = self._gripper_i
-            self._limits_lo[gripper_i] = open_pos
-            self._limits_hi[gripper_i] = open_pos + GRIPPER_TRAVEL
+            await self._restore_gripper_calibration()
 
         # Seed the max-step safety check from the held pose so the first
         # motion_control cannot command a violent jump away from it. Only the
         # arm-joint elements are compared (the gripper slot is masked out).
         self._last_q_commanded = (await self.get_positions()).astype(float)
+
+    async def _restore_gripper_calibration(self) -> None:
+        """Restore the gripper limits persisted by the last full bring-up.
+
+        The no-motion alternative to :meth:`_calibrate_gripper`, used when
+        the gripper is already live (attach, or an idempotent enable that
+        found it holding): re-measuring the open stop would sweep the jaw
+        open and drop anything held.
+
+        Raises:
+            MotorError: If no calibration was persisted, or it no longer
+                matches the encoder (motor re-zeroed or power-cycled).
+        """
+        open_pos = _load_gripper_calibration(self._is_left)
+        current = await self.motors[Joint.GRIPPER].get_position()
+        if not (
+            open_pos - _GRIPPER_CALIB_MARGIN
+            <= current
+            <= open_pos + GRIPPER_TRAVEL + _GRIPPER_CALIB_MARGIN
+        ):
+            side = "left" if self._is_left else "right"
+            raise MotorError(
+                f"Persisted {side} gripper calibration does not match the "
+                f"motor: current position {current:.2f} rad is outside the "
+                f"calibrated range [{open_pos:.2f}, "
+                f"{open_pos + GRIPPER_TRAVEL:.2f}] rad (motor re-zeroed or "
+                f"power-cycled?) — empty the gripper, then disable() and "
+                f"enable() to recalibrate"
+            )
+        gripper_i = self._gripper_i
+        self._limits_lo[gripper_i] = open_pos
+        self._limits_hi[gripper_i] = open_pos + GRIPPER_TRAVEL
 
     async def disable(self) -> None:
         """Disable all motors and engage brakes."""
@@ -552,6 +622,20 @@ class AxolArm:
         """
         values = await asyncio.gather(
             *[self.motors[j].get_error_code() for j in self.motors]
+        )
+        return list(values)
+
+    async def get_holding(self) -> list[bool]:
+        """Return each motor's enabled-and-holding state, fetched concurrently.
+
+        Read-only — safe on a robot of unknown state (pairs with
+        :meth:`Axol.connect` for inspecting before acting). See
+        :meth:`Motor.is_holding` for what "holding" means per motor family.
+        Returns a list in Joint enum order. On the gripperless SKU the
+        gripper entry is omitted (7 entries).
+        """
+        values = await asyncio.gather(
+            *[self.motors[j].is_holding() for j in self.motors]
         )
         return list(values)
 
@@ -915,16 +999,22 @@ class Axol(RobotBase):
 
             await axol.motion_control(left=np.array([0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 0.0, 0.0]))
 
-    To reconnect to a robot that is already torqued on and holding (e.g. the
-    previous process died mid-session), use :meth:`attach` / :meth:`detach`
-    instead of ``enable()`` / ``disable()`` — ``enable()`` reboots the motors
-    and recalibrates the grippers, dropping the arms and anything held:
+    Startup code never needs to know the robot's state: ``enable()`` is
+    idempotent per motor — joints still holding from a previous session (it
+    died or disconnected while live) are kept holding with reads only, and
+    everything else gets the full bring-up. :meth:`connect` opens the buses
+    without touching motor state, for inspecting a robot of unknown state
+    first (:meth:`get_holding`, :meth:`get_positions`, ...):
 
         axol = Axol()
-        await axol.attach()  # arms keep holding throughout
+        await axol.connect()      # open buses; inspect freely, nothing actuated
+        await axol.enable()       # holding joints kept holding; cold joints brought up
         pos_l, pos_r = await axol.get_positions()
         # ... resume motion_control from the measured pose ...
-        await axol.detach()  # exit, leaving the robot holding
+        await axol.disconnect()   # exit, leaving torque as-is
+
+    :meth:`attach` is the strict variant of a reconnect: reads only, and it
+    fails unless the whole robot is already holding.
 
     Attributes:
         left:  AxolArm for the left arm.
@@ -1029,14 +1119,40 @@ class Axol(RobotBase):
     # Arm-wide commands                                                    #
     # ------------------------------------------------------------------ #
 
-    async def enable(self) -> None:
-        """Start CAN buses and enable all motors on both arms."""
+    async def connect(self) -> None:
+        """Open the CAN buses without touching motor state.
+
+        Purely the transport step: after this, every read API works —
+        :meth:`get_holding`, :meth:`get_positions`, :meth:`get_error_codes`,
+        temperatures, … — so a process that starts with no knowledge of the
+        robot's state can inspect it before deciding to act. Nothing is
+        actuated and no frame that could affect torque is sent.
+
+        The typical startup is ``connect()``, optional inspection, then
+        :meth:`enable` — which is idempotent and never drops joints that are
+        already holding. Calling ``connect()`` first is optional:
+        :meth:`enable` and :meth:`attach` open the buses themselves.
+        """
         bus_tasks = []
         if self.left is not None:
             bus_tasks.append(self._left_bus.start())
         if self.right is not None:
             bus_tasks.append(self._right_bus.start())
         await asyncio.gather(*bus_tasks)
+
+    async def enable(self) -> None:
+        """Start CAN buses and bring every motor up, never dropping held joints.
+
+        Idempotent per motor: joints still enabled and holding from a
+        previous session (it died or disconnected while live) are attached to
+        with reads only and keep holding their pose — including a gripper
+        keeping its grasp — while cold motors get the full bring-up. Startup
+        code therefore doesn't need to know the robot's state; ``enable()``
+        converges holding, torque-off, and mixed robots alike. To force a
+        fresh bring-up of a live robot, call :meth:`disable` first. See
+        :meth:`AxolArm.enable` for details and failure modes.
+        """
+        await self.connect()
 
         motor_tasks = []
         if self.left is not None:
@@ -1046,14 +1162,12 @@ class Axol(RobotBase):
         await asyncio.gather(*motor_tasks)
 
     async def attach(self) -> None:
-        """Reconnect to an already-enabled robot without interrupting torque.
+        """Reconnect to an already-live robot, verifying torque is never touched.
 
-        The recovery path for "the process died while the robot was torqued
-        on and holding": calling :meth:`enable` there would drop the arms —
-        its mode switch reboots the MyActuator motors (torque off for ~2 s)
-        and its gripper calibration sweep forces the jaws open. This instead
-        starts the CAN buses and re-verifies/restores per-motor state with
-        reads only, so the arms keep holding their pose. See
+        The strict alternative to the idempotent :meth:`enable` for processes
+        that must not actuate anything: it starts the CAN buses and
+        re-verifies/restores per-motor state with reads only, and fails
+        unless the *whole robot* is already enabled and holding. See
         :meth:`AxolArm.attach` for the per-arm details.
 
         After attaching, resume control from the robot's *measured* positions
@@ -1061,22 +1175,16 @@ class Axol(RobotBase):
         against the held pose, so a stale or default target is rejected
         instead of yanking the arms.
 
-        Use :meth:`detach` (not :meth:`disable`) to end the session with the
-        robot still holding.
+        Use :meth:`disconnect` (not :meth:`disable`) to end the session with
+        the robot still holding.
 
         Raises:
             MotorError: If any motor is unreachable, disabled, faulted, in an
                 unexpected control mode, or missing persisted gripper
                 calibration — i.e. the robot is not in a cleanly-holding
-                state. Recover with a full :meth:`enable` bring-up on a fresh
-                :class:`Axol` instance.
+                state. Recover with :meth:`enable`.
         """
-        bus_tasks = []
-        if self.left is not None:
-            bus_tasks.append(self._left_bus.start())
-        if self.right is not None:
-            bus_tasks.append(self._right_bus.start())
-        await asyncio.gather(*bus_tasks)
+        await self.connect()
 
         arm_tasks = []
         if self.left is not None:
@@ -1085,12 +1193,13 @@ class Axol(RobotBase):
             arm_tasks.append(self.right.attach())
         await asyncio.gather(*arm_tasks)
 
-    async def detach(self) -> None:
-        """Close the CAN buses, leaving all motors enabled and holding.
+    async def disconnect(self) -> None:
+        """Close the CAN buses, leaving motor torque exactly as it is.
 
-        The counterpart to :meth:`attach` — ends this process's session
-        without torquing off, so the arms keep holding their pose and a later
-        process can :meth:`attach` again. Telemetry is stopped first.
+        The counterpart to :meth:`connect` — ends this process's session
+        without torquing off, so holding arms keep holding their pose and a
+        later process can :meth:`enable` or :meth:`attach` again. Telemetry
+        is stopped first. Use :meth:`disable` instead to torque off.
         """
         tasks = []
         if self.left is not None:
@@ -1225,6 +1334,19 @@ class Axol(RobotBase):
         return await self._gather_pair(
             self.left.get_error_codes() if self.left is not None else None,
             self.right.get_error_codes() if self.right is not None else None,
+        )
+
+    async def get_holding(self) -> tuple[list[bool] | None, list[bool] | None]:
+        """Return each motor's enabled-and-holding state as (left, right).
+
+        Read-only — safe on a robot of unknown state, e.g. right after
+        :meth:`connect`, to inspect before deciding to act. Each list is in
+        Joint enum order (gripper entry omitted on the gripperless SKU), or
+        ``None`` if that arm is absent.
+        """
+        return await self._gather_pair(
+            self.left.get_holding() if self.left is not None else None,
+            self.right.get_holding() if self.right is not None else None,
         )
 
     async def get_gains(

--- a/almond_axol/robot/axol.py
+++ b/almond_axol/robot/axol.py
@@ -62,13 +62,13 @@ _GRIPPER_CALIB_KP = 50.0
 _GRIPPER_CALIB_KD = 1.0
 
 # The gripper open position varies per unit and is measured at runtime by
-# ``_calibrate_gripper()``. It is persisted here so ``attach()`` can restore
-# it without re-running the sweep (which physically forces the jaw open —
-# dropping anything held — and is the reason attach must not recalibrate).
+# ``_calibrate_gripper()``. It is persisted here so a reconnecting
+# ``enable()`` can restore it without re-running the sweep (which physically
+# forces the jaw open, dropping anything a holding gripper grips).
 _GRIPPER_CALIB_PATH = Path.home() / ".almond" / "gripper_calibration.json"
 
 # Tolerance (rad) around the calibrated travel range when validating a
-# persisted calibration against the gripper's current position on attach().
+# persisted calibration against the gripper's current position on restore.
 # A shaft position outside the range means the calibration no longer matches
 # the encoder (motor re-zeroed or power-cycled) and must not be trusted.
 _GRIPPER_CALIB_MARGIN = 0.35
@@ -77,8 +77,9 @@ _GRIPPER_CALIB_MARGIN = 0.35
 def _save_gripper_calibration(is_left: bool, open_pos: float) -> None:
     """Persist one gripper's calibrated open position (raw motor rad).
 
-    A write failure only costs the ability to ``attach()`` later, so it is
-    logged rather than failing the enable that produced the calibration.
+    A write failure only costs the ability to reconnect to a holding gripper
+    later, so it is logged rather than failing the enable that produced the
+    calibration.
     """
     side = "left" if is_left else "right"
     data: dict = {}
@@ -116,8 +117,9 @@ def _load_gripper_calibration(is_left: bool) -> float:
     except (OSError, ValueError, KeyError, TypeError) as exc:
         raise MotorError(
             f"No persisted gripper calibration for the {side} arm in "
-            f"{_GRIPPER_CALIB_PATH} — run enable() once to calibrate before "
-            f"attach() can be used"
+            f"{_GRIPPER_CALIB_PATH} — a holding gripper cannot be reconnected "
+            f"to without it; empty the gripper, then disable() and enable() "
+            f"to calibrate"
         ) from exc
 
 
@@ -388,7 +390,7 @@ class AxolArm:
         self._limits_hi[gripper_i] = open_pos + GRIPPER_TRAVEL
         _save_gripper_calibration(self._is_left, open_pos)
 
-    async def enable(self) -> None:
+    async def enable(self, hold: bool = True) -> None:
         """Enable all arm motors in IMPEDANCE mode and the gripper in POSITION_FORCE mode.
 
         Idempotent per motor: joints that are already enabled and holding
@@ -402,23 +404,31 @@ class AxolArm:
         open). To force a fresh bring-up of a live robot, call
         :meth:`disable` first.
 
-        A motor only counts as holding once it has received a motion command;
-        a freshly-enabled-but-never-commanded motor holds no torque, so it
-        goes through the full bring-up again — there is nothing to drop.
+        With ``hold=True`` (the default) the arm finishes actively holding
+        its measured pose: one :meth:`motion_control` command is issued at
+        the measured positions (configured gains + gravity feedforward — the
+        arm is already there, so nothing moves). Enabled therefore *means*
+        holding, and the command history is seeded so the ``max_step_rad``
+        safety check applies from the very first caller command.
 
-        When any joint was kept holding, the command history is seeded from
-        the measured pose so the ``max_step_rad`` safety check applies to the
-        very first :meth:`motion_control` — resume commanding from the
-        measured positions, not from a stale or default target.
+        Pass ``hold=False`` to leave freshly brought-up joints enabled but
+        limp (no torque until the first command) — for callers that manage
+        control modes themselves via :meth:`set_control_mode` and would only
+        tear the hold down again. Joints kept holding from a previous
+        session still hold (their previous command stays active), and the
+        command history is still seeded when any exist.
 
         On the gripperless SKU the gripper calibration and mode switch are
         skipped (there is no gripper motor).
 
         Raises:
             MotorError: If a holding motor is unreachable or in an unexpected
-                control mode, or if a holding gripper has no valid persisted
-                calibration (re-measuring would drop whatever it grips —
-                empty the gripper, then :meth:`disable` and re-enable).
+                control mode (reconnecting targets the impedance workflow —
+                a session that died in another control mode needs
+                :meth:`disable` then re-enable), or if a holding gripper has
+                no valid persisted calibration (re-measuring would drop
+                whatever it grips — empty the gripper, then :meth:`disable`
+                and re-enable).
         """
         flags = dict(zip(self.motors.keys(), await self.get_holding()))
         held = [j for j, holding in flags.items() if holding]
@@ -448,62 +458,25 @@ class AxolArm:
                     ControlMode.POSITION_FORCE
                 )
 
+        if held or hold:
+            q = (await self.get_positions()).astype(float)
         if held:
             # Seed the max-step safety check from the measured pose so the
             # first motion_control cannot yank the joints that kept holding.
-            self._last_q_commanded = (await self.get_positions()).astype(float)
-
-    async def attach(self) -> None:
-        """Reattach to an already-enabled arm without disturbing its torque state.
-
-        The strict reconnect primitive: unlike the idempotent :meth:`enable`
-        (which brings up whatever isn't holding), this never actuates
-        anything and fails unless the *whole arm* is already live — for when
-        a controlling process died (or exited via :meth:`Axol.disconnect`)
-        while the motors were torqued on and holding. Every motor is verified
-        to be enabled, fault-free, and in the expected control mode; the
-        state needed for correct command scaling is re-read; and the gripper
-        calibration persisted by the last full bring-up is restored — all
-        with reads only, so the arm keeps holding its pose throughout.
-
-        The command history is seeded from the measured pose, so the
-        ``max_step_rad`` safety check applies to the very first
-        :meth:`motion_control` after attaching: resume commanding from the
-        arm's current positions, not from a stale or default target.
-
-        Raises:
-            MotorError: If any motor is unreachable, disabled, faulted, or in
-                an unexpected control mode, or if the persisted gripper
-                calibration is missing or no longer matches the encoder. The
-                arm is not in a cleanly-holding state; recover with
-                :meth:`enable`.
-        """
-        await asyncio.gather(
-            *[
-                m.attach(
-                    ControlMode.POSITION_FORCE
-                    if j == Joint.GRIPPER
-                    else ControlMode.IMPEDANCE
-                )
-                for j, m in self.motors.items()
-            ]
-        )
-
-        if self._has_gripper:
-            await self._restore_gripper_calibration()
-
-        # Seed the max-step safety check from the held pose so the first
-        # motion_control cannot command a violent jump away from it. Only the
-        # arm-joint elements are compared (the gripper slot is masked out).
-        self._last_q_commanded = (await self.get_positions()).astype(float)
+            self._last_q_commanded = q
+        if hold:
+            # Servo on: command the measured pose once so "enabled" means
+            # "holding" — without this, freshly brought-up joints stay limp
+            # until the caller's first motion_control.
+            await self.motion_control(q)
 
     async def _restore_gripper_calibration(self) -> None:
         """Restore the gripper limits persisted by the last full bring-up.
 
         The no-motion alternative to :meth:`_calibrate_gripper`, used when
-        the gripper is already live (attach, or an idempotent enable that
-        found it holding): re-measuring the open stop would sweep the jaw
-        open and drop anything held.
+        the idempotent :meth:`enable` finds the gripper already live and
+        holding: re-measuring the open stop would sweep the jaw open and
+        drop anything held.
 
         Raises:
             MotorError: If no calibration was persisted, or it no longer
@@ -539,6 +512,9 @@ class AxolArm:
 
     async def set_control_mode(self, mode: ControlMode) -> None:
         """Set the control mode on all motors.
+
+        WARNING: MyActuator motors reboot to switch modes (torque off ~2 s)
+        — never call this while the arm is holding a load; it will fall.
 
         Args:
             mode: Desired control mode.
@@ -1002,9 +978,10 @@ class Axol(RobotBase):
     Startup code never needs to know the robot's state: ``enable()`` is
     idempotent per motor — joints still holding from a previous session (it
     died or disconnected while live) are kept holding with reads only, and
-    everything else gets the full bring-up. :meth:`connect` opens the buses
-    without touching motor state, for inspecting a robot of unknown state
-    first (:meth:`get_holding`, :meth:`get_positions`, ...):
+    everything else gets the full bring-up, finishing with the arms actively
+    holding their measured pose. :meth:`connect` opens the buses without
+    touching motor state, for inspecting a robot of unknown state first
+    (:meth:`get_holding`, :meth:`get_positions`, ...):
 
         axol = Axol()
         await axol.connect()      # open buses; inspect freely, nothing actuated
@@ -1013,8 +990,12 @@ class Axol(RobotBase):
         # ... resume motion_control from the measured pose ...
         await axol.disconnect()   # exit, leaving torque as-is
 
-    :meth:`attach` is the strict variant of a reconnect: reads only, and it
-    fails unless the whole robot is already holding.
+    Pass ``enable(hold=False)`` to leave freshly brought-up joints limp, for
+    flows that manage control modes themselves (:meth:`set_control_mode` —
+    note it reboots MyActuator motors, so never switch modes on a loaded
+    arm). A process that must not actuate anything can ``connect()``, check
+    :meth:`get_holding`, and only proceed to ``enable()`` when every joint
+    is already holding.
 
     Attributes:
         left:  AxolArm for the left arm.
@@ -1131,7 +1112,7 @@ class Axol(RobotBase):
         The typical startup is ``connect()``, optional inspection, then
         :meth:`enable` — which is idempotent and never drops joints that are
         already holding. Calling ``connect()`` first is optional:
-        :meth:`enable` and :meth:`attach` open the buses themselves.
+        :meth:`enable` opens the buses itself.
         """
         bus_tasks = []
         if self.left is not None:
@@ -1140,7 +1121,7 @@ class Axol(RobotBase):
             bus_tasks.append(self._right_bus.start())
         await asyncio.gather(*bus_tasks)
 
-    async def enable(self) -> None:
+    async def enable(self, hold: bool = True) -> None:
         """Start CAN buses and bring every motor up, never dropping held joints.
 
         Idempotent per motor: joints still enabled and holding from a
@@ -1149,57 +1130,30 @@ class Axol(RobotBase):
         keeping its grasp — while cold motors get the full bring-up. Startup
         code therefore doesn't need to know the robot's state; ``enable()``
         converges holding, torque-off, and mixed robots alike. To force a
-        fresh bring-up of a live robot, call :meth:`disable` first. See
-        :meth:`AxolArm.enable` for details and failure modes.
+        fresh bring-up of a live robot, call :meth:`disable` first.
+
+        With ``hold=True`` (the default) the robot finishes actively holding
+        its measured pose ("enabled" means holding). Pass ``hold=False`` to
+        leave freshly brought-up joints enabled but limp, for flows that
+        manage control modes themselves. See :meth:`AxolArm.enable` for
+        details and failure modes.
         """
         await self.connect()
 
         motor_tasks = []
         if self.left is not None:
-            motor_tasks.append(self.left.enable())
+            motor_tasks.append(self.left.enable(hold=hold))
         if self.right is not None:
-            motor_tasks.append(self.right.enable())
+            motor_tasks.append(self.right.enable(hold=hold))
         await asyncio.gather(*motor_tasks)
-
-    async def attach(self) -> None:
-        """Reconnect to an already-live robot, verifying torque is never touched.
-
-        The strict alternative to the idempotent :meth:`enable` for processes
-        that must not actuate anything: it starts the CAN buses and
-        re-verifies/restores per-motor state with reads only, and fails
-        unless the *whole robot* is already enabled and holding. See
-        :meth:`AxolArm.attach` for the per-arm details.
-
-        After attaching, resume control from the robot's *measured* positions
-        (:meth:`get_positions`) — the first :meth:`motion_control` is checked
-        against the held pose, so a stale or default target is rejected
-        instead of yanking the arms.
-
-        Use :meth:`disconnect` (not :meth:`disable`) to end the session with
-        the robot still holding.
-
-        Raises:
-            MotorError: If any motor is unreachable, disabled, faulted, in an
-                unexpected control mode, or missing persisted gripper
-                calibration — i.e. the robot is not in a cleanly-holding
-                state. Recover with :meth:`enable`.
-        """
-        await self.connect()
-
-        arm_tasks = []
-        if self.left is not None:
-            arm_tasks.append(self.left.attach())
-        if self.right is not None:
-            arm_tasks.append(self.right.attach())
-        await asyncio.gather(*arm_tasks)
 
     async def disconnect(self) -> None:
         """Close the CAN buses, leaving motor torque exactly as it is.
 
         The counterpart to :meth:`connect` — ends this process's session
         without torquing off, so holding arms keep holding their pose and a
-        later process can :meth:`enable` or :meth:`attach` again. Telemetry
-        is stopped first. Use :meth:`disable` instead to torque off.
+        later process can reconnect and :meth:`enable` again. Telemetry is
+        stopped first. Use :meth:`disable` instead to torque off.
         """
         tasks = []
         if self.left is not None:
@@ -1246,6 +1200,11 @@ class Axol(RobotBase):
 
     async def set_control_mode(self, mode: ControlMode) -> None:
         """Set the control mode on all motors on both arms.
+
+        WARNING: MyActuator motors reboot to switch modes (torque off ~2 s)
+        — never call this while the arms are holding a load; they will fall.
+        Bring the robot to rest first (or use ``enable(hold=False)`` in
+        flows that manage modes themselves).
 
         Args:
             mode: Desired control mode.

--- a/docs/api/motor.mdx
+++ b/docs/api/motor.mdx
@@ -33,6 +33,7 @@ asyncio.run(main())
 | Method | Description |
 |---|---|
 | `enable()` / `disable()` | Enable motor / engage brake |
+| `attach(mode)` | Reconnect to an already-enabled motor without disturbing its torque state: verifies it is enabled, fault-free, and in `mode`, using reads only (`set_control_mode` would reboot a MyActuator motor, dropping torque for ~2 s) |
 | `clear_errors()` | Clear latched error flags |
 | `set_zero_position()` | Save current position as encoder zero (persisted to flash). Calibrated at a mechanical end stop, not the rest position |
 | `set_control_mode(mode)` | Set `ControlMode`; required before mode-specific commands |

--- a/docs/api/motor.mdx
+++ b/docs/api/motor.mdx
@@ -37,7 +37,7 @@ asyncio.run(main())
 | `is_holding()` | `True` if the motor is enabled and holding torque (read-only). Damiao: feedback status `ENABLED` (an enabled-but-never-commanded motor also reports `True`). MyActuator: status-1 running byte set and no fault latched |
 | `clear_errors()` | Clear latched error flags |
 | `set_zero_position()` | Save current position as encoder zero (persisted to flash). Calibrated at a mechanical end stop, not the rest position |
-| `set_control_mode(mode)` | Set `ControlMode`; required before mode-specific commands |
+| `set_control_mode(mode)` | Set `ControlMode`; required before mode-specific commands. **MyActuator motors reboot to switch (torque off ~2 s)** — never call it on a motor holding a load. Damiao is a plain register write; a live flip is non-disruptive |
 | `get_control_mode()` | Read active mode from hardware (`None` for MyActuator) |
 | `get_model()` | Motor model string, e.g. `"X8S2V"` (`None` for Damiao) |
 | `get_firmware_version()` | Firmware VersionDate `int`, e.g. `2026042402` (`None` for Damiao) |

--- a/docs/api/motor.mdx
+++ b/docs/api/motor.mdx
@@ -34,6 +34,7 @@ asyncio.run(main())
 |---|---|
 | `enable()` / `disable()` | Enable motor / engage brake |
 | `attach(mode)` | Reconnect to an already-enabled motor without disturbing its torque state: verifies it is enabled, fault-free, and in `mode`, using reads only (`set_control_mode` would reboot a MyActuator motor, dropping torque for ~2 s) |
+| `is_holding()` | `True` if the motor is enabled and holding torque (read-only). Damiao: feedback status `ENABLED` (an enabled-but-never-commanded motor also reports `True`). MyActuator: status-1 running byte set and no fault latched |
 | `clear_errors()` | Clear latched error flags |
 | `set_zero_position()` | Save current position as encoder zero (persisted to flash). Calibrated at a mechanical end stop, not the rest position |
 | `set_control_mode(mode)` | Set `ControlMode`; required before mode-specific commands |

--- a/docs/api/robot.mdx
+++ b/docs/api/robot.mdx
@@ -47,15 +47,14 @@ asyncio.run(main())
 | Method | Description |
 |---|---|
 | `connect()` | Open the CAN buses only — nothing is actuated; all read APIs (`get_holding()`, `get_positions()`, ...) become usable for inspecting a robot of unknown state |
-| `enable()` | Bring every motor up. Idempotent per motor: joints already holding keep holding (reads only, gripper keeps its grasp); cold joints get the full bring-up incl. gripper calibration — see [Reconnecting to a live robot](#reconnecting-to-a-live-robot) |
+| `enable(hold=True)` | Bring every motor up. Idempotent per motor: joints already holding keep holding (reads only, gripper keeps its grasp); cold joints get the full bring-up incl. gripper calibration. With `hold=True` (default) the robot finishes actively holding its measured pose — see [Reconnecting to a live robot](#reconnecting-to-a-live-robot) |
 | `disable()` | Disable all motors and close CAN buses |
-| `attach()` | Strict reconnect: reads only, fails unless the whole robot is already holding |
 | `disconnect()` | Close CAN buses leaving motor torque exactly as it is |
 | `start_telemetry(hz, torque=False)` | Begin background polling loop on all motors |
 | `wait_for_telemetry(timeout=5.0)` | Block until every motor has reported a position; call after `start_telemetry` before the first cached `positions` read |
 | `stop_telemetry()` | Stop background polling |
 | `clear_errors()` | Clear latched error flags on all motors |
-| `set_control_mode(mode)` | Set `ControlMode` on all motors |
+| `set_control_mode(mode)` | Set `ControlMode` on all motors. **MyActuator motors reboot to switch modes (torque off ~2 s)** — never call it while the arms hold a load; use `enable(hold=False)` in flows that manage modes themselves (Damiao takes a live mode flip in stride — it is a plain register write) |
 
 ### Reconnecting to a live robot
 
@@ -63,7 +62,8 @@ If a controlling process dies (or disconnects) while the robot is torqued on, th
 
 - joints that are **already holding** are attached to with reads only (never reset — a reset reboots MyActuator motors and drops the arm for ~2 s), and a holding gripper keeps its grasp: its open-stop calibration is restored from the values persisted by the last full bring-up instead of re-running the sweep that forces the jaws open;
 - **cold** joints get the classic full bring-up;
-- a mixed robot (e.g. the previous session died mid-`enable`) simply gets the cold joints brought up while the holding ones are left alone.
+- a mixed robot (e.g. the previous session died mid-`enable`) simply gets the cold joints brought up while the holding ones are left alone;
+- with `hold=True` (the default) `enable()` finishes by commanding the measured pose once (configured gains + gravity feedforward — the arm is already there, so nothing moves), so "enabled" always means *actively holding*.
 
 ```python
 import asyncio
@@ -93,11 +93,10 @@ asyncio.run(main())
 
 Notes:
 
-- `connect()` is optional — `enable()` opens the buses itself. Call it when you want to inspect state (`get_holding()`, positions, temperatures) before acting.
+- `connect()` is optional — `enable()` opens the buses itself. Call it when you want to inspect state (`get_holding()`, positions, temperatures) before acting. A process that must never actuate can `connect()`, check `get_holding()`, and only proceed when every joint is already holding.
+- Custom control modes: pass `enable(hold=False)` to leave freshly brought-up joints enabled but limp, then pick your mode with `set_control_mode()` (position/velocity/force). The reconnect machinery targets the impedance workflow — a session that died in another control mode is asked to `disable()` and re-enable rather than being reattached.
 - To force a fresh bring-up of a live robot (re-run gripper calibration, reset motors), call `disable()` first, then `enable()`.
 - One corner intentionally raises `MotorError`: a gripper that is holding but has no valid persisted calibration — re-measuring would sweep the jaws open and drop whatever it grips. Empty the gripper, then `disable()` and `enable()`.
-- A motor only counts as holding once it has received a motion command; a session that died after enabling but before commanding holds no torque, so those joints just go through the full bring-up again.
-- `attach()` is the strict variant for processes that must never actuate: reads only, and it fails unless the whole robot is already holding.
 - `disconnect()` closes the buses without touching torque, so the robot keeps holding and a later process can reconnect. Use `disable()` only when you actually want to torque off (with the arms in a safe pose).
 
 ### State reads

--- a/docs/api/robot.mdx
+++ b/docs/api/robot.mdx
@@ -48,11 +48,44 @@ asyncio.run(main())
 |---|---|
 | `enable()` | Start CAN buses, enable all motors, calibrate grippers |
 | `disable()` | Disable all motors and close CAN buses |
+| `attach()` | Reconnect to an already-enabled robot without interrupting torque — see [Reconnecting to a live robot](#reconnecting-to-a-live-robot) |
+| `detach()` | Close CAN buses leaving all motors enabled and holding |
 | `start_telemetry(hz, torque=False)` | Begin background polling loop on all motors |
 | `wait_for_telemetry(timeout=5.0)` | Block until every motor has reported a position; call after `start_telemetry` before the first cached `positions` read |
 | `stop_telemetry()` | Stop background polling |
 | `clear_errors()` | Clear latched error flags on all motors |
 | `set_control_mode(mode)` | Set `ControlMode` on all motors |
+
+### Reconnecting to a live robot
+
+If a controlling process dies (or detaches) while the robot is torqued on, the motors keep holding their last commanded pose. Do **not** call `enable()` to reconnect: its control-mode switch reboots the MyActuator motors (torque drops for ~2 s and the arms fall), and its gripper calibration sweep forces the jaws open, dropping anything held.
+
+Use `attach()` instead. It starts the CAN buses and restores everything the process needs — firmware capabilities, scaling registers, the persisted gripper calibration from the last `enable()`, and the per-motor control-mode bookkeeping — using reads only, so the arms keep holding throughout. It verifies every motor is enabled, fault-free, and in the expected control mode, and raises `MotorError` if the robot is not in a cleanly-holding state (e.g. it was power-cycled — then a full `enable()` bring-up is required).
+
+```python
+import asyncio
+from almond_axol.robot import Axol
+
+async def main():
+    axol = Axol()
+    await axol.attach()                    # arms keep holding throughout
+    await axol.start_telemetry(500)
+    await axol.wait_for_telemetry()
+
+    # Resume from the *measured* pose — the arms are wherever the previous
+    # session left them, and attach() arms the max_step_rad safety check
+    # against that pose, so a stale or default target is rejected instead
+    # of yanking the arms.
+    left = axol.left.positions
+    await axol.motion_control(left=left)
+    # ... ramp toward your desired target from here ...
+
+    await axol.detach()                    # exit, leaving the robot holding
+
+asyncio.run(main())
+```
+
+`detach()` is the complement: it closes the buses without disabling the motors, so the robot keeps holding and a later process can `attach()` again. Use `disable()` only when you actually want to torque off (with the arms in a safe pose).
 
 ### State reads
 

--- a/docs/api/robot.mdx
+++ b/docs/api/robot.mdx
@@ -46,10 +46,11 @@ asyncio.run(main())
 
 | Method | Description |
 |---|---|
-| `enable()` | Start CAN buses, enable all motors, calibrate grippers |
+| `connect()` | Open the CAN buses only — nothing is actuated; all read APIs (`get_holding()`, `get_positions()`, ...) become usable for inspecting a robot of unknown state |
+| `enable()` | Bring every motor up. Idempotent per motor: joints already holding keep holding (reads only, gripper keeps its grasp); cold joints get the full bring-up incl. gripper calibration — see [Reconnecting to a live robot](#reconnecting-to-a-live-robot) |
 | `disable()` | Disable all motors and close CAN buses |
-| `attach()` | Reconnect to an already-enabled robot without interrupting torque — see [Reconnecting to a live robot](#reconnecting-to-a-live-robot) |
-| `detach()` | Close CAN buses leaving all motors enabled and holding |
+| `attach()` | Strict reconnect: reads only, fails unless the whole robot is already holding |
+| `disconnect()` | Close CAN buses leaving motor torque exactly as it is |
 | `start_telemetry(hz, torque=False)` | Begin background polling loop on all motors |
 | `wait_for_telemetry(timeout=5.0)` | Block until every motor has reported a position; call after `start_telemetry` before the first cached `positions` read |
 | `stop_telemetry()` | Stop background polling |
@@ -58,9 +59,11 @@ asyncio.run(main())
 
 ### Reconnecting to a live robot
 
-If a controlling process dies (or detaches) while the robot is torqued on, the motors keep holding their last commanded pose. Do **not** call `enable()` to reconnect: its control-mode switch reboots the MyActuator motors (torque drops for ~2 s and the arms fall), and its gripper calibration sweep forces the jaws open, dropping anything held.
+If a controlling process dies (or disconnects) while the robot is torqued on, the motors keep holding their last commanded pose. Startup code does not need to know whether that happened: `enable()` queries each motor and converges —
 
-Use `attach()` instead. It starts the CAN buses and restores everything the process needs — firmware capabilities, scaling registers, the persisted gripper calibration from the last `enable()`, and the per-motor control-mode bookkeeping — using reads only, so the arms keep holding throughout. It verifies every motor is enabled, fault-free, and in the expected control mode, and raises `MotorError` if the robot is not in a cleanly-holding state (e.g. it was power-cycled — then a full `enable()` bring-up is required).
+- joints that are **already holding** are attached to with reads only (never reset — a reset reboots MyActuator motors and drops the arm for ~2 s), and a holding gripper keeps its grasp: its open-stop calibration is restored from the values persisted by the last full bring-up instead of re-running the sweep that forces the jaws open;
+- **cold** joints get the classic full bring-up;
+- a mixed robot (e.g. the previous session died mid-`enable`) simply gets the cold joints brought up while the holding ones are left alone.
 
 ```python
 import asyncio
@@ -68,24 +71,34 @@ from almond_axol.robot import Axol
 
 async def main():
     axol = Axol()
-    await axol.attach()                    # arms keep holding throughout
+    await axol.connect()                   # open buses; nothing actuated
+    held_l, held_r = await axol.get_holding()   # optional: inspect first
+    await axol.enable()                    # holding joints kept holding
+
     await axol.start_telemetry(500)
     await axol.wait_for_telemetry()
 
-    # Resume from the *measured* pose — the arms are wherever the previous
-    # session left them, and attach() arms the max_step_rad safety check
-    # against that pose, so a stale or default target is rejected instead
-    # of yanking the arms.
+    # Resume from the *measured* pose — after a reconnect the arms are
+    # wherever the previous session left them, and the max_step_rad safety
+    # check is seeded against that pose, so a stale or default target is
+    # rejected instead of yanking the arms.
     left = axol.left.positions
     await axol.motion_control(left=left)
     # ... ramp toward your desired target from here ...
 
-    await axol.detach()                    # exit, leaving the robot holding
+    await axol.disconnect()                # exit, leaving torque as-is
 
 asyncio.run(main())
 ```
 
-`detach()` is the complement: it closes the buses without disabling the motors, so the robot keeps holding and a later process can `attach()` again. Use `disable()` only when you actually want to torque off (with the arms in a safe pose).
+Notes:
+
+- `connect()` is optional — `enable()` opens the buses itself. Call it when you want to inspect state (`get_holding()`, positions, temperatures) before acting.
+- To force a fresh bring-up of a live robot (re-run gripper calibration, reset motors), call `disable()` first, then `enable()`.
+- One corner intentionally raises `MotorError`: a gripper that is holding but has no valid persisted calibration — re-measuring would sweep the jaws open and drop whatever it grips. Empty the gripper, then `disable()` and `enable()`.
+- A motor only counts as holding once it has received a motion command; a session that died after enabling but before commanding holds no torque, so those joints just go through the full bring-up again.
+- `attach()` is the strict variant for processes that must never actuate: reads only, and it fails unless the whole robot is already holding.
+- `disconnect()` closes the buses without touching torque, so the robot keeps holding and a later process can reconnect. Use `disable()` only when you actually want to torque off (with the arms in a safe pose).
 
 ### State reads
 
@@ -99,6 +112,7 @@ Each returns `(left_array, right_array)` where the absent arm is `None`.
 | `get_temperatures()` | °C |
 | `get_voltages()` | V |
 | `get_error_codes()` | `list[MotorStatus]` |
+| `get_holding()` | `list[bool]` — enabled-and-holding per motor (read-only; usable right after `connect()`) |
 | `get_gains()` | `list[MotorGains]` |
 
 ### State writes


### PR DESCRIPTION
## Summary

If a controlling process dies while the robot is torqued on, the motors keep holding — but reconnecting with the old `Axol.enable()` dropped the arms: its control-mode switch reboots the MyActuator motors via a `0x76` system reset (~2 s of torque loss, measured on hardware), and its gripper calibration sweep forces the jaws open, dropping anything held.

Startup code now needs no knowledge of the robot's state and no external bookkeeping:

```python
axol = Axol()
await axol.connect()      # open buses; optional inspection (get_holding, positions, ...)
await axol.enable()       # idempotent: holding joints kept holding, cold joints brought up,
                          # finishes actively holding the measured pose
...
await axol.disconnect()   # exit leaving torque as-is (disable() still torques off)
```

### API

- **`connect()` / `disconnect()`** — pure transport: open/close the CAN buses without touching motor state. After `connect()` every read API works (including the new **`get_holding()`** / **`Motor.is_holding()`**), so a process can inspect a robot of unknown state — or refuse to act unless it is already holding — before enabling.
- **`enable(hold=True)` is idempotent per motor** — each motor is queried: joints already enabled and holding are attached to with reads only (never reset), a holding gripper keeps its grasp (open-stop calibration restored from `~/.almond/gripper_calibration.json` instead of re-running the jaw sweep), and cold joints get the classic bring-up. Mixed robots (e.g. previous session died mid-enable) converge instead of erroring. With the default `hold=True`, `enable()` finishes by commanding the measured pose once (configured gains + gravity feedforward; the arm is already there, so nothing moves) — **"enabled" means actively holding**, and the `max_step_rad` guard is armed from the caller's very first command. Pass `hold=False` for flows that manage control modes themselves (`set_control_mode` + position/velocity/force commands). Force a fresh bring-up with `disable()` then `enable()`.
- **`set_control_mode()` docs now warn loudly**: MyActuator motors reboot to switch modes (~2 s torque gap) — never mode-switch a loaded arm. Damiao mode flips are plain register writes, verified live on hardware to be non-disruptive.
- The earlier public `Axol.attach()` was folded into `enable()` (per review feedback); `Motor.attach(mode)` remains as the per-motor strict primitive `enable()` builds on.
- Safety corner that intentionally raises: a holding gripper with missing/stale calibration (recalibrating would drop whatever it grips). Reconnect targets the impedance workflow; sessions that died in other control modes are asked to `disable()`/`enable()`.
- `CanBus.start()` made idempotent; gripper-calibration saving survives a corrupt calibration file.

## Test plan

- [x] Fake-bus unit harness (both motor families emulated), 15 scenarios: `connect()` sends zero frames; `enable()` on a holding robot emits no torque-affecting frame, restores gripper limits, and arms the seeded max-step guard (1 rad first command dropped, small step accepted); cold `enable()` calibrates/persists, leaves the gripper in `POSITION_FORCE`, and ends with every joint reporting holding; `enable(hold=False)` sends no motion commands; mixed robot heals (only the cold joint gets bring-up frames); holding-gripper with missing or stale calibration raises; `Motor.attach()` rejects disabled / faulted / mode-mismatched motors; `disconnect()` closes buses with no disable frames.
- [x] Physical robot, Damiao (left wrist_3): attach rejected while disabled; after hold + process death, fresh-process reattach took 2 ms with 0.0000 rad disturbance; actuated ±0.15 rad and back; **live mode-register flip on a holding motor verified non-disruptive** (status OK, 0.0000 rad across the flip, velocity command executed live, impedance resumed); robot restored to as-found state.
- [x] Physical robot, MyActuator (left elbow, legacy fw 2025070202): measured the 2.00 s reboot torque gap of the old mode switch; reattach took 2 ms with +0.0000 rad disturbance, applied legacy MIT ranges, lifted the forearm +0.1 rad with gravity feedforward and returned within 0.002 rad; `is_holding()` status-byte semantics confirmed in disabled / enabled-idle / post-reset / actively-holding states.
- [x] `pre-commit` (ruff, ruff-format) passes.
- [ ] Full 16-motor `enable()` + reconnect on hardware (requires torquing both arms + gripper calibration sweep).