### PR TITLE
Hold position on a lost VR link instead of returning to rest

### DIFF
--- a/almond_axol/lerobot/teleop/teleop_vr.py
+++ b/almond_axol/lerobot/teleop/teleop_vr.py
@@ -243,12 +243,6 @@ class AxolVRTeleop(Teleoperator):
     ) -> None:
         self._vr_server = VRServer(self.config.vr_server_config)
         self._vr_server.set_on_frame(self._on_vr_frame)
-        # Quitting the VR app closes the operator's socket without reliably
-        # delivering the Y-exit reset frame; send the arms home on that
-        # disconnect (a pause — system menu, doffed headset — keeps the
-        # socket open and only auto-disengages).
-        if self.config.vr_teleop_config.reset_on_disconnect:
-            self._vr_server.set_on_operator_gone(self._core.request_reset_if_away)
         # Lock the headset HUD to data collection: the operator can record
         # episodes but can't switch back to plain teleop.
         self._vr_server.set_mode("data_collection")

--- a/almond_axol/teleop/config.py
+++ b/almond_axol/teleop/config.py
@@ -103,23 +103,13 @@ class VRTeleopConfig:
             link dropped.  Without it the engage toggle survives the gap, so
             the next frames after re-entering VR are tracked against the old
             engage snapshot and the arms jerk toward wherever the controllers
-            now are.  The headset streams poses at 72+ Hz while presenting,
+            now are.  After the disengage the arms hold position wherever
+            they are — a lost link never moves the robot on its own — until
+            the operator deliberately re-engages (a fresh engage snapshot, so
+            motion resumes relative to the controllers' new pose) or presses
+            reset.  The headset streams poses at 72+ Hz while presenting,
             so anything beyond a few hundred ms is a real gap, not jitter.
             ``0`` disables the timeout.  Defaults to ``0.5`` s.
-        reset_on_disconnect: Return the arms to the rest pose when the
-            operator's last pose-sending connection closes while the arms are
-            away from rest — quitting the VR app (e.g. via the Quest menu)
-            can't reliably deliver the Y-exit reset frame.  Pausing without
-            quitting (system menu, doffed headset) keeps the socket open and
-            only auto-disengages; the arms hold in place.  Defaults to True.
-        exit_reset_timeout: Also return the arms to rest when no VR pose
-            frame has arrived for this many seconds while the arms are away
-            from rest.  This is the backstop for exits whose socket close is
-            delayed or lost — a killed headset app whose TCP FIN never went
-            out (WiFi power-save after quitting, a crash, a link drop) —
-            and it means stepping away mid-session parks the arms safely.
-            Long enough that a normal Quest-menu visit doesn't trigger it.
-            ``0`` disables.  Defaults to ``10`` s.
     """
 
     rest_pose_left: np.ndarray = field(
@@ -170,5 +160,3 @@ class VRTeleopConfig:
     position_multiplier: float = 1.0
     rotation_multiplier: float = 1.0
     disengage_timeout: float = 0.5
-    reset_on_disconnect: bool = True
-    exit_reset_timeout: float = 10.0

--- a/almond_axol/teleop/core.py
+++ b/almond_axol/teleop/core.py
@@ -239,22 +239,6 @@ class VRTeleopCore:
         """Programmatically trigger a return-to-rest move. Safe from any thread."""
         self._reset_latched = True
 
-    def request_reset_if_away(self) -> None:
-        """Return to rest, but only if the arms are away from it. Thread-safe.
-
-        Wired to the VR server's operator-gone notification (the last
-        pose-sending client disconnected): quitting the VR app can't reliably
-        deliver the Y-exit reset frame, so the disconnect itself sends the
-        arms home. A no-op at rest or mid-reset, so an idle operator
-        disconnecting never moves the robot.
-        """
-        if self._at_rest or self.is_resetting:
-            return
-        self._logger.info(
-            "Operator disconnected with the arms away from rest: returning to rest"
-        )
-        self._reset_latched = True
-
     def clear_reset_request(self) -> None:
         """Consume a pending reset latch without acting on it.
 
@@ -706,26 +690,25 @@ class VRTeleopCore:
         last_frame: object,
         process_alive: Callable[[], bool],
     ) -> None:
-        """Safety handling for a stopped pose stream, in two stages.
+        """Force-disengage when the pose stream stops (``disengage_timeout``).
 
         The pose stream only flows while the headset is presenting, so a gap
         means the operator left VR (or the link died) — through *any* exit
         path, including ones that never deliver the Y-press reset frame
         (system menu, headset doffed, app crash, WiFi drop).
 
-        Stage 1 (``disengage_timeout``): force-disengage. Staying engaged
-        across the gap is what makes the arms jerk on the next VR entry: the
-        resumed frames are measured against the old engage snapshot, so the
-        target jumps by however far the controllers moved in the meantime.
-        Disengaging freezes the arms in place and makes re-entry inert until
-        the operator deliberately re-engages (fresh engage snapshot — no
-        jump).
+        Staying engaged across the gap is what makes the arms jerk on the
+        next VR entry: the resumed frames are measured against the old engage
+        snapshot, so the target jumps by however far the controllers moved in
+        the meantime. Disengaging freezes the arms in place and makes
+        re-entry inert until the operator deliberately re-engages (fresh
+        engage snapshot — no jump).
 
-        Stage 2 (``exit_reset_timeout``): return to rest. The prompt path for
-        a quit is the operator-gone disconnect notification
-        (:meth:`request_reset_if_away`), but a killed app's socket close can
-        be delayed or lost entirely (WiFi power-save right after quitting, a
-        crash); sustained silence sends the arms home regardless.
+        That freeze is deliberately where it ends: the arms *hold position*
+        until an operator acts. A lost link, a quit app, or a crashed headset
+        must never move the robot on its own — the operator reconnects and
+        either re-engages (tracking resumes from where the arms are) or
+        presses reset (X) to send them home.
 
         Runs on the IK thread. Frame arrivals are timestamped at ingest
         (:meth:`note_frame_reset`) rather than via ``get_frame`` identity,
@@ -743,7 +726,8 @@ class VRTeleopCore:
             self.teleop_enabled = False
             self._logger.info(
                 "Teleop disabled: no VR poses for %.2fs (operator left VR or "
-                "the link dropped); re-engage with both grips",
+                "the link dropped); holding position — re-engage with both "
+                "grips, or press reset (X) to return to rest",
                 gap,
             )
             self._broadcast(False)
@@ -768,20 +752,6 @@ class VRTeleopCore:
                         )
                 except Exception as e:  # noqa: BLE001 - keep the loop alive
                     self._logger.error("IK disengage dispatch error: %s", e)
-
-        # Backstop for exits whose socket close is delayed or never arrives
-        # (a killed app whose TCP FIN was lost to WiFi power-save, a crash, a
-        # link drop): after a longer silence, send the arms home like the
-        # disconnect path would have. A no-op at rest, so an operator who
-        # never engaged can idle in the menu indefinitely.
-        reset_after = self.config.exit_reset_timeout
-        if 0 < reset_after <= gap and not self._at_rest and not self.is_resetting:
-            self._logger.info(
-                "Returning to rest: no VR poses for %.1fs and the arms are "
-                "away from rest",
-                gap,
-            )
-            self._reset_latched = True
 
     @staticmethod
     def _pace(t0: float, interval: float) -> None:

--- a/almond_axol/teleop/teleop.py
+++ b/almond_axol/teleop/teleop.py
@@ -111,13 +111,6 @@ class VRTeleop:
         # cannot drift apart.
         self._core = VRTeleopCore(config, _logger, self._broadcast_tracking)
 
-        # Quitting the VR app closes the operator's socket without reliably
-        # delivering the Y-exit reset frame; send the arms home on that
-        # disconnect (a pause — system menu, doffed headset — keeps the
-        # socket open and only auto-disengages).
-        if config.reset_on_disconnect:
-            self._vr_server.set_on_operator_gone(self._core.request_reset_if_away)
-
         self._parent_conn: multiprocessing.connection.Connection | None = None
         self._ik_process: multiprocessing.context.SpawnProcess | None = None
         self._ik_thread: threading.Thread | None = None

--- a/almond_axol/vr/server.py
+++ b/almond_axol/vr/server.py
@@ -55,15 +55,6 @@ if TYPE_CHECKING:
 
 _logger = logging.getLogger(__name__)
 
-# How recently (seconds) a client must have delivered a pose frame to still
-# count as one of the operator's live connections when deciding whether the
-# operator is gone (see ``set_on_operator_gone``). Long enough that the
-# paired transports of one headset (USB tunnel + network standby) shield
-# each other through a quit's near-simultaneous socket closes; short enough
-# that a stale connection which streamed poses minutes ago can't mask a
-# real quit.
-_OPERATOR_RECENCY_S = 10.0
-
 
 class VRServer:
     """Secure WebSocket server that receives VRFrame data from a VR headset.
@@ -164,16 +155,12 @@ class VRServer:
         # Monotonic time of the last valid pose frame per client (socket or
         # its control data channel) — i.e. the operator's connections, as
         # opposed to view-only ones like the control panel's camera mirror.
-        # When a pose-sending client disconnects and no *other* client has
-        # sent a pose recently (see _OPERATOR_RECENCY_S), the operator is
-        # gone for good (a quit/crash closes the socket; merely pausing —
-        # e.g. the Quest system menu — keeps it open) and
-        # ``_on_operator_gone`` fires. Recency matters: membership must not
-        # be sticky, or a lingering connection that streamed poses once
-        # (say, a desktop tab that briefly ran the emulated XR session)
-        # would block the quit handling for the whole session.
+        # When the last pose-sending client disconnects, the buffered pose
+        # state (latest frame, seq high-water mark, interpolator) is dropped
+        # so a relaunched headset — whose seq counter restarts at 1 — isn't
+        # gated against the old session's high-water mark while a view-only
+        # client keeps the connection count above zero.
         self._pose_last: dict[int, float] = {}
-        self._on_operator_gone: Callable[[], None] | None = None
         self._server_task: asyncio.Task[None] | None = None
         self._uvicorn_server: uvicorn.Server | None = None
         self._listen_socket: socket.socket | None = None
@@ -209,23 +196,6 @@ class VRServer:
     def set_on_frame(self, callback: Callable[[VRFrame], None] | None) -> None:
         """Replace the on_frame callback. Safe to call after construction."""
         self._on_frame = callback
-
-    def set_on_operator_gone(self, callback: Callable[[], None] | None) -> None:
-        """Called when the operator's pose-sending connections are gone.
-
-        Pose-sending clients are the operator's connections (headset app,
-        USB tunnel) — view-only clients such as the control panel's camera
-        mirror never send poses and don't count. The callback fires on the
-        server's event loop when a pose-sending client's socket closes and
-        no other client has delivered a pose within ``_OPERATOR_RECENCY_S``:
-        a quit or crash of the VR app, as opposed to a pause (Quest system
-        menu, doffed headset) which keeps the socket open. The recency test
-        keeps a stale connection that streamed poses once (e.g. an abandoned
-        browser tab) from masking a real quit. Teleop uses this to return
-        the arms to rest, since an app quit can't reliably deliver the
-        Y-exit reset frame.
-        """
-        self._on_operator_gone = callback
 
     def set_mode(self, mode: str | None) -> None:
         """Set the operating mode announced to headsets on connect.
@@ -414,9 +384,10 @@ class VRServer:
             # Tighter pings were tried for faster dead-peer detection, but
             # with the camera RTP saturating the operator's WiFi a pong can
             # take >5s on a perfectly healthy link, and killing the pose
-            # socket then tears down video and teleop with it. Exits with a
-            # lost FIN are covered by the pose-silence backstop instead
-            # (VRTeleopConfig.exit_reset_timeout).
+            # socket then tears down video and teleop with it. Prompt
+            # dead-peer detection isn't needed for safety: pose silence
+            # force-disengages teleop within VRTeleopConfig.disengage_timeout
+            # and the arms hold position until the operator acts.
         )
         self._uvicorn_server = uvicorn.Server(config)
         self._server_task = asyncio.create_task(
@@ -779,38 +750,21 @@ class VRServer:
                 if server._webrtc is not None:
                     await server._webrtc.close(client_id)
                 await server._control.close(client_id)
-                # A pose-sending client (the operator) disconnected — a
-                # quit/crash closes the socket, unlike a pause (system menu,
-                # doffed headset) which keeps it open. The operator is gone
-                # when no *other* client has sent a pose recently: a sibling
-                # transport of the same headset (USB tunnel + network
-                # standby) is fresh through a quit's near-simultaneous
-                # closes, while a stale connection that streamed poses
-                # minutes ago (an abandoned tab) doesn't mask the quit.
-                # Best-effort so it can't leak the socket accounting.
-                if server._pose_last.pop(client_id, None) is not None:
-                    if not server._pose_last:
-                        # Last pose sender gone: drop the buffered pose state
-                        # *now* rather than when every client disconnects — a
-                        # view-only client (the control panel's camera mirror)
-                        # can stay connected across the operator's app
-                        # relaunches, and a relaunched headset restarts its
-                        # seq counter at 1, so a kept high-water mark would
-                        # silently drop every frame it sends (no poses, no
-                        # engage) until the panel also left.
-                        server._latest_frame = None
-                        server._last_seq = None
-                        server._interp.reset()
-                    now = time.monotonic()
-                    others_recent = any(
-                        now - t <= _OPERATOR_RECENCY_S
-                        for t in server._pose_last.values()
-                    )
-                    if not others_recent and server._on_operator_gone:
-                        try:
-                            server._on_operator_gone()
-                        except Exception:  # noqa: BLE001 - never break cleanup
-                            _logger.exception("operator-gone callback failed")
+                # A pose-sending client (the operator) disconnected. When the
+                # last one goes, drop the buffered pose state *now* rather
+                # than when every client disconnects — a view-only client
+                # (the control panel's camera mirror) can stay connected
+                # across the operator's app relaunches, and a relaunched
+                # headset restarts its seq counter at 1, so a kept high-water
+                # mark would silently drop every frame it sends (no poses, no
+                # engage) until the panel also left.
+                if (
+                    server._pose_last.pop(client_id, None) is not None
+                    and not server._pose_last
+                ):
+                    server._latest_frame = None
+                    server._last_seq = None
+                    server._interp.reset()
                 # Last operator gone: drop buffered pose state so a fresh
                 # session's capture timestamps aren't blended with this one's
                 # stale frames (which would drive IK with incoherent poses

--- a/docs/guides/vr-interface.mdx
+++ b/docs/guides/vr-interface.mdx
@@ -102,7 +102,7 @@ The headset only shows the feeds for cameras that are actually being streamed (s
 </Note>
 
 <Note>
-  **You don't have to press Y to leave safely.** If the pose stream stops while tracking is engaged — you doff the headset, open the system menu, or the link drops — the arms **auto-disengage** after about half a second and re-engage cleanly when you return, so they never jerk toward the controllers on the next entry. And if you **quit the app** (Quest menu) or lose the connection with the arms away from rest, they **return to the rest pose on their own** (the same guarded return **X** and **Y** use) instead of holding wherever they were left.
+  **A dropped link never moves the robot.** If the pose stream stops while tracking is engaged — you doff the headset, open the system menu, quit the app, or the link drops — the arms **auto-disengage** after about half a second and **hold position** wherever they are. When you return, re-engaging (both grips) takes a fresh snapshot, so the arms never jerk toward the controllers on the next entry; press **X** to send them back to the rest pose when you're ready.
 </Note>
 
 ## Powered cart

--- a/docs/operations/teleop.mdx
+++ b/docs/operations/teleop.mdx
@@ -95,7 +95,7 @@ The easiest way is from the app itself: when you press **Connect** and the certi
 </Note>
 
 <Note>
-  **Leaving VR is handled for you.** If pose updates stop while tracking is engaged — you doff the headset, open the system menu, or the link drops — the arms **auto-disengage** (freeze in place) after about half a second, so re-entering VR re-engages cleanly instead of snapping the arms toward wherever the controllers drifted during the gap. And if you **quit the VR app** (Quest menu) or step away with the arms away from rest, they **return home on their own** — the same guarded return **X** / **Y** trigger — rather than being stranded mid-scene. A brief pause and return simply resumes.
+  **Losing the link never moves the robot.** If pose updates stop while tracking is engaged — you doff the headset, open the system menu, quit the VR app, or the link drops — the arms **auto-disengage** (freeze in place) after about half a second and then **hold position** wherever they are, for as long as it takes you to come back. Re-entering VR is inert until you deliberately re-engage (both grips), which takes a **fresh engage snapshot** — tracking resumes relative to where the arms already are, so they never snap toward wherever the controllers drifted during the gap. Press **X** when you want them back at the rest pose.
 </Note>
 
 <Note>


### PR DESCRIPTION
## Summary

Customer feedback on #176's release note ("the arms now return to rest on their own if you quit the headset app or lose the link") was right: the robot should never move unexpectedly. This removes both autonomous return-to-rest paths — the operator-disconnect reset and the 10s pose-silence backstop, along with their `reset_on_disconnect` / `exit_reset_timeout` config knobs and the VR server's now-unused operator-gone callback machinery.

New behavior on any link loss (app quit, crash, WiFi drop, doffed headset), identical in `axol teleop` and `axol collect-data` via the shared `VRTeleopCore`:

- The 0.5s pose-silence **auto-disengage** (kept from #176) freezes tracking, and the arms then **hold position** indefinitely — no motion without an operator.
- Re-entry is inert until a deliberate both-grip re-engage, which takes a **fresh engage snapshot** (One Euro filters reset, posture re-pinned, controller/FK snapshot at the held pose), so the arms cannot jerk toward wherever the controllers drifted.
- Explicit resets are unchanged: X, the Y-exit return, startup, and post-episode returns still play through #179's guarded return.

The VR server keeps the "last pose sender disconnected → drop seq high-water mark" logic so a relaunched headset can still engage; only the reset callback that piggybacked on it is gone.

Note: `--teleop.reset_on_disconnect` / `--teleop.exit_reset_timeout` (and the collect-data equivalents) no longer exist, so configs that set them will now be rejected.

## Test plan

- [x] Sim end-to-end over the real WSS pose socket (`VRTeleop(Sim())`): engage, move ~0.13 rad off rest, drop the socket → auto-disengage at 0.5s, **zero drift through 12s** of silence (past the old 10s backstop), no reset latched
- [x] Reconnect already holding both grips at a different controller pose → inert (no engage, no motion)
- [x] Release + re-engage while still → no jump (0.0000 rad); then move → tracking resumes
- [x] Relaunched client with seq restarting at 1 can engage (server pose-state reset still works)
- [x] `pre-commit run` (ruff, ruff-format) passes on all changed files
- [ ] Hardware smoke test: engage on a real robot, kill the headset app mid-move, confirm the arms hold and re-engage is smooth

Made with [Cursor](https://cursor.com)