### PR TITLE
Smooth run-policy execution across inference platforms + limp discard flow

### DIFF
--- a/almond_axol/cli/run_policy.py
+++ b/almond_axol/cli/run_policy.py
@@ -22,6 +22,7 @@ when no key has been pressed.
 
 from __future__ import annotations
 
+import gc
 import logging
 import socket
 import threading
@@ -38,7 +39,11 @@ from ..lerobot.rollout import (
     IKResetController,
     RolloutCaptureThread,
 )
+import numpy as np
+
 from ..recording import restore_dataset_ownership
+from ..teleop.config import VRTeleopConfig
+from ..teleop.filter import TrapezoidalFilter
 from .collect_data import check_resume_consistency
 from .config import AggregateFn, LogLevel, PolicyType, parse
 
@@ -76,6 +81,12 @@ def _default_robot_config() -> AxolRobotConfig:
             "right_arm": ZedCameraConfig(serial=0),
         },
         video_backend="sdk",
+        # The control loop runs motion_control every step, whose command
+        # replies keep the joint cache fresh — so the background telemetry
+        # poll loop is redundant CAN/CPU load that contends with the 60 Hz
+        # action stream on the same buses and event loop. Skipping it
+        # (telemetry_hz=0) matches collect-data and `axol teleop`.
+        telemetry_hz=0.0,
     )
 
 
@@ -131,6 +142,31 @@ class RunPolicyConfig:
     chunk_size_threshold: float = 0.9
     aggregate_fn: AggregateFn = "temporal_ensemble"
     temporal_ensemble_coeff: float = 0.01
+    # Horizon fade for the temporal ensemble: each chunk's weight tapers to
+    # near-zero over the last ``ensemble_blend_s`` seconds' worth of its
+    # prediction horizon, so the ensemble doesn't step when the oldest
+    # chunk's coverage expires mid-queue. 0 disables.
+    ensemble_blend_s: float = 0.2
+    # Chunk alignment: each incoming chunk's instantaneous offset from the
+    # currently executing trajectory (the stale-observation re-anchor
+    # disagreement, which scales with inference latency) is cancelled at
+    # arrival and faded back in over this many seconds. Removes the ~5 Hz
+    # advance/pull-back oscillation at its source while absolute corrections
+    # still land with a ~1 s time constant; shape corrections (the actual
+    # policy behavior) pass through unfaded. 0 disables.
+    align_fade_s: float = 1.0
+    # Per-joint velocity/acceleration limits for the execution-side
+    # TrapezoidalFilter that shapes every command sent to the arms. The
+    # defaults are teleop's constants — the only command profile the policy
+    # ever saw in training — so legitimate policy motion passes through
+    # essentially untouched while chunk-boundary snaps (which violate the
+    # acceleration limit ~10x regardless of how slow the inference platform
+    # is) get spread over the ticks the physical arm needs anyway. This is
+    # what keeps the arm smooth on any inference hardware: a late chunk
+    # decelerates the arm to a hold and ramps it back out instead of
+    # freeze-then-lurch. Set either to 0 to disable the filter.
+    exec_max_vel: float = VRTeleopConfig.teleop_max_vel
+    exec_max_accel: float = VRTeleopConfig.teleop_max_accel
     # Contact watchdog for the between-episode return-to-rest: a joint torque
     # residual (measured minus modeled gravity, Nm) sustained above this
     # drops the arms into a limp gravity-comp hold instead of pulling
@@ -190,6 +226,13 @@ _CONTACT_PROMPT = (
     "Clear them, then continue to replan the return from where they are."
 )
 
+# A discarded episode drops the arms into the same limp hold so the operator
+# can untangle/reposition them by hand before anything moves on its own.
+_DISCARD_LIMP_PROMPT = (
+    "Episode discarded — the arms are limp and free to move. "
+    "Reposition them and reset the scene, then return to rest."
+)
+
 
 class _StdinPolicyControl:
     """Terminal episode control: stdin keystrokes + Enter-to-continue prompts."""
@@ -208,6 +251,9 @@ class _StdinPolicyControl:
 
     def await_contact_clear(self) -> bool:
         return self.await_continue(_CONTACT_PROMPT)
+
+    def await_manual_reset(self) -> bool:
+        return self.await_continue(_DISCARD_LIMP_PROMPT)
 
     def begin_episode(self) -> None:
         from ..lerobot.rollout import stdin_watcher
@@ -291,7 +337,7 @@ class _QueuePolicyControl:
         """Thread-safe phase/count/message/buttons for the /api/op/status API."""
         with self._state_lock:
             phase = self._phase
-            if phase in ("ready", "contact"):
+            if phase in ("ready", "contact", "limp"):
                 message = self._gate_message
                 controls = [{"command": "start", "label": self._gate_label}]
             else:
@@ -346,6 +392,13 @@ class _QueuePolicyControl:
         if cleared:
             # The return replans and plays from here, so drop the contact
             # buttons rather than leave them up over a moving arm.
+            self._set_phase("resetting")
+        return cleared
+
+    def await_manual_reset(self) -> bool:
+        """Gate for the discard-cleanup limp hold; resolves to a return-to-rest."""
+        cleared = self._await_gate("limp", _DISCARD_LIMP_PROMPT, "Return to rest")
+        if cleared:
             self._set_phase("resetting")
         return cleared
 
@@ -474,6 +527,10 @@ def _build_axol_robot_client(
     publisher: ActionPublisher,
     aggregate_strategy: str = "temporal_ensemble",
     temporal_ensemble_coeff: float = 0.01,
+    ensemble_blend_s: float = 0.2,
+    align_fade_s: float = 1.0,
+    exec_max_vel: float = VRTeleopConfig.teleop_max_vel,
+    exec_max_accel: float = VRTeleopConfig.teleop_max_accel,
 ) -> Any:
     """Construct an ``AxolRobotClient`` against an already-connected robot.
 
@@ -485,6 +542,14 @@ def _build_axol_robot_client(
         publisher: Sink for executed actions, drained by the capture thread.
         aggregate_strategy: One of the ``--aggregate_fn`` choices.
         temporal_ensemble_coeff: Decay coefficient for temporal_ensemble.
+        ensemble_blend_s: Ensemble horizon-fade duration (seconds); 0
+            disables (see ``RunPolicyConfig.ensemble_blend_s``).
+        align_fade_s: Chunk-alignment offset fade duration (seconds); 0
+            disables (see ``RunPolicyConfig.align_fade_s``).
+        exec_max_vel: Execution filter joint-velocity limit (rad/s); 0
+            disables the filter (see ``RunPolicyConfig.exec_max_vel``).
+        exec_max_accel: Execution filter joint-acceleration limit (rad/s²);
+            0 disables the filter (see ``RunPolicyConfig.exec_max_accel``).
     """
     import threading as _threading
     from queue import Queue
@@ -535,8 +600,14 @@ def _build_axol_robot_client(
         re-recording doesn't pay the camera reconnect cost, publishes
         executed actions to ``ActionPublisher``, and ``stop()`` tears
         down only the gRPC channel (the robot is shared across episodes).
-        No post-filter is applied: training actions are already
-        EMA + trapezoidal-filtered in ``collect_data``.
+        No per-step post-filter is applied (training actions are already
+        EMA + trapezoidal-filtered in ``collect_data``); the only smoothing
+        added on top of the ensemble is chunk-boundary continuity: the
+        execution-side ``TrapezoidalFilter`` (same class and constants as
+        teleop, i.e. the exact command profile the training data went
+        through) shapes every command sent to the arms, and the horizon
+        fade in ``_temporal_ensemble_aggregate`` removes chunk-expiry
+        steps in the ensembled signal itself.
         """
 
         def __init__(  # type: ignore[no-untyped-def]
@@ -546,6 +617,10 @@ def _build_axol_robot_client(
             publisher,
             aggregate_strategy,
             temporal_ensemble_coeff,
+            ensemble_blend_s,
+            align_fade_s,
+            exec_max_vel,
+            exec_max_accel,
         ):
             # We override the private RobotClient._aggregate_action_queues to
             # inject temporal_ensemble (no public hook can express it — see the
@@ -575,6 +650,42 @@ def _build_axol_robot_client(
             self._publisher = publisher
             self._aggregate_strategy = aggregate_strategy
             self._temporal_ensemble_coeff = float(temporal_ensemble_coeff)
+            # Ticks over which each chunk's ensemble weight fades to near-zero
+            # at the end of its prediction horizon (0 = off).
+            self._blend_steps = max(0, round(float(ensemble_blend_s) * config.fps))
+            # Ticks over which a chunk's arrival-time alignment offset fades
+            # back to its absolute prediction (0 = alignment off).
+            self._align_ticks = max(0, round(float(align_fade_s) * config.fps))
+            # Execution-side command shaper: every popped action's arm-joint
+            # entries pass through a TrapezoidalFilter (velocity + acceleration
+            # limited target tracker — the same class and constants teleop runs
+            # and the training data was recorded through), so the commands the
+            # motors see are C1-smooth no matter how discontinuous the chunk
+            # stream is. Grippers bypass it (bang-bang by design), and the
+            # Cartesian action layout is excluded — its values are EE poses,
+            # not joint radians, so rad/s limits don't apply here; the robot
+            # applies the same shaping to the IK *output* instead (see
+            # ``AxolRobot._cartesian_action_to_targets``), so Cartesian
+            # policies get the identical guarantee post-IK.
+            self._arm_indices = [
+                i
+                for i in range(len(robot.action_features))
+                if i not in self._gripper_indices
+            ]
+            self._exec_filter = None
+            if (
+                exec_max_vel > 0.0
+                and exec_max_accel > 0.0
+                and not getattr(robot.config, "observe_cartesian", False)
+            ):
+                self._exec_filter = TrapezoidalFilter(
+                    float(exec_max_vel),
+                    float(exec_max_accel),
+                    config.environment_dt,
+                )
+            # Full unfiltered target of the last popped action (numpy), kept
+            # so starvation ticks can keep converging toward it.
+            self._exec_last_target: Any | None = None
             # ``(origin, packed_actions, timestamp)`` per chunk, sorted
             # oldest-first. ``packed_actions`` is a (chunk_size, action_dim)
             # tensor so aggregation runs as one batched op.
@@ -626,6 +737,12 @@ def _build_axol_robot_client(
                 self._chunk_buffer = []
             with self.latest_action_lock:
                 self.latest_action = -1
+            # Unseeded reset: the filter passes its first target through
+            # unchanged, which is safe because the first chunk is anchored on
+            # the arm's actual observed (resting) state.
+            if self._exec_filter is not None:
+                self._exec_filter.reset()
+            self._exec_last_target = None
             self.action_chunk_size = -1
             self.must_go.set()
             self.fps_tracker.reset()
@@ -644,6 +761,11 @@ def _build_axol_robot_client(
             ``action_queue_lock`` while re-filtering against the live
             ``latest_action`` prevents the post-swap queue from walking
             ``latest_action`` backwards and snapping the arm.
+
+            Discontinuities in the installed queue (chunk-boundary re-anchor
+            snaps) are tolerated here: the execution-side TrapezoidalFilter
+            in ``control_loop_action`` shapes whatever is popped before it
+            reaches the motors.
 
             Args:
                 future_queue: Newly aggregated action queue to install.
@@ -675,7 +797,11 @@ def _build_axol_robot_client(
             Each future timestep ``ts > latest_action`` covered by at
             least one buffered chunk gets ``commanded[ts] = Σ wᵢ ·
             chunkᵢ[ts] / Σ wᵢ`` with ``wᵢ = exp(-coeff · i)`` and
-            ``i = 0`` the oldest chunk. ``_gripper_indices`` bypass the
+            ``i = 0`` the oldest chunk, times a per-timestep fade over the
+            last ``_blend_steps`` of each chunk's horizon (see the taper
+            comment below). Incoming chunks are already aligned to the
+            executing trajectory by ``_align_incoming_chunk`` before they
+            reach this method. ``_gripper_indices`` bypass the
             average and snap to the newest contributing chunk's value.
             The rebuild is one batched op over an
             ``(n_chunks, n_ts, action_dim)`` grid, sub-ms even with
@@ -713,11 +839,11 @@ def _build_axol_robot_client(
                 new_packed[offset] = ta.get_action()
             new_timestamp = sorted_incoming[0].get_timestamp()
 
-            self._chunk_buffer.append((new_origin, new_packed, new_timestamp))
-            self._chunk_buffer.sort(key=lambda entry: entry[0])
-
             with self.latest_action_lock:
                 latest_action = self.latest_action
+
+            self._chunk_buffer.append((new_origin, new_packed, new_timestamp))
+            self._chunk_buffer.sort(key=lambda entry: entry[0])
 
             # Drop chunks whose entire range has already been executed.
             self._chunk_buffer = [
@@ -744,11 +870,23 @@ def _build_axol_robot_client(
             device = sample.device
             action_dim = sample.shape[0]
 
-            # ``mask[ci, ts]`` is 1.0 where chunk ``ci`` covers ``ts``.
+            # ``mask[ci, ts]`` is 1.0 where chunk ``ci`` covers ``ts`` (binary,
+            # used for coverage and the gripper newest-chunk one-hot).
+            # ``taper[ci, ts]`` additionally fades each chunk's ensemble
+            # weight to near-zero over the last ``_blend_steps`` timesteps of
+            # its horizon: without it, the timestep where the oldest chunk's
+            # coverage ends loses a full contributor at once and the ensemble
+            # steps by ~1/n_chunks of the inter-chunk spread — tens of mrad
+            # executed mid-queue, where the install-time blend can't reach.
+            # With the fade, a chunk's influence is already ~1/fade of its
+            # weight when it expires, and late-horizon ACT predictions are the
+            # least accurate anyway.
             action_grid = torch.zeros(
                 (n_chunks, n_ts, action_dim), dtype=dtype, device=device
             )
             mask = torch.zeros((n_chunks, n_ts), dtype=dtype, device=device)
+            taper = torch.zeros((n_chunks, n_ts), dtype=dtype, device=device)
+            fade = max(1, self._blend_steps)
             for ci, (origin, packed, _) in enumerate(self._chunk_buffer):
                 chunk_max = origin + packed.shape[0] - 1
                 lo = max(origin, grid_min_ts)
@@ -761,12 +899,21 @@ def _build_axol_robot_client(
                 dst_stop = hi - grid_min_ts + 1
                 action_grid[ci, dst_start:dst_stop] = packed[src_start:src_stop]
                 mask[ci, dst_start:dst_stop] = 1.0
+                # Remaining horizon per covered ts: chunk_max - ts + 1 (>= 1),
+                # so the fade never reaches exactly zero and a timestep covered
+                # by a single chunk still averages to that chunk's value.
+                remaining = torch.arange(
+                    chunk_max - lo + 1, chunk_max - hi, -1, dtype=dtype, device=device
+                )
+                taper[ci, dst_start:dst_stop] = (remaining / fade).clamp(max=1.0)
 
             coeff = self._temporal_ensemble_coeff
             chunk_weights = torch.exp(
                 -coeff * torch.arange(n_chunks, dtype=dtype, device=device)
             )
-            weighted_mask = chunk_weights.unsqueeze(1) * mask  # (n_chunks, n_ts)
+            weighted_mask = (
+                chunk_weights.unsqueeze(1) * mask * taper
+            )  # (n_chunks, n_ts)
             norm = weighted_mask.sum(dim=0).clamp(min=1e-12)
             ensembled = (action_grid * weighted_mask.unsqueeze(-1)).sum(
                 dim=0
@@ -783,6 +930,10 @@ def _build_axol_robot_client(
             contributed_indices = (
                 mask.any(dim=0).nonzero(as_tuple=False).flatten().tolist()
             )
+
+            # The chunk-boundary continuity blend runs in
+            # ``_install_future_queue`` (inside the queue lock), so the ramp is
+            # applied to exactly the entries that survive the pop-race filter.
             future_queue = Queue()
             for ti in contributed_indices:
                 future_queue.put(
@@ -794,11 +945,99 @@ def _build_axol_robot_client(
                 )
             self._install_future_queue(future_queue)
 
+        def _align_incoming_chunk(self, incoming_actions) -> None:  # type: ignore[no-untyped-def]
+            """Align an incoming chunk to the currently executing trajectory.
+
+            A chunk is predicted from an observation taken one inference
+            round-trip before it lands, of an arm that physically lags its
+            command — so at arrival it systematically disagrees with the
+            trajectory being executed by roughly the tracking error, and
+            installing it unmodified yanks the target backward by that offset
+            (a 5-6 Hz sawtooth measured on the CAN bus; with the execution
+            filter it survives as a bounded-acceleration wobble the arm still
+            tracks). Cancel the disagreement at the source: measure the
+            chunk's instantaneous offset from the executing trajectory at the
+            next-to-execute timestep once, at arrival, and add it to the
+            chunk's values in place — faded out linearly over
+            ``_align_ticks`` so the command still converges to the policy's
+            absolute intent. Corrections live in the chunk's *shape* and pass
+            through unfaded; only the stale-state DC disagreement is
+            smoothed. The offset magnitude scales with inference latency, so
+            a slow platform cancels a proportionally bigger step — smoothness
+            stays independent of the inference hardware.
+
+            Runs at the aggregation dispatch so every strategy benefits
+            (``temporal_ensemble`` and the upstream scalar blends alike), and
+            it is action-space agnostic: pure vector offsets work for joint
+            radians and for Cartesian pose values (positions in metres,
+            axis-angle orientation — locally linear; a wrap at ±π could
+            misread the offset, but poses one inference latency apart never
+            span that). Grippers are exempt (bang-bang by design).
+
+            Args:
+                incoming_actions: Chunk from the policy server; mutated in
+                    place (tensors are owned by the receive path).
+            """
+            if self._align_ticks <= 0 or not incoming_actions:
+                return
+            last_target = self._exec_last_target
+            if last_target is None:
+                return
+            import torch
+
+            sorted_in = sorted(incoming_actions, key=lambda a: a.get_timestep())
+            with self.latest_action_lock:
+                anchor_ts = self.latest_action + 1
+            origin = sorted_in[0].get_timestep()
+            idx = min(max(anchor_ts - origin, 0), len(sorted_in) - 1)
+            anchor_action = sorted_in[idx].get_action()
+            offset = (
+                torch.from_numpy(last_target).to(anchor_action.dtype) - anchor_action
+            )
+            for gidx in self._gripper_indices:
+                offset[gidx] = 0.0
+            for ta in sorted_in:
+                fade = 1.0 - (ta.get_timestep() - anchor_ts) / self._align_ticks
+                fade = min(max(fade, 0.0), 1.0)
+                if fade > 0.0:
+                    ta.get_action().add_(offset * fade)
+
         def _aggregate_action_queues(self, incoming_actions, aggregate_fn=None):  # type: ignore[no-untyped-def]
-            """Dispatch ``temporal_ensemble`` locally, else upstream scalar blends."""
+            """Align the chunk, then dispatch to the configured aggregation."""
+            self._align_incoming_chunk(incoming_actions)
             if self._aggregate_strategy == "temporal_ensemble":
                 return self._temporal_ensemble_aggregate(incoming_actions)
             return super()._aggregate_action_queues(incoming_actions, aggregate_fn)
+
+        def _shape_and_send(self, target_vec):  # type: ignore[no-untyped-def]
+            """Run ``target_vec`` through the execution filter and send it.
+
+            The arm-joint entries track the target under teleop's velocity +
+            acceleration limits; grippers pass through raw. With the filter
+            disabled the target is sent as-is.
+
+            Args:
+                target_vec: Full action vector (numpy, robot action order).
+
+            Returns:
+                The dict returned by ``robot.send_action``.
+            """
+            out = target_vec
+            if self._exec_filter is not None:
+                shaped = self._exec_filter.update(target_vec[self._arm_indices])
+                out = target_vec.copy()
+                out[self._arm_indices] = shaped
+            # Inlined from upstream RobotClient._action_tensor_to_action_dict
+            # so we depend only on the public ``robot.action_features`` rather
+            # than a private LeRobot method. Maps the flat action vector to a
+            # {motor_name: float} dict by position.
+            action = {
+                key: float(out[i]) for i, key in enumerate(self.robot.action_features)
+            }
+            performed = self.robot.send_action(action)
+            if self._publisher is not None and performed is not None:
+                self._publisher.publish(performed)
+            return performed
 
         def control_loop_action(self, verbose: bool = False):  # type: ignore[no-untyped-def]
             """Pop the next action, advance ``latest_action``, send to robot.
@@ -815,16 +1054,9 @@ def _build_axol_robot_client(
                     self.latest_action = timed_action.get_timestep()
                 qs_after = self.action_queue.qsize()
 
-            # Inlined from upstream RobotClient._action_tensor_to_action_dict
-            # so we depend only on the public ``robot.action_features`` rather
-            # than a private LeRobot method. Maps the flat action tensor to a
-            # {motor_name: float} dict by position.
-            action_tensor = timed_action.get_action()
-            action = {
-                key: action_tensor[i].item()
-                for i, key in enumerate(self.robot.action_features)
-            }
-            performed = self.robot.send_action(action)
+            target_vec = timed_action.get_action().numpy().astype(np.float32)
+            self._exec_last_target = target_vec
+            performed = self._shape_and_send(target_vec)
 
             if verbose:
                 self.logger.debug(
@@ -832,9 +1064,6 @@ def _build_axol_robot_client(
                     f"Action #{timed_action.get_timestep()} performed | "
                     f"Queue size: {qs_after}"
                 )
-
-            if self._publisher is not None and performed is not None:
-                self._publisher.publish(performed)
             return performed
 
         def control_loop(self, task, verbose: bool = False):  # type: ignore[no-untyped-def,override]
@@ -853,6 +1082,22 @@ def _build_axol_robot_client(
                     control_loop_start = time.perf_counter()
                     if self.actions_available():
                         self.control_loop_action(verbose)
+                    elif (
+                        self._exec_filter is not None
+                        and self._exec_last_target is not None
+                        and self._exec_filter.position is not None
+                        and not np.array_equal(
+                            self._exec_filter.position,
+                            self._exec_last_target[self._arm_indices],
+                        )
+                    ):
+                        # Queue starvation (slow inference platform or a lost
+                        # chunk): keep ticking the filter toward the last
+                        # target so the arm decelerates smoothly to a hold
+                        # instead of freezing mid-velocity, and ramps back out
+                        # when the late chunk lands. Once converged this stops
+                        # sending (the impedance controller holds position).
+                        self._shape_and_send(self._exec_last_target)
                     elapsed = time.perf_counter() - control_loop_start
                     time.sleep(max(0.0, self.config.environment_dt - elapsed))
             except Exception as exc:  # noqa: BLE001
@@ -864,13 +1109,40 @@ def _build_axol_robot_client(
                 self.shutdown_event.set()
 
         def observation_loop(self, task, verbose: bool = False):  # type: ignore[no-untyped-def]
-            """Dedicated thread: capture and send observations.
+            """Dedicated thread: capture and send paced observations.
 
-            Fires ``control_loop_observation`` once the action queue
-            drops to ``chunk_size_threshold``; sleeps one tick otherwise.
+            Upstream fires an observation whenever the queue is below
+            ``chunk_size_threshold`` — but chunks are consumed from the
+            moment they land, so with chunking latency the queue almost
+            never sits above the threshold and the loop free-runs: every
+            camera-capture interval it ships another multi-MB pickled
+            observation whose serialization competes with the 60 Hz
+            control thread for the GIL, and the server dedups most of
+            them by timestep anyway. Two extra gates restore the
+            intended cadence:
+
+            - progress gate: skip while ``latest_action`` hasn't
+              advanced since the last send — a re-send would carry the
+              same timestep the server already predicted (this alone
+              removes the episode-start burst while the first chunk is
+              still being inferred);
+            - pace gate: at most one send per drained-threshold's worth
+              of executed actions
+              (``(1 - chunk_size_threshold) × actions_per_chunk`` ticks).
+
+            A stale-send timeout overrides the progress gate so a lost
+            observation or chunk can't deadlock the episode.
             """
             self.start_barrier.wait()
-            self.logger.info("Observation loop thread starting")
+            self.logger.info("Observation loop thread starting (paced)")
+            min_interval = (
+                (1.0 - self.config.chunk_size_threshold)
+                * self.config.actions_per_chunk
+                * self.config.environment_dt
+            )
+            resend_timeout = max(1.0, 2.0 * min_interval)
+            last_sent_step = -1
+            last_send_time = float("-inf")
             while self.running:
                 try:
                     # Inlined from upstream RobotClient._ready_to_send_observation
@@ -882,8 +1154,20 @@ def _build_axol_robot_client(
                         queue_fraction = (
                             self.action_queue.qsize() / self.action_chunk_size
                         )
-                    if queue_fraction <= self.config.chunk_size_threshold:
+                    with self.latest_action_lock:
+                        # Match the timestep the observation would carry
+                        # (control_loop_observation clamps the same way).
+                        current_step = max(self.latest_action, 0)
+                    now = time.perf_counter()
+                    stale = (now - last_send_time) >= resend_timeout
+                    if (
+                        queue_fraction <= self.config.chunk_size_threshold
+                        and (now - last_send_time) >= min_interval
+                        and (current_step != last_sent_step or stale)
+                    ):
                         self.control_loop_observation(task, verbose)
+                        last_sent_step = current_step
+                        last_send_time = time.perf_counter()
                     else:
                         time.sleep(self.config.environment_dt)
                 except Exception as exc:  # noqa: BLE001
@@ -905,6 +1189,10 @@ def _build_axol_robot_client(
         publisher,
         aggregate_strategy,
         temporal_ensemble_coeff,
+        ensemble_blend_s,
+        align_fade_s,
+        exec_max_vel,
+        exec_max_accel,
     )
 
 
@@ -927,6 +1215,13 @@ def _run(
         stop_event = threading.Event()
     if control is None:
         control = _StdinPolicyControl()
+
+    # Import lerobot's RobotClient module first, through the shim that undoes
+    # its root-logger takeover — otherwise every CAN frame send gets debug-
+    # logged to disk, which throttles the 60 Hz control loop (arm jitter).
+    from ..lerobot.inference_patch import import_robot_client_preserving_logging
+
+    import_robot_client_preserving_logging()
 
     from lerobot.async_inference.configs import RobotClientConfig
     from lerobot.datasets.lerobot_dataset import LeRobotDataset
@@ -1147,6 +1442,10 @@ def _run(
             publisher=publisher,
             aggregate_strategy=aggregate_fn,
             temporal_ensemble_coeff=temporal_ensemble_coeff,
+            ensemble_blend_s=cfg.ensemble_blend_s,
+            align_fade_s=cfg.align_fade_s,
+            exec_max_vel=cfg.exec_max_vel,
+            exec_max_accel=cfg.exec_max_accel,
         )
 
         log_say("Loading policy on server (one-time)...")
@@ -1221,6 +1520,18 @@ def _run(
                 flush=True,
             )
 
+            # CPython's cyclic GC is stop-the-world: a gen-2 pass over this
+            # process (multi-MB observation graphs, grpc/protobuf cycles) was
+            # measured at ~516 ms and fired once per episode at the same
+            # allocation-driven point (~24 s in), freezing every thread
+            # including the 60 Hz control loop — the arm halts mid-motion and
+            # snaps. Sweep now, while the arm is still stationary, then hold
+            # automatic collection for the episode: refcounting still frees
+            # the (acyclic) tensors and frames immediately, and the deferred
+            # cyclic garbage is collected at teardown below.
+            gc.collect()
+            gc.disable()
+
             receiver_thread.start()
             control_thread.start()
             obs_thread.start()
@@ -1262,6 +1573,18 @@ def _run(
             receiver_thread.join(timeout=5.0)
             obs_thread.join(timeout=5.0)
 
+            # Sweep the cyclic garbage deferred during the episode. The
+            # duration doubles as confirmation of the mid-episode GC stall
+            # diagnosis: a multi-hundred-ms sweep here is the pause that
+            # previously landed inside the control loop.
+            gc.enable()
+            gc_t0 = time.perf_counter()
+            gc.collect()
+            _logger.info(
+                "End-of-episode gc.collect: %.0f ms",
+                (time.perf_counter() - gc_t0) * 1000.0,
+            )
+
             if interrupted or stop_event.is_set():
                 if dataset is not None:
                     dataset.clear_episode_buffer()
@@ -1284,12 +1607,24 @@ def _run(
                 log_say("Re-recording episode.")
                 if dataset is not None:
                     dataset.clear_episode_buffer()
+                # A discarded episode usually means the arms are somewhere they
+                # shouldn't be (hooked on the scene, mid-failure): drop them
+                # into a limp gravity-comp hold for hand-repositioning instead
+                # of pulling straight back to rest. The gate's "Return to rest"
+                # (Enter on the terminal) then plans the return from wherever
+                # the arms were left.
+                log_say("Arms are limp for cleanup.")
+                if not reset_controller.hold_limp(
+                    robot,
+                    gravity_comp_kd=cfg.reset_gravity_comp_kd,
+                    wait=control.await_manual_reset,
+                    stopped=stop_event.is_set,
+                ):
+                    break
                 log_say("Returning to rest pose.")
                 if not _return_to_rest_guarded():
                     break
-                if not control.await_continue(
-                    "Reset the scene, then start the episode again."
-                ):
+                if not control.await_continue("Start the episode again when ready."):
                     break
                 continue
 

--- a/almond_axol/cli/run_policy.py
+++ b/almond_axol/cli/run_policy.py
@@ -1528,62 +1528,66 @@ def _run(
             # snaps. Sweep now, while the arm is still stationary, then hold
             # automatic collection for the episode: refcounting still frees
             # the (acyclic) tensors and frames immediately, and the deferred
-            # cyclic garbage is collected at teardown below.
+            # cyclic garbage is collected in the ``finally`` below. The
+            # re-enable lives in a ``finally`` because run-policy also runs
+            # in-process under ``axol serve``: an exception escaping the
+            # episode must not leave automatic collection off for the rest
+            # of the serve process's lifetime.
             gc.collect()
             gc.disable()
-
-            receiver_thread.start()
-            control_thread.start()
-            obs_thread.start()
-            if capture is not None:
-                capture.start()
-
-            deadline = time.perf_counter() + episode_time_s
             timed_out = False
             interrupted = False
             try:
-                while True:
-                    if stop_event.is_set():
-                        break
-                    if control.poll_choice() is not None:
-                        break
-                    if time.perf_counter() >= deadline:
-                        timed_out = True
-                        break
-                    if client.fatal_error is not None:
-                        # Hardware fault from the control loop — drop the
-                        # episode and exit the run.
-                        log_say(
-                            f"Fatal error in control loop: "
-                            f"{client.fatal_error!r}. Aborting run without "
-                            "saving the current episode."
-                        )
-                        break
-                    time.sleep(0.1)
-            except KeyboardInterrupt:
-                interrupted = True
+                receiver_thread.start()
+                control_thread.start()
+                obs_thread.start()
+                if capture is not None:
+                    capture.start()
 
-            # Tear down per-episode threads (server + client stay alive).
-            control.end_episode()
-            client.shutdown_event.set()
-            if capture is not None:
-                capture.stop_event.set()
-                capture.join(timeout=5.0)
-            control_thread.join(timeout=5.0)
-            receiver_thread.join(timeout=5.0)
-            obs_thread.join(timeout=5.0)
+                deadline = time.perf_counter() + episode_time_s
+                try:
+                    while True:
+                        if stop_event.is_set():
+                            break
+                        if control.poll_choice() is not None:
+                            break
+                        if time.perf_counter() >= deadline:
+                            timed_out = True
+                            break
+                        if client.fatal_error is not None:
+                            # Hardware fault from the control loop — drop the
+                            # episode and exit the run.
+                            log_say(
+                                f"Fatal error in control loop: "
+                                f"{client.fatal_error!r}. Aborting run without "
+                                "saving the current episode."
+                            )
+                            break
+                        time.sleep(0.1)
+                except KeyboardInterrupt:
+                    interrupted = True
 
-            # Sweep the cyclic garbage deferred during the episode. The
-            # duration doubles as confirmation of the mid-episode GC stall
-            # diagnosis: a multi-hundred-ms sweep here is the pause that
-            # previously landed inside the control loop.
-            gc.enable()
-            gc_t0 = time.perf_counter()
-            gc.collect()
-            _logger.info(
-                "End-of-episode gc.collect: %.0f ms",
-                (time.perf_counter() - gc_t0) * 1000.0,
-            )
+                # Tear down per-episode threads (server + client stay alive).
+                control.end_episode()
+                client.shutdown_event.set()
+                if capture is not None:
+                    capture.stop_event.set()
+                    capture.join(timeout=5.0)
+                control_thread.join(timeout=5.0)
+                receiver_thread.join(timeout=5.0)
+                obs_thread.join(timeout=5.0)
+            finally:
+                # Sweep the cyclic garbage deferred during the episode. The
+                # duration doubles as confirmation of the mid-episode GC stall
+                # diagnosis: a multi-hundred-ms sweep here is the pause that
+                # previously landed inside the control loop.
+                gc.enable()
+                gc_t0 = time.perf_counter()
+                gc.collect()
+                _logger.info(
+                    "End-of-episode gc.collect: %.0f ms",
+                    (time.perf_counter() - gc_t0) * 1000.0,
+                )
 
             if interrupted or stop_event.is_set():
                 if dataset is not None:

--- a/almond_axol/lerobot/inference_patch.py
+++ b/almond_axol/lerobot/inference_patch.py
@@ -45,3 +45,35 @@ def disable_observation_similarity_filter() -> None:
 
     ps.observations_similar = lambda *args, **kwargs: False
     _logger.debug("Disabled PolicyServer observation-similarity filter.")
+
+
+def import_robot_client_preserving_logging() -> None:
+    """Import lerobot's ``RobotClient`` without letting it hijack root logging.
+
+    Importing ``lerobot.async_inference.robot_client`` runs ``get_logger`` at
+    class scope, which calls ``init_logging``: the root logger is reset to
+    ``NOTSET``, every installed handler is cleared, and lerobot's own console
+    handler plus a ``logs/`` file handler at DEBUG level are installed. With
+    the root effectively at DEBUG, python-can then emits two records per
+    transmitted CAN frame — thousands of synchronous disk writes per second
+    through the shared logging lock, sitting directly on the impedance-command
+    path. Measured on the robot host, that throttled run-policy's 60 Hz
+    control loop to an irregular 35-45 Hz per arm (visible arm jitter) and
+    grew a multi-hundred-MB log file per session.
+
+    Snapshot the root logger's level and handlers, trigger the import, then
+    restore both, so the process keeps exactly the logging its entry point
+    (CLI ``main`` or the serve runner's capture) configured. The ``can``
+    logger is additionally pinned to INFO so even a deliberate DEBUG session
+    can't re-enable per-frame TX logging on the control path.
+    """
+    root = logging.getLogger()
+    prior_level = root.level
+    prior_handlers = root.handlers[:]
+
+    import lerobot.async_inference.robot_client  # noqa: F401
+
+    root.setLevel(prior_level)
+    root.handlers[:] = prior_handlers
+    logging.getLogger("can").setLevel(logging.INFO)
+    _logger.debug("Restored root logging after lerobot robot_client import.")

--- a/almond_axol/lerobot/robot/robot_axol.py
+++ b/almond_axol/lerobot/robot/robot_axol.py
@@ -40,6 +40,8 @@ from lerobot.utils.decorators import check_if_already_connected, check_if_not_co
 
 from ...constants import Joint
 from ...robot.axol import Axol
+from ...teleop.config import VRTeleopConfig
+from ...teleop.filter import TrapezoidalFilter
 from .config_axol import AxolRobotConfig
 
 if TYPE_CHECKING:
@@ -107,6 +109,17 @@ class AxolRobot(Robot):
         # (run-policy). Collect-data commands joint targets, so it never builds
         # this; only the cheap forward-kinematics helper above runs there.
         self._ik: KinematicsSolver | None = None
+        # Post-IK command shapers for Cartesian actions (one per arm), built
+        # lazily alongside their first use. Cartesian clients stream EE poses
+        # whose IK solutions can step arbitrarily (discontinuous policy
+        # chunks, IK branch changes, a slow inference platform), so the joint
+        # targets are run through the same velocity/acceleration-limited
+        # tracker teleop uses — the exact command profile all training data
+        # went through. Joint-action clients (teleop, collect-data, joint
+        # policies) are untouched: their pipelines already shape commands
+        # upstream, and double-filtering a tuned path buys nothing.
+        self._cart_shapers: tuple[TrapezoidalFilter, TrapezoidalFilter] | None = None
+        self._cart_last_send: float = 0.0
 
     def _build_cameras(self) -> tuple[dict, list]:
         """Build the camera set, expanding any stereo camera into two eyes.
@@ -595,7 +608,11 @@ class AxolRobot(Robot):
 
         Each arm's 6-axis end-effector pose is solved to joint angles, seeded
         with the arm's current cached position so the solve tracks from where
-        the arm actually is. The gripper passes straight through. Returns
+        the arm actually is. The IK output is then shaped by the per-arm
+        :class:`TrapezoidalFilter` (teleop's velocity/acceleration limits) so
+        Cartesian clients can never command a joint-space discontinuity — the
+        smoothness guarantee holds regardless of how jumpy the pose stream or
+        the IK solution is. The gripper passes straight through. Returns
         ``(left, right)`` 8-vectors (7 arm joints + gripper) in Joint order.
         """
         from ...kinematics.fk import pose6_to_pos_rot
@@ -623,6 +640,35 @@ class AxolRobot(Robot):
             left[i] = q_out[gi]
         for i, gi in enumerate(solver.right_indices):
             right[i] = q_out[gi]
+
+        # Cartesian senders have no fixed rate contract, so the shapers run on
+        # measured inter-send spacing (clamped so a hiccup can't blow up the
+        # step size). After a gap the arm may have been moved by another path
+        # (return-to-rest, gravity comp), so re-seed from the actual measured
+        # positions rather than ramping from a stale command.
+        now = time.monotonic()
+        gap = now - self._cart_last_send
+        self._cart_last_send = now
+        if self._cart_shapers is None:
+            self._cart_shapers = (
+                TrapezoidalFilter(
+                    VRTeleopConfig.teleop_max_vel, VRTeleopConfig.teleop_max_accel, 0.0
+                ),
+                TrapezoidalFilter(
+                    VRTeleopConfig.teleop_max_vel, VRTeleopConfig.teleop_max_accel, 0.0
+                ),
+            )
+            gap = float("inf")
+        shaper_l, shaper_r = self._cart_shapers
+        if gap > 0.5:
+            shaper_l.reset(seed=np.asarray(left_cur, dtype=np.float32)[:7])
+            shaper_r.reset(seed=np.asarray(right_cur, dtype=np.float32)[:7])
+        dt = min(max(gap, 1.0 / 240.0), 0.1)
+        shaper_l.dt = dt
+        shaper_r.dt = dt
+        left[:7] = shaper_l.update(left[:7])
+        right[:7] = shaper_r.update(right[:7])
+
         # The gripperless SKU has no gripper keys; Axol ignores the padded slot.
         left[-1] = action[_LEFT_GRIPPER_KEY] if self._has_gripper else 0.0
         right[-1] = action[_RIGHT_GRIPPER_KEY] if self._has_gripper else 0.0

--- a/almond_axol/lerobot/robot/robot_axol.py
+++ b/almond_axol/lerobot/robot/robot_axol.py
@@ -642,10 +642,17 @@ class AxolRobot(Robot):
             right[i] = q_out[gi]
 
         # Cartesian senders have no fixed rate contract, so the shapers run on
-        # measured inter-send spacing (clamped so a hiccup can't blow up the
-        # step size). After a gap the arm may have been moved by another path
-        # (return-to-rest, gravity comp), so re-seed from the actual measured
-        # positions rather than ramping from a stale command.
+        # measured inter-send spacing — but the dt fed to the filter is capped
+        # at one nominal 60 Hz tick, so a single command can never advance the
+        # target by more than ``max_vel / 60`` no matter how long the sender
+        # paused (an uncapped dt would let one post-starvation command carry a
+        # whole gap's worth of motion in one step — exactly the snap this
+        # shaper exists to prevent; a slow sender is instead rate-limited,
+        # which is the correct graceful degradation). After a longer gap the
+        # arm may also have been moved by another path (return-to-rest,
+        # gravity comp) and the filter's velocity state is stale, so re-seed
+        # from the actual measured positions — which also zeroes the velocity
+        # — rather than ramping from a stale command at a stale speed.
         now = time.monotonic()
         gap = now - self._cart_last_send
         self._cart_last_send = now
@@ -660,10 +667,10 @@ class AxolRobot(Robot):
             )
             gap = float("inf")
         shaper_l, shaper_r = self._cart_shapers
-        if gap > 0.5:
+        if gap > 0.25:
             shaper_l.reset(seed=np.asarray(left_cur, dtype=np.float32)[:7])
             shaper_r.reset(seed=np.asarray(right_cur, dtype=np.float32)[:7])
-        dt = min(max(gap, 1.0 / 240.0), 0.1)
+        dt = min(max(gap, 1.0 / 240.0), 1.0 / 60.0)
         shaper_l.dt = dt
         shaper_r.dt = dt
         left[:7] = shaper_l.update(left[:7])

--- a/almond_axol/lerobot/rollout.py
+++ b/almond_axol/lerobot/rollout.py
@@ -159,6 +159,42 @@ class IKResetController:
             # the first command of the replanned move.
             robot.reset_command_state()
 
+    def hold_limp(
+        self,
+        robot: "AxolRobot",
+        *,
+        gravity_comp_kd: float = 0.25,
+        wait: Callable[[], bool] | None = None,
+        stopped: Callable[[], bool] | None = None,
+    ) -> bool:
+        """Hold the arms limp (gravity comp) until the operator resolves ``wait``.
+
+        Used by run-policy's discard flow: after a failed episode the operator
+        usually needs to untangle the grippers from the scene or reposition
+        the arms by hand before any planned move is safe, so the arms drop
+        into a free gravity-supported hold instead of pulling straight back
+        to rest. ``wait`` blocks in a helper thread while the hold streams
+        (same mechanics as the contact hold inside :meth:`return_to_rest`).
+
+        Needs no IK worker — only gravity-comp cycles — so it never blocks on
+        :meth:`wait_ready`.
+
+        Args:
+            robot: Connected robot to hold.
+            gravity_comp_kd: Velocity damping for the free joints (Nm·s/rad).
+            wait: Blocking operator gate; ``True`` = proceed.
+            stopped: Flow shutdown flag, polled while the hold streams.
+
+        Returns:
+            ``True`` when the operator asked to proceed — with the command
+            history cleared so the next planned move isn't rejected by the
+            max-step safety check; ``False`` when aborted.
+        """
+        if not self._hold_limp(robot, gravity_comp_kd, wait, stopped):
+            return False
+        robot.reset_command_state()
+        return True
+
     def _play_to_rest(
         self,
         robot: "AxolRobot",

--- a/web/app/src/components/operation-panel.tsx
+++ b/web/app/src/components/operation-panel.tsx
@@ -321,6 +321,13 @@ const PHASE_STYLES: Record<string, { label: string; cls: string; kind: "dot" | "
       cls: "border-orange-400/60 bg-orange-400/15 text-orange-200",
       kind: "pulse",
     },
+    // run-policy's discard cleanup: the arms are limp for hand-repositioning
+    // until the operator sends them back to rest.
+    limp: {
+      label: "Limp",
+      cls: "border-orange-400/60 bg-orange-400/15 text-orange-200",
+      kind: "pulse",
+    },
     saving: {
       label: "Saving",
       cls: "border-emerald-400/50 bg-emerald-400/10 text-emerald-200",


### PR DESCRIPTION
## Summary

Fixes visible arm jitter during ACT policy rollout and generalizes the fix so execution is smooth for any policy type, chunk configuration, aggregation strategy, action space, and inference platform LeRobot supports. Diagnosed from microsecond-timestamped CAN captures across four test episodes; each cause is removed at its own layer:

- **Logging hijack:** importing lerobot's `robot_client` reset root logging and enabled per-frame python-can DEBUG writes on the impedance-command path, throttling the 60 Hz control loop to an irregular 35–45 Hz. `import_robot_client_preserving_logging` snapshots/restores logging and pins the `can` logger to INFO. Redundant background telemetry polling (`telemetry_hz=0`) is also dropped, matching collect-data.
- **Chunk re-anchor sawtooth:** each chunk is predicted from a ~1-round-trip-old observation of an arm that lags its command, so queue rebuilds yanked targets backward 20–70 mrad in one tick, ~5x/s. `_align_incoming_chunk` cancels the arrival-time offset — for every aggregation strategy (`temporal_ensemble` and upstream blends alike) and any action space — and fades it out (`align_fade_s`) so absolute intent still converges. The offset scales with inference latency, so slow platforms are covered identically.
- **Chunk-expiry steps:** the ensemble lost a full contributor at the timestep where the oldest chunk's horizon ends. Each chunk's weight now fades over the tail of its horizon (`ensemble_blend_s`).
- **GC freeze:** a stop-the-world gen-2 collection (~516 ms, measured) fired mid-episode at the same allocation-driven point every run. Collection is held during episodes and swept between them (duration logged).

Independent of the signal fixes, execution is now guaranteed smooth by construction: joint commands pass through the same `TrapezoidalFilter` (velocity + acceleration limits) that teleop and all recorded training data go through — transparent to legitimate policy motion, and queue starvation on weak compute decelerates to a hold instead of freeze-then-lurch. Cartesian actions get the identical guarantee post-IK in the robot layer, on measured send spacing with stale-state re-seeding. Observations are paced to the chunk cadence instead of free-running (was ~9 uncompressed 6.6 MB sends/s competing for the GIL).

Also included (operator request): discarding an episode now drops the arms into a limp gravity-comp hold for hand-repositioning with a "Return to rest" gate in the control panel (new `limp` phase badge), instead of planning home from a failed pose.

## Validation

- CAN captures before/after on the robot: control cadence steady at 60 Hz (p99 24 ms), command sawtooth spikes eliminated, mid-episode 516 ms stall gone (end-of-episode sweep logs ~510 ms, confirming the diagnosis).
- Simulation of the measured failure modes through the real client code path: steady-state wobble 11.3 → 0.83 mrad p2p; slow policy motion passes bit-identical (no correction dilution); starvation decelerates and resumes within limits; grippers stay bang-bang; absolute-position consensus converges after alignment.
- Ruff clean; exercised on the robot across four rollout episodes during diagnosis.

## Test plan

- [ ] Rollout episode on the robot: arm smooth through chunk boundaries, grasp precision unchanged
- [ ] Discard flow: arms go limp, panel shows Limp badge + Return to rest, return plans from the hand-placed pose
- [ ] Non-ensemble aggregation (`--aggregate_fn latest_only`): still smooth
- [ ] Cartesian policy rollout: post-IK shaping engages, no joint snaps

Made with [Cursor](https://cursor.com)