### PR TITLE
Face the URDF forward and use the robot's joint order in the solver

### DIFF
--- a/almond_axol/cli/tune/repeatability.py
+++ b/almond_axol/cli/tune/repeatability.py
@@ -116,8 +116,7 @@ def _plan_joint_trajectory(
     the arc. Returns one full ``(N,)`` joint vector per control tick.
     """
     return plan_collision_aware_trajectory(
-        solver.robot,
-        solver.robot_coll,
+        solver,
         q_from,
         q_to,
         speed=speed_rad_s,

--- a/almond_axol/cli/waypoints.py
+++ b/almond_axol/cli/waypoints.py
@@ -720,8 +720,7 @@ class _Session:
         legs: list[Leg] = [
             (
                 plan_collision_aware_trajectory(
-                    solver.robot,
-                    solver.robot_coll,
+                    solver,
                     self._q_start,
                     q_waypoints[0],
                     speed=rest_cfg.reset_speed,
@@ -847,8 +846,7 @@ class _Session:
         self._publish("returning", "Returning to the rest pose…")
         trajectory = await asyncio.to_thread(
             plan_collision_aware_trajectory,
-            solver.robot,
-            solver.robot_coll,
+            solver,
             q_now,
             q_rest,
             speed=rest_cfg.reset_speed,

--- a/almond_axol/kinematics/fk.py
+++ b/almond_axol/kinematics/fk.py
@@ -31,8 +31,9 @@ _logger = logging.getLogger(__name__)
 
 
 # 6-axis end-effector pose layout: Cartesian position (metres) followed by an
-# axis-angle rotation vector (radians), both in the robot's world frame (FLU).
-# The order matches the per-arm vector returned by :meth:`AxolForwardKinematics.ee_poses`.
+# axis-angle rotation vector (radians), both in the robot's world frame
+# (FLU: +x forward, +y left, +z up). The order matches the per-arm vector
+# returned by :meth:`AxolForwardKinematics.ee_poses`.
 EE_AXES: tuple[str, ...] = ("x", "y", "z", "rx", "ry", "rz")
 
 
@@ -108,7 +109,8 @@ class AxolForwardKinematics:
         Returns:
             ``(left_pose, right_pose)``, each a ``(6,)`` array of
             ``[x, y, z, rx, ry, rz]`` (position + axis-angle rotation vector) in
-            the robot's world frame (FLU). See :data:`EE_AXES`.
+            the robot's world frame (FLU: +x forward, +y left, +z up). See
+            :data:`EE_AXES`.
         """
         n = len(self._left_indices)
         q = np.zeros(self._num_joints, dtype=np.float32)

--- a/almond_axol/kinematics/solver.py
+++ b/almond_axol/kinematics/solver.py
@@ -2,7 +2,15 @@
 Standalone bimanual IK solver for the Axol robot.
 
 Uses pyroki + jaxls to solve for joint positions given absolute Cartesian
-end-effector poses in the robot's world frame (FLU).
+end-effector poses in the robot's world frame (FLU: +x forward, +y left,
++z up).
+
+All public joint vectors are laid out as the robot itself orders them: the
+left arm's 7 joints in :data:`~almond_axol.constants.ARM_JOINTS` order
+(shoulder_1 … wrist_3) followed by the right arm's — so ``q[:7]`` /
+``q[7:]`` are exactly the arrays ``motion_control`` takes. pyroki orders
+the actuated joints its own way internally; the permutation is applied at
+every public boundary and callers never see it.
 """
 
 from __future__ import annotations
@@ -35,7 +43,8 @@ _logger = logging.getLogger(__name__)
 
 
 Pose = tuple[np.ndarray, np.ndarray]
-"""A frame as ``(position (3,), rotation (3, 3))`` numpy arrays, world frame (FLU).
+"""A frame as ``(position (3,), rotation (3, 3))`` numpy arrays, world frame
+(FLU: +x forward, +y left, +z up).
 
 The format :meth:`KinematicsSolver.fk` returns and :meth:`KinematicsSolver.ik`
 takes, so a pose can be read, edited, and solved for without conversion.
@@ -434,9 +443,14 @@ class KinematicsSolver:
     """Bimanual IK solver for the Axol robot.
 
     Loads the bundled URDF, builds a pyroki + jaxls solver, and resolves
-    absolute Cartesian end-effector poses (world frame, FLU) to joint angles.
-    JIT compilation is triggered during ``__init__`` so the first call to
-    :meth:`ik` is fast.
+    absolute Cartesian end-effector poses (world frame, FLU: +x forward,
+    +y left, +z up) to joint angles. JIT compilation is triggered during
+    ``__init__`` so the first call to :meth:`ik` is fast.
+
+    Every joint vector this class takes or returns is laid out left arm
+    then right arm, each in :data:`~almond_axol.constants.ARM_JOINTS` order
+    (shoulder_1 … wrist_3) — the same order ``motion_control`` and
+    ``rest_pose`` use, so ``q[:7]`` is the left arm and ``q[7:]`` the right.
 
     Args:
         config: Solver cost weights and parameters.
@@ -448,6 +462,7 @@ class KinematicsSolver:
         pos = np.array([0.3, 0.2, 0.4], dtype=np.float32)
         rot = np.eye(3, dtype=np.float32)
         q = solver.ik(q, left_pose=(pos, rot))
+        left_arm, right_arm = q[:7], q[7:]  # ARM_JOINTS order
 
         # fk returns the same (pos, rot_3x3) format ik takes, so nudging a
         # pose is a round trip:
@@ -510,14 +525,31 @@ class KinematicsSolver:
         self._left_shoulder_jax = jnp.asarray(self._left_shoulder_pos)
         self._right_shoulder_jax = jnp.asarray(self._right_shoulder_pos)
 
-        # Determine left/right joint indices in ARM_JOINTS order so that
-        # q[left_indices] / q[right_indices] align with rest_pose and motion_control.
+        # Public joint vectors are left-then-right in ARM_JOINTS order (the
+        # robot's own ordering); pyroki reorders the actuated joints
+        # internally (topologically — alphabetical for this URDF). The
+        # permutation between the two is applied at every public boundary,
+        # so callers never deal with pyroki's ordering.
+        canonical = _LEFT_JOINT_NAMES + _RIGHT_JOINT_NAMES
         actuated = list(self.robot.joints.actuated_names)
+        self._pyroki_index = np.array(
+            [actuated.index(n) for n in canonical], dtype=np.intp
+        )
+
+        # Per-arm joint indices in pyroki's order, for the internal costs.
         name_to_idx = {n: i for i, n in enumerate(actuated)}
-        self.left_indices = [name_to_idx[n] for n in _LEFT_JOINT_NAMES]
-        self.right_indices = [name_to_idx[n] for n in _RIGHT_JOINT_NAMES]
-        self._left_idx_jax = jnp.asarray(self.left_indices, dtype=jnp.int32)
-        self._right_idx_jax = jnp.asarray(self.right_indices, dtype=jnp.int32)
+        self._left_idx_jax = jnp.asarray(
+            [name_to_idx[n] for n in _LEFT_JOINT_NAMES], dtype=jnp.int32
+        )
+        self._right_idx_jax = jnp.asarray(
+            [name_to_idx[n] for n in _RIGHT_JOINT_NAMES], dtype=jnp.int32
+        )
+
+        # The public layout makes these trivial; kept because splitting a
+        # full vector into per-arm arrays reads better through them.
+        n_arm = len(_LEFT_JOINT_NAMES)
+        self.left_indices = list(range(n_arm))
+        self.right_indices = list(range(n_arm, 2 * n_arm))
 
         self._posture_pose = jnp.zeros(
             self.robot.joints.num_actuated_joints, dtype=jnp.float32
@@ -536,7 +568,7 @@ class KinematicsSolver:
         Args:
             q: Full ``(N,)`` joint array in radians (same ordering as :meth:`ik`).
         """
-        self._posture_pose = jnp.asarray(q, dtype=jnp.float32)
+        self._posture_pose = jnp.asarray(self.to_pyroki_order(q), dtype=jnp.float32)
 
     @property
     def posture_pose(self) -> np.ndarray:
@@ -545,19 +577,38 @@ class KinematicsSolver:
         Lets a caller that sweeps the attractor (e.g. Cartesian path planning
         in :mod:`almond_axol.kinematics.path`) restore what it found.
         """
-        return np.asarray(self._posture_pose, dtype=np.float32)
+        return self.from_pyroki_order(np.asarray(self._posture_pose, dtype=np.float32))
 
     # -- Properties ----------------------------------------------------------
 
     @property
     def joint_names(self) -> list[str]:
-        """Ordered list of all actuated joint names (left arm then right arm)."""
-        return list(self.robot.joints.actuated_names)
+        """All actuated joint names — left arm then right arm, ARM_JOINTS order."""
+        return list(_LEFT_JOINT_NAMES + _RIGHT_JOINT_NAMES)
 
     @property
     def num_joints(self) -> int:
         """Total number of actuated joints across both arms."""
         return self.robot.joints.num_actuated_joints
+
+    # -- Joint-order conversion ----------------------------------------------
+
+    def to_pyroki_order(self, q: np.ndarray) -> np.ndarray:
+        """Reorder a public joint vector into the order ``self.robot`` uses.
+
+        Only needed when driving the pyroki ``self.robot`` /
+        ``self.robot_coll`` objects directly (their joint limits, forward
+        kinematics, and collision pairs are indexed in pyroki's own actuated
+        order); every method on this class converts internally.
+        """
+        q = np.asarray(q, dtype=np.float32)
+        out = np.empty_like(q)
+        out[self._pyroki_index] = q
+        return out
+
+    def from_pyroki_order(self, q: np.ndarray) -> np.ndarray:
+        """Inverse of :meth:`to_pyroki_order`."""
+        return np.asarray(q, dtype=np.float32)[self._pyroki_index]
 
     # -- Public interface ----------------------------------------------------
 
@@ -569,9 +620,9 @@ class KinematicsSolver:
 
         Returns:
             Tuple ``(left_pose, right_pose)``, each a ``(pos (3,), rot (3, 3))``
-            pair of numpy arrays in the robot's world frame (FLU) — the same
-            format :meth:`ik` takes, so a pose can be read, nudged, and solved
-            for directly::
+            pair of numpy arrays in the robot's world frame (FLU: +x forward,
+            +y left, +z up) — the same format :meth:`ik` takes, so a pose can
+            be read, nudged, and solved for directly::
 
                 (l_pos, l_rot), _ = solver.fk(q)
                 q = solver.ik(q, left_pose=(l_pos + delta, l_rot))
@@ -579,10 +630,26 @@ class KinematicsSolver:
         The returned pose is the gripper *mount* frame — for the point the
         fingers close on, see :func:`almond_axol.kinematics.path.tip_poses`.
         """
-        fk = self.robot.forward_kinematics(jnp.asarray(q, dtype=jnp.float32))
+        fk = self.robot.forward_kinematics(jnp.asarray(self.to_pyroki_order(q)))
         return (
             _se3_to_pose(jaxlie.SE3(fk[self.l_ee_idx])),
             _se3_to_pose(jaxlie.SE3(fk[self.r_ee_idx])),
+        )
+
+    def elbow_positions(self, q: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        """World-frame elbow positions from joint positions.
+
+        Args:
+            q: Full ``(N,)`` joint array in radians.
+
+        Returns:
+            Tuple ``(left, right)`` of ``(3,)`` numpy arrays — the elbow link
+            origins in the robot's world frame.
+        """
+        fk = self.robot.forward_kinematics(jnp.asarray(self.to_pyroki_order(q)))
+        return (
+            np.asarray(jaxlie.SE3(fk[self.l_elbow_idx]).translation(), np.float32),
+            np.asarray(jaxlie.SE3(fk[self.r_elbow_idx]).translation(), np.float32),
         )
 
     def ik(
@@ -596,7 +663,8 @@ class KinematicsSolver:
         """Compute joint positions for absolute Cartesian end-effector targets.
 
         All positions and orientations must be expressed in the robot's world
-        frame (FLU). End-effector targets are soft-clamped between
+        frame (FLU: +x forward, +y left, +z up). End-effector targets are
+        soft-clamped between
         ``config.reach_soft_start`` and ``config.max_reach`` from each shoulder
         before solving; elbow hints are projected onto the robot's reachable
         elbow sphere and faded out for overhead targets; joint steps are
@@ -617,6 +685,10 @@ class KinematicsSolver:
         """
         if left_pose is None and right_pose is None:
             return q_current
+
+        # Everything below runs in pyroki's joint order; converted back at
+        # the return.
+        q_current = self.to_pyroki_order(q_current)
 
         cfg = self.config
 
@@ -732,7 +804,7 @@ class KinematicsSolver:
         if max_abs > cfg.max_joint_delta:
             delta = delta * (cfg.max_joint_delta / max_abs)
         q_out = (q_current + delta).astype(np.float32)
-        return q_out
+        return self.from_pyroki_order(q_out)
 
     def _elbow_fade(
         self, ee_target: np.ndarray | None, shoulder_pos: np.ndarray

--- a/almond_axol/kinematics/urdf/axol.urdf
+++ b/almond_axol/kinematics/urdf/axol.urdf
@@ -403,8 +403,10 @@
         <parent link="base" />
         <child link="s1" />
     </joint>
+    <!-- The CAD export faces -y; this +90-degree yaw turns the model so the
+         world frame is FLU: +x forward, +y left, +z up. -->
     <joint name="fixed_node_to_root_joint_0" type="fixed">
-        <origin xyz="-2.77556e-17 -6.93889e-18 0.86" rpy="0 -0 0" />
+        <origin xyz="-2.77556e-17 -6.93889e-18 0.86" rpy="0 0 1.5707963267948966" />
         <axis xyz="0 0 1" />
         <parent link="root" />
         <child link="base" />

--- a/almond_axol/teleop/trajectory.py
+++ b/almond_axol/teleop/trajectory.py
@@ -22,6 +22,8 @@ import jaxls
 import numpy as np
 import pyroki as pk
 
+from ..kinematics.solver import KinematicsSolver
+
 
 @functools.partial(jax.jit, static_argnames=("max_iterations",))
 def solve_path_step(
@@ -72,8 +74,7 @@ def solve_path_step(
 
 
 def plan_collision_aware_trajectory(
-    robot: pk.Robot,
-    robot_coll: pk.collision.RobotCollision,
+    solver: KinematicsSolver,
     q_from: np.ndarray,
     q_to: np.ndarray,
     *,
@@ -96,8 +97,9 @@ def plan_collision_aware_trajectory(
     handful of frames.
 
     Args:
-        robot:            pyroki ``Robot`` instance.
-        robot_coll:       pyroki collision model matched to ``robot``.
+        solver:           :class:`KinematicsSolver` providing the shared robot
+                          and collision models. Joint vectors use its public
+                          ordering (left then right arm, ARM_JOINTS order).
         q_from:           Starting joint configuration, shape ``(N,)``.
         q_to:             Target joint configuration, shape ``(N,)``.
         speed:            Average joint velocity (rad/s) for the worst-case
@@ -116,8 +118,11 @@ def plan_collision_aware_trajectory(
         A list of full ``(N,)`` joint vectors, one per control tick at
         ``rate`` Hz. Always at least two waypoints long.
     """
-    q_from = np.asarray(q_from, dtype=np.float32)
-    q_to = np.asarray(q_to, dtype=np.float32)
+    # The projection costs (joint limits, self-collision) index joints the
+    # way the pyroki robot does, so the solve runs in that order and the
+    # returned waypoints are converted back.
+    q_from = solver.to_pyroki_order(q_from)
+    q_to = solver.to_pyroki_order(q_to)
     max_dist = float(np.max(np.abs(q_from - q_to)))
     duration = max(max_dist / speed, min_duration)
     n_steps = max(2, round(duration * rate))
@@ -129,8 +134,8 @@ def plan_collision_aware_trajectory(
         alpha = t * t * (3.0 - 2.0 * t)
         q_interp = (q_from * (1.0 - alpha) + q_to * alpha).astype(np.float32)
         result = solve_path_step(
-            robot,
-            robot_coll,
+            solver.robot,
+            solver.robot_coll,
             jnp.asarray(q_interp),
             jnp.asarray(q),
             rest_weight,
@@ -140,5 +145,5 @@ def plan_collision_aware_trajectory(
             max_iterations,
         )
         q = np.asarray(result, dtype=np.float32)
-        trajectory.append(q.copy())
+        trajectory.append(solver.from_pyroki_order(q))
     return trajectory

--- a/almond_axol/teleop/worker.py
+++ b/almond_axol/teleop/worker.py
@@ -15,8 +15,6 @@ import multiprocessing.connection
 import os
 import time
 
-import jax.numpy as jnp
-import jaxlie
 import numpy as np
 
 from ..kinematics.config import KinematicsConfig
@@ -377,8 +375,7 @@ class IKWorker:
         """Collision-aware trajectory. Each item is a full (N,) array in radians."""
         cfg = self._config
         return plan_collision_aware_trajectory(
-            self._solver.robot,
-            self._solver.robot_coll,
+            self._solver,
             q_current,
             q_target,
             speed=cfg.reset_speed,
@@ -475,22 +472,8 @@ class IKWorker:
         at engage time.
         """
         q = self.get_rest_q()
-        fk = self._solver.robot.forward_kinematics(jnp.asarray(q))
-
-        def _pose(idx: int) -> tuple[np.ndarray, np.ndarray]:
-            T = jaxlie.SE3(fk[idx])
-            return (
-                np.asarray(T.translation(), dtype=np.float32),
-                np.asarray(T.rotation().as_matrix(), dtype=np.float32),
-            )
-
-        def _elbow(idx: int) -> np.ndarray:
-            return np.asarray(jaxlie.SE3(fk[idx]).translation(), dtype=np.float32)
-
-        l_pose = _pose(self._solver.l_ee_idx)
-        r_pose = _pose(self._solver.r_ee_idx)
-        l_elbow = _elbow(self._solver.l_elbow_idx)
-        r_elbow = _elbow(self._solver.r_elbow_idx)
+        l_pose, r_pose = self._solver.fk(q)
+        l_elbow, r_elbow = self._solver.elbow_positions(q)
 
         for _ in range(max_iterations):
             self._solver.set_posture_pose(q)
@@ -523,31 +506,16 @@ class IKWorker:
         :meth:`step`. Elbow snapshots are ``None`` when elbow tracking is
         disabled (``kinematics.elbow_weight == 0``) and are never read.
         """
-        fk = self._solver.robot.forward_kinematics(jnp.asarray(q_current))
-
-        def _fk_pos_rot(idx: int) -> tuple[np.ndarray, np.ndarray]:
-            T = jaxlie.SE3(fk[idx])
-            pos = np.asarray(T.translation(), dtype=np.float32)
-            rot = np.asarray(T.rotation().as_matrix(), dtype=np.float32)
-            return pos, rot
+        l_fk, r_fk = self._solver.fk(q_current)
+        l_elbow, r_elbow = self._solver.elbow_positions(q_current)
 
         self._snap_ctrl = {
             "left": (left_pos, left_rot),
             "right": (right_pos, right_rot),
         }
-        self._snap_fk = {
-            "left": _fk_pos_rot(self._solver.l_ee_idx),
-            "right": _fk_pos_rot(self._solver.r_ee_idx),
-        }
+        self._snap_fk = {"left": l_fk, "right": r_fk}
         self._snap_elbow_ctrl = {"left": left_e, "right": right_e}
-        self._snap_elbow_fk = {
-            "left": np.asarray(
-                jaxlie.SE3(fk[self._solver.l_elbow_idx]).translation(), dtype=np.float32
-            ),
-            "right": np.asarray(
-                jaxlie.SE3(fk[self._solver.r_elbow_idx]).translation(), dtype=np.float32
-            ),
-        }
+        self._snap_elbow_fk = {"left": l_elbow, "right": r_elbow}
 
 
 # ---------------------------------------------------------------------------

--- a/docs/api/kinematics.mdx
+++ b/docs/api/kinematics.mdx
@@ -20,17 +20,26 @@ Bimanual inverse kinematics using pyroki and JAX/jaxls. Loads the bundled URDF, 
 from almond_axol.kinematics import KinematicsSolver, KinematicsConfig
 ```
 
+All poses live in the robot's world frame — **+x forward, +y left, +z up**
+(FLU), origin at the base of the torso axis.
+
+Every joint vector the solver takes or returns is ordered the way the robot
+itself is: the left arm's 7 joints in `ARM_JOINTS` order (`shoulder_1` …
+`wrist_3`) followed by the right arm's. `q[:7]` and `q[7:]` are exactly the
+per-arm arrays `motion_control` takes (minus the gripper slot).
+
 ```python
 import numpy as np
 from almond_axol.kinematics import KinematicsSolver, KinematicsConfig
 
 solver = KinematicsSolver(KinematicsConfig(pos_weight=100.0))
-q = np.zeros(solver.num_joints, dtype=np.float32)
+q = np.zeros(solver.num_joints, dtype=np.float32)  # [left s1…w3, right s1…w3]
 
 # Inverse kinematics → new joint array
-pos = np.array([0.3, 0.2, 0.4], dtype=np.float32)
+pos = np.array([0.3, 0.2, 0.4], dtype=np.float32)  # 30 cm forward, 20 cm left
 rot = np.eye(3, dtype=np.float32)
 q = solver.ik(q, left_pose=(pos, rot))
+left_arm, right_arm = q[:7], q[7:]  # ARM_JOINTS order, ready for motion_control
 
 # Forward kinematics → (left, right), each a (pos (3,), rot (3, 3)) numpy
 # pair — the same format ik takes. Reading a pose, nudging it, and solving
@@ -44,11 +53,13 @@ q = solver.ik(q, left_pose=(l_pos + np.array([0.0, 0.0, 0.05]), l_rot))
 | Member | Description |
 |---|---|
 | `num_joints` | Total actuated joints across both arms |
-| `joint_names` | Joint name strings (left arm then right) |
-| `left_indices` / `right_indices` | Indices into the full `q` array for each arm |
+| `joint_names` | Joint name strings (left arm then right, `ARM_JOINTS` order) |
+| `left_indices` / `right_indices` | Indices into the full `q` array for each arm — `[0…6]` and `[7…13]`, kept as a readable way to split a full vector |
 | `fk(q)` | Forward kinematics → `((pos_3, rot_3x3), (pos_3, rot_3x3))` — the same format `ik` takes |
+| `elbow_positions(q)` | World-frame elbow positions → `(left_3, right_3)` |
 | `ik(q, left_pose, right_pose, left_elbow_pos, right_elbow_pos)` | IK; `pose` is `(pos_3, rot_3x3)`; elbow hints are optional `(3,)` arrays |
 | `set_posture_pose(q)` / `posture_pose` | Set / read the null-space attractor (home pose for joint drift prevention) |
+| `to_pyroki_order(q)` / `from_pyroki_order(q)` | Convert to/from the internal pyroki joint ordering — only needed when driving `solver.robot` / `solver.robot_coll` directly |
 
 ## Straight-line paths
 


### PR DESCRIPTION
## Summary
- The CAD-exported URDF faced -y, so IK/FK reported a forward reach as motion into -y. A +90° yaw on the root fixed joint makes the world frame true FLU (**+x forward, +y left, +z up**) — the frame the code always claimed. Teleop deltas are computed in the gripper's engage-snapshot frame and are unaffected (verified identical on old vs new code); the world-frame elbow-hint deltas, which were silently wrong, are now correct. Gravity comp is invariant under a z-rotation.
- `KinematicsSolver` no longer leaks pyroki's internal joint ordering (topological/alphabetical: `e1, e2, s1…`). Every public joint vector is now **left arm then right arm in `ARM_JOINTS` order**, so `q[:7]` / `q[7:]` are exactly the `motion_control` arrays and the docs sample code is correct by construction. The permutation is applied inside `ik` / `fk` / `set_posture_pose` / the new `elbow_positions`; `left_indices` / `right_indices` are kept (now trivially `[0…6]` / `[7…13]`) so existing marshalling code works unchanged.
- `plan_collision_aware_trajectory` takes the solver and converts internally (its limit/collision costs index joints pyroki's way); the teleop worker uses `fk()` / `elbow_positions()` instead of reaching into `solver.robot`; explicit `to_pyroki_order()` / `from_pyroki_order()` helpers cover anyone driving `solver.robot` directly.
- Docs now state the frame axes and q layout up front, with sample code that needs no index gymnastics.

Note: any persisted world-frame Cartesian data (e.g. recorded lerobot observations) was captured in the old rotated frame; joint-space data (waypoints, rest poses) is unaffected.

## Test plan
- [x] FK: forward reach now reports +x; arms rest at y=±0.2; per-arm q slots drive the correct arm
- [x] IK: converges to 1.1 mm at planning weights; solved joints byte-identical to unmodified code for the same physical target
- [x] Teleop worker end to end (settle, engage, VR-frame steps): identical output to unmodified code modulo the intended rotation
- [x] `plan_collision_aware_trajectory` and `plan_linear_segment` smoke tests pass with canonical vectors
- [x] `ruff check` / `ruff format --check` clean at the pinned version

Made with [Cursor](https://cursor.com)