### PR TITLE
Guided teach mode: axol teach-poses + server-driven headset banner

### DIFF
--- a/almond_axol/cli/__init__.py
+++ b/almond_axol/cli/__init__.py
@@ -60,6 +60,10 @@ _DRACCUS_COMMANDS: dict[str, tuple[str, str]] = {
         "Teach waypoints by hand, then replay them as straight-line moves.",
     ),
     "collect-data": ("collect_data", "Record teleoperation episodes."),
+    "teach-poses": (
+        "teach_poses",
+        "Record named key poses during teleop, guided by in-headset prompts.",
+    ),
     "replay-dataset": (
         "replay_dataset",
         "Replay a recorded dataset episode on the robot.",

--- a/almond_axol/cli/teach_poses.py
+++ b/almond_axol/cli/teach_poses.py
@@ -1,0 +1,196 @@
+"""``axol teach-poses`` — guided key-pose recording during a VR teleop session.
+
+Deploying taught-pose applications (pick stations, fixtured scenes) needs a
+fast way to record a set of named joint poses. Hand-guiding a limp arm works
+but is imprecise and slow; this mode instead runs a NORMAL teleop session and
+walks the operator through a label list with in-headset banner prompts:
+
+  RIGHT thumbstick CLICK  record the arm's current measured pose
+  LEFT  thumbstick CLICK  step back and re-record the previous label
+
+Each recorded pose is saved immediately (atomic ``WaypointSet.save``), so an
+interrupted session loses nothing. Prompts are shown in the headset via the
+VR server's banner channel (``VRServer.set_banner``) and mirrored to the
+terminal. The thumbstick clicks otherwise drive the powered cart's lift, so
+this command refuses ``--cart.enabled``.
+
+Example:
+  axol teach-poses --labels home pick_hover place_1 place_2 --out poses.json
+  axol teach-poses --labels home bin_a bin_b -- --teleop.position_multiplier 1.2
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+import queue
+import threading
+import time
+
+import numpy as np
+
+_logger = logging.getLogger(__name__)
+
+_DEBOUNCE_S = 0.6
+_SETTLE_S = 0.15
+
+
+class _Clicks:
+    """Rising-edge latch for the two stick clicks; fed from the VR frame
+    callback (must stay allocation-light), drained on the guide thread."""
+
+    def __init__(self) -> None:
+        self.events: "queue.Queue[str]" = queue.Queue()
+        self._prev = (False, False)
+        self._last = 0.0
+
+    def feed(self, frame) -> None:
+        now = time.monotonic()
+        r = bool(getattr(frame, "r_stick_click", False))
+        l = bool(getattr(frame, "l_stick_click", False))
+        pr, pl = self._prev
+        if r and not pr and now - self._last >= _DEBOUNCE_S:
+            self._last = now
+            self.events.put_nowait("record")
+        if l and not pl and now - self._last >= _DEBOUNCE_S:
+            self._last = now
+            self.events.put_nowait("redo")
+        self._prev = (r, l)
+
+
+def _guide(robot, server, clicks: _Clicks, labels: list[str], out: str,
+           done: threading.Event) -> None:
+    from ..waypoints import Waypoint, WaypointSet
+
+    try:
+        try:
+            ws = WaypointSet.load(out)
+        except Exception:  # noqa: BLE001 - new file
+            ws = WaypointSet(waypoints=[])
+        by_label = {w.label: w for w in ws.waypoints}
+        recorded: list[str] = []
+        i = 0
+        while i < len(labels):
+            name = labels[i]
+            state = "on file" if name in by_label else "new"
+            server.set_banner(
+                f"TEACH {i + 1}/{len(labels)}: {name}  ({state})  "
+                "[R-click record / L-click redo]"
+            )
+            print(f"\n>>> pose {i + 1}/{len(labels)}: {name} — drive there, "
+                  "hold still, RIGHT stick click to record", flush=True)
+            ev = None
+            while ev is None:
+                try:
+                    ev = clicks.events.get(timeout=0.5)
+                except queue.Empty:
+                    if done.is_set():
+                        return
+            if ev == "redo":
+                if recorded:
+                    i = labels.index(recorded.pop())
+                    print(f">>> redoing {labels[i]}", flush=True)
+                continue
+            time.sleep(_SETTLE_S)
+            left = np.asarray(robot.left.positions, dtype=np.float32).copy()
+            right = np.asarray(robot.right.positions, dtype=np.float32).copy()
+            wp = Waypoint(left=left, right=right, label=name)
+            if name in by_label:
+                ws.waypoints[ws.waypoints.index(by_label[name])] = wp
+            else:
+                ws.waypoints.append(wp)
+            by_label[name] = wp
+            ws.save(out)
+            recorded.append(name)
+            server.set_banner(f"RECORDED {name}  ({i + 1}/{len(labels)})")
+            print(f">>> recorded {name} -> {out}", flush=True)
+            time.sleep(0.8)
+            i += 1
+        server.set_banner("ALL POSES RECORDED — park the arm, then Ctrl-C")
+        print(f"\n>>> all {len(labels)} poses recorded to {out}; park the arm "
+              "and end the session with Ctrl-C", flush=True)
+    finally:
+        done.set()
+
+
+async def _run(cfg, labels: list[str], out: str) -> None:
+    from ..robot import Axol
+    from ..teleop import VRTeleop
+
+    robot = Axol(config=cfg.axol, left_channel=cfg.left_channel,
+                 right_channel=cfg.right_channel)
+    teleop = VRTeleop(robot, config=cfg.teleop, kinematics_config=cfg.kinematics,
+                      vr_server_config=cfg.vr_server, cart=None)
+
+    clicks = _Clicks()
+    vendor_cb = teleop._on_vr_frame
+
+    def _chained(frame) -> None:
+        vendor_cb(frame)
+        clicks.feed(frame)
+
+    teleop._vr_server.set_on_frame(_chained)
+
+    done = threading.Event()
+    async with teleop:
+        # Headset video, same wiring as `axol teleop`.
+        from .teleop import (
+            _connect_zed_cameras,
+            _register_zed_video,
+            _start_video_relay,
+            _stereo_serials_for,
+        )
+
+        relay = None
+        cameras = []
+        try:
+            stereo_set = await asyncio.to_thread(_stereo_serials_for, cfg)
+            relay = await asyncio.to_thread(_start_video_relay, cfg, stereo_set)
+            if relay is not None:
+                teleop.set_video_manager(relay)
+            else:
+                cameras = await asyncio.to_thread(_connect_zed_cameras, cfg, stereo_set)
+                _register_zed_video(teleop, cameras)
+        except Exception as exc:  # noqa: BLE001 - video is optional here
+            _logger.warning("headset video unavailable (%s)", exc)
+
+        t = threading.Thread(
+            target=_guide,
+            args=(robot, teleop._vr_server, clicks, labels, out, done),
+            daemon=True, name="teach-guide",
+        )
+        t.start()
+        try:
+            await teleop.run()
+        finally:
+            done.set()
+            teleop._vr_server.set_banner(None)
+            if relay is not None:
+                await asyncio.to_thread(relay.shutdown)
+            for _name, cam in cameras:
+                try:
+                    cam.disconnect()
+                except Exception:  # noqa: BLE001
+                    pass
+
+
+def main(argv: list[str]) -> None:
+    from .config import TeleopCmdConfig, normalize_bool_flags, parse
+
+    ap = argparse.ArgumentParser(prog="axol teach-poses", description=__doc__)
+    ap.add_argument("--labels", nargs="+", required=True,
+                    help="ordered pose labels to record")
+    ap.add_argument("--out", default="poses.json",
+                    help="WaypointSet file to write (default poses.json)")
+    args, vendor_argv = ap.parse_known_args(argv)
+    if vendor_argv[:1] == ["--"]:
+        vendor_argv = vendor_argv[1:]
+
+    cfg = parse(TeleopCmdConfig, normalize_bool_flags(vendor_argv, "sim", "cart_only"))
+    if getattr(cfg, "sim", False):
+        raise SystemExit("teach-poses records a real arm; --sim is not supported")
+    if getattr(cfg.cart, "enabled", False):
+        raise SystemExit("teach-poses uses the thumbstick clicks the cart lift "
+                         "owns; run without --cart.enabled")
+
+    asyncio.run(_run(cfg, list(args.labels), args.out))

--- a/almond_axol/vr/server.py
+++ b/almond_axol/vr/server.py
@@ -101,6 +101,11 @@ class VRServer:
         self._hud: dict[str, Any] | None = None
         self._hud_client: int | None = None
 
+        # Server-driven guidance banner shown by the headset HUD (guided teach
+        # mode and similar flows). ``None`` hides it. Announced to clients on
+        # connect and broadcast on change (see set_banner).
+        self._banner: str | None = None
+
         # The headset streams identical frames (same ``seq``) over both the USB
         # tunnel and the network (WebRTC data channel / WebSocket). We process
         # each ``seq`` once, from whichever transport delivers it first — the
@@ -220,6 +225,24 @@ class VRServer:
         thread (a plain attribute assignment).
         """
         self._episode = episode
+
+    def set_banner(self, text: str | None) -> None:
+        """Set (or clear, with ``None``) the guidance banner shown in-headset.
+
+        Used by guided flows (e.g. ``axol teach-poses``) to prompt the
+        operator inside the headset. Safe to call from any thread: the value
+        is stored for connect-time announcement and, when the server loop is
+        live, broadcast immediately to all connected clients.
+        """
+        self._banner = text
+        loop = self._loop
+        if loop is not None:
+            import json as _json
+
+            asyncio.run_coroutine_threadsafe(
+                self.broadcast_text(_json.dumps({"type": "banner", "value": text})),
+                loop,
+            )
 
     def set_video_expected(self, expected: bool) -> None:
         """Declare whether camera video is expected to become available.
@@ -726,6 +749,14 @@ class VRServer:
                     )
                 except Exception as exc:  # noqa: BLE001 - best-effort announce
                     _logger.warning("failed to send hud to client: %s", exc)
+            # Guidance banner (guided teach mode): announce to late joiners.
+            if server._banner is not None:
+                try:
+                    await websocket.send_text(
+                        json.dumps({"type": "banner", "value": server._banner})
+                    )
+                except Exception as exc:  # noqa: BLE001 - best-effort announce
+                    _logger.warning("failed to send banner to client: %s", exc)
             try:
                 while True:
                     data = await websocket.receive_text()

--- a/web/app/src/App.tsx
+++ b/web/app/src/App.tsx
@@ -916,6 +916,28 @@ function EpisodeDisplay({ episode }: { episode: number | null }) {
   )
 }
 
+// Server-driven guidance banner (guided teach mode), shown top-center.
+// Null renders nothing; plain teleop never sets one.
+function BannerDisplay({ text }: { text: string | null }) {
+  if (text === null || text === "") return null
+
+  return (
+    <HudText
+      position={[0, 0.075, -0.5]}
+      fontSize={0.018}
+      fontWeight="bold"
+      color="#a7f3d0"
+      anchorX="center"
+      anchorY="top"
+      renderOrder={999}
+      material-depthTest={false}
+      {...hudBg}
+    >
+      {text}
+    </HudText>
+  )
+}
+
 function HelpPanel({ onDismiss, mode }: { onDismiss: () => void; mode: AxolMode | null }) {
   const W = 0.44
   const H = 0.133
@@ -1184,6 +1206,7 @@ export default function App() {
   // Current 1-based episode number during data collection (null until the
   // server announces one; stays null in plain teleop).
   const [episode, setEpisode] = useState<number | null>(null)
+  const [banner, setBanner] = useState<string | null>(null)
   const { status, connect, disconnect, wsRef } = useAxolVRClient(hostname)
   // Controller poses can ride a wired USB `adb reverse` tunnel (localhost) to
   // avoid WiFi latency; camera video keeps using the LAN host above. The pose
@@ -1403,6 +1426,7 @@ export default function App() {
               onPendingConfirm={setPendingConfirm}
               onMode={setVrMode}
               onEpisode={setEpisode}
+              onBanner={setBanner}
               onExit={() => store.getState().session?.end()}
             />
             <ImmersiveCameraFeed wsRef={wsRef} />
@@ -1411,6 +1435,7 @@ export default function App() {
               <HelpIcon mode={vrMode} />
               <StateDisplay state={vrState} isRecordingPending={recordingPendingAt !== null} />
               <EpisodeDisplay episode={episode} />
+              <BannerDisplay text={banner} />
               <CountdownDisplay recordingPendingAt={recordingPendingAt} />
               <ConfirmDisplay action={pendingConfirm} />
             </XRHud>

--- a/web/packages/axol-vr-client/src/AxolVRClient.tsx
+++ b/web/packages/axol-vr-client/src/AxolVRClient.tsx
@@ -39,6 +39,7 @@ export function AxolVRClient({
   onPendingConfirm,
   onMode,
   onEpisode,
+  onBanner,
   onExit,
 }: {
   wsRef: RefObject<WebSocket | null>
@@ -61,6 +62,9 @@ export function AxolVRClient({
   // Called with the current 1-based episode number while collecting data (and
   // null if the server ever clears it). Drives the in-headset episode readout.
   onEpisode?: (episode: number | null) => void
+  // Called with the server-driven guidance banner text (guided teach mode);
+  // null clears it. Drives the in-headset banner readout.
+  onBanner?: (text: string | null) => void
   onExit?: () => void
 }) {
   const { gl } = useThree()
@@ -87,6 +91,9 @@ export function AxolVRClient({
   // the "unset" sentinel (distinct from a real episode value or an explicit
   // null the server could send); replaced with the parsed value on each push.
   const serverEpisodeRef = useRef<number | null | -1>(-1)
+  // Server-pushed banner, applied at the start of the next frame. The string
+  // sentinel "\u0000unset" is distinct from null (an explicit clear).
+  const serverBannerRef = useRef<string | null>("\u0000unset")
   // Track which WebSocket we have attached onmessage to avoid re-attaching.
   const wsWithHandlerRef = useRef<WebSocket | null>(null)
   // Change key of the last HUD state published to the server (see below).
@@ -122,6 +129,8 @@ export function AxolVRClient({
               serverModeRef.current = msg.value as AxolMode
             } else if (msg.type === "episode") {
               serverEpisodeRef.current = typeof msg.value === "number" ? msg.value : null
+            } else if (msg.type === "banner") {
+              serverBannerRef.current = typeof msg.value === "string" ? msg.value : null
             }
           } catch {
             // ignore malformed messages
@@ -188,6 +197,10 @@ export function AxolVRClient({
     if (serverEpisodeRef.current !== -1) {
       onEpisode?.(serverEpisodeRef.current)
       serverEpisodeRef.current = -1
+    }
+    if (serverBannerRef.current !== "\u0000unset") {
+      onBanner?.(serverBannerRef.current)
+      serverBannerRef.current = "\u0000unset"
     }
 
     // Apply server-pushed state override before processing button presses.


### PR DESCRIPTION
Guided key-pose recording during a normal VR teleop session — the teleop counterpart to `axol waypoints`.

## What it does

- **`axol teach-poses --labels home pick_hover place_1 place_2 --out poses.json`** runs a normal teleop session and walks the operator through an ordered list of *named* poses. RIGHT thumbstick click records the arm's current measured pose under the announced label (atomic per-pose `WaypointSet.save`, so an interrupted session loses nothing); LEFT click steps back to re-do the previous one.
- **In-headset prompts** via a new server→headset **banner channel** (`VRServer.set_banner`): announced to clients on connect, broadcast on change — the same pattern as the episode readout. The banner is generic; any guided flow can use it.

![in-headset banner during a guided session](https://raw.githubusercontent.com/yhindy/axol/assets/guided-teach/banner.png)

*(captured from this branch's build in the app's bundled emulator)*

## Why

`axol waypoints` covers teach-and-repeat by hand-guiding with a keyboard/panel at the arm. Taught-pose applications (fixtured pick/place stations, scripted transport between known poses plus learned contact-rich phases) start the same way — "record N named poses on this station" — but hand-guiding is slow, needs a second person at the keyboard, and in our measurements is much less precise. Teleop-teach is one person, headset-on the whole time, and lands poses where the operator aimed them.

## Validated on our rig

We run an Axol on a fixtured pick-and-place pilot: 15 named poses (staging poses, per-target hovers and releases, home) plus a learned grasp phase. Hand-taught sets spread ~5–6 cm in release depth across targets; teleop-taught sets land within ~2 cm of intent in x/y, and re-teaching the full 15 for a new table fixture took a single pass with no redos. We ran this flow out-of-tree first (`VRServer.set_on_frame` chaining) before writing this first-class version.

## Notes for review

- Thumbstick clicks are unused on cart-less rigs (they drive the cart lift), hence the `--cart.enabled` refusal rather than a new binding.
- Web: `AxolVRClient` gains an `onBanner` callback mirroring `onEpisode`; the app renders it top-center via the existing `HudText`. No new deps. `set_banner` is thread-safe (stores + `run_coroutine_threadsafe` onto the server loop).
- Happy to reshape this as a mode of `axol waypoints` instead of a separate command if you'd prefer — same file format, same teach-and-repeat idea, different input device.
- Follow-ups we run downstream and would gladly upstream if wanted: recording on the right A button via a raw `r_a` frame field (free in teleop mode), and a richer guided panel (progress, live measurement against an expected band) beside the camera screens.
