### PR TITLE
Add a scroll-to-bottom button to the log console

### DIFF
--- a/web/app/src/components/log-console.tsx
+++ b/web/app/src/components/log-console.tsx
@@ -35,7 +35,11 @@ export function LogConsole({ lines }: { lines: string[] }) {
     if (!el) return
     stickToBottom.current = true
     setShowJumpToBottom(false)
-    el.scrollTo({ top: el.scrollHeight, behavior: "smooth" })
+    // Instant jump: a smooth scroll's intermediate frames fire scroll events
+    // that handleScroll would read as the user scrolling away, clearing
+    // stick-to-bottom before the animation lands (and streaming logs would
+    // make the animated target stale anyway).
+    el.scrollTop = el.scrollHeight
   }
 
   function downloadLogs() {

--- a/web/app/src/components/log-console.tsx
+++ b/web/app/src/components/log-console.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef } from "react"
-import { Download, Terminal } from "lucide-react"
+import { useEffect, useRef, useState } from "react"
+import { ArrowDown, Download, Terminal } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { cn } from "@/lib/utils"
@@ -11,6 +11,7 @@ export function LogConsole({ lines }: { lines: string[] }) {
   // is at (or near) the bottom; cleared once they scroll up so they can read
   // back through history without being yanked down by incoming logs.
   const stickToBottom = useRef(true)
+  const [showJumpToBottom, setShowJumpToBottom] = useState(false)
 
   // Distance from the bottom (px) still treated as "following"; absorbs
   // sub-pixel rounding and wrapped-line reflow.
@@ -19,13 +20,23 @@ export function LogConsole({ lines }: { lines: string[] }) {
   function handleScroll() {
     const el = scrollRef.current
     if (!el) return
-    stickToBottom.current = el.scrollHeight - el.scrollTop - el.clientHeight <= STICK_THRESHOLD_PX
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight <= STICK_THRESHOLD_PX
+    stickToBottom.current = atBottom
+    setShowJumpToBottom(!atBottom)
   }
 
   useEffect(() => {
     const el = scrollRef.current
     if (el && stickToBottom.current) el.scrollTop = el.scrollHeight
   }, [lines])
+
+  function scrollToBottom() {
+    const el = scrollRef.current
+    if (!el) return
+    stickToBottom.current = true
+    setShowJumpToBottom(false)
+    el.scrollTo({ top: el.scrollHeight, behavior: "smooth" })
+  }
 
   function downloadLogs() {
     const blob = new Blob([lines.join("\n") + "\n"], { type: "text/plain" })
@@ -57,25 +68,39 @@ export function LogConsole({ lines }: { lines: string[] }) {
           <Download />
         </Button>
       </div>
-      <div
-        ref={scrollRef}
-        onScroll={handleScroll}
-        className="max-h-[60vh] min-h-[280px] overflow-auto px-4 pb-4 font-mono text-xs leading-relaxed"
-      >
-        {lines.length === 0 ? (
-          <p className="text-white/30">No output yet.</p>
-        ) : (
-          lines.map((line, i) => (
-            <div
-              key={i}
-              className={cn(
-                "break-words whitespace-pre-wrap",
-                line.startsWith("[serve]") ? "text-[#eff483]/70" : "text-white/70"
-              )}
-            >
-              {line}
-            </div>
-          ))
+      <div className="relative min-h-0">
+        <div
+          ref={scrollRef}
+          onScroll={handleScroll}
+          className="max-h-[60vh] min-h-[280px] overflow-auto px-4 pb-4 font-mono text-xs leading-relaxed"
+        >
+          {lines.length === 0 ? (
+            <p className="text-white/30">No output yet.</p>
+          ) : (
+            lines.map((line, i) => (
+              <div
+                key={i}
+                className={cn(
+                  "break-words whitespace-pre-wrap",
+                  line.startsWith("[serve]") ? "text-[#eff483]/70" : "text-white/70"
+                )}
+              >
+                {line}
+              </div>
+            ))
+          )}
+        </div>
+        {showJumpToBottom && (
+          <Button
+            variant="secondary"
+            size="icon"
+            className="absolute right-4 bottom-4 size-8 rounded-full border border-white/10 bg-black/60 text-white/70 shadow-lg backdrop-blur hover:bg-black/80 hover:text-white"
+            onClick={scrollToBottom}
+            aria-label="Scroll to bottom"
+            title="Scroll to bottom"
+          >
+            <ArrowDown />
+          </Button>
         )}
       </div>
     </Card>


### PR DESCRIPTION
## Summary
- The shared `LogConsole` (control panel operation views and setup page) now shows a floating arrow button in the lower-right corner of the log area whenever the view is scrolled away from the bottom.
- Clicking it smooth-scrolls to the latest line and re-engages the existing auto-follow behavior; the button hides when already at (or within 24px of) the bottom, including when logs fit without scrolling.

## Test plan
- [ ] Run `axol serve`, open the control panel, start an operation that streams logs
- [ ] Scroll up in the log console and verify the button appears and auto-follow pauses
- [ ] Click the button and verify it scrolls to the bottom, hides, and new lines resume following

Made with [Cursor](https://cursor.com)