### PR TITLE
Keep ops running on UI host disconnect and fail connect fast

### DIFF
--- a/web/app/src/lib/supervisor.ts
+++ b/web/app/src/lib/supervisor.ts
@@ -474,8 +474,28 @@ export interface CameraSpec {
   resolution?: string
 }
 
+/**
+ * How long the connect probe waits before declaring the host unreachable.
+ * Without this, a fetch to an absent host sits in TCP retries for a minute or
+ * more with the UI stuck on "Connecting…". Kept just high enough for a live
+ * LAN host's worst case (mDNS .local resolution + TCP + TLS handshake over
+ * Wi-Fi); much lower and slow-but-alive hosts get misreported as offline.
+ */
+const CONNECT_TIMEOUT_MS = 2_000
+
 export async function fetchCommands(): Promise<CommandSpec[]> {
-  return json(await fetch(apiUrl("/api/commands")))
+  let res: Response
+  try {
+    res = await fetch(apiUrl("/api/commands"), {
+      signal: AbortSignal.timeout(CONNECT_TIMEOUT_MS),
+    })
+  } catch (e) {
+    if (e instanceof DOMException && (e.name === "TimeoutError" || e.name === "AbortError")) {
+      throw new Error(`no response from the host after ${CONNECT_TIMEOUT_MS / 1000}s`)
+    }
+    throw e
+  }
+  return json(res)
 }
 
 export async function fetchSessions(): Promise<SessionInfo[]> {

--- a/web/app/src/routes/ControlPanel.tsx
+++ b/web/app/src/routes/ControlPanel.tsx
@@ -372,19 +372,10 @@ export default function ControlPanel() {
     // usbConnectClick is stable (only uses state setters / fetch).
   }, [conn.state, usb, usbBusy])
 
-  async function hostDisconnectClick() {
-    // Kill any running task and wait for it to exit before dropping the host,
-    // so disconnecting never leaves an orphaned op running server-side. Only
-    // then tear down the (client-side) host connection.
-    setBusy(true)
-    try {
-      await stopRunningOp()
-    } catch (e) {
-      toast.error(String(e))
-      setBusy(false)
-      return
-    }
-    setBusy(false)
+  function hostDisconnectClick() {
+    // Purely client-side: drop this browser's view of the host without
+    // touching server state. Other control panels on the network may be
+    // driving the same host, so never stop a running op from here.
     setConn({ state: "idle" })
     setCommands([])
     setRobot(null)


### PR DESCRIPTION
## Summary
- The control panel's host "Disconnect" button previously stopped any running op server-side before dropping the connection. With multiple control panels on the same network, one person disconnecting killed the task everyone else was using. Host disconnect is now purely client-side: it clears the browser's local state and never touches the running op. (The robot-tile disconnect still stops the task first, since releasing the hardware inherently ends it.)
- Connecting to a nonexistent host used to hang on "Connecting…" for a minute or more while the browser retried TCP. The connect probe (`GET /api/commands`) now aborts after 2 seconds and reports the host as unreachable. Hosts that actively refuse the connection still fail instantly; the timeout only covers black-hole addresses, and 2s leaves headroom for mDNS + TCP + TLS on a live Wi-Fi host.

## Test plan
- [ ] Start an op from panel A, press the host tile's Disconnect on panel B, confirm the op keeps running and panel A is unaffected
- [ ] Reconnect panel B and confirm it picks up the running op and can stop it
- [ ] Enter an unused LAN IP as the host and confirm connect fails with "Can't reach …" within ~2s
- [ ] Connect to a real serve host and confirm normal connect still works

Made with [Cursor](https://cursor.com)