### PR TITLE
Zero wrist_2/wrist_3 at either end stop, auto-detecting the side at r…

### DIFF
--- a/almond_axol/cli/motor/set_zero_pos.py
+++ b/almond_axol/cli/motor/set_zero_pos.py
@@ -2,10 +2,15 @@
 axol motor.set-zero-pos
 
 Set the zero position of a single motor, or use ``--guided`` to zero every
-arm joint against its closer end stop. Guided mode first captures an in-range
-start reference for all joints at once, then walks each joint to its end stop
-and zeros it. The current mechanical position becomes the new zero reference
+arm joint against an end stop. Guided mode first captures an in-range start
+reference for all joints at once, then walks each joint to its end stop and
+zeros it. The current mechanical position becomes the new zero reference
 (persisted to flash).
+
+Most joints are zeroed at one specific end stop (the closer one). WRIST_2 and
+WRIST_3 accept EITHER end stop — their stops are not laser-aligned, so per
+unit one may be better placed than the other; move to whichever you trust and
+the runtime detects the side automatically from the encoder reading.
 
 Note: each motor's encoder zero is calibrated at one of the joint's
 mechanical END STOPS, not at the robot's rest position. ``AxolArm`` adds a
@@ -27,7 +32,7 @@ from ...constants import ARM_JOINTS, Joint
 from ...motor.bus import CanBus
 from ...motor.damiao import DamiaoMotor
 from ...motor.motor import Motor, make_driver
-from ...robot.axol import closer_end_stop
+from ...robot.axol import EITHER_STOP_JOINTS, closer_end_stop
 from . import add_side_and_channel_arguments, resolve_channel
 
 # Marker prefix a --web-prompts step prints before blocking on stdin (same
@@ -60,7 +65,8 @@ def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[
     p.add_argument(
         "--guided",
         action="store_true",
-        help="Walk the arm joints, zeroing each at its closer end stop.",
+        help="Walk the arm joints, zeroing each at an end stop "
+        "(wrist_2/wrist_3 accept either side).",
     )
     p.add_argument(
         "--joints",
@@ -180,6 +186,58 @@ def _fmt(rad: float) -> str:
     return f"{rad:+.4f} rad ({math.degrees(rad):+.1f}°)"
 
 
+async def _calibrate_joint_either_stop(
+    motor: Motor,
+    joint: Joint,
+    p_start: float,
+    magnitude_rad: float,
+    web_prompts: bool,
+) -> bool:
+    """Zero one joint at whichever of its two end stops the operator chose.
+
+    For :data:`EITHER_STOP_JOINTS` (symmetric limits ±``magnitude_rad``):
+    the operator moves from the in-range start reference ``p_start`` to
+    either stop; the direction of travel identifies which one, and the
+    runtime later re-detects the side from the encoder reading, so no side
+    needs to be recorded. Returns ``True`` on success.
+    """
+    mag_deg = math.degrees(magnitude_rad)
+    print(f"\n— {joint.name}  →  EITHER end stop (±{mag_deg:.1f}°) —")
+    print(f"     start: {_fmt(p_start)}")
+
+    while True:
+        if not _prompt(
+            f"{joint.name}: move to EITHER end stop (+{mag_deg:.1f}° or "
+            f"-{mag_deg:.1f}° — whichever is better placed)",
+            web_prompts,
+        ):
+            return False
+        p_end = await motor.get_position()
+        print(f"     end:   {_fmt(p_end)}")
+
+        delta = p_end - p_start
+        print(f"     moved: {_fmt(delta)}")
+
+        if abs(delta) < _MIN_MOTION_RAD:
+            print("    ✗ no motion — retry.")
+            continue
+
+        mag_diff = abs(abs(delta) - magnitude_rad)
+        if mag_diff > _MAGNITUDE_WARN_RAD:
+            print(
+                f"    ⚠  moved {math.degrees(abs(delta)):.1f}°, expected"
+                f" ~{mag_deg:.1f}° — make sure you're against the stop."
+            )
+
+        chosen_deg = math.copysign(mag_deg, delta)
+        await motor.set_zero_position()
+        print(
+            f"    ✓ zeroed at the {chosen_deg:+.1f}° end stop at {_fmt(p_end)} "
+            f"(side is auto-detected at runtime)."
+        )
+        return True
+
+
 async def _calibrate_joint(
     motor: Motor,
     joint: Joint,
@@ -288,9 +346,14 @@ async def _run_guided(args: argparse.Namespace) -> None:
             target, sign = closer_end_stop(joint, is_left)
             motor = motors[joint]
             try:
-                ok = await _calibrate_joint(
-                    motor, joint, starts[joint], target, sign, args.web_prompts
-                )
+                if joint in EITHER_STOP_JOINTS:
+                    ok = await _calibrate_joint_either_stop(
+                        motor, joint, starts[joint], abs(target), args.web_prompts
+                    )
+                else:
+                    ok = await _calibrate_joint(
+                        motor, joint, starts[joint], target, sign, args.web_prompts
+                    )
             except KeyboardInterrupt:
                 print("\naborted.")
                 break

--- a/almond_axol/cli/tune/repeatability.py
+++ b/almond_axol/cli/tune/repeatability.py
@@ -83,6 +83,11 @@ def _build_pose(
     calibration end stop). The control stack works in joint frame (0 = rest),
     where ``joint = motor + closer_end_stop(j, is_left)[0]``. The right arm is
     held at its rest configuration so only the left arm differs from rest.
+
+    Note: this static conversion assumes wrist_2/wrist_3 were zeroed at their
+    historical (closer) end stop. If the arm is re-zeroed at the other stop
+    (the guided flow now accepts either side), the pasted poses are stale —
+    re-pose the arm and paste fresh numbers, as the module docstring says.
     """
     q = q_rest.copy()
     for i, j in enumerate(ARM_JOINTS):

--- a/almond_axol/diagnostics/can/receive.py
+++ b/almond_axol/diagnostics/can/receive.py
@@ -98,11 +98,17 @@ def _read_positions(
     Monitored motors that have reported use their transformed cached position;
     every other entry falls back to ``fallback`` (so unmonitored joints and
     motors still awaiting their first frame do not blow up the whole read).
+    Joints whose zeroed-end-stop side could not be detected (NaN offset —
+    this passive monitor tolerates an unreadable robot) also fall back.
     """
     vals: list[float] = []
     for i, j in enumerate(Joint):
         m = arm.motors[j]
-        if j in monitored and m.has_position:
+        if (
+            j in monitored
+            and m.has_position
+            and not math.isnan(float(arm._joint_offsets[i]))
+        ):
             vals.append(_joint_frame(arm, i, j, m.position))
         else:
             vals.append(float(fallback[i]))
@@ -288,6 +294,20 @@ async def _run(
                 _stats_monitor(channel, arm, log, monitored_set),
                 name="can_stats_monitor",
             )
+
+            # Detect which end stop the monitored either-stop joints were
+            # zeroed at while direct reads are still allowed (telemetry
+            # rejects them once running). This monitor must keep working on
+            # an unpowered robot, so a failed detection only warns — the
+            # affected joints then display the fallback value.
+            try:
+                await arm.resolve_joint_offsets(monitored_set)
+            except Exception as exc:
+                log.warning(
+                    "Could not detect zeroed end stops (%s) — wrist_2/wrist_3 "
+                    "rows will show fallback values until readable.",
+                    exc,
+                )
 
             try:
                 await asyncio.gather(

--- a/almond_axol/diagnostics/can/send.py
+++ b/almond_axol/diagnostics/can/send.py
@@ -79,6 +79,9 @@ async def _enable(arm: AxolArm, present: set[Joint]) -> None:
     await asyncio.gather(
         *[arm.motors[j].set_control_mode(ControlMode.IMPEDANCE) for j in present]
     )
+    # This subset path bypasses AxolArm.enable, so detect which end stop the
+    # present either-stop joints were zeroed at before any _joint_offsets use.
+    await arm.resolve_joint_offsets(present)
     if Joint.GRIPPER in present:
         await arm._calibrate_gripper()
         await arm.motors[Joint.GRIPPER].set_control_mode(ControlMode.POSITION_FORCE)

--- a/almond_axol/diagnostics/rom/enable.py
+++ b/almond_axol/diagnostics/rom/enable.py
@@ -165,6 +165,10 @@ class HardwareController:
         await asyncio.gather(
             *[m.set_control_mode(ControlMode.IMPEDANCE) for m in motors]
         )
+        # This subset path bypasses AxolArm.enable, so detect which end stop
+        # the present either-stop joints were zeroed at before any
+        # _joint_offsets use.
+        await arm.resolve_joint_offsets(self._present)
         if Joint.GRIPPER in self._present:
             await arm._calibrate_gripper()
             await arm.motors[Joint.GRIPPER].set_control_mode(ControlMode.POSITION_FORCE)

--- a/almond_axol/motor/damiao.py
+++ b/almond_axol/motor/damiao.py
@@ -124,13 +124,31 @@ class DamiaoMotor(MotorDriver):
     # Private helpers                                                      #
     # ------------------------------------------------------------------ #
 
+    # Payload byte 2 of register-protocol traffic addressed by [id_lo, id_hi]:
+    # 0x33 read replies (handled), plus 0x55 write acks, 0xAA store acks, and
+    # 0xCC feedback-request echoes, which carry no data we consume but must
+    # never reach the feedback decoder (see _on_message).
+    _REGISTER_TRAFFIC_CMDS = frozenset({0x33, 0x55, 0xAA, 0xCC})
+
     def _on_message(self, msg: can.Message) -> None:
         if len(msg.data) != 8:
             return
         data = bytes(msg.data)
 
-        if data[1] <= 0x0F and data[2] == 0x33 and data[3] <= 81:
-            if (data[0] | (data[1] << 8)) == self._motor_id:
+        # Register-protocol traffic: [id_lo, id_hi, cmd, rid, ...]. Only the
+        # 0x33 read reply carries data we consume, but the motor also acks
+        # 0x55 writes / 0xAA stores by echoing the frame on its MST_ID —
+        # observed live when enable()'s set_control_mode (register 10 write)
+        # races the next position read: the ack [id_lo, 0x00, 0x55, rid, ...]
+        # passed the feedback checks below and decoded to ≈ -12.47 rad
+        # (position bytes 0x0055), a physically impossible -714° that
+        # poisoned the cached position. Swallow the whole ack/echo family
+        # here. (In principle a real feedback frame could match this
+        # signature, but only with the position in the bottom ~6% of the
+        # ±p_max range AND that exact low byte — unreachable on a jointed
+        # arm, and the 0x33 branch has always accepted the same trade-off.)
+        if data[1] <= 0x0F and data[2] in self._REGISTER_TRAFFIC_CMDS and data[3] <= 81:
+            if (data[0] | (data[1] << 8)) == self._motor_id and data[2] == 0x33:
                 self._handle_register_reply(data)
             return
 

--- a/almond_axol/motor/motor.py
+++ b/almond_axol/motor/motor.py
@@ -292,6 +292,11 @@ class Motor:
             await asyncio.sleep(max(0.0, interval - elapsed))
 
     @property
+    def telemetry_active(self) -> bool:
+        """True while the background telemetry polling loop is running."""
+        return self._telemetry_task is not None
+
+    @property
     def has_position(self) -> bool:
         """True once a position has been cached by telemetry or a set_impedance() response."""
         return self._position is not None

--- a/almond_axol/robot/__init__.py
+++ b/almond_axol/robot/__init__.py
@@ -1,6 +1,13 @@
 """Public re-exports for almond_axol.robot."""
 
-from .axol import Axol, AxolArm, arm_limits, closer_end_stop
+from .axol import (
+    EITHER_STOP_JOINTS,
+    Axol,
+    AxolArm,
+    arm_limits,
+    closer_end_stop,
+    end_stop_offset_from_position,
+)
 from .base import RobotBase
 from .cart import Cart, CartConfig
 from .config import (
@@ -18,6 +25,8 @@ __all__ = [
     "AxolArm",
     "arm_limits",
     "closer_end_stop",
+    "EITHER_STOP_JOINTS",
+    "end_stop_offset_from_position",
     "ArmConfig",
     "AxolConfig",
     "Cart",

--- a/almond_axol/robot/axol.py
+++ b/almond_axol/robot/axol.py
@@ -150,6 +150,70 @@ def arm_limits(joint: Joint, is_left: bool) -> tuple[float, float]:
 # disambiguated by their range and don't need to be listed here.
 _MIRRORED_SYMMETRIC_JOINTS: frozenset[Joint] = frozenset({Joint.WRIST_2, Joint.WRIST_3})
 
+# Joints that may be zeroed at EITHER of their two end stops.  The wrist_2 /
+# wrist_3 stops are the only ones that are not laser-aligned, so per unit one
+# stop can be better placed than the other; the guided zeroing flow therefore
+# accepts whichever stop the operator brings the joint to.  Which stop a
+# given robot was zeroed at is detected at runtime from the encoder reading
+# itself (see end_stop_offset_from_position) — no per-robot file is needed,
+# and robots zeroed by the old forced-side flow resolve to the offsets they
+# have always had.
+EITHER_STOP_JOINTS: frozenset[Joint] = frozenset({Joint.WRIST_2, Joint.WRIST_3})
+
+# A motor-frame reading within this band of 0 means the joint is parked at
+# (or pressed against) its calibration end stop — the one position where the
+# two zeroing conventions cannot be told apart.  The reading at the
+# calibration stop is ~0 by construction regardless of the stop's placement
+# error, so only backlash/compliance widens the band; 3° is generous.
+_STOP_SIDE_AMBIGUOUS_RAD = math.radians(3.0)
+
+# Slack past the nominal end-to-end travel when sanity-checking a reading in
+# end_stop_offset_from_position, covering stop placement error on both ends.
+_STOP_SIDE_RANGE_SLACK_RAD = math.radians(15.0)
+
+
+def end_stop_offset_from_position(joint: Joint, motor_pos: float) -> float:
+    """Infer an either-stop joint's motor→joint offset from one encoder reading.
+
+    Joints in :data:`EITHER_STOP_JOINTS` have symmetric limits ``(-L, +L)``
+    and are zeroed at one of the two physical end stops.  The zero location
+    fixes the sign of every reachable motor-frame reading, so a single read
+    reveals which stop was used:
+
+    - zeroed at the upper stop (``+L``): readings span ``[-2L, 0]`` → offset ``+L``
+    - zeroed at the lower stop (``-L``): readings span ``[0, +2L]`` → offset ``-L``
+
+    Args:
+        joint:     Joint to resolve; must be in :data:`EITHER_STOP_JOINTS`.
+        motor_pos: Current motor-frame position (rad).
+
+    Returns:
+        The offset such that ``joint_angle = motor_angle + offset``.
+
+    Raises:
+        MotorError: If the reading is too close to 0 (parked at the
+            calibration stop — ambiguous) or outside the joint's physical
+            travel (the encoder zero is not at either stop; re-zero).
+    """
+    if joint not in EITHER_STOP_JOINTS:
+        raise ValueError(f"{joint} is not zeroed at a variable end stop")
+    lo, hi = LIMITS[joint]
+    travel = hi - lo
+    if abs(motor_pos) < _STOP_SIDE_AMBIGUOUS_RAD:
+        raise MotorError(
+            f"Cannot tell which end stop {joint.name} was zeroed at: the "
+            f"joint is at/near an end stop (motor frame "
+            f"{math.degrees(motor_pos):+.1f}°). Move it away from the end "
+            f"stops and retry."
+        )
+    if abs(motor_pos) > travel + _STOP_SIDE_RANGE_SLACK_RAD:
+        raise MotorError(
+            f"{joint.name} reads {math.degrees(motor_pos):+.1f}° in the motor "
+            f"frame — outside its physical travel, so its encoder zero is not "
+            f"at an end stop. Re-run `axol motor.set-zero-pos --guided`."
+        )
+    return hi if motor_pos < 0 else lo
+
 
 def closer_end_stop(joint: Joint, is_left: bool) -> tuple[float, int]:
     """Return ``(target_rad, expected_motion_sign)`` for the joint's calibration end stop.
@@ -169,7 +233,11 @@ def closer_end_stop(joint: Joint, is_left: bool) -> tuple[float, int]:
 
     Used by the guided ``set-zero-pos`` flow and by :class:`AxolArm` to derive
     the per-joint offset between motor frame (zero at end stop) and joint
-    frame (zero at rest).  Not defined for ``Joint.GRIPPER``.
+    frame (zero at rest).  For joints in :data:`EITHER_STOP_JOINTS` this is
+    only the historical/default side: those may be zeroed at either stop, and
+    the side actually used is detected at runtime from the encoder reading
+    (:func:`end_stop_offset_from_position`).  Not defined for
+    ``Joint.GRIPPER``.
     """
     if joint == Joint.GRIPPER:
         raise ValueError("closer_end_stop is undefined for the gripper")
@@ -260,16 +328,26 @@ class AxolArm:
         # Per-joint offset between motor frame and joint frame:
         #   joint_angle (rad) = motor_angle (rad) + offset
         # After end-stop calibration the motor's encoder zero coincides with
-        # the closer end stop, so motor 0 → joint angle ``target_rad``.  The
-        # gripper offset is 0 because the gripper uses its own [0, 1]
-        # normalisation and is calibrated against torque, not an end stop.
+        # an end stop, so motor 0 → joint angle = that stop's limit.  Most
+        # joints are always zeroed at closer_end_stop(); EITHER_STOP_JOINTS
+        # (wrist_2/wrist_3) may be zeroed at either stop, so their offsets
+        # start as NaN and are detected from the first encoder reading by
+        # resolve_joint_offsets().  The gripper offset is 0 because the
+        # gripper uses its own [0, 1] normalisation and is calibrated against
+        # torque, not an end stop.
         self._joint_offsets = np.array(
             [
-                0.0 if j == Joint.GRIPPER else closer_end_stop(j, is_left)[0]
+                0.0
+                if j == Joint.GRIPPER
+                else math.nan
+                if j in EITHER_STOP_JOINTS
+                else closer_end_stop(j, is_left)[0]
                 for j in joints
             ],
             dtype=float,
         )
+        self._unresolved_offsets: set[Joint] = set(EITHER_STOP_JOINTS)
+        self._offset_lock = asyncio.Lock()
 
     def _pad_gripper(self, values: list) -> list:
         """Insert a ``0.0`` placeholder in the gripper slot when absent.
@@ -283,6 +361,103 @@ class AxolArm:
         return values
 
     # ------------------------------------------------------------------ #
+    # Joint-offset resolution                                              #
+    # ------------------------------------------------------------------ #
+
+    async def resolve_joint_offsets(self, joints: set[Joint] | None = None) -> None:
+        """Detect which end stop each :data:`EITHER_STOP_JOINTS` joint was zeroed at.
+
+        Reads each unresolved joint's encoder once and derives its motor→joint
+        offset from the sign of the reading (see
+        :func:`end_stop_offset_from_position`).  Idempotent and near-free once
+        resolved, so every ``AxolArm`` entry point that uses joint-frame
+        values calls it; diagnostics that enable motors directly and then
+        read ``_joint_offsets`` must call it themselves.
+
+        Args:
+            joints: Restrict resolution to this subset (for flows where only
+                some motors are on the bus).  ``None`` resolves all.
+
+        Raises:
+            MotorError: If a joint cannot be read, is parked at an end stop
+                (ambiguous), or reads outside its physical travel.
+        """
+        if not self._unresolved_offsets:
+            return
+        async with self._offset_lock:
+            pending = (
+                set(self._unresolved_offsets)
+                if joints is None
+                else self._unresolved_offsets & set(joints)
+            )
+            if not pending:
+                return
+            joint_index = {j: i for i, j in enumerate(Joint)}
+            side = "left" if self._is_left else "right"
+            for joint in pending:
+                offset, pos = await self._detect_stop_side(joint, side)
+                self._joint_offsets[joint_index[joint]] = offset
+                self._unresolved_offsets.discard(joint)
+                _logger.info(
+                    "%s %s zero detected at the %+.0f° end stop "
+                    "(motor %+.3f rad → joint offset %+.3f rad)",
+                    side,
+                    joint.name,
+                    math.degrees(offset),
+                    pos,
+                    offset,
+                )
+
+    async def _detect_stop_side(self, joint: Joint, side: str) -> tuple[float, float]:
+        """Read one joint's position and detect its zeroed end stop.
+
+        Retries once on an implausible reading: detection is a one-shot gate
+        at bring-up, and a single poisoned frame (e.g. a command ack decoded
+        as feedback) must not abort the whole enable when a fresh read
+        settles it.  Returns ``(offset, motor_pos)``.
+        """
+        motor = self.motors[joint]
+        last_exc: MotorError | None = None
+        for attempt in range(2):
+            if attempt:
+                await asyncio.sleep(0.05)
+            try:
+                if attempt == 0 and motor.has_position:
+                    pos = motor.position
+                elif not motor.telemetry_active:
+                    pos = await motor.get_position()
+                else:
+                    # Telemetry is polling (direct reads are rejected while
+                    # it runs); wait for a (fresh) sample.
+                    loop = asyncio.get_event_loop()
+                    deadline = loop.time() + 5.0
+                    while not motor.has_position:
+                        if loop.time() >= deadline:
+                            raise MotorError("no telemetry sample within 5 s")
+                        await asyncio.sleep(0.01)
+                    pos = motor.position
+            except MotorError as exc:
+                raise MotorError(
+                    f"Could not read {side} {joint.name} to detect its "
+                    f"zeroed end stop: {exc}"
+                ) from exc
+            try:
+                return end_stop_offset_from_position(joint, pos), pos
+            except MotorError as exc:
+                last_exc = exc
+        raise MotorError(f"{side} arm: {last_exc}") from last_exc
+
+    def _require_offsets_resolved(self) -> None:
+        """Raise if any either-stop joint's offset is still undetected."""
+        if self._unresolved_offsets:
+            names = ", ".join(j.name for j in Joint if j in self._unresolved_offsets)
+            raise MotorError(
+                f"Which end stop {names} was zeroed at has not been detected "
+                f"yet — enable(), start_telemetry(), or get_positions() first "
+                f"(each resolves it automatically)"
+            )
+
+    # ------------------------------------------------------------------ #
     # Polling                                                              #
     # ------------------------------------------------------------------ #
 
@@ -293,6 +468,10 @@ class AxolArm:
             hz:     Poll frequency in Hz.
             torque: If True, also fetch and cache torque each cycle.
         """
+        # Resolve before polling starts: direct position reads are rejected
+        # while telemetry runs, and the ``positions`` property needs the
+        # offsets as soon as the cache fills.
+        await self.resolve_joint_offsets()
         await asyncio.gather(
             *[m.start_telemetry(hz, torque=torque) for m in self.motors.values()]
         )
@@ -335,6 +514,7 @@ class AxolArm:
         with set_position_velocity and motion_control. On the gripperless
         SKU the gripper element is 0.0.
         """
+        self._require_offsets_resolved()
         values = self._pad_gripper([self.motors[j].position for j in self.motors])
         gripper_i = self._gripper_i
         if self._has_gripper:
@@ -449,6 +629,10 @@ class AxolArm:
             *[self.motors[j].set_control_mode(ControlMode.IMPEDANCE) for j in cold]
         )
 
+        # Motors are reachable now — detect which end stop the either-stop
+        # joints were zeroed at, so "enabled" implies joint-frame reads work.
+        await self.resolve_joint_offsets()
+
         if self._has_gripper:
             if Joint.GRIPPER in held:
                 await self._restore_gripper_calibration()
@@ -534,6 +718,7 @@ class AxolArm:
         with set_position_velocity and motion_control. On the gripperless
         SKU the gripper element is 0.0.
         """
+        await self.resolve_joint_offsets()
         values = self._pad_gripper(
             list(
                 await asyncio.gather(
@@ -640,14 +825,22 @@ class AxolArm:
     async def set_zero_position(self, joints: list[Joint]) -> None:
         """Save the current shaft position as the encoder zero for the specified joints.
 
-        The encoder zero is calibrated at the joint's mechanical end stop, not
-        at the rest position; ``AxolArm`` applies a per-joint offset so the
-        public API stays in joint frame (``0`` = rest).
+        The encoder zero is calibrated at one of the joint's mechanical end
+        stops, not at the rest position; ``AxolArm`` applies a per-joint
+        offset so the public API stays in joint frame (``0`` = rest).
 
         Args:
             joints: List of joints to zero.
         """
         await asyncio.gather(*[self.motors[j].set_zero_position() for j in joints])
+        # An either-stop joint's zero just moved, so the detected offset no
+        # longer describes the encoder (Damiao applies the new zero after a
+        # power cycle, but the old detection is stale either way).
+        joint_index = {j: i for i, j in enumerate(Joint)}
+        for j in joints:
+            if j in EITHER_STOP_JOINTS:
+                self._joint_offsets[joint_index[j]] = math.nan
+                self._unresolved_offsets.add(j)
 
     async def set_acceleration(self, accelerations: dict[Joint, float]) -> None:
         """Set the acceleration ramp per joint. Deceleration matches acceleration.
@@ -675,6 +868,7 @@ class AxolArm:
                        gripperless SKU).
             max_speed: Maximum speed for all joints (rad/s).
         """
+        await self.resolve_joint_offsets()
         positions = positions.copy()
         gripper_i = self._gripper_i
         if self._has_gripper:
@@ -730,6 +924,7 @@ class AxolArm:
                Arm joints are in radians in the joint frame (0 = rest);
                gripper is normalized to [0, 1] (0.0 = closed, 1.0 = fully open).
         """
+        await self.resolve_joint_offsets()
         q = q.copy()
 
         # Safety: reject commands with arm-joint deltas that exceed max_step_rad.
@@ -862,6 +1057,7 @@ class AxolArm:
                 hand-guided (``axol waypoints``). ``None`` (the default) holds
                 wherever the gripper currently is, softly.
         """
+        await self.resolve_joint_offsets()
         free_set: frozenset[Joint] = (
             frozenset(ARM_JOINTS) if free_joints is None else frozenset(free_joints)
         )

--- a/docs/cli/motor-set-zero-pos.mdx
+++ b/docs/cli/motor-set-zero-pos.mdx
@@ -6,7 +6,7 @@ description: "Set a motor's zero-position reference to its current mechanical po
 Sets the motor's zero-position reference to its current mechanical position (persisted to flash). Damiao motors require a power cycle afterward.
 
 <Warning>
-  Each motor's encoder zero is calibrated at one of the joint's mechanical **end stops**, **not** at the robot's rest position. In `--guided` mode the CLI drives every joint to its closer end stop and zeroes there; in single-`--id` mode you are responsible for holding the joint at the intended end stop before zeroing. `AxolArm` carries a per-joint offset so the public API stays in joint frame (`0` = rest).
+  Each motor's encoder zero is calibrated at one of the joint's mechanical **end stops**, **not** at the robot's rest position. In `--guided` mode the CLI walks every joint to an end stop and zeroes there; in single-`--id` mode you are responsible for holding the joint at the intended end stop before zeroing. `AxolArm` carries a per-joint offset so the public API stays in joint frame (`0` = rest).
 </Warning>
 
 | Flag | Description |
@@ -15,10 +15,12 @@ Sets the motor's zero-position reference to its current mechanical position (per
 | `--channel IFACE` | SocketCAN interface to use instead of the selected arm's Axol hub interface, for setups without the Axol hub CAN adapter (e.g. `can0`) |
 | `--id ID` | CAN ID of the motor to zero, hex or decimal (required unless `--guided`) |
 | `--type {myactuator,damiao}` | Motor type (inferred from `--id` if omitted) |
-| `--guided` | Walk through the arm joints, zeroing each at its closer end stop |
+| `--guided` | Walk through the arm joints, zeroing each at an end stop |
 | `--joints j1,j2,…` | Subset of arm joints to walk in `--guided` mode (default: all seven; the gripper has no zero — it self-calibrates at enable time) |
 
 In `--guided` mode the CLI first asks you to hold every selected joint somewhere inside its operating range (away from the end stops) and press Enter **once** — it captures each joint's in-range start reference concurrently. It then walks the selected arm joints one at a time (the gripper is auto-calibrated at runtime): for each, move it to the prompted end stop and press Enter. If the motion is in the expected direction the zero is committed immediately. If you moved the wrong way, the CLI keeps your starting reference and asks you to travel to the *other* end stop instead; pressing Enter there sets the zero. Press Ctrl-C to skip a joint.
+
+`wrist_2` and `wrist_3` are special: their end stops are the only ones that are not laser-aligned, so per unit one stop can be better placed than the other. For these two joints the guided flow accepts **either** end stop — move to whichever you trust and press Enter. Which side a robot was zeroed at is detected automatically at runtime from the encoder reading (zeroed at the upper stop, all readings are ≤ 0; at the lower stop, ≥ 0), so no side has to be recorded anywhere and robots zeroed by the older forced-side flow keep working unchanged. The only requirement: don't park these joints exactly at an end stop when connecting, since that one position is ambiguous.
 
 ```bash
 axol motor.set-zero-pos --l --id 0x01                        # single motor
@@ -27,5 +29,5 @@ axol motor.set-zero-pos --l --guided --joints wrist_2,wrist_3  # just the wrist 
 ```
 
 <Note>
-  After `--guided` calibration each motor's encoder zero coincides with its calibration end stop. `AxolArm` carries a per-joint offset internally so the public API (`positions`, `motion_control`, etc.) stays in joint frame (`0` = rest position). Damiao motors (`WRIST_2`, `WRIST_3`) need a power cycle for the new zero to take effect.
+  After `--guided` calibration each motor's encoder zero coincides with its calibration end stop. `AxolArm` carries a per-joint offset internally so the public API (`positions`, `motion_control`, etc.) stays in joint frame (`0` = rest position); for `wrist_2`/`wrist_3` the offset's sign is detected from the encoder at connect time. Damiao motors (`WRIST_2`, `WRIST_3`) need a power cycle for the new zero to take effect.
 </Note>

--- a/web/app/src/routes/Diagnostics.tsx
+++ b/web/app/src/routes/Diagnostics.tsx
@@ -514,8 +514,9 @@ export default function Diagnostics() {
           key: "guided",
           label: "Guided",
           description:
-            "Walk the selected joints of one arm and zero each against its closer " +
-            "end stop — each step pauses with instructions and a Continue button.",
+            "Walk the selected joints of one arm and zero each against an end " +
+            "stop (wrist_2/wrist_3 accept either side) — each step pauses with " +
+            "instructions and a Continue button.",
           presetArgs: { guided: true },
           hideKeys: ["id", "type"],
         },


### PR DESCRIPTION
…untime

The w2/w3 end stops are the only ones not laser-aligned, so per unit one stop can be better placed than the other. Guided set-zero-pos now accepts whichever stop the operator brings the joint to, and AxolArm detects which side a robot was zeroed at from the first encoder reading (zeroed at the upper stop every reachable position reads <= 0; at the lower stop >= 0). No per-robot files, and field robots resolve to the offsets they have always had. Implausible readings fail closed at bring-up instead of driving the arm with a garbage frame.

Also fix a Damiao driver bug this exposed: register-write acks (0x55 echoes on the feedback ID) were decoded as position feedback, poisoning reads with -12.47 rad spikes when enable()'s set_control_mode raced the next position request.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes motor-frame/joint-frame conversion and bring-up gating for wrist joints on real hardware; incorrect detection or ambiguous end-stop poses could yield wrong commands until re-zeroed.
> 
> **Overview**
> **Guided zeroing** for `wrist_2` and `wrist_3` now accepts **either** mechanical end stop (not only the closer one), with a new `_calibrate_joint_either_stop` path in `motor.set-zero-pos`. Docs and the diagnostics dashboard copy are updated to match.
> 
> **Runtime joint framing** for those joints no longer assumes a fixed “closer” side: `AxolArm` starts their motor→joint offsets as **NaN**, infers the side from the first encoder read via `end_stop_offset_from_position`, and exposes `resolve_joint_offsets()` (called from `enable`, telemetry, motion control, etc.). Subset-enable diagnostics (`can/receive`, `can/send`, `rom/enable`) call resolution explicitly; re-zeroing invalidates detection. Cached `positions` fail closed until offsets are resolved.
> 
> **Damiao driver fix:** register-protocol ack/echo frames (`0x55`, `0xAA`, `0xCC`, not just `0x33` replies) are no longer mistaken for position feedback—fixing poisoned reads when `set_control_mode` races position polling. `Motor.telemetry_active` supports waiting on telemetry during detection.
> 
> **Minor:** `tune.repeatability` notes that pasted motor poses assume the historical closer-stop offset if wrists were zeroed on the other side.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bc0e63e1f9934d2c555642d28d9453108af5f20. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->