### PR TITLE
Fix first connect after cert authorization timing out

### DIFF
--- a/web/app/src/lib/supervisor.ts
+++ b/web/app/src/lib/supervisor.ts
@@ -475,7 +475,7 @@ export interface CameraSpec {
 }
 
 /**
- * How long the connect probe waits before declaring the host unreachable.
+ * How long the reachability probe waits before declaring the host absent.
  * Without this, a fetch to an absent host sits in TCP retries for a minute or
  * more with the UI stuck on "Connecting…". Kept just high enough for a live
  * LAN host's worst case (mDNS .local resolution + TCP + TLS handshake over
@@ -484,9 +484,16 @@ export interface CameraSpec {
 const CONNECT_TIMEOUT_MS = 2_000
 
 export async function fetchCommands(): Promise<CommandSpec[]> {
-  let res: Response
+  // Fail fast on an absent host by racing the timer against a probe that
+  // answers from memory (/api/op/status — any HTTP response, even a 404 from
+  // an older host, proves it's alive). The timer must not cover /api/commands
+  // itself: its first call after a serve start imports every command's config
+  // module to build the schemas and can take well past the timeout, so racing
+  // it misreported a slow-but-alive host as offline — the first connect after
+  // a cert authorization always failed and only the retry (against the
+  // then-warm schema cache) got through.
   try {
-    res = await fetch(apiUrl("/api/commands"), {
+    await fetch(apiUrl("/api/op/status"), {
       signal: AbortSignal.timeout(CONNECT_TIMEOUT_MS),
     })
   } catch (e) {
@@ -495,7 +502,7 @@ export async function fetchCommands(): Promise<CommandSpec[]> {
     }
     throw e
   }
-  return json(res)
+  return json(await fetch(apiUrl("/api/commands")))
 }
 
 export async function fetchSessions(): Promise<SessionInfo[]> {


### PR DESCRIPTION
## Summary
- The 2s fail-fast connect timer added in #200 raced `/api/commands`, whose first call after a serve start builds every command schema (importing each command's config modules) and takes well past 2s. The connect right after "Authorize certificate" therefore always failed, and only a second press (against the then-warm schema cache) got through.
- The timer now races a cheap reachability probe (`/api/op/status`, answered from memory — any HTTP response, even a 404 from an older host, proves it's alive). Once the host is confirmed reachable, `/api/commands` is fetched without the timer, so a cold schema build just shows "Connecting…" a moment longer instead of being misreported as offline.
- Absent hosts still fail in 2s as intended.

## Test plan
- [ ] `npm run build --workspace app` passes (tsc + vite) — done
- [ ] `eslint .` shows only the 8 pre-existing issues, none new — done
- [ ] On a freshly restarted serve host with an unaccepted cert: press "Authorize certificate", accept the warning — the panel connects on the first press
- [ ] With no host running: connect still reports "no response from the host after 2s" quickly

Made with [Cursor](https://cursor.com)