### PR TITLE
Server-driven text-input episode controls in the panel

### DIFF
--- a/web/app/src/components/operation-panel.tsx
+++ b/web/app/src/components/operation-panel.tsx
@@ -31,6 +31,7 @@ import { CameraFeeds, type VrHud } from "@/components/camera-feeds"
 import { Card, CardContent } from "@/components/ui/card"
 import { Button, buttonVariants } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
+import { Input } from "@/components/ui/input"
 import { cn } from "@/lib/utils"
 
 /**
@@ -596,6 +597,9 @@ function EpisodeControls({
     onEpisode(control.command)
   }
 
+  const buttons = controls.filter((c) => !c.input)
+  const inputs = controls.filter((c) => c.input)
+
   return (
     <div className="flex flex-col gap-3 rounded-lg border border-[#eff483]/25 bg-[#eff483]/[0.04] p-3">
       <div className="flex flex-wrap items-center justify-between gap-3">
@@ -612,9 +616,9 @@ function EpisodeControls({
         </span>
       </div>
       <span className="text-sm text-white/60">{displayStatus}</span>
-      {controls.length > 0 && (
+      {buttons.length > 0 && (
         <div className="flex flex-wrap gap-2">
-          {controls.map((c, i) => (
+          {buttons.map((c, i) => (
             <Button
               key={c.command}
               variant={armed === c.command ? "destructive" : i === 0 ? "default" : "outline"}
@@ -626,6 +630,58 @@ function EpisodeControls({
           ))}
         </div>
       )}
+      {inputs.map((c) => (
+        // Keyed on the placeholder too: a new target (e.g. the next saved
+        // episode) resets the field even though the command stays the same.
+        <EpisodeInputControl
+          key={`${c.command}:${c.placeholder ?? ""}`}
+          control={c}
+          onEpisode={onEpisode}
+        />
+      ))}
+    </div>
+  )
+}
+
+/**
+ * A server-driven episode control rendered as a text field + submit button
+ * (`input: true` on the spec): submitting posts `${command} ${text}` to
+ * /api/op/episode — e.g. axol-pi's post-episode notes, where the op attaches
+ * the text to the just-saved episode. The field starts from the spec's
+ * `value` (the current server-side text), so an earlier submission survives
+ * phase changes and can be edited; submit is disabled while the text matches
+ * what the server already has.
+ */
+function EpisodeInputControl({
+  control,
+  onEpisode,
+}: {
+  control: EpisodeControlSpec
+  onEpisode: (command: string) => void
+}) {
+  const [text, setText] = useState(control.value ?? "")
+  const serverValue = control.value ?? ""
+  const unchanged = text.trim() === serverValue.trim()
+
+  function submit() {
+    if (unchanged || !text.trim()) return
+    onEpisode(`${control.command} ${text.trim()}`)
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <Input
+        value={text}
+        placeholder={control.placeholder}
+        onChange={(e) => setText(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") submit()
+        }}
+        className="h-8 flex-1"
+      />
+      <Button variant="outline" size="sm" disabled={unchanged || !text.trim()} onClick={submit}>
+        {control.label}
+      </Button>
     </div>
   )
 }

--- a/web/app/src/components/operation-panel.tsx
+++ b/web/app/src/components/operation-panel.tsx
@@ -646,8 +646,8 @@ function EpisodeControls({
 /**
  * A server-driven episode control rendered as a text field + submit button
  * (`input: true` on the spec): submitting posts `${command} ${text}` to
- * /api/op/episode — e.g. axol-pi's post-episode notes, where the op attaches
- * the text to the just-saved episode. The field starts from the spec's
+ * /api/op/episode — e.g. a downstream op's post-episode notes, where the op
+ * attaches the text to the just-saved episode. The field starts from the spec's
  * `value` (the current server-side text), so an earlier submission survives
  * phase changes and can be edited; submit is disabled while the text matches
  * what the server already has.

--- a/web/app/src/lib/supervisor.ts
+++ b/web/app/src/lib/supervisor.ts
@@ -398,6 +398,16 @@ export interface EpisodeControlSpec {
   /** Arm on first click and require a second, confirming click — the panel's
    *  stand-in for the headset's double-press save/discard confirmation. */
   confirm?: boolean
+  /** Render as a text field + submit button instead of a plain button;
+   *  submitting posts `${command} ${text}` (e.g. axol-pi's post-episode
+   *  notes). */
+  input?: boolean
+  /** The input's placeholder — doubles as the operator instruction (e.g.
+   *  which episode the text attaches to). */
+  placeholder?: string
+  /** The current server-side text, prefilled whenever the input (re)appears
+   *  so a submitted value survives phase changes and can be edited. */
+  value?: string
 }
 
 export interface PolicyState {

--- a/web/app/src/lib/supervisor.ts
+++ b/web/app/src/lib/supervisor.ts
@@ -399,8 +399,8 @@ export interface EpisodeControlSpec {
    *  stand-in for the headset's double-press save/discard confirmation. */
   confirm?: boolean
   /** Render as a text field + submit button instead of a plain button;
-   *  submitting posts `${command} ${text}` (e.g. axol-pi's post-episode
-   *  notes). */
+   *  submitting posts `${command} ${text}` (e.g. a downstream op's
+   *  post-episode notes). */
   input?: boolean
   /** The input's placeholder — doubles as the operator instruction (e.g.
    *  which episode the text attaches to). */


### PR DESCRIPTION
## Summary
- `EpisodeControlSpec` gains an `input` variant (`input` / `placeholder` / `value`): the panel renders it as a text field + submit button and posts `${command} ${text}` through the existing `/api/op/episode` channel — no new endpoint, and ops that only publish plain buttons are unaffected.
- The field prefills from the spec's `value` (the current server-side text) and is keyed on the placeholder, so a new target resets it, an earlier submission survives phase changes, and submit stays disabled while the text matches what the server already has.
- Motivation: lets a downstream package's episode control collect free-text operator input server-driven — e.g. post-episode notes typed at the between-episode gate and attached to the just-saved episode — without the panel knowing that flow.

## Test plan
- [x] `npm run build` (tsc + vite) clean
- [x] eslint clean on the touched files (the `supervisor.ts:1003` set-state-in-effect error pre-exists on main)
- [ ] Against a downstream op publishing an input control: submit text at the gate, confirm the command posts and the field prefills from the next status poll