### PR TITLE
Purge stale CAN TX frames on e-stop so the arm doesn't replay them on power-up

### DIFF
--- a/almond_axol/cli/can/setup.py
+++ b/almond_axol/cli/can/setup.py
@@ -29,7 +29,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from ...constants import CAN_BASE, CAN_LEFT, CAN_RIGHT
+from ...constants import CAN_BASE, CAN_BRINGUP_SCRIPT, CAN_LEFT, CAN_RIGHT
 from ...utils.sudo import run_root
 from . import driver
 
@@ -42,8 +42,8 @@ _BITRATE = 1_000_000
 _TXQUEUELEN = 512
 
 _UDEV_RULES_FILE = Path("/etc/udev/rules.d/90-can.rules")
-_CAN_DIR = Path.home() / ".almond" / "can"
-_CRON_SCRIPT = _CAN_DIR / "startup.sh"
+_CAN_DIR = CAN_BRINGUP_SCRIPT.parent
+_CRON_SCRIPT = CAN_BRINGUP_SCRIPT
 
 # Hotplug bring-up: pulled in via the udev rules (SYSTEMD_WANTS) whenever an
 # adapter (re-)enumerates, so interfaces recreated by a mid-session USB drop

--- a/almond_axol/constants.py
+++ b/almond_axol/constants.py
@@ -29,6 +29,13 @@ CAN_RIGHT = "can_alm_axol_r"
 # so this can't be the more readable "can_alm_axol_base".
 CAN_BASE = "can_alm_axol_b"
 
+# CAN bring-up script written by `axol can.setup`. Runs at boot and on adapter
+# hotplug, and is also the sanctioned way to reset the interfaces at runtime:
+# it flaps both arm-hub channels *together* (flapping one at a time can wedge
+# the adapter's RX path). The CAN bus layer reuses it to purge stale TX frames
+# after an e-stop (see almond_axol/motor/bus.py).
+CAN_BRINGUP_SCRIPT: Path = Path.home() / ".almond" / "can" / "startup.sh"
+
 ARM_JOINTS: list[Joint] = [j for j in Joint if j != Joint.GRIPPER]
 
 

--- a/almond_axol/motor/bus.py
+++ b/almond_axol/motor/bus.py
@@ -5,10 +5,14 @@ from __future__ import annotations
 import asyncio
 import errno
 import logging
+import time
 from pathlib import Path
 from typing import Callable
 
 import can
+
+from ..constants import CAN_BRINGUP_SCRIPT
+from ..utils.sudo import run_root
 
 _logger = logging.getLogger(__name__)
 
@@ -32,6 +36,27 @@ _RECONNECT_POLL_S = 0.2
 # is missing — remind operators at this cadence rather than spamming.
 _RECONNECT_REMIND_S = 30.0
 
+# A send failing with ENOBUFS means the interface TX queue is full because no
+# node on the bus is ACKing frames — on the Axol that's the e-stop cutting
+# motor power mid-stream. Everything queued behind the dead bus is a stale
+# motion command that would replay all at once when power returns (the arm
+# suddenly snapping back to its pre-e-stop position), so the queue must be
+# purged and sends held off until the bus is proven alive again.
+
+# Arbitration ID of the aliveness probe frame. Unused by both motor protocols
+# (Damiao: motor IDs 0x01-0x08 plus 0x100/0x200/0x300 offsets, feedback
+# 0x11-0x18, register access 0x7FF; MyActuator: 0x140/0x240/0x400/0x500 + ID),
+# so every device on the bus ignores it — but any powered CAN node still ACKs
+# it at the link layer, which is exactly the signal we need.
+_PROBE_ID = 0x7F0
+_PROBE_POLL_S = 0.25
+# One flush of the bring-up script flaps *every* channel, so when both arms'
+# buses stall together (they share the e-stop), the second one can skip it.
+_FLUSH_DEDUPE_S = 3.0
+
+_flush_lock = asyncio.Lock()
+_last_flush_monotonic = 0.0
+
 
 def _iface_lost(exc: BaseException) -> bool:
     """True when *exc* is a socket failure meaning the interface went away."""
@@ -39,6 +64,14 @@ def _iface_lost(exc: BaseException) -> bool:
     if code is None:
         code = getattr(exc, "errno", None)
     return code in _IFACE_LOST_ERRNOS
+
+
+def _tx_stalled(exc: BaseException) -> bool:
+    """True when *exc* means the TX queue is full (no node is ACKing frames)."""
+    code = getattr(exc, "error_code", None)  # python-can CanOperationError
+    if code is None:
+        code = getattr(exc, "errno", None)
+    return code == errno.ENOBUFS
 
 
 def _iface_is_up(channel: str) -> bool:
@@ -63,6 +96,14 @@ class CanBus:
     during the gap are dropped, so request/response commands fall into their
     usual timeout path (``MotorError``) and resume after the reconnect.
 
+    A stalled bus — the e-stop cutting motor power so nothing ACKs frames and
+    the kernel TX queue fills (``ENOBUFS``) — is handled the same way, with
+    two extra steps: the queued (now stale) motion commands are purged by
+    flapping the interface, and sends stay dropped until a probe frame is
+    actually ACKed on the wire again. Without the purge, up to ``txqueuelen``
+    stale position commands replay the instant the arm is powered back on,
+    snapping it to its pre-e-stop pose.
+
     Use as an async context manager:
 
         async with CanBus("can_alm_axol_l") as bus:
@@ -86,6 +127,9 @@ class CanBus:
         # Set while the interface is gone (USB drop): sends are dropped and
         # the reader loop is waiting to reopen the socket.
         self._lost = False
+        # Set while the bus is stalled (e-stop cut motor power, nothing ACKs):
+        # sends are dropped until a probe frame is ACKed on the wire again.
+        self._stalled = False
         # Poked by socket readability or a failed send, so the idle reader
         # wakes both for frames and for lost-interface handling.
         self._wake = asyncio.Event()
@@ -128,9 +172,10 @@ class CanBus:
         self._listeners.append(listener)
 
     async def _send(self, arbitration_id: int, data: bytes) -> None:
-        if self._lost or self._bus is None:
-            # Interface is gone (USB drop) — drop the frame; motor commands
-            # time out upstream and resume once the reader has reconnected.
+        if self._lost or self._stalled or self._bus is None:
+            # Interface is gone (USB drop) or the bus is stalled (e-stop) —
+            # drop the frame; motor commands time out upstream and resume
+            # once the reader has recovered the bus.
             return
         msg = can.Message(
             arbitration_id=arbitration_id, data=data, is_extended_id=False
@@ -140,9 +185,12 @@ class CanBus:
         try:
             self._bus.send(msg)
         except (can.CanError, OSError) as exc:
-            if not _iface_lost(exc):
+            if _tx_stalled(exc):
+                self._mark_stalled(exc)
+            elif _iface_lost(exc):
+                self._mark_lost(exc)
+            else:
                 raise
-            self._mark_lost(exc)
 
     def _mark_lost(self, cause: BaseException) -> None:
         """Flag the interface as gone and wake the reader to start reconnecting."""
@@ -156,11 +204,34 @@ class CanBus:
         )
         self._wake.set()
 
+    def _mark_stalled(self, cause: BaseException) -> None:
+        """Flag the bus as stalled and wake the reader to purge the TX queue."""
+        if self._stalled:
+            return
+        self._stalled = True
+        # Also flag lost so the pump exits and hands control to the recovery
+        # path; _reconnect clears it once the socket is reopened, while
+        # _stalled keeps sends dropped until the bus is proven alive.
+        self._lost = True
+        _logger.warning(
+            "CAN %s: TX queue full (%s) — no node is ACKing frames, so the "
+            "motors are most likely unpowered (e-stop?). Dropping commands and "
+            "purging the queued ones so the arm doesn't replay them when power "
+            "returns.",
+            self._channel,
+            cause,
+        )
+        self._wake.set()
+
     async def _reader_loop(self) -> None:
         loop = asyncio.get_running_loop()
         while True:
             await self._pump(loop)
+            if self._stalled:
+                await self._flush_tx_queue()
             await self._reconnect(loop)
+            if self._stalled:
+                await self._wait_bus_alive(loop)
 
     async def _pump(self, loop: asyncio.AbstractEventLoop) -> None:
         """Dispatch frames until the interface is lost (or the task is cancelled)."""
@@ -231,6 +302,124 @@ class CanBus:
         self._lost = False
         _logger.warning(
             "CAN %s: interface is back after %.1fs — resuming",
+            self._channel,
+            loop.time() - started,
+        )
+
+    async def _flush_tx_queue(self) -> None:
+        """Purge the stale frames queued behind a dead (e-stopped) bus.
+
+        Closing the socket does not help: frames already handed to the
+        interface queue survive socket close and transmit the moment a
+        powered-on motor ACKs again. Only taking the interface down drops
+        them. Robots configured by ``axol can.setup`` have the bring-up
+        script, which flaps both arm-hub channels together (flapping one at
+        a time can wedge the adapter's RX path) and leaves them configured
+        and up; without it, flap just this channel.
+        """
+        global _last_flush_monotonic
+        async with _flush_lock:
+            script_exists = CAN_BRINGUP_SCRIPT.exists()
+            if (
+                script_exists
+                and time.monotonic() - _last_flush_monotonic < _FLUSH_DEDUPE_S
+            ):
+                # The other arm's bus just ran the script, which flapped this
+                # channel too — the queue is already empty.
+                return
+            try:
+                if script_exists:
+                    await asyncio.to_thread(
+                        run_root, ["bash", str(CAN_BRINGUP_SCRIPT)], check=True
+                    )
+                else:
+                    await asyncio.to_thread(
+                        run_root,
+                        ["ip", "link", "set", self._channel, "down"],
+                        check=True,
+                    )
+                    await asyncio.to_thread(
+                        run_root, ["ip", "link", "set", self._channel, "up"], check=True
+                    )
+            except (RuntimeError, OSError) as exc:
+                _logger.error(
+                    "CAN %s: could not purge the TX queue (%s) — stale motion "
+                    "commands will replay when the motors power back on. Flap "
+                    "the interface (`axol can.setup`, or ip link set %s "
+                    "down/up) before re-powering the arm.",
+                    self._channel,
+                    exc,
+                    self._channel,
+                )
+                return
+            _last_flush_monotonic = time.monotonic()
+            _logger.warning(
+                "CAN %s: purged the stale TX queue — commands stay disabled "
+                "until the motors are powered back on",
+                self._channel,
+            )
+
+    async def _wait_bus_alive(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Hold sends off until a probe frame is ACKed on the wire again.
+
+        A CAN frame only completes once *some* powered node ACKs it, so a
+        single probe on an ID no motor listens to (:data:`_PROBE_ID`) detects
+        power returning without commanding anything: it sits at the head of
+        the (freshly purged) TX queue, silently retrying, and its own-message
+        echo arrives the moment the transmission actually completes. Only
+        then are application sends re-enabled — everything commanded while
+        the bus was dead stays dropped instead of becoming the next stale
+        replay.
+        """
+        started = loop.time()
+        next_reminder = started + _RECONNECT_REMIND_S
+        try:
+            probe_bus = can.Bus(
+                channel=self._channel,
+                bustype="socketcan",
+                receive_own_messages=True,
+                can_filters=[{"can_id": _PROBE_ID, "can_mask": 0x7FF}],
+            )
+        except (can.CanError, OSError) as exc:
+            self._mark_lost(exc)
+            return
+        # 8 zero bytes rather than an empty payload: motor-driver listeners
+        # index into msg.data, and this frame loops back to their socket too.
+        probe = can.Message(
+            arbitration_id=_PROBE_ID, data=bytes(8), is_extended_id=False
+        )
+        sent = False
+        try:
+            while True:
+                try:
+                    if not sent:
+                        probe_bus.send(probe)
+                        sent = True
+                    if sent and probe_bus.recv(timeout=0) is not None:
+                        break
+                except (can.CanError, OSError) as exc:
+                    if _iface_lost(exc):
+                        self._mark_lost(exc)
+                        return
+                    if not _tx_stalled(exc):
+                        raise
+                    # Queue still full (the purge failed, e.g. no root) — the
+                    # probe doesn't fit yet; keep trying so recovery is still
+                    # detected once the stale frames drain on power-up.
+                if loop.time() >= next_reminder:
+                    _logger.warning(
+                        "CAN %s: still waiting for a motor to ACK (%.0fs) — "
+                        "commands stay disabled until the arm is powered on",
+                        self._channel,
+                        loop.time() - started,
+                    )
+                    next_reminder = loop.time() + _RECONNECT_REMIND_S
+                await asyncio.sleep(_PROBE_POLL_S)
+        finally:
+            probe_bus.shutdown()
+        self._stalled = False
+        _logger.warning(
+            "CAN %s: bus is ACKing again after %.1fs — resuming commands",
             self._channel,
             loop.time() - started,
         )


### PR DESCRIPTION
## Summary

Pressing the e-stop mid-run cuts motor power, so nothing on the bus ACKs frames anymore: the adapter retries the head frame forever while teleop keeps streaming, and up to `txqueuelen` (512) stale motion commands pile up in the kernel TX queue — the "transmit buffer" (ENOBUFS) error operators see. Those frames survive socket close and even a process restart, and the moment the arm is powered back on the whole backlog blasts out, snapping the arm to its pre-e-stop position.

`CanBus` now handles this the same way it survives USB drops, with two extra steps:

- **Detect the stall**: a send failing with ENOBUFS flags the bus stalled instead of raising; all further sends are dropped, so commands time out upstream with `MotorError` as usual.
- **Purge the queue**: closing the socket doesn't drop queued frames, so the reader loop flaps the interface — via the `axol can.setup` bring-up script when present (flaps both hub channels together, avoiding the known RX wedge; deduped when both arms stall at once), falling back to `ip link down/up` on the single channel for non-hub setups. If the purge fails (no root), it logs exactly what to do instead.
- **Hold sends until power is really back**: after purging, a single probe frame on CAN ID `0x7F0` (unused by both motor protocols, ignored by every device) is queued and sends stay disabled until its own-message echo arrives — which only happens once a powered node ACKs it on the wire. Nothing commanded during the e-stop becomes the next stale replay.

Also moves the bring-up script path into `constants.py` so `motor/bus.py` and `cli/can/setup.py` share it.

## Test plan

- [x] `ruff check` / `ruff format --check` pass
- [x] vcan integration test: injected stall → sends dropped → queue purged via interface flap → socket reconnected → probe echoed → sends and RX dispatch resume
- [ ] On a real robot: press e-stop mid-teleop, confirm the "TX queue full … purging" log, power the arm back on, and confirm it stays put instead of jumping to the pre-e-stop pose

Made with [Cursor](https://cursor.com)