### PR TITLE
Add a host shutdown button to the diagnostics dashboard

### DIFF
--- a/almond_axol/serve/app.py
+++ b/almond_axol/serve/app.py
@@ -8,7 +8,9 @@ is available it is served too, with SPA-style fallback to ``index.html``.
 from __future__ import annotations
 
 import asyncio
+import os
 import socket
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -20,6 +22,7 @@ from pydantic import BaseModel
 from ..constants import URDF_PATH
 from ..utils import adb, ports
 from ..utils.certs import ACCEPT_PAGE_HTML
+from ..utils.sudo import prime_sudo
 from .commands import COMMANDS, command_specs, operation_ids
 from .manager import Session, SessionManager
 from .robot_link import RobotLink, scoped_motor_faults
@@ -319,6 +322,40 @@ def create_app(static_dir: Path | None = None) -> FastAPI:
         if not started:
             return JSONResponse({"error": reason}, status_code=409)
         return JSONResponse({"started": True})
+
+    # -- host power ----------------------------------------------------------
+
+    @app.post("/api/host/shutdown")
+    async def host_shutdown() -> JSONResponse:
+        """Power off the serve host (``shutdown -h now``).
+
+        Refused while an operation or session is running — cutting power mid-
+        run would drop the arms. The hosted install runs as root; a dev serve
+        escalates via ``sudo -n`` so a headless context fails fast instead of
+        blocking on a password prompt.
+        """
+        if not _is_idle():
+            return JSONResponse(
+                {"error": "an operation or session is running — stop it first"},
+                status_code=409,
+            )
+
+        def _halt() -> tuple[bool, str]:
+            cmd = ["shutdown", "-h", "now"]
+            if os.geteuid() != 0:
+                if not prime_sudo():
+                    return False, "root required (no passwordless sudo)"
+                cmd = ["sudo", "-n", *cmd]
+            proc = subprocess.run(cmd, capture_output=True, text=True)
+            return proc.returncode == 0, (proc.stderr or proc.stdout).strip()
+
+        ok, detail = await asyncio.to_thread(_halt)
+        if not ok:
+            return JSONResponse(
+                {"error": f"shutdown failed: {detail or 'unknown error'}"},
+                status_code=500,
+            )
+        return JSONResponse({"ok": True})
 
     # -- robot connection (detached CAN + 1 Hz motor ping) ------------------
 

--- a/web/app/src/lib/supervisor.ts
+++ b/web/app/src/lib/supervisor.ts
@@ -207,6 +207,14 @@ export async function startUpdate(): Promise<{ started: boolean }> {
   return json(await fetch(apiUrl("/api/update/start"), { method: "POST" }))
 }
 
+/**
+ * Power off the serve host (`shutdown -h now`). Refused (409) while an
+ * operation or session is running.
+ */
+export async function shutdownHost(): Promise<{ ok: boolean }> {
+  return json(await fetch(apiUrl("/api/host/shutdown"), { method: "POST" }))
+}
+
 // ---------------------------------------------------------------------------
 // Robot connection (detached CAN + 1 Hz motor ping)
 // ---------------------------------------------------------------------------

--- a/web/app/src/routes/Diagnostics.tsx
+++ b/web/app/src/routes/Diagnostics.tsx
@@ -5,6 +5,7 @@ import {
   Crosshair,
   ClipboardList,
   Loader2,
+  Power,
   Radio,
   SlidersHorizontal,
   Tag,
@@ -13,6 +14,7 @@ import {
 } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import { Card } from "@/components/ui/card"
 import { SiteNav } from "@/components/site-nav"
 import { useToast } from "@/components/ui/toast"
 import { MotorGrid } from "@/components/diagnostics/motor-grid"
@@ -39,6 +41,7 @@ import {
   robotConnect,
   sendSessionInput,
   setServerBase,
+  shutdownHost,
   stopSession,
   useSessionLogs,
   type CommandSpec,
@@ -330,6 +333,23 @@ export default function Diagnostics() {
       setLaunchBusy(false)
     }
   }, [activeRun, toast])
+
+  // Host power-off (shutdown -h now), behind a confirmation dialog. The
+  // server refuses while an operation or session is running.
+  const [shutdownOpen, setShutdownOpen] = useState(false)
+  const [shutdownBusy, setShutdownBusy] = useState(false)
+  const confirmShutdown = useCallback(async () => {
+    setShutdownBusy(true)
+    try {
+      await shutdownHost()
+      setShutdownOpen(false)
+      toast.success("Host is shutting down.")
+    } catch (e) {
+      toast.error(String(e))
+    } finally {
+      setShutdownBusy(false)
+    }
+  }, [toast])
 
   const connectRobot = useCallback(async () => {
     setRobotBusy(true)
@@ -829,7 +849,19 @@ export default function Diagnostics() {
 
         {/* Diagnostics actions */}
         <section className="flex flex-col gap-3">
-          <h2 className="font-heading text-base font-semibold">Diagnostics</h2>
+          <div className="flex flex-wrap items-center gap-3">
+            <h2 className="font-heading text-base font-semibold">Diagnostics</h2>
+            <Button
+              variant="outline"
+              size="sm"
+              className="ml-auto text-red-300 hover:bg-red-400/10"
+              title="Power off the robot host (shutdown -h now)."
+              disabled={!serverOk}
+              onClick={() => setShutdownOpen(true)}
+            >
+              <Power /> Shut down host
+            </Button>
+          </div>
           <DiagnosticActions
             commands={diagCommands}
             activeCommand={activeRun?.command ?? null}
@@ -875,6 +907,46 @@ export default function Diagnostics() {
           onStop={stopActive}
           onClose={() => setMotorTool(null)}
         />
+      )}
+
+      {/* Host shutdown confirmation */}
+      {shutdownOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+          onClick={() => setShutdownOpen(false)}
+        >
+          <Card
+            className="w-full max-w-sm gap-4 bg-[#1a1a1a] p-5"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex flex-col gap-1">
+              <h3 className="font-heading text-base font-semibold">Shut down host</h3>
+              <p className="text-sm leading-relaxed text-white/45">
+                Power off the robot host (<span className="font-mono">shutdown -h now</span>).
+                This panel loses its connection immediately, and turning the robot back on
+                requires physical access to it.
+              </p>
+            </div>
+            {(activeRun != null || busyElsewhere) && (
+              <p className="text-xs text-amber-200/70">
+                A run or operation is in flight — stop it before shutting down.
+              </p>
+            )}
+            <div className="flex items-center justify-end gap-2 pt-1">
+              <Button variant="ghost" size="sm" onClick={() => setShutdownOpen(false)}>
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={confirmShutdown}
+                disabled={shutdownBusy || activeRun != null || busyElsewhere}
+              >
+                {shutdownBusy ? <Loader2 className="animate-spin" /> : <Power />} Shut down
+              </Button>
+            </div>
+          </Card>
+        </div>
       )}
 
       {/* Manual CAN interface selection (non-Axol-hub adapters) */}


### PR DESCRIPTION
## Summary
- New `POST /api/host/shutdown` endpoint on `axol serve` that powers off the host with `shutdown -h now` — run directly when the server is root (hosted systemd install), else via `sudo -n` after `prime_sudo()`, matching the ZED daemon restart pattern. Refused with a 409 while an operation or session is running, since cutting power mid-run would drop the arms.
- "Shut down host" button in the diagnostics dashboard's Diagnostics section, behind a confirmation dialog that warns the panel loses its connection and powering back on needs physical access. The confirm button is disabled while a run is in flight.

## Test plan
- [ ] `ruff check` / `ruff format --check` pass on the backend (verified)
- [ ] Web app `tsc -b && vite build` passes (verified; remaining eslint errors pre-exist on main)
- [ ] On a robot host: click Shut down host → confirm → host powers off
- [ ] With a diagnostic running: confirm button is disabled / server returns 409

Made with [Cursor](https://cursor.com)