### PR TITLE
Return ik's (pos, rot_3x3) pose format from fk so poses round-trip

### DIFF
--- a/almond_axol/cli/tune/repeatability.py
+++ b/almond_axol/cli/tune/repeatability.py
@@ -299,8 +299,7 @@ async def _run(args: argparse.Namespace) -> None:
     # Report the FK gripper position at each waypoint so the operator can
     # eyeball the geometry before any motors move.
     for name, q_wp in (("rest", q_rest), ("A", q_a), ("B", q_b)):
-        se3, _ = solver.fk(q_wp)
-        p = np.asarray(se3.translation())
+        (p, _), _ = solver.fk(q_wp)
         print(f"  left gripper @ {name:4} → ({p[0]:+.3f}, {p[1]:+.3f}, {p[2]:+.3f}) m")
 
     # The arm moves rest → A once, then bounces A → B → A → B … for every

--- a/almond_axol/kinematics/__init__.py
+++ b/almond_axol/kinematics/__init__.py
@@ -2,14 +2,14 @@
 
 from .config import KinematicsConfig
 from .jax_cache import enable_persistent_compilation_cache
-from .path import PathPlanningError, ee_poses, plan_linear_segment, tip_poses
-from .solver import KinematicsSolver
+from .path import PathPlanningError, plan_linear_segment, tip_poses
+from .solver import KinematicsSolver, Pose
 
 __all__ = [
     "KinematicsConfig",
     "KinematicsSolver",
     "PathPlanningError",
-    "ee_poses",
+    "Pose",
     "enable_persistent_compilation_cache",
     "plan_linear_segment",
     "tip_poses",

--- a/almond_axol/kinematics/path.py
+++ b/almond_axol/kinematics/path.py
@@ -49,7 +49,7 @@ from numpy.typing import ArrayLike
 from scipy.interpolate import CubicSpline
 
 from ..constants import GRIPPER_TIP_OFFSET
-from .solver import KinematicsSolver
+from .solver import KinematicsSolver, Pose
 
 _logger = logging.getLogger(__name__)
 
@@ -81,9 +81,6 @@ _PEAK_SPEED_FACTOR = 1.875
 # its first-order term, which is exact to float32 precision at that scale.
 _SMALL_ANGLE = 1e-8
 
-Pose = tuple[np.ndarray, np.ndarray]
-"""A frame as ``(position (3,), rotation (3, 3))`` in the world frame."""
-
 Offset = np.ndarray | tuple[float, float, float]
 """A tool point in the gripper link frame."""
 
@@ -113,16 +110,6 @@ class PathPlanningError(RuntimeError):
     """
 
 
-def ee_poses(solver: KinematicsSolver, q: np.ndarray) -> tuple[Pose, Pose]:
-    """Return ``(left, right)`` gripper-mount poses for a full joint vector.
-
-    This is the frame :meth:`KinematicsSolver.ik` targets. For the point the
-    fingers close on, see :func:`tip_poses`.
-    """
-    left, right = solver.fk(np.asarray(q, dtype=np.float32))
-    return _to_pose(left), _to_pose(right)
-
-
 def tip_poses(
     solver: KinematicsSolver,
     q: np.ndarray,
@@ -130,10 +117,11 @@ def tip_poses(
 ) -> tuple[Pose, Pose]:
     """Return ``(left, right)`` gripper-tip poses for a full joint vector.
 
-    Same orientation as the mount, translated out to the fingertips.
+    Same orientation as the mount frame :meth:`KinematicsSolver.fk` returns,
+    translated out to the fingertips.
     """
     offset = np.asarray(tool_offset, dtype=np.float32)
-    left, right = ee_poses(solver, q)
+    left, right = solver.fk(q)
     return _apply_offset(left, offset), _apply_offset(right, offset)
 
 
@@ -146,13 +134,6 @@ def _remove_offset(pose: Pose, offset: np.ndarray) -> Pose:
     """Invert :func:`_apply_offset`: the mount pose that puts the tip here."""
     position, rotation = pose
     return (position - rotation @ offset, rotation)
-
-
-def _to_pose(se3: jaxlie.SE3) -> Pose:
-    return (
-        np.asarray(se3.translation(), dtype=np.float32),
-        np.asarray(se3.rotation().as_matrix(), dtype=np.float32),
-    )
 
 
 def _rot_log(r_from: np.ndarray, r_to: np.ndarray) -> np.ndarray:

--- a/almond_axol/kinematics/solver.py
+++ b/almond_axol/kinematics/solver.py
@@ -29,6 +29,14 @@ from .model import shared_robot, shared_robot_collision
 _logger = logging.getLogger(__name__)
 
 
+Pose = tuple[np.ndarray, np.ndarray]
+"""A frame as ``(position (3,), rotation (3, 3))`` numpy arrays, world frame (FLU).
+
+The format :meth:`KinematicsSolver.fk` returns and :meth:`KinematicsSolver.ik`
+takes, so a pose can be read, edited, and solved for without conversion.
+"""
+
+
 # Convenience aliases for URDF link / joint names. The single source of
 # truth for these strings lives in :mod:`almond_axol.constants`; the helpers
 # below just compose ``"left_*"`` / ``"right_*"`` from a side-agnostic
@@ -258,6 +266,14 @@ def _pos3_to_se3(pos: np.ndarray) -> jaxlie.SE3:
     )
 
 
+def _se3_to_pose(se3: jaxlie.SE3) -> Pose:
+    """Convert an SE3 to the numpy ``(pos, rot_3x3)`` format :meth:`KinematicsSolver.ik` takes."""
+    return (
+        np.asarray(se3.translation(), dtype=np.float32),
+        np.asarray(se3.rotation().as_matrix(), dtype=np.float32),
+    )
+
+
 # ---------------------------------------------------------------------------
 # KinematicsSolver
 # ---------------------------------------------------------------------------
@@ -281,6 +297,11 @@ class KinematicsSolver:
         pos = np.array([0.3, 0.2, 0.4], dtype=np.float32)
         rot = np.eye(3, dtype=np.float32)
         q = solver.ik(q, left_pose=(pos, rot))
+
+        # fk returns the same (pos, rot_3x3) format ik takes, so nudging a
+        # pose is a round trip:
+        (l_pos, l_rot), _ = solver.fk(q)
+        q = solver.ik(q, left_pose=(l_pos + np.array([0.0, 0.0, 0.05]), l_rot))
     """
 
     def __init__(self, config: KinematicsConfig = KinematicsConfig()) -> None:
@@ -375,24 +396,35 @@ class KinematicsSolver:
 
     # -- Public interface ----------------------------------------------------
 
-    def fk(self, q: np.ndarray) -> tuple[jaxlie.SE3, jaxlie.SE3]:
+    def fk(self, q: np.ndarray) -> tuple[Pose, Pose]:
         """Compute end-effector poses from joint positions.
 
         Args:
             q: Full ``(N,)`` joint array in radians.
 
         Returns:
-            Tuple ``(left_pose, right_pose)`` as :class:`jaxlie.SE3` transforms
-            in the robot's world frame (FLU).
+            Tuple ``(left_pose, right_pose)``, each a ``(pos (3,), rot (3, 3))``
+            pair of numpy arrays in the robot's world frame (FLU) — the same
+            format :meth:`ik` takes, so a pose can be read, nudged, and solved
+            for directly::
+
+                (l_pos, l_rot), _ = solver.fk(q)
+                q = solver.ik(q, left_pose=(l_pos + delta, l_rot))
+
+        The returned pose is the gripper *mount* frame — for the point the
+        fingers close on, see :func:`almond_axol.kinematics.path.tip_poses`.
         """
         fk = self.robot.forward_kinematics(jnp.asarray(q, dtype=jnp.float32))
-        return jaxlie.SE3(fk[self.l_ee_idx]), jaxlie.SE3(fk[self.r_ee_idx])
+        return (
+            _se3_to_pose(jaxlie.SE3(fk[self.l_ee_idx])),
+            _se3_to_pose(jaxlie.SE3(fk[self.r_ee_idx])),
+        )
 
     def ik(
         self,
         q_current: np.ndarray,
-        left_pose: tuple[np.ndarray, np.ndarray] | None = None,
-        right_pose: tuple[np.ndarray, np.ndarray] | None = None,
+        left_pose: Pose | None = None,
+        right_pose: Pose | None = None,
         left_elbow_pos: np.ndarray | None = None,
         right_elbow_pos: np.ndarray | None = None,
     ) -> np.ndarray:

--- a/docs/api/kinematics.mdx
+++ b/docs/api/kinematics.mdx
@@ -27,13 +27,16 @@ from almond_axol.kinematics import KinematicsSolver, KinematicsConfig
 solver = KinematicsSolver(KinematicsConfig(pos_weight=100.0))
 q = np.zeros(solver.num_joints, dtype=np.float32)
 
-# Forward kinematics → (left_SE3, right_SE3) as jaxlie.SE3
-left_se3, right_se3 = solver.fk(q)
-
 # Inverse kinematics → new joint array
 pos = np.array([0.3, 0.2, 0.4], dtype=np.float32)
 rot = np.eye(3, dtype=np.float32)
 q = solver.ik(q, left_pose=(pos, rot))
+
+# Forward kinematics → (left, right), each a (pos (3,), rot (3, 3)) numpy
+# pair — the same format ik takes. Reading a pose, nudging it, and solving
+# for the joints is a round trip:
+(l_pos, l_rot), (r_pos, r_rot) = solver.fk(q)
+q = solver.ik(q, left_pose=(l_pos + np.array([0.0, 0.0, 0.05]), l_rot))
 ```
 
 ## `KinematicsSolver` interface
@@ -43,7 +46,7 @@ q = solver.ik(q, left_pose=(pos, rot))
 | `num_joints` | Total actuated joints across both arms |
 | `joint_names` | Joint name strings (left arm then right) |
 | `left_indices` / `right_indices` | Indices into the full `q` array for each arm |
-| `fk(q)` | Forward kinematics → `(left_SE3, right_SE3)` |
+| `fk(q)` | Forward kinematics → `((pos_3, rot_3x3), (pos_3, rot_3x3))` — the same format `ik` takes |
 | `ik(q, left_pose, right_pose, left_elbow_pos, right_elbow_pos)` | IK; `pose` is `(pos_3, rot_3x3)`; elbow hints are optional `(3,)` arrays |
 | `set_posture_pose(q)` / `posture_pose` | Set / read the null-space attractor (home pose for joint drift prevention) |
 


### PR DESCRIPTION
## Summary

- `KinematicsSolver.fk` now returns `((pos, rot_3x3), (pos, rot_3x3))` numpy pairs — exactly the format `ik` takes — instead of `jaxlie.SE3` transforms. Customer feedback: taking a known joint pose, adding an EE delta, and solving for joints required manual SE3→numpy conversion that every internal caller was also doing privately.
- Adds a public `Pose` type alias (exported from `almond_axol.kinematics`) used by both `fk` and `ik` signatures, plus docstring/docs examples showing the round trip (`fk` → nudge → `ik`).
- Removes the now-redundant `path.ee_poses` (was a public alias for the same operation, and collided conceptually with `AxolForwardKinematics.ee_poses`, which returns 6-vectors) and the private SE3→tuple converters; `tip_poses` calls `solver.fk` directly.

**Breaking change** (pre-1.0): `fk`'s return type changed, loudly — `.translation()` on a tuple raises immediately. Migration: callers converting to numpy delete their conversion code; callers wanting SE3 can lift a pose via `jaxlie.SE3.from_rotation_and_translation(jaxlie.SO3.from_matrix(rot), pos)`; `ee_poses(solver, q)` → `solver.fk(q)`. Version bump left to the usual release PR.

## Test plan

- [x] Sim validation: `fk` returns float32 `(3,)`/`(3, 3)` numpy pairs; `tip_poses` keeps mount orientation with offset translation
- [x] Customer workflow end-to-end: from the settled rest pose, `fk` → +5 cm nudge → `ik` (posture swept per solve, 10 mm substeps) converges to 1.77 mm
- [x] `ruff` / `ruff-format` pass on all changed files; edited modules byte-compile
- [x] Confirm no other external consumers of the old SE3 return before the next release

Made with [Cursor](https://cursor.com)