### PR TITLE
Add Cartesian dataset migration for URDF frame change

### DIFF
--- a/almond_axol/cli/__init__.py
+++ b/almond_axol/cli/__init__.py
@@ -5,6 +5,7 @@ import importlib
 import sys
 
 from ..utils.dotenv import load_local_env
+from . import migrate_dataset as migrate_dataset_cmd
 from . import provision as provision_cmd
 from . import serve as serve_cmd
 from .can import driver as can_driver
@@ -118,6 +119,7 @@ def main() -> None:
     pid.add_parser(subparsers)
     friction.add_parser(subparsers)
     repeatability.add_parser(subparsers)
+    migrate_dataset_cmd.add_parser(subparsers)
     serve_cmd.add_parser(subparsers)
 
     # Register the draccus + diagnostics commands as bare subparsers purely so

--- a/almond_axol/cli/migrate_dataset.py
+++ b/almond_axol/cli/migrate_dataset.py
@@ -1,0 +1,414 @@
+"""Migrate pre-v0.1.32 Cartesian datasets to the forward-facing URDF frame.
+
+Axol v0.1.32 added a +90 degree yaw to the URDF root.  Cartesian datasets
+recorded by earlier versions therefore contain end-effector poses in the old
+world frame.  Replaying those poses with the new URDF rotates the motion by
+roughly 90 degrees.
+
+This command applies the same rigid transform as the URDF change to every
+Cartesian action and observation, then refreshes per-episode and dataset
+statistics.  Videos and all non-Cartesian values are left untouched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+from pathlib import Path
+from typing import Any
+
+
+_MIGRATION_ID = "axol-urdf-root-yaw-v0.1.32"
+_FIELDS = ("action", "observation.state")
+_ARMS = ("left", "right")
+
+
+def _atomic_json(path: Path, data: dict[str, Any]) -> None:
+    tmp = path.with_name(f".{path.name}.tmp")
+    tmp.write_text(json.dumps(data, indent=4, ensure_ascii=False) + "\n")
+    os.replace(tmp, path)
+
+
+def _resolve_dataset(repo_id: str, root: str | None) -> Path:
+    from ..recording.datasets import is_dataset_dir, lerobot_home, list_datasets
+
+    direct = Path(repo_id).expanduser()
+    if is_dataset_dir(direct):
+        return direct.resolve()
+
+    base = Path(root).expanduser() if root else lerobot_home()
+    candidate = base / repo_id
+    if is_dataset_dir(candidate):
+        return candidate.resolve()
+
+    available = list_datasets(base)
+    listing = "\n".join(f"  {item.repo_id}" for item in available)
+    suffix = f"\nDatasets found under {base}:\n{listing}" if listing else ""
+    raise FileNotFoundError(
+        f"No local LeRobot dataset found at {candidate} (missing meta/info.json)."
+        f"{suffix}"
+    )
+
+
+def _validate_source_version(source_version: str) -> str:
+    """Normalize and verify that the supplied recording version is old."""
+    match = re.fullmatch(r"v?(\d+)\.(\d+)\.(\d+)(?:[.-].*)?", source_version)
+    if match is None:
+        raise ValueError(
+            f"Invalid --from-version {source_version!r}; expected a version like v0.1.29."
+        )
+    parsed = tuple(int(part) for part in match.groups())
+    if parsed >= (0, 1, 32):
+        raise ValueError(
+            f"axol {source_version} already uses the forward-facing URDF frame; "
+            "this dataset must not be migrated."
+        )
+    return ".".join(str(part) for part in parsed)
+
+
+def _pose_indices(info: dict[str, Any]) -> dict[str, list[tuple[list[int], list[int]]]]:
+    """Return position/rotation indices for every Cartesian field and arm."""
+    layouts: dict[str, list[tuple[list[int], list[int]]]] = {}
+    features = info.get("features", {})
+    for field in _FIELDS:
+        spec = features.get(field)
+        if spec is None:
+            continue
+        names = spec.get("names") or []
+        ee_names = [name for name in names if isinstance(name, str) and "_ee." in name]
+        if not ee_names:
+            continue
+        arms: list[tuple[list[int], list[int]]] = []
+        for arm in _ARMS:
+            expected = [
+                f"{arm}_ee.{axis}" for axis in ("x", "y", "z", "rx", "ry", "rz")
+            ]
+            missing = [name for name in expected if name not in names]
+            if missing:
+                raise ValueError(
+                    f"{field} has an unrecognized Cartesian layout; missing {missing}. "
+                    "No files were changed."
+                )
+            arms.append(
+                (
+                    [names.index(name) for name in expected[:3]],
+                    [names.index(name) for name in expected[3:]],
+                )
+            )
+        layouts[field] = arms
+
+    if "action" not in layouts:
+        raise ValueError(
+            "This is not an Axol Cartesian dataset: action does not contain the "
+            "left/right 6-axis EE pose names. Joint-space datasets do not need this migration."
+        )
+    return layouts
+
+
+def _transform_matrix(matrix: Any, arms: list[tuple[list[int], list[int]]]) -> Any:
+    """Premultiply each pose in ``matrix`` by the URDF's +90 degree root yaw."""
+    import numpy as np
+    from scipy.spatial.transform import Rotation
+
+    from ..recording.cartesian_frame import URDF_ROOT_YAW_RADIANS
+
+    out = np.asarray(matrix, dtype=np.float32).copy()
+    root_rotation = Rotation.from_rotvec(np.array([0.0, 0.0, URDF_ROOT_YAW_RADIANS]))
+    for pos_idx, rot_idx in arms:
+        pos = out[:, pos_idx].copy()
+        # Rz(+90): (x, y, z) -> (-y, x, z).  Spell this out to avoid an
+        # unnecessary float round trip for positions.
+        out[:, pos_idx[0]] = -pos[:, 1]
+        out[:, pos_idx[1]] = pos[:, 0]
+        out[:, pos_idx[2]] = pos[:, 2]
+        old_rotation = Rotation.from_rotvec(out[:, rot_idx])
+        out[:, rot_idx] = (root_rotation * old_rotation).as_rotvec().astype(np.float32)
+    return out
+
+
+def _table_matrix(table: Any, field: str) -> Any:
+    import numpy as np
+
+    return np.asarray(table[field].combine_chunks().to_pylist(), dtype=np.float32)
+
+
+def _replace_matrix(table: Any, field: str, matrix: Any) -> Any:
+    import pyarrow as pa
+
+    index = table.schema.get_field_index(field)
+    original_type = table.schema.field(index).type
+    values = pa.array(matrix.tolist(), type=original_type)
+    return table.set_column(index, field, values)
+
+
+def _write_parquet_atomic(path: Path, table: Any) -> None:
+    import pyarrow.parquet as pq
+
+    parquet = pq.ParquetFile(path)
+    compression = "snappy"
+    if parquet.metadata.num_row_groups and parquet.metadata.num_columns:
+        compression = parquet.metadata.row_group(0).column(0).compression.lower()
+    tmp = path.with_name(f".{path.name}.tmp")
+    pq.write_table(table, tmp, compression=compression)
+    shutil.copymode(path, tmp)
+    os.replace(tmp, path)
+
+
+def _backup_files(
+    dataset_root: Path, files: list[Path], backup_root: Path
+) -> dict[str, Any]:
+    marker = dataset_root / "meta" / "axol.json"
+    manifest: dict[str, Any] = {
+        "migration": _MIGRATION_ID,
+        "state": "backed_up",
+        "files": [str(path.relative_to(dataset_root)) for path in files],
+        "marker_existed": marker.exists(),
+    }
+    files_root = backup_root / "files"
+    files_root.mkdir(parents=True, exist_ok=True)
+    for source in files:
+        destination = files_root / source.relative_to(dataset_root)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+    _atomic_json(backup_root / "manifest.json", manifest)
+    return manifest
+
+
+def _restore_backup(
+    dataset_root: Path, backup_root: Path, manifest: dict[str, Any]
+) -> None:
+    files_root = backup_root / "files"
+    for relative in manifest["files"]:
+        source = files_root / relative
+        destination = dataset_root / relative
+        tmp = destination.with_name(f".{destination.name}.restore.tmp")
+        shutil.copy2(source, tmp)
+        os.replace(tmp, destination)
+    if not manifest.get("marker_existed", False):
+        (dataset_root / "meta" / "axol.json").unlink(missing_ok=True)
+
+
+def _stats_from_row(row: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    import numpy as np
+
+    nested: dict[str, dict[str, Any]] = {}
+    for key, value in row.items():
+        if not key.startswith("stats/") or value is None:
+            continue
+        _, feature, statistic = key.split("/", 2)
+        nested.setdefault(feature, {})[statistic] = np.asarray(value)
+    return nested
+
+
+def _refresh_episode_stats(
+    dataset_root: Path,
+    info: dict[str, Any],
+    layouts: dict[str, list[tuple[list[int], list[int]]]],
+    episode_files: list[Path],
+) -> list[dict[str, dict[str, Any]]]:
+    import numpy as np
+    import pyarrow.parquet as pq
+    from lerobot.datasets.compute_stats import compute_episode_stats
+
+    data_template = info.get(
+        "data_path", "data/chunk-{chunk_index:03d}/file-{file_index:03d}.parquet"
+    )
+    features = info["features"]
+    all_stats: list[dict[str, dict[str, Any]]] = []
+    cached_path: Path | None = None
+    cached_table: Any = None
+
+    for episode_file in episode_files:
+        metadata_table = pq.read_table(episode_file)
+        rows = metadata_table.to_pylist()
+        for row in rows:
+            data_path = dataset_root / data_template.format(
+                chunk_index=int(row["data/chunk_index"]),
+                file_index=int(row["data/file_index"]),
+            )
+            if data_path != cached_path:
+                cached_table = pq.read_table(
+                    data_path, columns=[*layouts, "episode_index"]
+                )
+                cached_path = data_path
+            episode_index = int(row["episode_index"])
+            episode_ids = np.asarray(cached_table["episode_index"].combine_chunks())
+            mask = episode_ids == episode_index
+            if not mask.any():
+                raise ValueError(f"Episode {episode_index} has no rows in {data_path}.")
+
+            for field in layouts:
+                matrix = _table_matrix(cached_table, field)[mask]
+                computed = compute_episode_stats(
+                    {field: matrix}, {field: features[field]}
+                )[field]
+                for statistic, value in computed.items():
+                    row[f"stats/{field}/{statistic}"] = np.asarray(value).tolist()
+            all_stats.append(_stats_from_row(row))
+
+        import pyarrow as pa
+
+        updated = pa.Table.from_pylist(rows, schema=metadata_table.schema)
+        _write_parquet_atomic(episode_file, updated)
+
+    return all_stats
+
+
+def migrate_dataset(
+    dataset_root: Path, *, source_version: str, dry_run: bool = False
+) -> dict[str, int]:
+    """Apply the pre-v0.1.32 -> current URDF frame migration in place."""
+    import pyarrow.parquet as pq
+    from lerobot.datasets.compute_stats import aggregate_stats
+    from lerobot.datasets.utils import serialize_dict
+
+    from ..recording.cartesian_frame import (
+        CARTESIAN_FRAME_ID,
+        write_cartesian_frame_marker,
+    )
+
+    source_version = _validate_source_version(source_version)
+    dataset_root = dataset_root.resolve()
+    info_path = dataset_root / "meta" / "info.json"
+    info = json.loads(info_path.read_text())
+    layouts = _pose_indices(info)
+    data_files = sorted((dataset_root / "data").glob("**/*.parquet"))
+    episode_files = sorted((dataset_root / "meta" / "episodes").glob("**/*.parquet"))
+    stats_path = dataset_root / "meta" / "stats.json"
+    if not data_files or not episode_files or not stats_path.is_file():
+        raise ValueError(
+            "Dataset is incomplete: expected data parquet files, episode metadata, "
+            "and meta/stats.json. No files were changed."
+        )
+
+    backup_root = dataset_root / "meta" / "migrations" / _MIGRATION_ID
+    manifest_path = backup_root / "manifest.json"
+    if manifest_path.exists():
+        manifest = json.loads(manifest_path.read_text())
+        if manifest.get("state") == "complete":
+            raise ValueError(f"Dataset was already migrated ({manifest_path}).")
+        if not dry_run:
+            print(
+                "Recovering an interrupted migration from its backup before retrying."
+            )
+            _restore_backup(dataset_root, backup_root, manifest)
+
+    marker_path = dataset_root / "meta" / "axol.json"
+    if marker_path.exists():
+        marker = json.loads(marker_path.read_text())
+        if marker.get("cartesian_pose_frame") == CARTESIAN_FRAME_ID:
+            raise ValueError("Dataset is already in the v0.1.32+ Cartesian pose frame.")
+        raise ValueError(
+            f"Dataset has an unknown Cartesian pose-frame marker at {marker_path}; "
+            "refusing to guess."
+        )
+
+    row_count = sum(pq.ParquetFile(path).metadata.num_rows for path in data_files)
+    summary = {
+        "data_files": len(data_files),
+        "episode_files": len(episode_files),
+        "rows": row_count,
+    }
+    if dry_run:
+        return summary
+
+    files_to_backup = [*data_files, *episode_files, stats_path]
+    if not manifest_path.exists():
+        manifest = _backup_files(dataset_root, files_to_backup, backup_root)
+    else:
+        manifest = json.loads(manifest_path.read_text())
+        manifest["state"] = "backed_up"
+        _atomic_json(manifest_path, manifest)
+
+    try:
+        manifest["state"] = "transforming_data"
+        _atomic_json(manifest_path, manifest)
+        for path in data_files:
+            table = pq.read_table(path)
+            for field, arms in layouts.items():
+                if field not in table.column_names:
+                    raise ValueError(f"{path} is missing the declared {field} column.")
+                table = _replace_matrix(
+                    table, field, _transform_matrix(_table_matrix(table, field), arms)
+                )
+            _write_parquet_atomic(path, table)
+
+        manifest["state"] = "refreshing_stats"
+        _atomic_json(manifest_path, manifest)
+        episode_stats = _refresh_episode_stats(
+            dataset_root, info, layouts, episode_files
+        )
+        if not episode_stats:
+            raise ValueError("No episode statistics were found.")
+        _atomic_json(stats_path, serialize_dict(aggregate_stats(episode_stats)))
+
+        write_cartesian_frame_marker(
+            dataset_root,
+            migration={
+                "id": _MIGRATION_ID,
+                "source_axol_version": source_version,
+                "target": "axol >= v0.1.32",
+            },
+        )
+        manifest["state"] = "complete"
+        _atomic_json(manifest_path, manifest)
+    except BaseException:
+        _restore_backup(dataset_root, backup_root, manifest)
+        manifest["state"] = "failed_restored"
+        _atomic_json(manifest_path, manifest)
+        raise
+
+    return summary
+
+
+def add_parser(subparsers: Any) -> None:
+    parser = subparsers.add_parser(
+        "migrate-dataset",
+        help="Migrate pre-v0.1.32 Cartesian data to the current URDF frame.",
+        description=(
+            "Rotate Cartesian actions and observations recorded by axol <= v0.1.31 "
+            "into the forward-facing URDF frame introduced in v0.1.32. The migration "
+            "is in-place and creates a recovery backup under meta/migrations first."
+        ),
+    )
+    parser.add_argument(
+        "--repo_id",
+        "--repo-id",
+        required=True,
+        help="Local repo id under --root, or a path to a LeRobot dataset.",
+    )
+    parser.add_argument("--root", help="Dataset root (default: $HF_LEROBOT_HOME).")
+    parser.add_argument(
+        "--from-version",
+        required=True,
+        help="Axol version that recorded the data (must be older than v0.1.32).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate and report what would change without writing files.",
+    )
+    parser.set_defaults(func=run)
+
+
+def run(args: argparse.Namespace) -> None:
+    try:
+        dataset_root = _resolve_dataset(args.repo_id, args.root)
+        summary = migrate_dataset(
+            dataset_root,
+            source_version=args.from_version,
+            dry_run=args.dry_run,
+        )
+    except (FileNotFoundError, ValueError) as exc:
+        raise SystemExit(f"migrate-dataset: {exc}") from None
+    verb = "Would migrate" if args.dry_run else "Migrated"
+    print(
+        f"{verb} {summary['rows']} rows in {summary['data_files']} data file(s) "
+        f"and refreshed {summary['episode_files']} episode metadata file(s)."
+    )
+    if not args.dry_run:
+        backup = dataset_root / "meta" / "migrations" / _MIGRATION_ID
+        print(f"Original parquet/stat files are recoverable from {backup}.")

--- a/almond_axol/cli/run_policy.py
+++ b/almond_axol/cli/run_policy.py
@@ -1407,6 +1407,15 @@ def _run(
                 encoder_threads=4,
                 rgb_encoder=rgb_encoder,
             )
+            # LeRobot's codebase_version only identifies its dataset schema;
+            # record Axol's Cartesian world frame separately so this fresh
+            # dataset can never be mistaken for pre-v0.1.32 data and rotated
+            # a second time by migrate-dataset.
+            action_names = (action_features.get(ACTION) or {}).get("names") or []
+            if any("_ee." in name for name in action_names):
+                from ..recording.cartesian_frame import write_cartesian_frame_marker
+
+                write_cartesian_frame_marker(dataset_root)
 
     if rerun_ip:
         init_rerun(session_name="axol_run_policy", ip=rerun_ip, port=rerun_port)

--- a/almond_axol/recording/cartesian_frame.py
+++ b/almond_axol/recording/cartesian_frame.py
@@ -1,0 +1,41 @@
+"""Pose-frame provenance for Axol Cartesian LeRobot datasets."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Any
+
+
+CARTESIAN_FRAME_ID = "flu-urdf-root-v0.1.32"
+"""Forward-facing FLU world frame introduced by axol v0.1.32."""
+
+URDF_ROOT_YAW_RADIANS = math.pi / 2
+
+
+def write_cartesian_frame_marker(
+    dataset_root: Path | str, *, migration: dict[str, Any] | None = None
+) -> None:
+    """Atomically record the frame used by a new or migrated Cartesian dataset."""
+    try:
+        axol_version = version("almond-axol")
+    except PackageNotFoundError:
+        axol_version = "unknown"
+    data: dict[str, Any] = {
+        "schema_version": 1,
+        "cartesian_pose_frame": CARTESIAN_FRAME_ID,
+        "urdf_root_yaw_radians": URDF_ROOT_YAW_RADIANS,
+    }
+    if migration is not None:
+        data["migrated_by_axol_version"] = axol_version
+        data["migration"] = migration
+    else:
+        data["recorded_by_axol_version"] = axol_version
+
+    path = Path(dataset_root) / "meta" / "axol.json"
+    tmp = path.with_name(f".{path.name}.tmp")
+    tmp.write_text(json.dumps(data, indent=4, ensure_ascii=False) + "\n")
+    os.replace(tmp, path)

--- a/almond_axol/recording/record_proc.py
+++ b/almond_axol/recording/record_proc.py
@@ -1192,7 +1192,7 @@ def _open_dataset(config: dict) -> "LeRobotDataset":
             encoder_threads=_ENCODER_THREADS,
             rgb_encoder=rgb_encoder,
         )
-    return LeRobotDataset.create(
+    dataset = LeRobotDataset.create(
         repo_id=config["repo_id"],
         fps=config["fps"],
         root=config["root"],
@@ -1204,6 +1204,15 @@ def _open_dataset(config: dict) -> "LeRobotDataset":
         encoder_threads=_ENCODER_THREADS,
         rgb_encoder=rgb_encoder,
     )
+    # LeRobot's codebase_version describes the dataset format, not the Axol
+    # URDF/world frame.  Record our pose-frame provenance on fresh Cartesian
+    # datasets so future migrations can distinguish them without guessing.
+    action_names = (config["features"].get("action") or {}).get("names") or []
+    if any("_ee." in name for name in action_names):
+        from .cartesian_frame import write_cartesian_frame_marker
+
+        write_cartesian_frame_marker(config["dataset_root"])
+    return dataset
 
 
 def make_episode_durable(dataset: "LeRobotDataset") -> dict[str, Any]:

--- a/docs/cli/migrate-dataset.mdx
+++ b/docs/cli/migrate-dataset.mdx
@@ -1,0 +1,53 @@
+---
+title: "migrate-dataset"
+description: "Migrate Cartesian datasets recorded before the v0.1.32 URDF frame change."
+---
+
+`axol migrate-dataset` updates Cartesian LeRobot datasets recorded with axol
+v0.1.31 or earlier so they replay correctly with v0.1.32 and later.
+
+In v0.1.32, the URDF root gained a +90° yaw so its world frame is FLU (+x
+forward, +y left, +z up). Older Cartesian datasets store poses in the previous
+frame. The migration applies that root transform to the position and
+orientation of both end effectors in `action` and `observation.state`. It does
+not alter videos, gripper values, timestamps, or joint-space datasets.
+
+```bash
+# Inspect the dataset and report the scope without changing it
+axol migrate-dataset --repo_id ilanri/checkers-demo-bimanual \
+  --from-version v0.1.29 --dry-run
+
+# Migrate it in place
+axol migrate-dataset --repo_id ilanri/checkers-demo-bimanual \
+  --from-version v0.1.29
+
+# A dataset outside $HF_LEROBOT_HOME can be addressed directly
+axol migrate-dataset --repo_id /data/checkers-demo-bimanual \
+  --from-version v0.1.29
+```
+
+The command updates every data parquet, recomputes per-episode and global
+statistics, and writes `meta/axol.json` to prevent accidental double migration.
+Before making changes it backs up every file it will replace under
+`meta/migrations/axol-urdf-root-yaw-v0.1.32/`. If migration fails, those files
+are restored automatically; a later run also recovers an interrupted migration
+before retrying.
+
+Only run this on Cartesian data recorded with axol v0.1.31 or earlier. A
+joint-space dataset does not need migration and is rejected. Legacy datasets do
+not record their axol version, so recording provenance is the reliable way to
+decide whether an unmarked dataset needs it. Fresh Cartesian datasets now write
+their pose-frame provenance to `meta/axol.json` automatically.
+
+`--from-version` is required because datasets made before pose-frame metadata
+was added cannot distinguish pre-v0.1.32 data that needs migration from later
+data that is already correct. The command rejects v0.1.32 and newer values.
+
+## Options
+
+| Option | Description |
+|---|---|
+| `--repo_id <id-or-path>` | Local repo id under `$HF_LEROBOT_HOME`, or a dataset directory path (required) |
+| `--root <path>` | Alternate root containing the repo id |
+| `--from-version <version>` | Axol version that recorded the dataset; must be older than v0.1.32 (required) |
+| `--dry-run` | Validate and report the files/rows that would change without writing |

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -77,6 +77,7 @@
               "cli/motor-flash",
               "cli/teleop",
               "cli/collect-data",
+              "cli/migrate-dataset",
               "cli/replay-dataset",
               "cli/run-policy",
               "cli/inference-server",

--- a/docs/operations/replay-dataset.mdx
+++ b/docs/operations/replay-dataset.mdx
@@ -5,6 +5,13 @@ description: "Replay a recorded LeRobot dataset episode on the arms — from the
 
 Replay plays one episode of an existing [LeRobot](/api/lerobot) dataset straight back onto the arms: the episode's recorded `action` column is streamed to the motors frame by frame, then the robot returns to its rest pose. It's the inverse of [data collection](/operations/data-collection) — instead of recording teleop actions it reproduces an already-recorded take on the hardware. You can launch it from the **web control panel** or the **CLI** (`axol replay-dataset`).
 
+<Warning>
+  Cartesian datasets recorded with axol v0.1.31 or earlier use the world frame
+  from the old URDF and replay about 90° off on current releases. Run
+  [`axol migrate-dataset`](/cli/migrate-dataset) once before replaying them.
+  Joint-space datasets are unaffected.
+</Warning>
+
 No VR, cameras, or policy server are involved — replay only drives the arms, so the robot config carries no cameras. The arm is first moved to the rest pose (the same collision-aware return-to-rest [run-policy](/operations/run-policy) uses) so it starts where every recorded episode does: episodes are recorded from rest, so the first replayed action is ~rest and there's no jump.
 
 <Warning>


### PR DESCRIPTION
## Summary

- add axol migrate-dataset for Cartesian datasets recorded before v0.1.32
- apply the exact +90-degree URDF-root SE(3) transform to actions and observations
- recompute episode/global statistics with recoverable backups and interruption recovery
- record pose-frame provenance for migrated and newly recorded Cartesian datasets
- document the affected versions and migration workflow

## Root cause

v0.1.32 commit 4794d1f added a +90-degree yaw to the URDF root. Cartesian poses recorded on v0.1.31 and earlier remained in the prior world frame, so current IK interpreted them about 90 degrees off.

## Validation

- migrated all 1,173 rows from attached episode 20
- verified p_new = Rz(90) p_old and R_new = Rz(90) R_old for both arms
- verified gripper values are unchanged and episode statistics are refreshed
- verified double-migration rejection and interrupted-run recovery
- uvx ruff@0.9.7 check .
- uvx ruff@0.9.7 format --check .
- uv run python -m compileall -q almond_axol

Hardware replay was not run in the cloud environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> In-place parquet mutation affects training/replay data correctness; safeguards (backups, markers, version checks) are substantial but wrong `--from-version` or layout edge cases could still corrupt datasets.
> 
> **Overview**
> Adds **`axol migrate-dataset`** so Cartesian LeRobot datasets recorded before v0.1.32 can replay correctly after the URDF root gained a +90° yaw. The command applies that same rigid transform to left/right end-effector poses in **`action`** and **`observation.state`**, leaves videos and non-Cartesian columns untouched, recomputes episode and global stats, and writes **`meta/axol.json`** so double migration is rejected.
> 
> Migration is **in-place** with backups under `meta/migrations/axol-urdf-root-yaw-v0.1.32/`, automatic restore on failure, and recovery of interrupted runs. **`--from-version`** (must be &lt; v0.1.32) is required for legacy datasets without frame metadata; **`--dry-run`** validates scope without writing.
> 
> New **`cartesian_frame`** helpers record pose-frame provenance; fresh Cartesian datasets get **`meta/axol.json`** at creation in **`record_proc`**. Docs cover the CLI, nav entry, and a replay warning for old Cartesian data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad775fcaf541a3a40955a1c47c50e233c4266b98. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->