### PR TITLE
Host shutdown/restart on the connection tile + headless Quest docs

### DIFF
--- a/almond_axol/cli/can/setup.py
+++ b/almond_axol/cli/can/setup.py
@@ -204,20 +204,28 @@ def _resolve_hub_serial() -> str | None:
     """Pick the hub serial without prompting (for headless ``ensure_setup``).
 
     A previously configured serial (named ``can_alm_axol_*`` interfaces, or
-    the pinned serial in the udev rules) wins outright, so re-running setup on
-    an already-configured host works no matter how many other candlelight
-    adapters are attached. Only a genuinely fresh machine falls back to live
-    detection — returning None when no hub is attached (the hub is optional),
-    and raising when several dual-channel candidates are present, since that
-    needs the interactive ``axol can.setup`` flow to disambiguate.
+    the pinned serial in the udev rules) wins while its adapter is attached —
+    or while no dual-channel candidate is attached at all (an unplugged hub
+    keeps its pin for whenever it returns) — so re-running setup on an
+    already-configured host works no matter how many other candlelight
+    adapters are attached.
+
+    A configured serial that is *absent* while a different hub is attached is
+    stale — this host last ran on another Axol, or the hub was replaced — and
+    must not win: preferring it would re-pin the missing adapter and leave the
+    attached hub unnamed on ``canX``, which is exactly what the control
+    panel's Connect used to trip over. The attached hub is registered instead
+    (when it's unambiguous), matching what the interactive ``axol can.setup``
+    picks in the same situation. Several attached candidates still raise,
+    since that needs the interactive flow to disambiguate.
     """
     configured = _configured_serial()
-    if configured:
+    attached = _detect_serials()
+    if configured and (configured in attached or not attached):
         return configured
-    unique = _detect_serials()
-    if len(unique) == 1:
-        return unique[0]
-    if not unique:
+    if len(attached) == 1:
+        return attached[0]
+    if not attached:
         return None
     raise RuntimeError(
         "Multiple CAN adapters found — run `axol can.setup` once to pick the Axol's"

--- a/almond_axol/serve/app.py
+++ b/almond_axol/serve/app.py
@@ -118,6 +118,16 @@ class EpisodeRequest(BaseModel):
     command: str
 
 
+class ProximityRequest(BaseModel):
+    """Disable (default) or restore the headset's proximity sensor over adb.
+
+    Disabling keeps the Quest awake with nobody wearing it, so headless
+    sessions driven from the panel don't die when the headset is set down.
+    """
+
+    disabled: bool = True
+
+
 class SessionInputRequest(BaseModel):
     """A line written to a session's stdin (answers an interactive prompt).
 
@@ -708,6 +718,22 @@ def create_app(static_dir: Path | None = None) -> FastAPI:
         the USB-debugging authorization popup on the device.
         """
         return _usb_status_dict(await asyncio.to_thread(adb.connect))
+
+    @app.post("/api/usb/proximity")
+    async def usb_proximity(req: ProximityRequest) -> JSONResponse:
+        """Disable/restore the headset's proximity sensor (`adb shell am broadcast`).
+
+        Disabled, the headset stays awake with nobody wearing it — headless
+        sessions driven from the panel keep their pose stream and camera relay.
+        The override holds until restored or the headset reboots. Needs an
+        attached, authorized headset (same requirement as the pose tunnel).
+        """
+        ok, error = await asyncio.to_thread(adb.set_proximity_disabled, req.disabled)
+        if not ok:
+            return JSONResponse(
+                {"error": error or "adb broadcast failed"}, status_code=502
+            )
+        return JSONResponse({"ok": True})
 
     # -- in-process operations (teleop / gravity / collect / policy) --------
 

--- a/almond_axol/serve/app.py
+++ b/almond_axol/serve/app.py
@@ -325,9 +325,8 @@ def create_app(static_dir: Path | None = None) -> FastAPI:
 
     # -- host power ----------------------------------------------------------
 
-    @app.post("/api/host/shutdown")
-    async def host_shutdown() -> JSONResponse:
-        """Power off the serve host (``shutdown -h now``).
+    async def _host_power(flag: str, verb: str) -> JSONResponse:
+        """Run ``shutdown <flag> now`` on the serve host.
 
         Refused while an operation or session is running — cutting power mid-
         run would drop the arms. The hosted install runs as root; a dev serve
@@ -340,8 +339,8 @@ def create_app(static_dir: Path | None = None) -> FastAPI:
                 status_code=409,
             )
 
-        def _halt() -> tuple[bool, str]:
-            cmd = ["shutdown", "-h", "now"]
+        def _run() -> tuple[bool, str]:
+            cmd = ["shutdown", flag, "now"]
             if os.geteuid() != 0:
                 if not prime_sudo():
                     return False, "root required (no passwordless sudo)"
@@ -349,13 +348,23 @@ def create_app(static_dir: Path | None = None) -> FastAPI:
             proc = subprocess.run(cmd, capture_output=True, text=True)
             return proc.returncode == 0, (proc.stderr or proc.stdout).strip()
 
-        ok, detail = await asyncio.to_thread(_halt)
+        ok, detail = await asyncio.to_thread(_run)
         if not ok:
             return JSONResponse(
-                {"error": f"shutdown failed: {detail or 'unknown error'}"},
+                {"error": f"{verb} failed: {detail or 'unknown error'}"},
                 status_code=500,
             )
         return JSONResponse({"ok": True})
+
+    @app.post("/api/host/shutdown")
+    async def host_shutdown() -> JSONResponse:
+        """Power off the serve host (``shutdown -h now``)."""
+        return await _host_power("-h", "shutdown")
+
+    @app.post("/api/host/restart")
+    async def host_restart() -> JSONResponse:
+        """Reboot the serve host (``shutdown -r now``)."""
+        return await _host_power("-r", "restart")
 
     # -- robot connection (detached CAN + 1 Hz motor ping) ------------------
 

--- a/almond_axol/utils/adb.py
+++ b/almond_axol/utils/adb.py
@@ -30,7 +30,14 @@ _logger = logging.getLogger(__name__)
 
 # ``VR_PORT`` (the port we forward the headset's loopback copy of) is owned by
 # ``utils.ports`` so the tunnel target and the VR server's bind can't drift.
-__all__ = ["VR_PORT", "AdbStatus", "install", "status", "connect"]
+__all__ = [
+    "VR_PORT",
+    "AdbStatus",
+    "install",
+    "status",
+    "connect",
+    "set_proximity_disabled",
+]
 
 # Meta/Oculus USB vendor id. The udev rule lets a non-root user open the
 # headset for interactive ``adb`` (the root ``axol serve`` process opens it
@@ -224,6 +231,33 @@ def status(port: int = VR_PORT) -> AdbStatus:
         state=state,
         reverse_active=_reverse_active(port),
     )
+
+
+# The headset's power manager listens for these broadcasts (Meta's scriptable
+# testing services): ``prox_close`` fakes a continuously-covered proximity
+# sensor so the headset stays awake with nobody wearing it; ``automation_
+# disable`` restores normal sensor behavior. The override holds until it's
+# restored or the headset reboots.
+_PROX_DISABLE_ACTION = "com.oculus.vrpowermanager.prox_close"
+_PROX_RESTORE_ACTION = "com.oculus.vrpowermanager.automation_disable"
+
+
+def set_proximity_disabled(disabled: bool) -> tuple[bool, str | None]:
+    """Disable or restore the headset's proximity sensor over adb.
+
+    Disabling keeps the headset awake without being worn (headless teleop /
+    data-collection sessions driven from the control panel). Returns
+    ``(ok, error)`` — a broadcast needs an attached, authorized headset, so
+    the error passes adb's own complaint through for the panel to surface.
+    """
+    action = _PROX_DISABLE_ACTION if disabled else _PROX_RESTORE_ACTION
+    proc = _run(["shell", "am", "broadcast", "-a", action])
+    if proc is None:
+        return False, "adb is not installed on the host"
+    if proc.returncode != 0 or "Broadcast completed" not in proc.stdout:
+        detail = (proc.stderr or proc.stdout).strip().splitlines()
+        return False, detail[-1].strip() if detail else "adb broadcast failed"
+    return True, None
 
 
 def connect(port: int = VR_PORT) -> AdbStatus:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -46,7 +46,8 @@
           "guides/control-panel",
           "guides/diagnostics-dashboard",
           "guides/vr-interface",
-          "guides/quest-over-usb"
+          "guides/quest-over-usb",
+          "guides/quest-headless"
         ]
       },
       {

--- a/docs/guides/control-panel.mdx
+++ b/docs/guides/control-panel.mdx
@@ -41,7 +41,15 @@ The top of the panel is a pair of tiles — **Axol Host** and **Axol** — each 
 
 ### Axol Host
 
-The **Axol Host** is the machine running `axol serve` — the computer wired to the robot, with the ZED cameras attached. Press **Connect** on the tile to open the host dialog and enter its address (just the IP — port `8001` is assumed); if the host can't be reached the attempt gives up after a couple of seconds with a *can't reach the host* message instead of leaving the tile stuck on *Connecting…*. When connected, the tile shows the host's name, its installed release version (e.g. `axol v0.1.2`), and a green dot. Pressing the power button disconnects **this browser only** — a client-side drop that leaves the server, the robot link, and any running operation untouched, so another operator driving the same host isn't affected. Teleop and gravity comp need only this connection.
+The **Axol Host** is the machine running `axol serve` — the computer wired to the robot, with the ZED cameras attached. Press **Connect** on the tile to open the host dialog and enter its address (just the IP — port `8001` is assumed); if the host can't be reached the attempt gives up after a couple of seconds with a *can't reach the host* message instead of leaving the tile stuck on *Connecting…*. When connected, the tile shows the host's name, its installed release version (e.g. `axol v0.1.2`), and a green dot. Teleop and gravity comp need only this connection.
+
+A connected tile carries three buttons:
+
+- **Restart** reboots the robot host (`shutdown -r now`) behind a confirmation dialog. The panel loses its connection while the host reboots — reconnect once it's back up, typically under a minute.
+- **Shut down** powers the host off (`shutdown -h now`), also behind a confirmation. Turning the robot back on requires physical access to it.
+- **Disconnect** (the unplug button) drops **this browser only** — a client-side disconnect that leaves the server, the robot link, and any running operation untouched, so another operator driving the same host isn't affected.
+
+Restart and shut down are **refused while any operation or session is running** — cutting power mid-run would drop the arms — so stop what's in flight first; the confirm button stays disabled until the host is idle. (The one-command install runs as root and powers off directly; a development `axol serve` escalates with `sudo -n`, so a host with no passwordless sudo reports that it couldn't and stays up.)
 
 #### Updates
 

--- a/docs/guides/control-panel.mdx
+++ b/docs/guides/control-panel.mdx
@@ -112,6 +112,8 @@ The assignments and stream/record selection persist **on the host** with the res
 
 The **Quest USB** tab manages the optional [Quest-over-USB](/guides/quest-over-usb) link, which streams controller poses over a USB cable instead of Wi-Fi for lower latency. When a headset is plugged into the host and authorized (accept the **Allow USB debugging?** prompt the first time), the host sets up the `adb reverse` tunnel **automatically** and turns green (*Controller over USB*); the **Connect** button is a manual fallback / reconnect. Camera video keeps using the LAN — USB carries poses only. The headset sends every pose over both the cable and Wi-Fi, so a dropped cable **fails over to Wi-Fi instantly** with no reconnect, and the cable reclaims the link when it returns.
 
+The tab also carries the [headless](/guides/quest-headless) **Keep awake** / **Restore** buttons: with the headset plugged in and authorized, **Keep awake** disables its proximity sensor over adb so the VR session keeps running with the headset set down, and **Restore** brings normal sleep behavior back (a headset reboot also resets it).
+
 ## Operations
 
 Pick an operation from the selector. Each panel asks only for its **per-run inputs** — the dataset repo id and task for collect data, the policy path/type for run policy, the episode to replay — plus **Start**/**Stop**. Everything reusable lives in [Settings](#settings). Hover the **ⓘ** next to a field for its description, pulled from the CLI's own help.

--- a/docs/guides/diagnostics-dashboard.mdx
+++ b/docs/guides/diagnostics-dashboard.mdx
@@ -39,4 +39,4 @@ Powering the robot host off or rebooting it is done from the [control panel's Ax
 
 ## Run history
 
-Every *diagnostic test* (the cards above — not the ad-hoc CAN/calibration buttons) is recorded as a run: command, arguments, duration, exit status, log, and the telemetry observed while it executed (persisted under `~/.almond/diagnostics/runs` on the serve host; the **Clear** button deletes the history). The ROM test additionally writes its own 5 Hz position/torque capture, since it owns the CAN bus while it runs — opening a run charts its capture with the same joint filter and zoom/pan as the live charts.
+Every *diagnostic test* (the cards above — not the ad-hoc CAN/calibration buttons) is recorded as a run: command, arguments, duration, exit status, log, and the telemetry observed while it executed (persisted under `~/.almond/diagnostics/runs` on the serve host; the **Clear** button deletes the history). The list is paginated newest-first (10 runs per page). The ROM test additionally writes its own 5 Hz position/torque capture, since it owns the CAN bus while it runs — opening a run charts its capture with the same joint filter and zoom/pan as the live charts.

--- a/docs/guides/diagnostics-dashboard.mdx
+++ b/docs/guides/diagnostics-dashboard.mdx
@@ -35,7 +35,7 @@ Motor-driving runs are fault-gated, but only for the motors they actually touch:
 
 Hands-on steps — like clamping an item in the ROM grasp test — pause the run and surface a **Continue** button on the card with the instruction (e.g. "Position the item in the RIGHT gripper, then close it."). The test waits for you and proceeds when you click, so nothing moves until you're ready. Under the hood the diagnostic prints a `[prompt]` marker and blocks on stdin; the button writes a line back to it. (The `motor.info` / `motor.health` read set needs no action here — the motor cards above show it live.)
 
-A **Shut down host** button sits at the top-right of this section and powers the robot host off (`shutdown -h now`) behind a confirmation dialog. It's **refused while any operation or session is running** — cutting power mid-run would drop the arms — so stop what's in flight first; the confirm button stays disabled until the host is idle. The panel loses its connection the moment the host goes down, and bringing the robot back up needs physical access to it. (The one-command install runs as root and powers off directly; a development `axol serve` escalates with `sudo -n`, so a host with no passwordless sudo reports that it couldn't and stays up.)
+Powering the robot host off or rebooting it is done from the [control panel's Axol Host tile](/guides/control-panel#axol-host), which carries the **Restart** and **Shut down** buttons whenever a host is connected.
 
 ## Run history
 

--- a/docs/guides/quest-headless.mdx
+++ b/docs/guides/quest-headless.mdx
@@ -1,0 +1,59 @@
+---
+title: "Quest Without Wearing It"
+description: "Keep the Quest awake with nobody wearing it — disable the proximity sensor so headless teleop and data-collection sessions keep running."
+---
+
+The Quest's **proximity sensor** (inside the visor, between the lenses) puts the headset to sleep the moment it stops seeing a face. Sleep pauses the WebXR session, which stops the controller pose stream and the camera relay — so a headset set down on a desk kills the teleop link within seconds.
+
+That gets in the way of every headless workflow: driving a [data-collection session from the control panel's episode controls](/guides/control-panel#episode-controls), watching the [mirrored camera feeds](/guides/control-panel#operator-view) while the headset only serves as the pose source, or leaving the VR app connected between takes. **Disabling the proximity sensor keeps the headset awake** as if it were being worn.
+
+## One-time setup
+
+The headset must be in **Developer Mode** — the same one-time step used for [Quest over USB](/guides/quest-over-usb#one-time-setup): in the **Meta Quest** phone app, go to **Menu → Devices →** your headset **→ Headset Settings → Developer Mode**, toggle it on, and restart the headset.
+
+## Disable the sensor over adb (recommended)
+
+No extra software is needed: the robot host already has `adb` ([`axol provision`](/cli/provision) installs it for the [Quest-over-USB](/guides/quest-over-usb) link). Plug the headset into the robot host with a USB-C cable, accept the **Allow USB debugging?** prompt in the headset if it appears, then run on the host:
+
+```bash
+adb shell am broadcast -a com.oculus.vrpowermanager.prox_close
+```
+
+The headset now behaves as if it were worn continuously — the display stays on and the VR session keeps running with the headset sitting on a desk. You can unplug the cable afterwards; the setting holds until you undo it or the headset reboots.
+
+To restore normal proximity behavior:
+
+```bash
+adb shell am broadcast -a com.oculus.vrpowermanager.automation_disable
+```
+
+<Note>
+  The override **does not survive a headset reboot** — after a restart the proximity sensor is back to normal and the command has to be run again.
+</Note>
+
+<Warning>
+  With the sensor disabled the display never sleeps, so the battery drains at full VR rate and the lenses keep projecting. Keep the headset on its charger for long sessions, and re-enable the sensor when you're done.
+</Warning>
+
+## Alternative: Meta Quest Developer Hub
+
+If you'd rather use a GUI, the [Meta Quest Developer Hub](https://developers.meta.com/horizon/documentation/unity/ts-odh/) (MQDH) desktop app has the same switch: connect the headset over USB, open **Device Manager**, and turn off **Proximity Sensor** (or press `Ctrl+Shift+P`). Note that MQDH re-enables the sensor about 10 minutes after the headset disconnects from it, so the adb command above is the better fit for a headset that stays plugged into the robot instead of a laptop.
+
+## Running headless
+
+With the sensor disabled, set the headset down facing somewhere convenient and drive the session from the [control panel](/guides/control-panel):
+
+1. Open the VR app at [axol.almond.bot](https://axol.almond.bot) in the headset, connect to the robot, and press **Enter VR** as usual.
+2. Set the headset down. The pose stream and camera relay keep running.
+3. Use the panel's [episode controls](/guides/control-panel#episode-controls) to start, save, and discard takes, and the [operator view](/guides/control-panel#operator-view) to watch the camera feeds. The controllers stay live throughout, so an operator can pick them back up at any time.
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Quest over USB" icon="usb" href="/guides/quest-over-usb">
+    Wire the controller pose link over the same USB cable for lower latency.
+  </Card>
+  <Card title="Web Control Panel" icon="sliders" href="/guides/control-panel">
+    Episode controls and mirrored camera feeds for headset-off sessions.
+  </Card>
+</CardGroup>

--- a/docs/guides/quest-headless.mdx
+++ b/docs/guides/quest-headless.mdx
@@ -11,19 +11,21 @@ That gets in the way of every headless workflow: driving a [data-collection sess
 
 The headset must be in **Developer Mode** — the same one-time step used for [Quest over USB](/guides/quest-over-usb#one-time-setup): in the **Meta Quest** phone app, go to **Menu → Devices →** your headset **→ Headset Settings → Developer Mode**, toggle it on, and restart the headset.
 
-## Disable the sensor over adb (recommended)
+## Keep awake from the control panel (recommended)
 
-No extra software is needed: the robot host already has `adb` ([`axol provision`](/cli/provision) installs it for the [Quest-over-USB](/guides/quest-over-usb) link). Plug the headset into the robot host with a USB-C cable, accept the **Allow USB debugging?** prompt in the headset if it appears, then run on the host:
+The [control panel](/guides/control-panel#quest-usb)'s **Quest USB** settings tab has a **Keep awake** button that disables the proximity sensor for you — no terminal, no extra software. Plug the headset into the robot host with a USB-C cable, accept the **Allow USB debugging?** prompt in the headset if it appears (the same authorization the pose tunnel uses), and press **Keep awake**.
+
+The headset now behaves as if it were worn continuously — the display stays on and the VR session keeps running with the headset sitting on a desk. You can unplug the cable afterwards; the setting holds until you press **Restore** (or the headset reboots).
+
+## Or over adb directly
+
+The panel buttons run these `adb` broadcasts on the robot host ([`axol provision`](/cli/provision) installs `adb` there), so the same thing works from any shell with the headset plugged in:
 
 ```bash
+# Disable the proximity sensor (keep the headset awake)
 adb shell am broadcast -a com.oculus.vrpowermanager.prox_close
-```
 
-The headset now behaves as if it were worn continuously — the display stays on and the VR session keeps running with the headset sitting on a desk. You can unplug the cable afterwards; the setting holds until you undo it or the headset reboots.
-
-To restore normal proximity behavior:
-
-```bash
+# Restore normal proximity behavior
 adb shell am broadcast -a com.oculus.vrpowermanager.automation_disable
 ```
 
@@ -37,7 +39,7 @@ adb shell am broadcast -a com.oculus.vrpowermanager.automation_disable
 
 ## Alternative: Meta Quest Developer Hub
 
-If you'd rather use a GUI, the [Meta Quest Developer Hub](https://developers.meta.com/horizon/documentation/unity/ts-odh/) (MQDH) desktop app has the same switch: connect the headset over USB, open **Device Manager**, and turn off **Proximity Sensor** (or press `Ctrl+Shift+P`). Note that MQDH re-enables the sensor about 10 minutes after the headset disconnects from it, so the adb command above is the better fit for a headset that stays plugged into the robot instead of a laptop.
+The [Meta Quest Developer Hub](https://developers.meta.com/horizon/documentation/unity/ts-odh/) (MQDH) desktop app has the same switch: connect the headset over USB, open **Device Manager**, and turn off **Proximity Sensor** (or press `Ctrl+Shift+P`). Note that MQDH re-enables the sensor about 10 minutes after the headset disconnects from it — and it means installing an app on a laptop — so the panel button above is the better fit for a headset that plugs into the robot.
 
 ## Running headless
 

--- a/docs/guides/quest-over-usb.mdx
+++ b/docs/guides/quest-over-usb.mdx
@@ -64,4 +64,7 @@ When USB is selected, the headset sends every pose frame over **both** the cable
   <Card title="VR Interface" icon="vr-cardboard" href="/guides/vr-interface">
     The WebXR app, camera views, and connection details.
   </Card>
+  <Card title="Quest Without Wearing It" icon="eye-slash" href="/guides/quest-headless">
+    Keep the headset awake headless — the same cable also disables the proximity sensor.
+  </Card>
 </CardGroup>

--- a/web/app/src/components/connections-bar.tsx
+++ b/web/app/src/components/connections-bar.tsx
@@ -1,8 +1,10 @@
-import { Cpu, Loader2, Plug, Server, Power } from "lucide-react"
-import type { ReactNode } from "react"
+import { Cpu, Loader2, Plug, Power, RotateCcw, Server, Unplug } from "lucide-react"
+import { useCallback, useState, type ReactNode } from "react"
 import type { ConnState } from "@/components/setup-dialog"
-import type { MotorHealth, RobotStatus } from "@/lib/supervisor"
+import { restartHost, shutdownHost, type MotorHealth, type RobotStatus } from "@/lib/supervisor"
 import { Button } from "@/components/ui/button"
+import { Card } from "@/components/ui/card"
+import { useToast } from "@/components/ui/toast"
 import { cn } from "@/lib/utils"
 
 type Dot = "ok" | "busy" | "warn" | "err" | "idle"
@@ -58,11 +60,42 @@ function Tile({
   )
 }
 
+/** The two host power actions offered on the connected Axol Host tile. */
+type PowerAction = "shutdown" | "restart"
+
+const POWER_ACTIONS: Record<
+  PowerAction,
+  { title: string; command: string; body: string; button: string; done: string }
+> = {
+  shutdown: {
+    title: "Shut down host",
+    command: "shutdown -h now",
+    body:
+      "This panel loses its connection immediately, and turning the robot " +
+      "back on requires physical access to it.",
+    button: "Shut down",
+    done: "Host is shutting down.",
+  },
+  restart: {
+    title: "Restart host",
+    command: "shutdown -r now",
+    body:
+      "This panel loses its connection while the host reboots — reconnect " +
+      "once it's back up (typically under a minute).",
+    button: "Restart",
+    done: "Host is restarting.",
+  },
+}
+
 /**
  * The two connection tiles: the Axol Host (the machine running `axol serve`)
  * and the Axol robot itself, with live per-motor health and any active motor
  * faults called out (a fault blocks every hardware operation from starting).
  * Cameras and Quest USB live in the Settings tabs below.
+ *
+ * The host tile also carries the host power controls (restart / shut down,
+ * each behind a confirmation) — the Disconnect button only drops this
+ * browser's view and never touches the machine.
  */
 export function ConnectionsBar({
   conn,
@@ -71,6 +104,7 @@ export function ConnectionsBar({
   version,
   onOpenSetup,
   onHostDisconnect,
+  opRunning = false,
   robot,
   robotBusy,
   onRobotConnect,
@@ -83,12 +117,36 @@ export function ConnectionsBar({
   version?: string | null
   onOpenSetup: () => void
   onHostDisconnect: () => void
+  /** An operation or session is in flight — the server would refuse a power
+   *  action (409), so the confirm button is disabled with an explanation. */
+  opRunning?: boolean
   robot: RobotStatus | null
   robotBusy: boolean
   onRobotConnect: () => void
   onRobotDisconnect: () => void
 }) {
+  const toast = useToast()
   const online = conn === "ok"
+
+  // Host power (shutdown -h/-r now), behind a confirmation dialog. The server
+  // refuses while an operation or session is running.
+  const [powerOpen, setPowerOpen] = useState<PowerAction | null>(null)
+  const [powerBusy, setPowerBusy] = useState(false)
+  const confirmPower = useCallback(
+    async (action: PowerAction) => {
+      setPowerBusy(true)
+      try {
+        await (action === "shutdown" ? shutdownHost() : restartHost())
+        setPowerOpen(null)
+        toast.success(POWER_ACTIONS[action].done)
+      } catch (e) {
+        toast.error(String(e))
+      } finally {
+        setPowerBusy(false)
+      }
+    },
+    [toast]
+  )
 
   // -- axol host --
   const wsDot: Dot =
@@ -145,15 +203,38 @@ export function ConnectionsBar({
         }
       >
         {online ? (
-          <Button
-            variant="outline"
-            size="icon"
-            onClick={onHostDisconnect}
-            aria-label="Disconnect Axol Host"
-            className="size-8"
-          >
-            <Power />
-          </Button>
+          <div className="flex items-center gap-1.5">
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={() => setPowerOpen("restart")}
+              aria-label="Restart host"
+              title="Reboot the robot host (shutdown -r now)."
+              className="size-8"
+            >
+              <RotateCcw />
+            </Button>
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={() => setPowerOpen("shutdown")}
+              aria-label="Shut down host"
+              title="Power off the robot host (shutdown -h now)."
+              className="size-8 text-red-300 hover:bg-red-400/10"
+            >
+              <Power />
+            </Button>
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={onHostDisconnect}
+              aria-label="Disconnect Axol Host"
+              title="Disconnect this panel from the host. The host keeps running."
+              className="size-8"
+            >
+              <Unplug />
+            </Button>
+          </div>
         ) : (
           <Button variant="outline" size="sm" onClick={onOpenSetup}>
             <Plug />
@@ -181,9 +262,10 @@ export function ConnectionsBar({
             onClick={onRobotDisconnect}
             disabled={robotBusy}
             aria-label="Disconnect Axol"
+            title="Release the robot link (CAN). The robot stays powered."
             className="size-8"
           >
-            <Power />
+            <Unplug />
           </Button>
         ) : (
           <Button
@@ -197,6 +279,55 @@ export function ConnectionsBar({
           </Button>
         )}
       </Tile>
+
+      {/* Host power confirmation (shutdown / restart) */}
+      {powerOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+          onClick={() => setPowerOpen(null)}
+        >
+          <Card
+            className="w-full max-w-sm gap-4 bg-[#1a1a1a] p-5"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex flex-col gap-1">
+              <h3 className="font-heading text-base font-semibold">
+                {POWER_ACTIONS[powerOpen].title}
+              </h3>
+              <p className="text-sm leading-relaxed text-white/45">
+                {powerOpen === "shutdown" ? "Power off" : "Reboot"} the robot host (
+                <span className="font-mono">{POWER_ACTIONS[powerOpen].command}</span>).{" "}
+                {POWER_ACTIONS[powerOpen].body}
+              </p>
+            </div>
+            {opRunning && (
+              <p className="text-xs text-amber-200/70">
+                A run or operation is in flight — stop it first.
+              </p>
+            )}
+            <div className="flex items-center justify-end gap-2 pt-1">
+              <Button variant="ghost" size="sm" onClick={() => setPowerOpen(null)}>
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={() => confirmPower(powerOpen)}
+                disabled={powerBusy || opRunning}
+              >
+                {powerBusy ? (
+                  <Loader2 className="animate-spin" />
+                ) : powerOpen === "shutdown" ? (
+                  <Power />
+                ) : (
+                  <RotateCcw />
+                )}{" "}
+                {POWER_ACTIONS[powerOpen].button}
+              </Button>
+            </div>
+          </Card>
+        </div>
+      )}
     </div>
   )
 }

--- a/web/app/src/components/diagnostics/run-history.tsx
+++ b/web/app/src/components/diagnostics/run-history.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react"
-import { ChevronRight, History, Loader2 } from "lucide-react"
+import { ChevronLeft, ChevronRight, History, Loader2 } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
@@ -45,11 +45,16 @@ function runBadge(meta: DiagnosticsRunMeta): {
   return { variant: "success", text: "ok" }
 }
 
+/** Runs shown per page — telemetry-heavy details load per run on expand, so
+ * the page size only bounds the visible list, not any data transfer. */
+const PAGE_SIZE = 10
+
 /**
  * Past diagnostics runs (ROM test, homing, …) with their captured telemetry
  * re-charted — same joint filter and zoom/pan as the live charts. Captures
  * record position + torque (velocity is not cached by the motor layer during
- * a script's own control loop).
+ * a script's own control loop). Paginated newest-first so a long history
+ * doesn't stretch the page.
  */
 export function RunHistory({
   runs,
@@ -63,6 +68,12 @@ export function RunHistory({
   onClear: () => void
 }) {
   const [openId, setOpenId] = useState<string | null>(null)
+  const [rawPage, setRawPage] = useState(0)
+  // Clamp instead of storing: a shrinking list (Clear, deletions on refresh)
+  // must never leave the view on a page past the end.
+  const pageCount = Math.max(1, Math.ceil(runs.length / PAGE_SIZE))
+  const page = Math.min(rawPage, pageCount - 1)
+  const pageRuns = runs.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE)
 
   return (
     <Card className="gap-3 p-4">
@@ -99,35 +110,70 @@ export function RunHistory({
           No runs yet — launch a diagnostic above and it will be recorded here.
         </p>
       ) : (
-        <div className="flex flex-col divide-y divide-white/[0.06]">
-          {runs.map((meta) => {
-            const open = openId === meta.id
-            const badge = runBadge(meta)
-            return (
-              <div key={meta.id} className="py-1">
-                <button
-                  type="button"
-                  onClick={() => setOpenId(open ? null : meta.id)}
-                  className="flex w-full items-center gap-3 rounded-md px-1 py-2 text-left hover:bg-white/[0.03]"
+        <>
+          <div className="flex flex-col divide-y divide-white/[0.06]">
+            {pageRuns.map((meta) => {
+              const open = openId === meta.id
+              const badge = runBadge(meta)
+              return (
+                <div key={meta.id} className="py-1">
+                  <button
+                    type="button"
+                    onClick={() => setOpenId(open ? null : meta.id)}
+                    className="flex w-full items-center gap-3 rounded-md px-1 py-2 text-left hover:bg-white/[0.03]"
+                  >
+                    <ChevronRight
+                      className={cn(
+                        "size-4 shrink-0 text-white/40 transition-transform",
+                        open && "rotate-90"
+                      )}
+                    />
+                    <span className="font-mono text-xs text-white/85">{meta.command}</span>
+                    <Badge variant={badge.variant}>{badge.text}</Badge>
+                    <span className="ml-auto hidden text-xs text-white/40 sm:inline">
+                      {fmtDuration(meta)}
+                    </span>
+                    <span className="text-xs text-white/40">{fmtWhen(meta.startedAt)}</span>
+                  </button>
+                  {open && <RunDetail id={meta.id} />}
+                </div>
+              )
+            })}
+          </div>
+          {pageCount > 1 && (
+            <div className="flex items-center justify-between border-t border-white/[0.06] pt-2">
+              <span className="text-xs text-white/40">
+                {page * PAGE_SIZE + 1}–{Math.min((page + 1) * PAGE_SIZE, runs.length)} of{" "}
+                {runs.length} runs
+              </span>
+              <div className="flex items-center gap-1">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-white/50"
+                  onClick={() => setRawPage(page - 1)}
+                  disabled={page === 0}
+                  aria-label="Previous page"
                 >
-                  <ChevronRight
-                    className={cn(
-                      "size-4 shrink-0 text-white/40 transition-transform",
-                      open && "rotate-90"
-                    )}
-                  />
-                  <span className="font-mono text-xs text-white/85">{meta.command}</span>
-                  <Badge variant={badge.variant}>{badge.text}</Badge>
-                  <span className="ml-auto hidden text-xs text-white/40 sm:inline">
-                    {fmtDuration(meta)}
-                  </span>
-                  <span className="text-xs text-white/40">{fmtWhen(meta.startedAt)}</span>
-                </button>
-                {open && <RunDetail id={meta.id} />}
+                  <ChevronLeft /> Prev
+                </Button>
+                <span className="text-xs text-white/40">
+                  {page + 1} / {pageCount}
+                </span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="text-white/50"
+                  onClick={() => setRawPage(page + 1)}
+                  disabled={page >= pageCount - 1}
+                  aria-label="Next page"
+                >
+                  Next <ChevronRight />
+                </Button>
               </div>
-            )
-          })}
-        </div>
+            </div>
+          )}
+        </>
       )}
     </Card>
   )

--- a/web/app/src/components/settings/settings-section.tsx
+++ b/web/app/src/components/settings/settings-section.tsx
@@ -1,7 +1,18 @@
 import { useMemo, useRef, useState } from "react"
-import { ChevronDown, Download, Loader2, Plug, RotateCcw, Search, Upload } from "lucide-react"
+import {
+  ChevronDown,
+  Download,
+  Eye,
+  EyeOff,
+  Loader2,
+  Plug,
+  RotateCcw,
+  Search,
+  Upload,
+} from "lucide-react"
 import {
   flattenFields,
+  setQuestProximityDisabled,
   type AdvancedSection,
   type CameraDevice,
   type CameraSpec,
@@ -371,7 +382,9 @@ function UpdateRequired({ error }: { error: string }) {
   )
 }
 
-/** The Quest-over-USB pose link: live status + connect, from the old tile. */
+/** The Quest-over-USB pose link: live status + connect, from the old tile —
+ * plus the headless "keep awake" proximity-sensor override over the same
+ * cable, so nobody has to type adb commands. */
 function UsbPanel({
   usb,
   usbBusy,
@@ -381,6 +394,27 @@ function UsbPanel({
   usbBusy: boolean
   onUsbConnect: () => void
 }) {
+  const toast = useToast()
+  // Which proximity action is in flight ("off" = disabling the sensor).
+  const [proxBusy, setProxBusy] = useState<"off" | "on" | null>(null)
+  const setProximity = async (disabled: boolean) => {
+    setProxBusy(disabled ? "off" : "on")
+    try {
+      await setQuestProximityDisabled(disabled)
+      toast.success(
+        disabled
+          ? "Proximity sensor disabled — the headset stays awake until it reboots."
+          : "Proximity sensor restored."
+      )
+    } catch (e) {
+      toast.error(String(e))
+    } finally {
+      setProxBusy(null)
+    }
+  }
+  // The broadcast needs an attached, authorized headset — same bar as the
+  // pose tunnel's Connect.
+  const proxReady = usb?.state === "device"
   const dotClass = !usb
     ? "bg-white/30"
     : !usb.installed
@@ -441,6 +475,38 @@ function UsbPanel({
           </Button>
         </div>
         <p className="max-w-prose text-xs text-white/35">{hint}</p>
+      </div>
+      <div className="flex max-w-xl flex-col gap-1.5">
+        <div className="flex items-center justify-between gap-4">
+          <Label>Keep awake (headless)</Label>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setProximity(true)}
+              disabled={!proxReady || proxBusy != null}
+              title="Disable the proximity sensor (adb) so the headset stays awake with nobody wearing it."
+            >
+              {proxBusy === "off" ? <Loader2 className="animate-spin" /> : <EyeOff />}
+              Keep awake
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setProximity(false)}
+              disabled={!proxReady || proxBusy != null}
+              title="Restore normal proximity-sensor behavior (the headset sleeps when taken off)."
+            >
+              {proxBusy === "on" ? <Loader2 className="animate-spin" /> : <Eye />}
+              Restore
+            </Button>
+          </div>
+        </div>
+        <p className="max-w-prose text-xs text-white/35">
+          Disables the headset's proximity sensor so it keeps running when set down — for sessions
+          driven from this panel with nobody wearing it. Resets when the headset reboots; battery
+          drains at full rate, so keep it charging. Needs the headset plugged in and authorized.
+        </p>
       </div>
     </div>
   )

--- a/web/app/src/lib/supervisor.ts
+++ b/web/app/src/lib/supervisor.ts
@@ -215,6 +215,14 @@ export async function shutdownHost(): Promise<{ ok: boolean }> {
   return json(await fetch(apiUrl("/api/host/shutdown"), { method: "POST" }))
 }
 
+/**
+ * Reboot the serve host (`shutdown -r now`). Refused (409) while an
+ * operation or session is running.
+ */
+export async function restartHost(): Promise<{ ok: boolean }> {
+  return json(await fetch(apiUrl("/api/host/restart"), { method: "POST" }))
+}
+
 // ---------------------------------------------------------------------------
 // Robot connection (detached CAN + 1 Hz motor ping)
 // ---------------------------------------------------------------------------

--- a/web/app/src/lib/supervisor.ts
+++ b/web/app/src/lib/supervisor.ts
@@ -360,6 +360,21 @@ export async function usbConnect(): Promise<UsbStatus> {
   return json(await fetch(apiUrl("/api/usb/connect"), { method: "POST" }))
 }
 
+/**
+ * Disable (true) or restore (false) the headset's proximity sensor over adb.
+ * Disabled, the Quest stays awake with nobody wearing it — headless sessions
+ * keep their pose stream. Holds until restored or the headset reboots.
+ */
+export async function setQuestProximityDisabled(disabled: boolean): Promise<{ ok: boolean }> {
+  return json(
+    await fetch(apiUrl("/api/usb/proximity"), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ disabled }),
+    })
+  )
+}
+
 // ---------------------------------------------------------------------------
 // In-process operations (teleop / gravity-comp / collect-data / run-policy)
 // ---------------------------------------------------------------------------

--- a/web/app/src/routes/ControlPanel.tsx
+++ b/web/app/src/routes/ControlPanel.tsx
@@ -539,13 +539,15 @@ export default function ControlPanel() {
   const selectedLive = isLive && runningOp === opId
   const selectedStopping = isStopping && runningOp === opId
 
-  // Whether an update is currently unsafe to apply. `isLive` is the immediate,
-  // local signal (reacts the instant an op starts/stops) so the banner blocks
-  // without waiting for the slow status poll; the server's `update.idle` is the
-  // backstop for any other non-idle reason (and the server guards the request
-  // regardless). Mirrors the server's _is_idle: only a running operation blocks
-  // a restart (a connected robot is fine).
-  const updateBlocked = isLive || !(update?.idle ?? true)
+  // Whether the host is currently unsafe to restart / power off / update.
+  // `isLive` is the immediate, local signal (reacts the instant an op starts/
+  // stops) so the UI blocks without waiting for the slow status poll; the
+  // server's `update.idle` is the backstop for any other non-idle reason —
+  // e.g. a diagnostics run launched from another page or browser — (and the
+  // server guards each request regardless). Mirrors the server's _is_idle:
+  // only a running operation/session blocks (a connected robot is fine).
+  // Shared by the update banner and the host tile's power confirmations.
+  const hostBusy = isLive || !(update?.idle ?? true)
   // Reason shown in the banner; capitalized clause, no trailing period.
   const updateBusyReason = isLive ? "Stop the running operation" : "The server is busy"
 
@@ -787,7 +789,7 @@ export default function ControlPanel() {
             update={update}
             updating={updating}
             phase={updatePhase}
-            blocked={updateBlocked}
+            blocked={hostBusy}
             busyReason={updateBusyReason}
             onUpdate={handleUpdate}
           />
@@ -804,7 +806,7 @@ export default function ControlPanel() {
           version={update?.version ?? hostInfo?.version ?? null}
           onOpenSetup={() => setSetupOpen(true)}
           onHostDisconnect={hostDisconnectClick}
-          opRunning={isLive}
+          opRunning={hostBusy}
           robot={robot}
           robotBusy={robotBusy}
           onRobotConnect={() => robotConnectClick()}

--- a/web/app/src/routes/ControlPanel.tsx
+++ b/web/app/src/routes/ControlPanel.tsx
@@ -804,6 +804,7 @@ export default function ControlPanel() {
           version={update?.version ?? hostInfo?.version ?? null}
           onOpenSetup={() => setSetupOpen(true)}
           onHostDisconnect={hostDisconnectClick}
+          opRunning={isLive}
           robot={robot}
           robotBusy={robotBusy}
           onRobotConnect={() => robotConnectClick()}

--- a/web/app/src/routes/Diagnostics.tsx
+++ b/web/app/src/routes/Diagnostics.tsx
@@ -5,7 +5,6 @@ import {
   Crosshair,
   ClipboardList,
   Loader2,
-  Power,
   Radio,
   SlidersHorizontal,
   Tag,
@@ -14,7 +13,6 @@ import {
 } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { Card } from "@/components/ui/card"
 import { SiteNav } from "@/components/site-nav"
 import { useToast } from "@/components/ui/toast"
 import { MotorGrid } from "@/components/diagnostics/motor-grid"
@@ -41,7 +39,6 @@ import {
   robotConnect,
   sendSessionInput,
   setServerBase,
-  shutdownHost,
   stopSession,
   useSessionLogs,
   type CommandSpec,
@@ -333,23 +330,6 @@ export default function Diagnostics() {
       setLaunchBusy(false)
     }
   }, [activeRun, toast])
-
-  // Host power-off (shutdown -h now), behind a confirmation dialog. The
-  // server refuses while an operation or session is running.
-  const [shutdownOpen, setShutdownOpen] = useState(false)
-  const [shutdownBusy, setShutdownBusy] = useState(false)
-  const confirmShutdown = useCallback(async () => {
-    setShutdownBusy(true)
-    try {
-      await shutdownHost()
-      setShutdownOpen(false)
-      toast.success("Host is shutting down.")
-    } catch (e) {
-      toast.error(String(e))
-    } finally {
-      setShutdownBusy(false)
-    }
-  }, [toast])
 
   const connectRobot = useCallback(async () => {
     setRobotBusy(true)
@@ -849,19 +829,7 @@ export default function Diagnostics() {
 
         {/* Diagnostics actions */}
         <section className="flex flex-col gap-3">
-          <div className="flex flex-wrap items-center gap-3">
-            <h2 className="font-heading text-base font-semibold">Diagnostics</h2>
-            <Button
-              variant="outline"
-              size="sm"
-              className="ml-auto text-red-300 hover:bg-red-400/10"
-              title="Power off the robot host (shutdown -h now)."
-              disabled={!serverOk}
-              onClick={() => setShutdownOpen(true)}
-            >
-              <Power /> Shut down host
-            </Button>
-          </div>
+          <h2 className="font-heading text-base font-semibold">Diagnostics</h2>
           <DiagnosticActions
             commands={diagCommands}
             activeCommand={activeRun?.command ?? null}
@@ -907,46 +875,6 @@ export default function Diagnostics() {
           onStop={stopActive}
           onClose={() => setMotorTool(null)}
         />
-      )}
-
-      {/* Host shutdown confirmation */}
-      {shutdownOpen && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
-          onClick={() => setShutdownOpen(false)}
-        >
-          <Card
-            className="w-full max-w-sm gap-4 bg-[#1a1a1a] p-5"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="flex flex-col gap-1">
-              <h3 className="font-heading text-base font-semibold">Shut down host</h3>
-              <p className="text-sm leading-relaxed text-white/45">
-                Power off the robot host (<span className="font-mono">shutdown -h now</span>).
-                This panel loses its connection immediately, and turning the robot back on
-                requires physical access to it.
-              </p>
-            </div>
-            {(activeRun != null || busyElsewhere) && (
-              <p className="text-xs text-amber-200/70">
-                A run or operation is in flight — stop it before shutting down.
-              </p>
-            )}
-            <div className="flex items-center justify-end gap-2 pt-1">
-              <Button variant="ghost" size="sm" onClick={() => setShutdownOpen(false)}>
-                Cancel
-              </Button>
-              <Button
-                variant="destructive"
-                size="sm"
-                onClick={confirmShutdown}
-                disabled={shutdownBusy || activeRun != null || busyElsewhere}
-              >
-                {shutdownBusy ? <Loader2 className="animate-spin" /> : <Power />} Shut down
-              </Button>
-            </div>
-          </Card>
-        </div>
       )}
 
       {/* Manual CAN interface selection (non-Axol-hub adapters) */}


### PR DESCRIPTION
## Summary

Customer feedback: the host power-off was buried in the diagnostics page, there were no docs for using the Quest without wearing it, connecting a swapped Axol required manually re-running can.setup, and a long diagnostics run history stretched the page.

- **Host power controls moved to the control panel's Axol Host tile.** When a host is connected the tile now shows **Restart** and **Shut down** buttons (each behind a confirmation dialog, disabled while the host is busy — locally-known ops plus the server's idle backstop, and the server refuses with a 409 regardless), plus the existing client-side **Disconnect**, re-iconed from a power symbol to an unplug so it can't be mistaken for powering the robot off. The robot tile's disconnect got the same icon swap. The **Shut down host** button was removed from the diagnostics page.
- **New `/api/host/restart` endpoint** (`shutdown -r now`), sharing the shutdown handler's idle guard and `sudo -n` escalation.
- **Connect now registers a swapped Axol hub.** `ensure_setup`'s hub-serial resolution preferred the serial pinned by a previous setup even when that adapter was absent and a different hub was attached (host last ran on another Axol, or the hub was replaced) — re-pinning the missing adapter and leaving the attached hub unnamed on `canX`, so the operator had to run the interactive `can.setup` from diagnostics. A stale pin now loses to the attached hub (when unambiguous), matching what the interactive flow picks; an unplugged hub with nothing else attached still keeps its pin.
- **Diagnostics run history is paginated** newest-first, 10 runs per page, with prev/next controls and a range indicator. Details still load per run on expand.
- **Headless "Keep awake" from the panel.** The Quest USB settings tab gets **Keep awake** / **Restore** buttons that disable/restore the headset's proximity sensor through the host's adb (new `/api/usb/proximity`, broadcasting `com.oculus.vrpowermanager.prox_close` / `automation_disable`) — same cable and USB-debugging authorization the pose tunnel already uses, so nobody has to type adb commands.
- **New docs guide: [Quest Without Wearing It](docs/guides/quest-headless.mdx)** — leads with the panel button, keeps the raw adb broadcasts as the shell path (verified against Meta's scriptable-testing docs), and covers MQDH as a fallback. Cross-linked from the Quest-over-USB guide and added to the nav. The control-panel and diagnostics-dashboard guides were updated for the moved buttons, pagination, and the new tab controls.

## Test plan

- [x] ruff check + format clean on `serve/app.py`, `cli/can/setup.py`, `utils/adb.py`
- [x] Web build (`tsc` + Vite, both workspaces) passes; eslint clean on all touched files
- [x] Verified `/api/host/shutdown`, `/api/host/restart`, and `/api/usb/proximity` register on the FastAPI app
- [x] `_resolve_hub_serial` exercised across 8 configured/attached scenarios (fresh host, same hub, swapped hub, unplugged hub, ambiguous)
- [ ] On a robot host: confirm restart/shutdown from the tile work and are refused while an op runs
- [ ] Swap an Axol hub on a configured host and confirm Connect registers it without a manual can.setup
- [ ] With a headset on USB: Keep awake keeps the set-down headset streaming; Restore brings sleep back