### PR TITLE
Auto-recover from Axol hub USB drops and raise Pi 5 EMI tolerance

### DIFF
--- a/almond_axol/cli/can/setup.py
+++ b/almond_axol/cli/can/setup.py
@@ -1,8 +1,12 @@
 """
 axol can.setup
 
-Sets persistent CAN interface names for the Almond Axol CAN bus adapters
-and registers a root crontab @reboot entry to bring up the interfaces.
+Sets persistent CAN interface names for the Almond Axol CAN bus adapters,
+registers a root crontab @reboot entry to bring up the interfaces, and
+installs a udev-triggered systemd unit that re-runs the bring-up whenever the
+adapter (re-)enumerates — so a mid-session USB drop of the hub (EMI from the
+arms can kick it off the bus, most visibly on Raspberry Pi 5 hosts) heals
+itself without operator action.
 
 The Almond Axol arm hub adapter (VID 0x1D50 / PID 0x606F) exposes two CAN
 channels on a single USB device:
@@ -13,6 +17,11 @@ Robots on the powered cart additionally carry a single-channel candlelight
 adapter (same generic VID/PID) for the wheel bus, named can_alm_axol_b. The
 channel count tells the two apart: the hub always enumerates both channels
 under one serial, the cart adapter exactly one.
+
+On Raspberry Pi 5 hosts the setup additionally raises the RP1 USB
+controllers' EMI tolerance (see :func:`_setup_rp1_usb_quirk`), which targets
+the disconnects at their source; the hotplug bring-up covers whatever still
+gets through.
 """
 
 import re
@@ -35,6 +44,20 @@ _TXQUEUELEN = 512
 _UDEV_RULES_FILE = Path("/etc/udev/rules.d/90-can.rules")
 _CAN_DIR = Path.home() / ".almond" / "can"
 _CRON_SCRIPT = _CAN_DIR / "startup.sh"
+
+# Hotplug bring-up: pulled in via the udev rules (SYSTEMD_WANTS) whenever an
+# adapter (re-)enumerates, so interfaces recreated by a mid-session USB drop
+# come back configured and up without operator action.
+_HOTPLUG_UNIT = "axol-can-up.service"
+_HOTPLUG_UNIT_FILE = Path("/etc/systemd/system") / _HOTPLUG_UNIT
+
+# Raspberry Pi 5 RP1 USB EMI-tolerance quirk (see _setup_rp1_usb_quirk).
+_RP1_QUIRK_SCRIPT = _CAN_DIR / "rp1-usb-quirk.sh"
+_RP1_QUIRK_UNIT = "axol-rp1-usb-quirk.service"
+_RP1_QUIRK_UNIT_FILE = Path("/etc/systemd/system") / _RP1_QUIRK_UNIT
+# GUCTL1 register of each RP1 xHCI controller (DWC3 global registers live at
+# base + 0xc100; the Pi 5 has one controller per USB-A port pair).
+_RP1_GUCTL1_REGS = ("0x1f0020c11c", "0x1f0030c11c")
 
 
 def _die(msg: str) -> None:
@@ -224,6 +247,12 @@ def _write_udev_rules(serial: str, base_serial: str | None = None) -> None:
         f'SUBSYSTEM=="net", ACTION=="add", ATTRS{{idVendor}}=="{_VID}", ATTRS{{idProduct}}=="{_PID}", ATTRS{{serial}}=="{serial}", ATTR{{dev_id}}=="0x0", NAME="{_CAN_L}"\n'
         f"# Channel 1 -> right arm\n"
         f'SUBSYSTEM=="net", ACTION=="add", ATTRS{{idVendor}}=="{_VID}", ATTRS{{idProduct}}=="{_PID}", ATTRS{{serial}}=="{serial}", ATTR{{dev_id}}=="0x1", NAME="{_CAN_R}"\n'
+        f"# Every (re-)enumeration — boot or a mid-session USB drop — pulls in\n"
+        f"# the bring-up service so the channels come back configured and up.\n"
+        f"# Tagged on the USB device rather than the net interfaces: the NAME=\n"
+        f"# rules above put every real hotplug add mid-rename, and systemd\n"
+        f'# skips SYSTEMD_WANTS on renaming devices ("device is renaming").\n'
+        f'SUBSYSTEM=="usb", ENV{{DEVTYPE}}=="usb_device", ACTION=="add", ATTR{{idVendor}}=="{_VID}", ATTR{{idProduct}}=="{_PID}", ATTR{{serial}}=="{serial}", TAG+="systemd", ENV{{SYSTEMD_WANTS}}+="{_HOTPLUG_UNIT}"\n'
     )
     if base_serial:
         # Matched by serial alone: CANable firmware variants ship various
@@ -232,6 +261,7 @@ def _write_udev_rules(serial: str, base_serial: str | None = None) -> None:
             f"# Powered-cart wheel bus (single-channel adapter)\n"
             f"# Adapter serial: {base_serial}\n"
             f'SUBSYSTEM=="net", ACTION=="add", ATTRS{{serial}}=="{base_serial}", NAME="{_CAN_B}"\n'
+            f'SUBSYSTEM=="usb", ENV{{DEVTYPE}}=="usb_device", ACTION=="add", ATTR{{serial}}=="{base_serial}", TAG+="systemd", ENV{{SYSTEMD_WANTS}}+="{_HOTPLUG_UNIT}"\n'
         )
     run_root(["tee", str(_UDEV_RULES_FILE)], input_text=content, check=True)
     print("  Done.")
@@ -285,6 +315,10 @@ def _write_cron_script(*, with_base: bool = False) -> None:
         f"#!/bin/bash\n"
         f"# Bring up Almond Axol CAN interfaces\n"
         f"#\n"
+        f"# Runs at boot (@reboot root crontab) and on every (re-)enumeration\n"
+        f"# of the adapter (udev -> {_HOTPLUG_UNIT}), so a mid-session USB\n"
+        f"# drop of the hub comes back configured without operator action.\n"
+        f"#\n"
         f"# The arm interfaces are channels of one dual-channel gs_usb adapter.\n"
         f"# Bring them down together, configure, then up together — flapping\n"
         f"# the channels one at a time (down/up L, then down/up R) toggles the\n"
@@ -292,6 +326,19 @@ def _write_cron_script(*, with_base: bool = False) -> None:
         f"# Skipped entirely when the hub is unplugged (a cart-only session\n"
         f"# must still bring up the wheel bus below).\n"
         f"set -euo pipefail\n\n"
+        f"# Boot and hotplug triggers can race (the hub's two channels fire one\n"
+        f"# udev add event each) — serialize whole runs.\n"
+        f'exec 9>"/run/lock/axol-can-up.lock"\n'
+        f"flock 9\n\n"
+        f"# The two channels enumerate a beat apart, so the trigger for the\n"
+        f"# first can run before the second exists. Give the pair a moment.\n"
+        f"for _ in $(seq 1 30); do\n"
+        f"    if ip link show {_CAN_L} >/dev/null 2>&1 "
+        f"&& ip link show {_CAN_R} >/dev/null 2>&1; then\n"
+        f"        break\n"
+        f"    fi\n"
+        f"    sleep 0.1\n"
+        f"done\n\n"
         f"if ip link show {_CAN_L} >/dev/null 2>&1 "
         f"&& ip link show {_CAN_R} >/dev/null 2>&1; then\n"
         f"    for IFACE in {_CAN_L} {_CAN_R}; do\n"
@@ -335,6 +382,105 @@ def _register_cron() -> None:
         new_crontab = existing.rstrip("\n") + "\n" + cron_entry + "\n"
         run_root(["crontab", "-"], input_text=new_crontab, check=True)
         print(f"  Added: {cron_entry}")
+
+
+def _write_hotplug_unit() -> None:
+    """Install the systemd unit the udev rules pull in on adapter hotplug.
+
+    udev tags the adapter's net devices with ``SYSTEMD_WANTS=axol-can-up.service``
+    (see :func:`_write_udev_rules`), so every (re-)enumeration — boot or a
+    mid-session USB drop — runs the startup script and the interfaces come
+    back configured and up within a second, no operator action needed.
+    """
+    print(f"Writing hotplug bring-up unit to {_HOTPLUG_UNIT_FILE} (requires sudo)...")
+    content = (
+        f"# Installed by `axol can.setup`. Pulled in by {_UDEV_RULES_FILE}\n"
+        f"# whenever an Axol CAN adapter (re-)enumerates: a mid-session USB\n"
+        f"# drop recreates the interfaces down and unconfigured, and this\n"
+        f"# service brings them back up without operator action.\n"
+        f"[Unit]\n"
+        f"Description=Bring up Almond Axol CAN interfaces on adapter hotplug\n"
+        f"\n"
+        f"[Service]\n"
+        f"Type=oneshot\n"
+        f"ExecStart=/bin/bash {_CRON_SCRIPT}\n"
+    )
+    run_root(["tee", str(_HOTPLUG_UNIT_FILE)], input_text=content, check=True)
+    run_root(["systemctl", "daemon-reload"], check=True)
+    print("  Done.")
+
+
+def _is_raspberry_pi_5() -> bool:
+    """True on Raspberry Pi 5 family boards (the RP1-southbridge USB ports)."""
+    try:
+        model = Path("/proc/device-tree/model").read_text()
+    except OSError:
+        return False
+    return "Raspberry Pi 5" in model
+
+
+def _setup_rp1_usb_quirk() -> None:
+    """Raise the RP1 xHCI's EMI tolerance on Raspberry Pi 5 hosts.
+
+    The Pi 5's RP1 USB controllers ship with a hair-trigger loss-of-activity /
+    babble detector. Electrical noise from the arms' motor drivers coupling
+    into the hub's full-speed USB link trips it, and the kernel disables the
+    port (``usb usb3-port1: disabled by hub (EMI?), re-enabling...``) or the
+    adapter drops off the bus entirely — disconnects that the same robot never
+    shows on ZED Box / Jetson hosts. Setting bit 0 (the LOA filter) of each
+    controller's GUCTL1 register makes the detector ride out those glitches;
+    it's the workaround recommended by Raspberry Pi engineers
+    (forums.raspberrypi.com/viewtopic.php?t=363780).
+
+    The register resets on reboot, so this installs a boot-time oneshot unit
+    and also applies it immediately. No-op on non-Pi-5 hosts.
+    """
+    if not _is_raspberry_pi_5():
+        return
+    if not Path("/usr/bin/busybox").exists():
+        print(
+            "WARNING: busybox not found — skipping the RP1 USB EMI quirk "
+            "(install busybox and re-run `axol can.setup`)."
+        )
+        return
+    print("Applying RP1 USB EMI-tolerance quirk (Pi 5 only, requires sudo)...")
+    _CAN_DIR.mkdir(parents=True, exist_ok=True)
+    regs = " ".join(_RP1_GUCTL1_REGS)
+    script = (
+        f"#!/bin/bash\n"
+        f"# Raspberry Pi 5 (RP1) USB EMI-tolerance quirk for the Axol CAN hub.\n"
+        f"#\n"
+        f"# Sets bit 0 (LOA filter enable) of GUCTL1 in each RP1 xHCI\n"
+        f"# controller so EMI glitches on the hub's full-speed link no longer\n"
+        f'# disable the port ("disabled by hub (EMI?)" disconnects in dmesg).\n'
+        f"# Recommended by Raspberry Pi engineers:\n"
+        f"#   https://forums.raspberrypi.com/viewtopic.php?t=363780\n"
+        f"#\n"
+        f"# The register resets on reboot; {_RP1_QUIRK_UNIT} re-applies it.\n"
+        f"set -euo pipefail\n\n"
+        f"for reg in {regs}; do\n"
+        f'    val=$(busybox devmem "$reg")\n'
+        f'    busybox devmem "$reg" 32 $(( val | 1 ))\n'
+        f"done\n"
+    )
+    _RP1_QUIRK_SCRIPT.write_text(script)
+    _RP1_QUIRK_SCRIPT.chmod(0o755)
+    unit = (
+        f"# Installed by `axol can.setup` on Raspberry Pi 5 hosts.\n"
+        f"[Unit]\n"
+        f"Description=RP1 USB EMI-tolerance quirk for the Axol CAN hub\n"
+        f"\n"
+        f"[Service]\n"
+        f"Type=oneshot\n"
+        f"ExecStart=/bin/bash {_RP1_QUIRK_SCRIPT}\n"
+        f"\n"
+        f"[Install]\n"
+        f"WantedBy=multi-user.target\n"
+    )
+    run_root(["tee", str(_RP1_QUIRK_UNIT_FILE)], input_text=unit, check=True)
+    run_root(["systemctl", "daemon-reload"], check=True)
+    run_root(["systemctl", "enable", "--now", _RP1_QUIRK_UNIT], check=True)
+    print("  Done.")
 
 
 def add_parser(subparsers) -> None:  # type: ignore[type-arg]
@@ -455,7 +601,11 @@ def is_configured() -> bool:
     full :func:`ensure_setup` (first time on a machine) or can just bring the
     already-named interfaces up.
     """
-    return _UDEV_RULES_FILE.exists() and _CRON_SCRIPT.exists()
+    return (
+        _UDEV_RULES_FILE.exists()
+        and _CRON_SCRIPT.exists()
+        and _HOTPLUG_UNIT_FILE.exists()
+    )
 
 
 def ensure_setup(*, serial: str | None = None, base_serial: str | None = None) -> None:
@@ -471,10 +621,15 @@ def ensure_setup(*, serial: str | None = None, base_serial: str | None = None) -
     serial = serial or _resolve_serial()
     base_serial = base_serial or _configured_base_serial()
     _write_udev_rules(serial, base_serial)
+    _write_cron_script(with_base=base_serial is not None)
+    _write_hotplug_unit()
     _reload_udev()
     _rename_interfaces(serial, base_serial)
-    _write_cron_script(with_base=base_serial is not None)
     _register_cron()
+    try:
+        _setup_rp1_usb_quirk()
+    except Exception as exc:  # noqa: BLE001 - the quirk must never block CAN setup
+        print(f"  WARNING: RP1 USB quirk setup failed: {exc}")
     bring_up_can()
 
 
@@ -522,3 +677,9 @@ def run(_args: object = None) -> None:
     if base_serial:
         print(f"  Cart     : {_CAN_B}")
     print(f"  Startup  : {_CRON_SCRIPT} (runs at @reboot via root crontab)")
+    print(
+        f"  Hotplug  : {_HOTPLUG_UNIT} (re-runs the startup script whenever "
+        f"the adapter re-enumerates, e.g. after a mid-session USB drop)"
+    )
+    if _is_raspberry_pi_5():
+        print(f"  Pi 5     : {_RP1_QUIRK_UNIT} (RP1 USB EMI-tolerance quirk)")

--- a/almond_axol/motor/bus.py
+++ b/almond_axol/motor/bus.py
@@ -3,12 +3,51 @@
 from __future__ import annotations
 
 import asyncio
+import errno
 import logging
+from pathlib import Path
 from typing import Callable
 
 import can
 
 _logger = logging.getLogger(__name__)
+
+# Socket failures with these errnos mean the interface went away or lost its
+# link mid-session. On the Axol hub that's a USB disconnect — EMI from the
+# arms' motor drivers can kick the adapter off the bus — after which the
+# gs_usb netdevs are destroyed and recreated when the adapter re-enumerates.
+_IFACE_LOST_ERRNOS = {
+    errno.ENODEV,  # netdev unregistered (adapter dropped off the USB bus)
+    errno.ENXIO,
+    errno.ENETDOWN,  # netdev exists but its link is (still) down
+    errno.ENETUNREACH,
+    errno.EBADF,  # socket torn down under us
+}
+
+# Cadence for probing /sys while waiting for the interface to come back; the
+# hotplug bring-up installed by `axol can.setup` normally has a re-enumerated
+# adapter configured and up again within a second or two.
+_RECONNECT_POLL_S = 0.2
+# A long wait means the adapter is really unplugged or the hotplug bring-up
+# is missing — remind operators at this cadence rather than spamming.
+_RECONNECT_REMIND_S = 30.0
+
+
+def _iface_lost(exc: BaseException) -> bool:
+    """True when *exc* is a socket failure meaning the interface went away."""
+    code = getattr(exc, "error_code", None)  # python-can CanOperationError
+    if code is None:
+        code = getattr(exc, "errno", None)
+    return code in _IFACE_LOST_ERRNOS
+
+
+def _iface_is_up(channel: str) -> bool:
+    """True when *channel* exists and is administratively up (IFF_UP)."""
+    try:
+        flags = int((Path("/sys/class/net") / channel / "flags").read_text(), 16)
+    except (OSError, ValueError):
+        return False
+    return bool(flags & 0x1)
 
 
 class CanBus:
@@ -17,6 +56,12 @@ class CanBus:
     A single instance is shared between all Motor objects on the same physical
     interface.  The background reader task dispatches every incoming frame to
     registered listeners.
+
+    A lost interface — the Axol hub dropping off the USB bus and re-enumerating
+    — is survived transparently: the reader loop reopens the socket once the
+    interface is back up, keeping every registered listener attached. Sends
+    during the gap are dropped, so request/response commands fall into their
+    usual timeout path (``MotorError``) and resume after the reconnect.
 
     Use as an async context manager:
 
@@ -34,9 +79,16 @@ class CanBus:
         Args:
             channel: SocketCAN interface name, e.g. ``"can_alm_axol_l"``.
         """
-        self._bus = can.Bus(channel=channel, bustype="socketcan")
+        self._channel = channel
+        self._bus: can.BusABC | None = can.Bus(channel=channel, bustype="socketcan")
         self._listeners: list[Callable[[can.Message], None]] = []
         self._reader_task: asyncio.Task | None = None
+        # Set while the interface is gone (USB drop): sends are dropped and
+        # the reader loop is waiting to reopen the socket.
+        self._lost = False
+        # Poked by socket readability or a failed send, so the idle reader
+        # wakes both for frames and for lost-interface handling.
+        self._wake = asyncio.Event()
 
     async def start(self) -> None:
         """Start the background frame-dispatch loop. Idempotent.
@@ -50,7 +102,7 @@ class CanBus:
             return
         self._reader_task = asyncio.create_task(
             self._reader_loop(),
-            name=f"can_reader:{self._bus.channel_info}",
+            name=f"can_reader:{self._channel}",
         )
 
     async def close(self) -> None:
@@ -61,7 +113,9 @@ class CanBus:
                 await self._reader_task
             except asyncio.CancelledError:
                 pass
-        self._bus.shutdown()
+        if self._bus is not None:
+            self._bus.shutdown()
+            self._bus = None
 
     async def __aenter__(self) -> CanBus:
         await self.start()
@@ -74,40 +128,109 @@ class CanBus:
         self._listeners.append(listener)
 
     async def _send(self, arbitration_id: int, data: bytes) -> None:
+        if self._lost or self._bus is None:
+            # Interface is gone (USB drop) — drop the frame; motor commands
+            # time out upstream and resume once the reader has reconnected.
+            return
         msg = can.Message(
             arbitration_id=arbitration_id, data=data, is_extended_id=False
         )
         # Send synchronously — SocketCAN send is fast non-blocking at OS level.
         # This prevents asyncio thread pool starvation at high telemetry rates.
-        self._bus.send(msg)
+        try:
+            self._bus.send(msg)
+        except (can.CanError, OSError) as exc:
+            if not _iface_lost(exc):
+                raise
+            self._mark_lost(exc)
+
+    def _mark_lost(self, cause: BaseException) -> None:
+        """Flag the interface as gone and wake the reader to start reconnecting."""
+        if self._lost:
+            return
+        self._lost = True
+        _logger.warning(
+            "CAN %s: interface lost (%s) — waiting for it to come back",
+            self._channel,
+            cause,
+        )
+        self._wake.set()
 
     async def _reader_loop(self) -> None:
         loop = asyncio.get_running_loop()
-        readable = asyncio.Event()
+        while True:
+            await self._pump(loop)
+            await self._reconnect(loop)
+
+    async def _pump(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Dispatch frames until the interface is lost (or the task is cancelled)."""
+        assert self._bus is not None
         fd = self._bus.fileno()
-        loop.add_reader(fd, readable.set)
+        loop.add_reader(fd, self._wake.set)
         try:
-            while True:
+            while not self._lost:
                 try:
                     msg: can.Message | None = self._bus.recv(timeout=0)
-                    if msg is not None:
-                        for listener in self._listeners:
-                            try:
-                                listener(msg)
-                            except Exception as e:
-                                _logger.error(
-                                    "CAN listener %s error: %s", listener.__name__, e
-                                )
-                    else:
-                        # No data — wait until the socket is readable instead of
-                        # polling on a fixed 1ms timer, cutting up to 1ms of
-                        # response latency per round-trip.
-                        readable.clear()
-                        await readable.wait()
-                except asyncio.CancelledError:
-                    break
-                except Exception as e:
-                    _logger.warning("CAN reader loop warning: %s", e)
+                except Exception as exc:  # noqa: BLE001 - classified below
+                    if _iface_lost(exc):
+                        self._mark_lost(exc)
+                        return
+                    _logger.warning("CAN reader loop warning: %s", exc)
                     await asyncio.sleep(0.01)
+                    continue
+                if msg is not None:
+                    for listener in self._listeners:
+                        try:
+                            listener(msg)
+                        except Exception as e:
+                            _logger.error(
+                                "CAN listener %s error: %s", listener.__name__, e
+                            )
+                    continue
+                # No data — wait until the socket is readable instead of
+                # polling on a fixed 1ms timer, cutting up to 1ms of response
+                # latency per round-trip. The timeout is a safety net: a
+                # failed send can flag the interface lost without the socket
+                # ever becoming readable again.
+                self._wake.clear()
+                try:
+                    await asyncio.wait_for(self._wake.wait(), timeout=0.5)
+                except TimeoutError:
+                    pass
         finally:
             loop.remove_reader(fd)
+
+    async def _reconnect(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Reopen the socket once the interface is back up; waits indefinitely."""
+        started = loop.time()
+        if self._bus is not None:
+            try:
+                self._bus.shutdown()
+            except Exception as exc:  # noqa: BLE001 - dead-socket teardown is best-effort
+                _logger.debug("CAN %s: socket shutdown failed: %s", self._channel, exc)
+            self._bus = None
+        next_reminder = started + _RECONNECT_REMIND_S
+        while True:
+            if _iface_is_up(self._channel):
+                try:
+                    self._bus = can.Bus(channel=self._channel, bustype="socketcan")
+                    break
+                except (can.CanError, OSError) as exc:
+                    # Raced the interface going away again — keep waiting.
+                    _logger.debug("CAN %s: reopen failed: %s", self._channel, exc)
+            if loop.time() >= next_reminder:
+                _logger.warning(
+                    "CAN %s: still waiting for the interface (%.0fs) — is the "
+                    "adapter plugged in, and the hotplug bring-up installed "
+                    "(re-run `axol can.setup` once to add it)?",
+                    self._channel,
+                    loop.time() - started,
+                )
+                next_reminder = loop.time() + _RECONNECT_REMIND_S
+            await asyncio.sleep(_RECONNECT_POLL_S)
+        self._lost = False
+        _logger.warning(
+            "CAN %s: interface is back after %.1fs — resuming",
+            self._channel,
+            loop.time() - started,
+        )

--- a/docs/advanced/development-install.mdx
+++ b/docs/advanced/development-install.mdx
@@ -78,7 +78,7 @@ Before using any motor or robot commands, initialize the CAN hardware once:
 axol can.setup
 ```
 
-`sudo` is invoked automatically where required. See [`can.setup`](/cli/can-setup) for what it configures, and [`can.enable`](/cli/can-enable) for bringing the interfaces back up after a mid-session replug.
+`sudo` is invoked automatically where required. See [`can.setup`](/cli/can-setup) for what it configures — including the hotplug service that brings the interfaces back up on its own after a mid-session replug — and [`can.enable`](/cli/can-enable) for re-running the bring-up manually.
 
 ## Build the web UI
 

--- a/docs/cli/can-enable.mdx
+++ b/docs/cli/can-enable.mdx
@@ -1,9 +1,9 @@
 ---
 title: "can.enable"
-description: "Bring the CAN interfaces back up after re-plugging the Axol Hub."
+description: "Manually re-run the CAN interface bring-up."
 ---
 
-Re-runs the CAN startup script to bring interfaces up after plugging in the Axol without a system restart. ([`can.setup`](/cli/can-setup) registers a `@reboot` cron hook, so this is only needed when the Axol Hub is re-plugged mid-session.) Requires [`can.setup`](/cli/can-setup) to have been run first.
+Re-runs the CAN startup script to configure and bring up the interfaces. Normally you don't need it: [`can.setup`](/cli/can-setup) registers a `@reboot` cron hook **and** a hotplug service that re-runs the bring-up whenever the Axol Hub (re-)enumerates, so both reboots and mid-session replugs recover on their own. It remains useful as a manual fallback (e.g. after stopping the interfaces yourself, or on a machine set up with an older `can.setup` that lacked the hotplug service). Requires [`can.setup`](/cli/can-setup) to have been run first.
 
 For setups without the Axol Hub CAN adapter, pass `--channels` to bring up other SocketCAN interfaces directly — one for a single arm, two for both. This skips the hub startup script (no `can.setup` needed): each named interface is configured (1 Mbit/s bitrate, txqueuelen) and brought up; interfaces already up are left untouched.
 

--- a/docs/cli/can-setup.mdx
+++ b/docs/cli/can-setup.mdx
@@ -3,7 +3,7 @@ title: "can.setup"
 description: "One-time CAN bus setup for the Almond Axol Hub."
 ---
 
-One-time setup for the Almond Axol Hub (dual-channel USB CAN adapter). Installs the `gs_usb` kernel driver if the kernel lacks it (see [`can.driver`](/cli/can-driver) — needed on NVIDIA Jetson / ZED Box), writes persistent udev rules, assigns fixed interface names, registers a startup script in the root crontab, and brings up the interfaces immediately.
+One-time setup for the Almond Axol Hub (dual-channel USB CAN adapter). Installs the `gs_usb` kernel driver if the kernel lacks it (see [`can.driver`](/cli/can-driver) — needed on NVIDIA Jetson / ZED Box), writes persistent udev rules, assigns fixed interface names, registers a startup script in the root crontab, installs a hotplug bring-up service, and brings up the interfaces immediately.
 
 - Left arm → `can_alm_axol_l`
 - Right arm → `can_alm_axol_r`
@@ -20,5 +20,9 @@ If a **single-channel** CAN adapter is also attached — the [powered cart](/gui
 </Note>
 
 <Info>
-  After setup, the interfaces come up automatically on every reboot (via a `@reboot` cron hook). If the Axol Hub is re-plugged mid-session without a restart, bring the interfaces back up with [`can.enable`](/cli/can-enable). You don't need `can.setup` just to use the cart — [`axol teleop`](/cli/teleop) brings the cart's own interface up on its own — but pinning it gives the adapter a stable name across reboots.
+  After setup, the interfaces come up automatically on every reboot (via a `@reboot` cron hook) **and** whenever the adapter re-enumerates mid-session: a udev rule pulls in the `axol-can-up.service` bring-up whenever the hub (re-)appears, so a replug — or a USB drop caused by motor EMI — heals itself within a second or two without operator action. You don't need `can.setup` just to use the cart — [`axol teleop`](/cli/teleop) brings the cart's own interface up on its own — but pinning it gives the adapter a stable name across reboots.
 </Info>
+
+<Note>
+  On Raspberry Pi 5 hosts, `can.setup` additionally applies an RP1 USB quirk (`axol-rp1-usb-quirk.service`): the Pi 5's USB controllers ship with a hair-trigger babble/loss-of-activity detector that EMI from the arms can trip, kicking the hub off the bus (`disabled by hub (EMI?)` in `dmesg`). The quirk enables the controller's noise filter — the workaround recommended by Raspberry Pi engineers. If disconnects persist, add a ferrite choke to (or shield) the hub's USB cable, or put a small powered USB hub between the Pi and the Axol Hub.
+</Note>


### PR DESCRIPTION
## Summary

The Axol hub intermittently drops off the USB bus on Raspberry Pi 5 hosts (never on ZED Box) — dmesg shows `usb usb3-port1: disabled by hub (EMI?), re-enabling...` followed by re-enumeration, correlated with the arms being driven. Root cause: EMI from the motor drivers coupling into the hub's full-speed USB link, which the Pi 5's RP1 USB controllers tolerate far worse than other hosts ([known Pi 5 behavior](https://forums.raspberrypi.com/viewtopic.php?t=363780)). Ruled out on-device: power (no throttling, `usb_max_current_enable=1`, 100 mA draw), a bad unit (two hubs, identical drops), and driver differences (firmware doesn't advertise hw timestamps). Previously a drop left the recreated interfaces down/unconfigured until someone re-ran setup — a dead robot mid-session.

- **Reduce the disconnects (Pi 5 only):** `can.setup` sets the RP1 GUCTL1 noise-filter bit (the workaround recommended by Raspberry Pi engineers) on both controllers, immediately and at every boot via `axol-rp1-usb-quirk.service`. Gated on `/proc/device-tree/model`; read-modify-write so other register bits survive firmware revisions.
- **Auto bring-up on re-enumeration (all hosts):** `can.setup` installs `axol-can-up.service`, pulled in by udev whenever the adapter (re-)appears, re-running the startup script (now `flock`-serialized and tolerant of the two channels enumerating a beat apart). The udev trigger sits on the USB device, not the net interfaces: systemd skips `SYSTEMD_WANTS` on devices that are mid-rename ("device is renaming"), which our `NAME=` rules make true for every real hotplug add.
- **SDK survives the gap:** `CanBus` detects the dead socket (ENODEV/ENETDOWN & co.), drops sends during the outage so motor commands degrade into their existing `MotorError` timeout path instead of crashing control loops, and transparently reopens the socket with all listeners attached once the interface is back up.
- Docs updated (`can.setup`, `can.enable`, development install) — mid-session replugs no longer need manual `can.enable`.

## Test plan

All verified on a Pi 5 with a live robot (motors powered), simulating drops via USB port power-cycle (`usb3-port1/disable`):

- [x] `axol can.setup` (via `ensure_setup`) installs rules, script, both units; idempotent on re-run; motors respond after bring-up
- [x] GUCTL1 reads back with bit 0 set on both RP1 controllers; quirk unit enabled for boot
- [x] Real port power-cycle: `axol-can-up.service` fires and both interfaces are back UP @ 1 Mbps, txqueuelen 512, within ~2 s — no operator action
- [x] Motor-polling loop through a mid-run replug: one "interface lost" warning, 1.6 s of `MotorError` timeouts, then "interface is back — resuming" with clean reads; no unhandled exceptions
- [x] `pre-commit` ruff + ruff-format pass

Remaining risk: device-side firmware brownouts (if any) aren't addressable from software — if drops persist under heavy load, ferrite/shielded cable or a small powered hub between Pi and Axol hub is the hardware fix.

Made with [Cursor](https://cursor.com)