### PR TITLE
Share one robot model across kinematics instances to stop repeated jaxls re-tracing

### DIFF
--- a/almond_axol/kinematics/__init__.py
+++ b/almond_axol/kinematics/__init__.py
@@ -1,6 +1,7 @@
 """Public re-exports for almond_axol.kinematics."""
 
 from .config import KinematicsConfig
+from .jax_cache import enable_persistent_compilation_cache
 from .path import PathPlanningError, ee_poses, plan_linear_segment, tip_poses
 from .solver import KinematicsSolver
 
@@ -9,6 +10,7 @@ __all__ = [
     "KinematicsSolver",
     "PathPlanningError",
     "ee_poses",
+    "enable_persistent_compilation_cache",
     "plan_linear_segment",
     "tip_poses",
 ]

--- a/almond_axol/kinematics/fk.py
+++ b/almond_axol/kinematics/fk.py
@@ -18,16 +18,14 @@ import logging
 import jax.numpy as jnp
 import jaxlie
 import numpy as np
-import pyroki as pk
-import yourdfpy
 
 from ..constants import (
-    URDF_PATH,
     Joint,
     urdf_arm_joint_names,
     urdf_body_name,
 )
 from .jax_cache import enable_persistent_compilation_cache
+from .model import shared_robot
 
 _logger = logging.getLogger(__name__)
 
@@ -63,16 +61,18 @@ def pose6_to_pos_rot(pose6: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
 class AxolForwardKinematics:
     """Forward kinematics for the Axol end-effectors, no IK or collision model.
 
-    Loads the bundled URDF, builds the pyroki robot, and caches the EE link and
-    per-arm joint indices. A single warm-up call JIT-compiles the forward pass
-    so the first :meth:`ee_poses` in the observation loop isn't slow.
+    Reuses the per-process pyroki robot (built on first use) and caches the EE
+    link and per-arm joint indices. A single warm-up call JIT-compiles the
+    forward pass so the first :meth:`ee_poses` in the observation loop isn't
+    slow.
     """
 
     def __init__(self) -> None:
         enable_persistent_compilation_cache()
-        _logger.info("Loading Axol URDF for forward kinematics...")
-        urdf = yourdfpy.URDF.load(str(URDF_PATH), mesh_dir=str(URDF_PATH.parent))
-        self.robot = pk.Robot.from_urdf(urdf)
+        # Shared per-process robot (see .model): a KinematicsSolver in the
+        # same process reuses this instance and vice versa, so the forward
+        # pass is only ever traced once.
+        self.robot = shared_robot()
 
         names = self.robot.links.names
         self._l_ee_idx = names.index(urdf_body_name(Joint.GRIPPER, is_left=True))

--- a/almond_axol/kinematics/model.py
+++ b/almond_axol/kinematics/model.py
@@ -1,0 +1,122 @@
+"""Process-wide shared robot model for the kinematics entry points.
+
+The bundled URDF never changes at runtime, but ``pyroki.Robot.from_urdf``
+mints a fresh ``JointVar`` class on every call — and that class is a
+*static* field of the ``Robot`` pytree. Two ``Robot`` instances built from
+the same URDF therefore never compare equal for JIT-cache purposes: every
+jitted function that takes a ``Robot`` (the IK solve, forward kinematics)
+re-traces and re-runs jaxls problem analysis per instance, costing seconds
+of pure Python work each time even though the compiled XLA executable is
+identical (and served from the persistent cache, see :mod:`.jax_cache`).
+
+Building the robot once per process and handing the same instance to every
+:class:`~almond_axol.kinematics.solver.KinematicsSolver` /
+:class:`~almond_axol.kinematics.fk.AxolForwardKinematics` makes each
+instance after the first hit JAX's in-memory jit cache, so constructing
+additional objects is close to free.
+
+The collision model is built lazily and separately: forward-kinematics-only
+users (observation recording) never pay for capsule fitting.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+
+import jax.numpy as jnp
+import numpy as np
+import pyroki as pk
+import yourdfpy
+
+from ..constants import URDF_PATH
+
+_logger = logging.getLogger(__name__)
+
+_TORSO_LINKS: tuple[str, ...] = ("base", "s1")
+"""Static body links that the arms must not collide into.
+
+Self-collision on Axol is restricted to ``arm <-> torso`` pairs only.
+"""
+
+_lock = threading.RLock()
+_urdf: yourdfpy.URDF | None = None
+_robot: pk.Robot | None = None
+_robot_coll: pk.collision.RobotCollision | None = None
+
+
+def _load_urdf() -> yourdfpy.URDF:
+    global _urdf
+    if _urdf is None:
+        _logger.info("Loading Axol URDF...")
+        _urdf = yourdfpy.URDF.load(str(URDF_PATH), mesh_dir=str(URDF_PATH.parent))
+    return _urdf
+
+
+def shared_robot() -> pk.Robot:
+    """The pyroki robot for the bundled Axol URDF, built once per process."""
+    global _robot
+    with _lock:
+        if _robot is None:
+            _robot = pk.Robot.from_urdf(_load_urdf())
+        return _robot
+
+
+def shared_robot_collision() -> pk.collision.RobotCollision:
+    """The torso<->arm collision model, built once per process."""
+    global _robot_coll
+    with _lock:
+        if _robot_coll is None:
+            _robot_coll = _build_robot_collision(_load_urdf(), shared_robot())
+        return _robot_coll
+
+
+def _build_robot_collision(
+    urdf: yourdfpy.URDF, robot: pk.Robot
+) -> pk.collision.RobotCollision:
+    """Build ``RobotCollision`` with self-collision restricted to torso<->arm pairs.
+
+    Each Axol arm is a serial chain attached to a static torso (``base`` +
+    ``s1``). pyroki's PCA capsule fit produces conservative single-capsule-
+    per-link shapes that always overlap at adjacent-link joint interfaces,
+    so blanket self-collision causes persistent jitter the IK cannot
+    resolve. We restrict the active pair set to the only collisions that
+    actually matter: any link pair where exactly one side is the torso
+    and the other is an arm link. Within-arm, cross-arm, and torso<->torso
+    pairs are filtered out (cross-arm contacts are unreachable, within-arm
+    is constrained by joint limits, and torso<->torso is rigidly fixed).
+
+    A second pass excludes any remaining pair that is already penetrating
+    at the home pose — those are over-conservative capsule fits the IK
+    can never separate (e.g. ``base <-> shoulder`` capsules that overlap
+    by construction because the arms mount onto the torso).
+    """
+    link_names = [link.name for link in urdf.robot.links]
+
+    def is_arm(n: str) -> bool:
+        return n.startswith("left_") or n.startswith("right_")
+
+    def is_torso(n: str) -> bool:
+        return n in _TORSO_LINKS
+
+    ignore: set[tuple[str, str]] = set()
+    for i, a in enumerate(link_names):
+        for b in link_names[i + 1 :]:
+            keep = (is_torso(a) and is_arm(b)) or (is_torso(b) and is_arm(a))
+            if not keep:
+                ignore.add((a, b))
+
+    rc = pk.collision.RobotCollision.from_urdf(urdf, user_ignore_pairs=tuple(ignore))
+    q0 = jnp.zeros(robot.joints.num_actuated_joints)
+    d = np.asarray(rc.compute_self_collision_distance(robot, q0))
+    ai = np.asarray(rc.active_idx_i)
+    aj = np.asarray(rc.active_idx_j)
+    for k in np.where(d < 0.0)[0]:
+        ignore.add((rc.link_names[ai[k]], rc.link_names[aj[k]]))
+
+    rc = pk.collision.RobotCollision.from_urdf(urdf, user_ignore_pairs=tuple(ignore))
+    _logger.info(
+        "RobotCollision: restricted to %d torso<->arm pairs.",
+        len(rc.active_idx_i),
+    )
+    return rc

--- a/almond_axol/kinematics/solver.py
+++ b/almond_axol/kinematics/solver.py
@@ -16,76 +16,17 @@ import jaxlie
 import jaxls
 import numpy as np
 import pyroki as pk
-import yourdfpy
 
 from ..constants import (
-    URDF_PATH,
     Joint,
     urdf_arm_joint_names,
     urdf_body_name,
 )
 from .config import KinematicsConfig
 from .jax_cache import enable_persistent_compilation_cache
+from .model import shared_robot, shared_robot_collision
 
 _logger = logging.getLogger(__name__)
-
-
-_TORSO_LINKS: tuple[str, ...] = ("base", "s1")
-"""Static body links that the arms must not collide into.
-
-Self-collision on Axol is restricted to ``arm <-> torso`` pairs only.
-"""
-
-
-def _build_robot_collision(
-    urdf: yourdfpy.URDF, robot: pk.Robot
-) -> pk.collision.RobotCollision:
-    """Build ``RobotCollision`` with self-collision restricted to torso<->arm pairs.
-
-    Each Axol arm is a serial chain attached to a static torso (``base`` +
-    ``s1``). pyroki's PCA capsule fit produces conservative single-capsule-
-    per-link shapes that always overlap at adjacent-link joint interfaces,
-    so blanket self-collision causes persistent jitter the IK cannot
-    resolve. We restrict the active pair set to the only collisions that
-    actually matter: any link pair where exactly one side is the torso
-    and the other is an arm link. Within-arm, cross-arm, and torso<->torso
-    pairs are filtered out (cross-arm contacts are unreachable, within-arm
-    is constrained by joint limits, and torso<->torso is rigidly fixed).
-
-    A second pass excludes any remaining pair that is already penetrating
-    at the home pose — those are over-conservative capsule fits the IK
-    can never separate (e.g. ``base <-> shoulder`` capsules that overlap
-    by construction because the arms mount onto the torso).
-    """
-    link_names = [link.name for link in urdf.robot.links]
-
-    def is_arm(n: str) -> bool:
-        return n.startswith("left_") or n.startswith("right_")
-
-    def is_torso(n: str) -> bool:
-        return n in _TORSO_LINKS
-
-    ignore: set[tuple[str, str]] = set()
-    for i, a in enumerate(link_names):
-        for b in link_names[i + 1 :]:
-            keep = (is_torso(a) and is_arm(b)) or (is_torso(b) and is_arm(a))
-            if not keep:
-                ignore.add((a, b))
-
-    rc = pk.collision.RobotCollision.from_urdf(urdf, user_ignore_pairs=tuple(ignore))
-    q0 = jnp.zeros(robot.joints.num_actuated_joints)
-    d = np.asarray(rc.compute_self_collision_distance(robot, q0))
-    ai = np.asarray(rc.active_idx_i)
-    aj = np.asarray(rc.active_idx_j)
-    for k in np.where(d < 0.0)[0]:
-        ignore.add((rc.link_names[ai[k]], rc.link_names[aj[k]]))
-
-    rc = pk.collision.RobotCollision.from_urdf(urdf, user_ignore_pairs=tuple(ignore))
-    _logger.info(
-        "RobotCollision: restricted to %d torso<->arm pairs.",
-        len(rc.active_idx_i),
-    )
-    return rc
 
 
 # Convenience aliases for URDF link / joint names. The single source of
@@ -343,10 +284,13 @@ class KinematicsSolver:
     """
 
     def __init__(self, config: KinematicsConfig = KinematicsConfig()) -> None:
-        """Load the bundled Axol URDF, build the pyroki robot and collision model, and warm up JIT.
+        """Build (or reuse) the robot model and warm up JIT.
 
-        Resolves link and joint indices, computes fixed shoulder positions, and
-        triggers JAX JIT compilation via a dummy solve so the first real call to
+        The URDF, pyroki robot, and collision model are built once per process
+        and shared across instances, so only the first solver pays for them —
+        and for the JAX trace + jaxls problem analysis its warm-up solve
+        triggers. Each instance resolves link and joint indices, computes fixed
+        shoulder positions, and runs a dummy solve so the first real call to
         :meth:`ik` is fast.
 
         Args:
@@ -356,10 +300,12 @@ class KinematicsSolver:
 
         enable_persistent_compilation_cache()
 
-        _logger.info("Loading Axol URDF...")
-        urdf = yourdfpy.URDF.load(str(URDF_PATH), mesh_dir=str(URDF_PATH.parent))
-        self.robot = pk.Robot.from_urdf(urdf)
-        self.robot_coll = _build_robot_collision(urdf, self.robot)
+        # One robot model per process (see .model): reusing the same pytree —
+        # including pyroki's per-instance JointVar class, a static field —
+        # lets every solver after the first hit the in-memory jit cache
+        # instead of re-tracing and re-running jaxls analysis.
+        self.robot = shared_robot()
+        self.robot_coll = shared_robot_collision()
 
         names = self.robot.links.names
         self.l_ee_idx = names.index(_LEFT_EE)

--- a/docs/api/kinematics.mdx
+++ b/docs/api/kinematics.mdx
@@ -3,10 +3,17 @@ title: "almond_axol.kinematics"
 description: "Bimanual inverse kinematics solver using pyroki and JAX/jaxls."
 ---
 
-Bimanual inverse kinematics using pyroki and JAX/jaxls. Loads the bundled URDF, builds a collision model, and JIT-compiles the solver during `__init__` — the first call takes a few seconds; subsequent calls are fast.
+Bimanual inverse kinematics using pyroki and JAX/jaxls. Loads the bundled URDF, builds a collision model, and JIT-compiles the solver during `__init__` — the first solver in a process takes a few seconds; subsequent calls (and subsequent solver instances) are fast.
 
 <Note>
-  The XLA compile is cached to disk (`~/.almond/jax-cache`), so that cost is paid **once per machine**, not on every process start — a fresh `axol teleop` / `serve` boots straight into the fast path instead of recompiling. The cache key covers the solver graph plus the `jax`/`jaxlib` versions and backend, so upgrading JAX or changing the solver simply recompiles and refreshes the cache (stale entries are never reused). Only the XLA backend compile is skipped; Python-side tracing/lowering still runs each session. Set `JAX_COMPILATION_CACHE_DIR` to override the location.
+  Solver startup is cached at two levels, both automatic:
+
+  - **Per machine** — the XLA compile (the expensive part, minutes cold on a Jetson) is cached to disk (`~/.almond/jax-cache`), so it's paid **once per machine**, not on every process start. The cache key covers the solver graph plus the `jax`/`jaxlib` versions and backend, so upgrading JAX or changing the solver simply recompiles and refreshes the cache (stale entries are never reused). Set `JAX_COMPILATION_CACHE_DIR` to override the location.
+  - **Per process** — the URDF, pyroki robot, and collision model are built once per process and shared by every `KinematicsSolver` / `AxolForwardKinematics` instance, so creating additional instances doesn't repeat the JAX trace or jaxls problem analysis.
+
+  What remains on every fresh process start is the Python side: imports, URDF parsing, and the jaxls analysis/tracing pass (the `Building optimization problem` / `Vectorizing group` log lines) — several seconds that no disk cache can skip. Within a process it's paid once, up front: additional solver instances reuse the shared model and the already-traced solve. (`axol teleop` / `serve` absorb it in the IK worker's startup handshake, which is why it isn't felt there.)
+
+  The disk cache only covers compiles that happen after it's enabled, which `KinematicsSolver` / `AxolForwardKinematics` do in `__init__`. A script that runs its own JAX/jaxls work **before** creating a solver can call `almond_axol.kinematics.enable_persistent_compilation_cache()` first so those compiles are disk-cached too.
 </Note>
 
 ```python


### PR DESCRIPTION
## Summary
- Fix creating multiple `KinematicsSolver` / `AxolForwardKinematics` objects re-running the full JAX trace + jaxls problem analysis (~7s each on Jetson) per instance: pyroki's `Robot.from_urdf` mints a fresh `JointVar` class per call, a *static* pytree field, so each instance missed JAX's in-memory jit cache. New `almond_axol/kinematics/model.py` builds the URDF, pyroki robot, and collision model once per process and shares them (`_build_robot_collision` moved there verbatim). Measured: second solver 7.4s → 0.0s, FK-after-solver 2s → 0.04s.
- Export `enable_persistent_compilation_cache` from `almond_axol.kinematics` so scripts that run their own JAX/jaxls work before constructing a solver can get those compiles disk-cached too (the solver/FK constructors already call it).
- Document the two cache levels in `docs/api/kinematics.mdx`: what the on-disk XLA cache covers, what the shared per-process model covers, and the Python-side tracing/analysis cost that remains per fresh process.

## Test plan
- [x] Two `KinematicsSolver()` in one process: jaxls analysis runs once; second instance ~0.0s (was 7.4s)
- [x] `AxolForwardKinematics` after a solver shares the same `Robot` instance (0.04s) and `ee_poses` output shape unchanged
- [x] Solver outputs byte-identical to unmodified tree on the same inputs; IK tracks a nearby target from a non-singular seed
- [x] Public re-export smoke test (`enable_persistent_compilation_cache` imported and called first)
- [x] Pinned ruff check + format pass

Made with [Cursor](https://cursor.com)