### PR TITLE
Fix decimal point input in COM and other numeric config fields

### DIFF
--- a/web/app/src/components/config-form.tsx
+++ b/web/app/src/components/config-form.tsx
@@ -33,7 +33,12 @@ const vectorDefault = (field: SchemaField): number[] =>
 /** Parse one component's text: number when it is one, raw text while mid-edit. */
 const parseComponent = (text: string): number | string => {
   const t = text.trim()
-  return t !== "" && Number.isFinite(Number(t)) ? Number(t) : text
+  const n = Number(t)
+  // Only commit to a number when it round-trips exactly: Number("0.") is 0,
+  // so converting eagerly would rewrite "0." to "0" under the cursor and make
+  // it impossible to type a decimal point. Non-canonical text ("0.", "-0",
+  // ".5") stays a string and is coerced server-side.
+  return t !== "" && Number.isFinite(n) && String(n) === t ? n : text
 }
 
 /** Current component values: the override if set, else the defaults. */

--- a/web/app/src/components/settings/settings-section.tsx
+++ b/web/app/src/components/settings/settings-section.tsx
@@ -568,8 +568,11 @@ function SettingRow({
           const raw = e.target.value
           if (raw === "") return onChange(field.key, null)
           if (field.type === "number") {
+            // Store a number only when the text round-trips exactly, so
+            // mid-edit states like "0." aren't rewritten to "0" under the
+            // cursor (see parseComponent in config-form.tsx).
             const n = Number(raw)
-            return onChange(field.key, Number.isFinite(n) ? n : raw)
+            return onChange(field.key, Number.isFinite(n) && String(n) === raw.trim() ? n : raw)
           }
           onChange(field.key, raw)
         }}


### PR DESCRIPTION
## Summary
- Typing `.` in the Advanced tab's COM (vector) fields was impossible: every keystroke was parsed through `Number()`, and `Number("0.")` is a finite `0`, so the controlled input re-rendered `0` and ate the dot (a trailing minus like `-0` was eaten the same way).
- `parseComponent` now converts text to a number only when it round-trips exactly (`String(Number(t)) === t`); mid-edit text like `0.` stays a string in the draft and is coerced server-side, matching the existing mid-edit design.
- Applied the same guard to the curated number fields in `SettingRow` (settings tabs), which had the identical eager-`Number()` bug.

## Test plan
- [x] `tsc -b && vite build` passes (`npm run build --workspace=app` after building `packages/axol-vr-client`)
- [x] eslint clean on both changed files
- [x] Simulated keystroke sequence `-` → `-0` → `-0.` → `-0.025`: every intermediate state renders as typed, final value commits as a number
- [ ] Manual: type `0.05` into a COM field on the Advanced tab and into a curated number setting, then Save and confirm the stored value

Made with [Cursor](https://cursor.com)