### PR TITLE
Add comprehensive tests and GitHub CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: uv
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      python-dependencies:
+        patterns: ["*"]
+
+  - package-ecosystem: npm
+    directory: /web
+    schedule:
+      interval: weekly
+    groups:
+      web-dependencies:
+        patterns: ["*"]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,74 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  merge_group:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  python:
+    name: Python
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - name: Install Python 3.13 and locked dependencies
+        run: |
+          uv python install 3.13
+          uv sync --locked --extra sim --dev
+      - name: Lint and format check
+        run: |
+          uvx --from ruff==0.9.7 ruff check .
+          uvx --from ruff==0.9.7 ruff format --check .
+      - name: Unit and integration tests
+        run: uv run pytest --junitxml=pytest.xml
+      - name: Build distributable packages
+        run: |
+          uv build
+          uv build --project plugins/lerobot_robot_axol
+      - name: Upload Python test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-test-report
+          path: pytest.xml
+          if-no-files-found: ignore
+
+  web:
+    name: Web
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - name: Install locked dependencies
+        run: npm ci
+      - name: Format and lint
+        run: |
+          npm run format:check
+          npm run lint
+      - name: Unit and component tests
+        run: npm test
+      - name: Production build and type check
+        run: npm run build
+      - name: Dependency audit
+        run: npm audit --audit-level=high

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,11 @@ wheels/
 
 # Test logs
 logs/
+.coverage
+coverage.json
+coverage.xml
+htmlcov/
+pytest.xml
 
 # macOS
 .DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,9 @@ The browser UIs live under `web/` (a Vite + React monorepo: the WebXR `/vr` tele
 
 ### Testing
 
-- No automated test suite exists in this repository. Validate changes by importing the package and exercising the `Sim`-based code paths.
+- Run the Python unit/integration suite with `uv run pytest`. It covers hardware-independent behavior and mocks or contracts the robot/CAN/ZED boundaries.
+- Run the web unit/component suite from `web/` with `npm test`; use `npm run lint`, `npm run format:check`, and `npm run build` for the remaining front-end gates.
+- For hardware-facing behavior that cannot be automated in the VM, also import the package and exercise the `Sim`-based code paths.
 
 ### Dependency extras
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Almond Axol SDK
 
+[![CI](https://github.com/almond-bot/axol/actions/workflows/ci.yml/badge.svg)](https://github.com/almond-bot/axol/actions/workflows/ci.yml)
+
 <img src="assets/axol.png" width="400" alt="Axol dual-arm robot" />
 
 Command-line interface and Python SDK for the Almond Axol dual-arm robot. CLI invoked as `axol <command> [flags]`.
@@ -83,6 +85,29 @@ npm run build --workspace=app                        # → web/app/dist
 ```
 
 See the [installation guide](https://docs.almond.bot/installation) for the full walkthrough.
+
+## Testing
+
+The automated suite is hardware-independent: robot, CAN, ZED, and headset boundaries are exercised through protocol and API contracts, while simulation-capable code is imported with the `sim` extra. CI enforces aggregate coverage floors of 30% for the Python package and 75% for the tested browser libraries.
+
+```bash
+# Python unit/integration tests, coverage, lint, and package builds
+uv sync --extra sim --dev
+uv run pytest
+uvx --from ruff==0.9.7 ruff check .
+uvx --from ruff==0.9.7 ruff format --check .
+uv build
+
+# React/TypeScript tests, lint, formatting, and production build
+cd web
+npm ci
+npm test
+npm run lint
+npm run format:check
+npm run build
+```
+
+Pull requests must pass the `Python` and `Web` GitHub Actions checks before merging to `main`.
 
 ## Sitemap
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,3 +48,31 @@ axol = "almond_axol.cli:main"
 [tool.hatch.build.targets.wheel]
 packages = ["almond_axol"]
 
+[dependency-groups]
+dev = [
+    "pytest>=8.3",
+    "pytest-cov>=6.0",
+]
+
+[tool.pytest.ini_options]
+addopts = [
+    "--strict-config",
+    "--strict-markers",
+    "--cov=almond_axol",
+    "--cov-report=term-missing:skip-covered",
+]
+testpaths = ["tests"]
+
+[tool.coverage.run]
+branch = true
+source = ["almond_axol"]
+omit = [
+    "almond_axol/lerobot/*",
+]
+
+[tool.coverage.report]
+fail_under = 30
+exclude_also = [
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+
+from almond_axol.vr.models import VRFrame, VRPose, VRPosition, VRQuaternion
+
+
+@pytest.fixture
+def frame_factory() -> Callable[..., VRFrame]:
+    def make(**overrides: object) -> VRFrame:
+        pose = VRPose(
+            position=VRPosition(x=0.0, y=0.0, z=0.0),
+            quaternion=VRQuaternion(x=0.0, y=0.0, z=0.0, w=1.0),
+        )
+        values: dict[str, object] = {
+            "l_ee": pose,
+            "r_ee": pose.model_copy(deep=True),
+            "l_elbow": VRPosition(x=0.0, y=0.0, z=0.0),
+            "r_elbow": VRPosition(x=0.0, y=0.0, z=0.0),
+        }
+        values.update(overrides)
+        return VRFrame(**values)  # type: ignore[arg-type]
+
+    return make

--- a/tests/test_can_bus_resilience.py
+++ b/tests/test_can_bus_resilience.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import asyncio
+import errno
+from pathlib import Path
+
+import can
+import pytest
+
+from almond_axol.motor import bus
+
+
+class _FakeBus:
+    def __init__(self, *, send_error: BaseException | None = None) -> None:
+        self.send_error = send_error
+        self.sent: list[can.Message] = []
+        self.shutdown_calls = 0
+        self.received: list[can.Message | None] = []
+
+    def send(self, message: can.Message) -> None:
+        if self.send_error is not None:
+            raise self.send_error
+        self.sent.append(message)
+
+    def recv(self, timeout=0):
+        return self.received.pop(0) if self.received else None
+
+    def shutdown(self) -> None:
+        self.shutdown_calls += 1
+
+    def fileno(self) -> int:
+        return 10
+
+
+class _Loop:
+    def __init__(self, *times: float) -> None:
+        self.times = iter(times or (0.0, 0.1))
+        self.readers: list[int] = []
+
+    def time(self) -> float:
+        return next(self.times)
+
+    def add_reader(self, fd, callback) -> None:
+        self.readers.append(fd)
+
+    def remove_reader(self, fd) -> None:
+        self.readers.remove(fd)
+
+
+def test_can_error_classification_and_interface_flags(
+    tmp_path: Path, monkeypatch
+) -> None:
+    assert bus._error_code(OSError(errno.ENODEV, "gone")) == errno.ENODEV
+    assert bus._iface_lost(OSError(errno.ENETDOWN, "down"))
+    assert bus._tx_queue_full(OSError(errno.ENOBUFS, "full"))
+    assert not bus._iface_lost(RuntimeError("other"))
+
+    root = tmp_path / "net"
+    (root / "can0").mkdir(parents=True)
+    (root / "can0" / "flags").write_text("1")
+
+    monkeypatch.setattr(
+        bus, "Path", lambda value: root if value == "/sys/class/net" else Path(value)
+    )
+    assert bus._iface_is_up("can0")
+    assert not bus._iface_is_up("missing")
+
+
+def test_can_send_success_drop_and_error_paths(monkeypatch) -> None:
+    fake = _FakeBus()
+    monkeypatch.setattr(bus.can, "Bus", lambda **kwargs: fake)
+    can_bus = bus.CanBus("can0")
+
+    async def exercise() -> None:
+        await can_bus._send(1, b"abc")
+        assert fake.sent[0].arbitration_id == 1
+        assert can_bus._enobufs_since is None
+
+        can_bus._lost = True
+        await can_bus._send(2, b"drop")
+        assert len(fake.sent) == 1
+        can_bus._lost = False
+
+        fake.send_error = OSError(errno.ENOBUFS, "full")
+        await can_bus._send(3, b"full")
+        assert can_bus._enobufs_since is not None
+
+        fake.send_error = OSError(errno.ENODEV, "gone")
+        await can_bus._send(4, b"gone")
+        assert can_bus._lost
+
+        can_bus._lost = False
+        fake.send_error = OSError(errno.EINVAL, "bad")
+        with pytest.raises(OSError):
+            await can_bus._send(5, b"bad")
+
+    asyncio.run(exercise())
+
+
+def test_persistent_full_queue_marks_bus_stalled(monkeypatch) -> None:
+    fake = _FakeBus()
+    monkeypatch.setattr(bus.can, "Bus", lambda **kwargs: fake)
+    can_bus = bus.CanBus("can0")
+    error = OSError(errno.ENOBUFS, "full")
+
+    class Clock:
+        values = iter([1.0, 2.1])
+
+        def time(self):
+            return next(self.values)
+
+    async def exercise() -> None:
+        clock = Clock()
+        monkeypatch.setattr(asyncio, "get_running_loop", lambda: clock)
+        can_bus._on_tx_queue_full(error)
+        can_bus._on_tx_queue_full(error)
+        assert can_bus._stalled
+        assert can_bus._lost
+        assert can_bus._wake.is_set()
+        can_bus._mark_lost(error)
+        can_bus._mark_stalled(error)
+
+    asyncio.run(exercise())
+
+
+def test_reconnect_flush_and_probe_recovery(tmp_path: Path, monkeypatch) -> None:
+    initial = _FakeBus()
+    reopened = _FakeBus()
+    probe = _FakeBus()
+    probe.received = [can.Message(arbitration_id=bus._PROBE_ID, data=b"")]
+    created = iter([initial, reopened, probe])
+    monkeypatch.setattr(bus.can, "Bus", lambda **kwargs: next(created))
+    monkeypatch.setattr(bus, "_iface_is_up", lambda channel: True)
+    can_bus = bus.CanBus("can0")
+    can_bus._lost = True
+
+    commands: list[list[str]] = []
+    monkeypatch.setattr(bus, "run_root", lambda argv, check: commands.append(argv))
+    monkeypatch.setattr(bus, "CAN_BRINGUP_SCRIPT", tmp_path / "missing-script")
+
+    async def exercise() -> None:
+        await can_bus._reconnect(_Loop(1.0, 1.1))  # type: ignore[arg-type]
+        assert can_bus._bus is reopened
+        assert not can_bus._lost
+        assert initial.shutdown_calls == 1
+
+        await can_bus._flush_tx_queue()
+        assert commands == [
+            ["ip", "link", "set", "can0", "down"],
+            ["ip", "link", "set", "can0", "up"],
+        ]
+
+        can_bus._stalled = True
+        await can_bus._wait_bus_alive(_Loop(2.0, 2.1))  # type: ignore[arg-type]
+        assert not can_bus._stalled
+        assert probe.sent[0].arbitration_id == bus._PROBE_ID
+        assert probe.shutdown_calls == 1
+
+    asyncio.run(exercise())
+
+
+def test_listener_dispatch_and_close(monkeypatch) -> None:
+    fake = _FakeBus()
+    message = can.Message(arbitration_id=1, data=b"x")
+    fake.received = [message]
+    monkeypatch.setattr(bus.can, "Bus", lambda **kwargs: fake)
+    can_bus = bus.CanBus("can0")
+    received: list[can.Message] = []
+    can_bus._add_listener(received.append)
+
+    class StopAfterDispatch:
+        def __init__(self) -> None:
+            self.readers: list[int] = []
+
+        def add_reader(self, fd, callback) -> None:
+            self.readers.append(fd)
+
+        def remove_reader(self, fd) -> None:
+            self.readers.remove(fd)
+
+    async def exercise() -> None:
+        async def stop_wait(awaitable, timeout):
+            awaitable.close()
+            can_bus._lost = True
+            raise TimeoutError
+
+        monkeypatch.setattr(bus.asyncio, "wait_for", stop_wait)
+        await can_bus._pump(StopAfterDispatch())  # type: ignore[arg-type]
+        assert received == [message]
+        await can_bus.close()
+        assert fake.shutdown_calls == 1
+        assert can_bus._bus is None
+
+    asyncio.run(exercise())

--- a/tests/test_datasets_and_utils.py
+++ b/tests/test_datasets_and_utils.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from almond_axol.recording.cartesian_frame import (
+    CARTESIAN_FRAME_ID,
+    write_cartesian_frame_marker,
+)
+from almond_axol.recording.datasets import is_dataset_dir, lerobot_home, list_datasets
+from almond_axol.utils import adb
+from almond_axol.utils.dotenv import _find_upwards, _parse, load_local_env
+
+
+def _dataset(root: Path, repo_id: str, episodes: int, fps: int) -> Path:
+    path = root / repo_id
+    (path / "meta").mkdir(parents=True)
+    (path / "meta" / "info.json").write_text(
+        json.dumps({"total_episodes": episodes, "fps": fps})
+    )
+    return path
+
+
+def test_dataset_discovery_reads_metadata_and_skips_hidden(tmp_path: Path) -> None:
+    first = _dataset(tmp_path, "org/first", 3, 30)
+    second = _dataset(tmp_path, "second", 7, 60)
+    hidden = _dataset(tmp_path, ".hidden/data", 1, 10)
+    os.utime(first / "meta" / "info.json", (1, 1))
+    os.utime(second / "meta" / "info.json", (2, 2))
+
+    datasets = list_datasets(tmp_path)
+
+    assert [d.repo_id for d in datasets] == ["second", "org/first"]
+    assert datasets[0].episodes == 7
+    assert datasets[0].fps == 60
+    assert is_dataset_dir(first)
+    assert hidden not in [Path(d.root) for d in datasets]
+
+
+def test_lerobot_home_honors_environment(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("HF_HOME", str(tmp_path / "hf"))
+    monkeypatch.delenv("HF_LEROBOT_HOME", raising=False)
+    assert lerobot_home() == tmp_path / "hf" / "lerobot"
+    monkeypatch.setenv("HF_LEROBOT_HOME", str(tmp_path / "custom"))
+    assert lerobot_home() == tmp_path / "custom"
+
+
+def test_cartesian_frame_marker_is_atomic_metadata(tmp_path: Path) -> None:
+    (tmp_path / "meta").mkdir()
+    write_cartesian_frame_marker(tmp_path, migration={"source": "legacy"})
+
+    marker = json.loads((tmp_path / "meta" / "axol.json").read_text())
+    assert marker["cartesian_pose_frame"] == CARTESIAN_FRAME_ID
+    assert marker["migration"] == {"source": "legacy"}
+    assert not (tmp_path / "meta" / ".axol.json.tmp").exists()
+
+
+def test_dotenv_parsing_precedence_and_real_env_wins(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    parent = tmp_path / "project"
+    nested = parent / "a" / "b"
+    nested.mkdir(parents=True)
+    (parent / ".env").write_text("PLAIN=base\nexport QUOTED='hello world'\nBAD\n")
+    (parent / ".env.local").write_text('PLAIN=local\nEXTRA="yes"\n')
+    monkeypatch.setenv("PLAIN", "process")
+    monkeypatch.delenv("QUOTED", raising=False)
+    monkeypatch.delenv("EXTRA", raising=False)
+
+    assert _parse(parent / ".env") == {"PLAIN": "base", "QUOTED": "hello world"}
+    assert _find_upwards(".env", nested) == parent / ".env"
+    load_local_env(nested)
+    assert os.environ["PLAIN"] == "process"
+    assert os.environ["QUOTED"] == "hello world"
+    assert os.environ["EXTRA"] == "yes"
+
+
+def test_adb_status_ready_contract() -> None:
+    assert adb.AdbStatus(True, "quest", "device", True).ready
+    assert not adb.AdbStatus(True, "quest", "unauthorized", True).ready
+    assert not adb.AdbStatus(False, None, "none", False).ready

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from almond_axol.teleop.filter import (
+    AlphaSmoothFilter,
+    OneEuroFilter,
+    TrapezoidalFilter,
+)
+
+
+def test_alpha_filter_smooths_and_resets() -> None:
+    filt = AlphaSmoothFilter(alpha=0.25)
+    np.testing.assert_allclose(filt.update(np.array([0.0, 4.0])), [0.0, 4.0])
+    np.testing.assert_allclose(filt.update(np.array([4.0, 0.0])), [1.0, 3.0])
+    assert filt.update(None) is None
+    filt.reset(np.array([2.0]))
+    np.testing.assert_allclose(filt.update(np.array([6.0])), [3.0])
+
+
+def test_trapezoidal_filter_respects_acceleration_and_velocity() -> None:
+    filt = TrapezoidalFilter(max_vel=1.0, max_accel=2.0, dt=0.1)
+    filt.update(np.array([0.0]))
+    positions = [float(filt.update(np.array([10.0]))[0]) for _ in range(10)]
+
+    deltas = np.diff([0.0, *positions])
+    assert np.all(deltas <= 0.10001)
+    assert deltas[0] == pytest.approx(0.02)
+    assert positions == sorted(positions)
+
+
+def test_one_euro_filter_is_stable_and_uses_real_timing() -> None:
+    filt = OneEuroFilter(freq=100.0, min_cutoff=1.0, beta=2.0)
+    first = filt.update(np.array([0.0]), t=1.0)
+    second = filt.update(np.array([1.0]), t=1.01)
+    third = filt.update(np.array([1.0]), t=1.03)
+
+    np.testing.assert_allclose(first, [0.0])
+    assert 0.0 < second[0] < 1.0
+    assert second[0] < third[0] <= 1.0
+    filt.reset()
+    np.testing.assert_allclose(filt.update(np.array([3.0])), [3.0])

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import importlib
+import pkgutil
+
+import almond_axol
+
+
+def test_all_core_modules_import_without_hardware() -> None:
+    failures: list[str] = []
+    optional_prefixes = (
+        "almond_axol.lerobot",
+        "almond_axol.recording.record_proc",
+        "almond_axol.cli.collect_",
+        "almond_axol.cli.inference_server",
+        "almond_axol.cli.replay_dataset",
+        "almond_axol.cli.run_policy",
+    )
+    for module in pkgutil.walk_packages(
+        almond_axol.__path__, almond_axol.__name__ + "."
+    ):
+        if module.name.startswith(optional_prefixes):
+            continue
+        try:
+            importlib.import_module(module.name)
+        except ImportError as exc:
+            failures.append(f"{module.name}: {exc}")
+
+    assert not failures, "core module import failures:\n" + "\n".join(failures)

--- a/tests/test_jetson.py
+++ b/tests/test_jetson.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from almond_axol.utils import jetson
+
+
+class _Writer:
+    def __init__(self, results: list[tuple[bool, str]] | None = None) -> None:
+        self.results = list(results or [])
+        self.writes: list[tuple[Path, str]] = []
+
+    def write(self, path: Path, value: str) -> tuple[bool, str]:
+        self.writes.append((path, value))
+        return self.results.pop(0) if self.results else (True, "")
+
+
+def _proc(
+    returncode: int, stdout: str = "", stderr: str = ""
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess([], returncode, stdout, stderr)
+
+
+def test_root_escalator_prefers_direct_operations(tmp_path: Path) -> None:
+    escalator = jetson._RootEscalator(interactive=False)
+    target = tmp_path / "setting"
+    assert escalator.write(target, "value") == (True, "")
+    assert target.read_text() == "value"
+    assert escalator.run(["true"]) == (True, "")
+
+
+def test_root_escalator_primes_once_and_falls_back_to_sudo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    primes: list[bool] = []
+    monkeypatch.setattr(jetson, "prime_sudo", lambda: primes.append(True) or True)
+
+    class Unwritable:
+        def write_text(self, value: str) -> None:
+            raise PermissionError("direct denied")
+
+        def __str__(self) -> str:
+            return "/sys/setting"
+
+    calls: list[list[str]] = []
+
+    def run(argv: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(argv)
+        return _proc(0)
+
+    monkeypatch.setattr(jetson.subprocess, "run", run)
+    escalator = jetson._RootEscalator(interactive=True)
+    assert escalator.write(Unwritable(), "42") == (True, "")  # type: ignore[arg-type]
+    assert escalator.write(Unwritable(), "43") == (True, "")  # type: ignore[arg-type]
+    assert primes == [True]
+    assert calls[0] == ["sudo", "-n", "tee", "/sys/setting"]
+
+
+def test_root_escalator_reports_best_command_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    outcomes = [
+        _proc(2, stdout="direct output"),
+        _proc(1, stderr="sudo output"),
+    ]
+    monkeypatch.setattr(
+        jetson.subprocess, "run", lambda *args, **kwargs: outcomes.pop(0)
+    )
+    escalator = jetson._RootEscalator(interactive=False)
+    assert escalator.run(["command"], input_text="n\n") == (False, "sudo output")
+
+    def missing(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if args[0][0] != "sudo":
+            raise FileNotFoundError("missing executable")
+        return _proc(1)
+
+    monkeypatch.setattr(jetson.subprocess, "run", missing)
+    assert escalator.run(["missing"]) == (False, "missing executable")
+
+
+def test_power_mode_query_handles_output_and_missing_binary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        jetson.subprocess,
+        "run",
+        lambda *args, **kwargs: _proc(0, stdout="NV Power Mode: MAXN\n0\n"),
+    )
+    assert jetson._query_power_mode("nvpmodel") == "0"
+    monkeypatch.setattr(
+        jetson.subprocess,
+        "run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(FileNotFoundError()),
+    )
+    assert jetson._query_power_mode("nvpmodel") is None
+
+
+def test_max_power_mode_is_gated_and_skips_when_already_active(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    escalator = SimpleNamespace(
+        run=lambda *args, **kwargs: pytest.fail("unexpected run")
+    )
+    monkeypatch.setattr(jetson, "_is_jetson", lambda: False)
+    jetson._set_max_power_mode(escalator)
+
+    monkeypatch.setattr(jetson, "_is_jetson", lambda: True)
+    monkeypatch.setattr(jetson.shutil, "which", lambda name: None)
+    jetson._set_max_power_mode(escalator)
+
+    monkeypatch.setattr(jetson.shutil, "which", lambda name: "/usr/bin/nvpmodel")
+    monkeypatch.setattr(jetson, "_query_power_mode", lambda binary: jetson._MAXN_MODE)
+    jetson._set_max_power_mode(escalator)
+
+
+def test_max_power_mode_switches_or_persists_for_next_boot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(jetson, "_is_jetson", lambda: True)
+    monkeypatch.setattr(jetson.shutil, "which", lambda name: "/usr/bin/nvpmodel")
+    modes = iter(["2", "0"])
+    monkeypatch.setattr(jetson, "_query_power_mode", lambda binary: next(modes))
+    calls: list[tuple[list[str], str | None]] = []
+    escalator = SimpleNamespace(
+        run=lambda argv, input_text=None: calls.append((argv, input_text))
+        or (True, ""),
+        write=lambda *args: pytest.fail("unexpected write"),
+    )
+    jetson._set_max_power_mode(escalator)
+    assert calls == [(["/usr/bin/nvpmodel", "-m", "0"], "n\n")]
+
+    monkeypatch.setattr(jetson, "_query_power_mode", lambda binary: "2")
+    writer = _Writer()
+    escalator = SimpleNamespace(
+        run=lambda *args, **kwargs: (True, "reboot required"), write=writer.write
+    )
+    jetson._set_max_power_mode(escalator)
+    assert writer.writes == [(jetson._NVPMODEL_STATUS, "pmode:0000")]
+
+
+def test_engine_and_cpu_pinning_cover_changed_equal_and_unreadable_nodes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    engine = tmp_path / "engine.nvenc"
+    engine.mkdir()
+    (engine / "max_freq").write_text("100\n")
+    (engine / "min_freq").write_text("20\n")
+    already = tmp_path / "engine.vic"
+    already.mkdir()
+    (already / "max_freq").write_text("80\n")
+    (already / "min_freq").write_text("80\n")
+    unreadable = tmp_path / "missing.vic"
+
+    cpu0 = tmp_path / "cpu0"
+    cpu1 = tmp_path / "cpu1"
+    cpu2 = tmp_path / "cpu2"
+    for cpu, governor in ((cpu0, "schedutil"), (cpu1, "performance")):
+        (cpu / "cpufreq").mkdir(parents=True)
+        (cpu / "cpufreq" / "scaling_governor").write_text(governor)
+
+    original_glob = Path.glob
+
+    def glob(path: Path, pattern: str):
+        if str(path) == "/sys/class/devfreq":
+            if pattern == "*.nvenc":
+                return iter([engine])
+            return iter([already, unreadable])
+        if str(path) == "/sys/devices/system/cpu":
+            return iter([cpu2, cpu1, cpu0])
+        return original_glob(path, pattern)
+
+    monkeypatch.setattr(Path, "glob", glob)
+    writer = _Writer(results=[(True, ""), (False, "read only")])
+    jetson._pin_engines(writer)
+    assert writer.writes == [(engine / "min_freq", "100")]
+
+    monkeypatch.setattr(jetson, "_is_jetson", lambda: True)
+    jetson._pin_cpu(writer)
+    assert writer.writes[-1] == (cpu0 / "cpufreq" / "scaling_governor", "performance")
+
+    monkeypatch.setattr(jetson, "_is_jetson", lambda: False)
+    before = list(writer.writes)
+    jetson._pin_cpu(writer)
+    assert writer.writes == before
+
+
+def test_public_clock_helpers_share_escalator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: list[tuple[str, object]] = []
+    monkeypatch.setattr(
+        jetson, "_pin_engines", lambda esc: seen.append(("engine", esc))
+    )
+    monkeypatch.setattr(jetson, "_pin_cpu", lambda esc: seen.append(("cpu", esc)))
+    monkeypatch.setattr(
+        jetson, "_set_max_power_mode", lambda esc: seen.append(("mode", esc))
+    )
+
+    jetson.pin_engine_clocks(interactive=True)
+    jetson.pin_realtime_clocks(interactive=True)
+    assert [name for name, _ in seen] == ["engine", "mode", "engine", "cpu"]
+    assert seen[1][1] is seen[2][1] is seen[3][1]

--- a/tests/test_motor_protocols.py
+++ b/tests/test_motor_protocols.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import pytest
+
+from almond_axol.motor.config import (
+    DAMIAO_PARAMS,
+    MYACTUATOR_PARAMS,
+    Access,
+    DamiaoParam,
+    MyActuatorParam,
+)
+from almond_axol.motor.damiao import _float_to_uint as dm_float_to_uint
+from almond_axol.motor.damiao import _uint_to_float as dm_uint_to_float
+from almond_axol.motor.firmware import FirmwareUpdater, _crc16
+from almond_axol.motor.myactuator import _float_to_uint as ma_float_to_uint
+from almond_axol.motor.myactuator import _model_max_torque, _uint_to_float
+
+
+@pytest.mark.parametrize("encoder", [ma_float_to_uint, dm_float_to_uint])
+def test_protocol_float_encoding_clamps_to_wire_range(encoder) -> None:  # type: ignore[no-untyped-def]
+    assert encoder(-100.0, -1.0, 1.0, 12) == 0
+    assert encoder(100.0, -1.0, 1.0, 12) == 4095
+    mid = encoder(0.0, -1.0, 1.0, 12)
+    assert mid in (2047, 2048)
+
+
+def test_protocol_round_trip_is_within_quantization() -> None:
+    encoded = ma_float_to_uint(3.25, -12.5, 12.5, 16)
+    assert _uint_to_float(encoded, -12.5, 12.5, 16) == pytest.approx(3.25, abs=4e-4)
+    assert dm_uint_to_float(encoded, -12.5, 12.5, 16) == pytest.approx(3.25, abs=4e-4)
+
+
+def test_motor_parameter_tables_remain_distinct_and_typed() -> None:
+    assert MyActuatorParam.OVER_VOLTAGE in MYACTUATOR_PARAMS
+    assert DamiaoParam.TIMEOUT in DAMIAO_PARAMS
+    assert DAMIAO_PARAMS[DamiaoParam.HW_VER].access is Access.READ_ONLY
+    assert DAMIAO_PARAMS[DamiaoParam.TIMEOUT].scale == 0.05
+
+
+def test_crc16_xmodem_known_vector_and_firmware_id_validation() -> None:
+    assert _crc16(b"123456789") == 0x31C3
+    with pytest.raises(ValueError, match="motor_id"):
+        FirmwareUpdater(None, 0)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="motor_id"):
+        FirmwareUpdater(None, 0x20)  # type: ignore[arg-type]
+
+
+def test_known_myactuator_torque_models() -> None:
+    assert _model_max_torque("RMD-X6") > 0
+    assert _model_max_torque(None) > 0

--- a/tests/test_network_controls.py
+++ b/tests/test_network_controls.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import asyncio
+import errno
+import signal
+from types import SimpleNamespace
+
+from almond_axol.utils import ports
+from almond_axol.vr import control_channel
+
+
+def test_listening_pids_and_port_reclaim(monkeypatch) -> None:
+    monkeypatch.setattr(ports.shutil, "which", lambda name: "/usr/bin/ss")
+    monkeypatch.setattr(ports.os, "getpid", lambda: 20)
+    monkeypatch.setattr(
+        ports.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(
+            stdout='users:(("python",pid=10,fd=3)) users:(("self",pid=20,fd=4))'
+        ),
+    )
+    assert ports.listening_pids(8000) == {10}
+    monkeypatch.setattr(ports.shutil, "which", lambda name: None)
+    assert ports.listening_pids(8000) == set()
+
+    polls = iter([{10, 11}, {11}])
+    monkeypatch.setattr(ports, "listening_pids", lambda port: next(polls))
+    monkeypatch.setattr(ports.time, "sleep", lambda seconds: None)
+    signals: list[tuple[int, signal.Signals]] = []
+    monkeypatch.setattr(
+        ports, "_signal_pid", lambda pid, sig: signals.append((pid, sig))
+    )
+    ports.reclaim_port(8000)
+    assert signals == [(10, signal.SIGTERM), (11, signal.SIGTERM), (11, signal.SIGKILL)]
+
+
+def test_open_socket_retries_and_tracks_owner(monkeypatch) -> None:
+    class FakeSocket:
+        attempts = 0
+
+        def __init__(self, *args) -> None:
+            self.closed = False
+            self.bound = None
+
+        def setsockopt(self, *args) -> None:
+            return None
+
+        def bind(self, address) -> None:
+            FakeSocket.attempts += 1
+            if FakeSocket.attempts == 1:
+                raise OSError(errno.EADDRINUSE, "busy")
+            self.bound = address
+
+        def close(self) -> None:
+            self.closed = True
+
+    reclaimed: list[int] = []
+    monkeypatch.setattr(ports.socket, "socket", FakeSocket)
+    monkeypatch.setattr(ports.time, "sleep", lambda seconds: None)
+    monkeypatch.setattr(ports, "reclaim_port", reclaimed.append)
+    ports._owned_listen_sockets.clear()
+    sock = ports.open_listen_socket("127.0.0.1", 8002)
+    assert sock.bound == ("127.0.0.1", 8002)
+    assert ports._owned_listen_sockets[8002] is sock
+    assert reclaimed == []
+
+
+class _Channel:
+    def __init__(self) -> None:
+        self.handlers = {}
+
+    def on(self, event):
+        def decorate(callback):
+            self.handlers[event] = callback
+            return callback
+
+        return decorate
+
+
+class _Peer:
+    def __init__(self, config) -> None:
+        self.config = config
+        self.channel = _Channel()
+        self.handlers = {}
+        self.connectionState = "new"
+        self.localDescription = SimpleNamespace(sdp="offer-sdp")
+        self.remote = None
+        self.closed = False
+
+    def createDataChannel(self, label, **kwargs):
+        self.channel_args = (label, kwargs)
+        return self.channel
+
+    def on(self, event):
+        def decorate(callback):
+            self.handlers[event] = callback
+            return callback
+
+        return decorate
+
+    async def createOffer(self):
+        return SimpleNamespace(sdp="draft", type="offer")
+
+    async def setLocalDescription(self, offer) -> None:
+        self.offer = offer
+
+    async def setRemoteDescription(self, answer) -> None:
+        self.remote = answer
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def test_control_channel_offer_messages_answer_and_close(monkeypatch) -> None:
+    peers: list[_Peer] = []
+
+    def make_peer(config):
+        peer = _Peer(config)
+        peers.append(peer)
+        return peer
+
+    monkeypatch.setattr(control_channel, "RTCPeerConnection", make_peer)
+    monkeypatch.setattr(control_channel, "ice_servers", lambda: [])
+    received: list[tuple[int, str]] = []
+    manager = control_channel.ControlChannelManager(
+        lambda client, msg: received.append((client, msg))
+    )
+
+    async def exercise() -> None:
+        assert await manager.create_offer(7) == "offer-sdp"
+        peer = peers[0]
+        assert peer.channel_args == ("pose", {"ordered": False, "maxRetransmits": 0})
+        peer.channel.handlers["message"]("pose-json")
+        peer.channel.handlers["message"](b"ignored")
+        assert received == [(7, "pose-json")]
+
+        await manager.set_answer(7, "answer-sdp")
+        assert peer.remote.sdp == "answer-sdp"
+        await manager.set_answer(99, "ignored")
+
+        peer.connectionState = "failed"
+        await peer.handlers["connectionstatechange"]()
+        assert peer.closed
+
+        await manager.create_offer(8)
+        await manager.create_offer(9)
+        await manager.close_all()
+        assert all(item.closed for item in peers)
+
+    asyncio.run(exercise())

--- a/tests/test_process_boundaries.py
+++ b/tests/test_process_boundaries.py
@@ -1,0 +1,313 @@
+from __future__ import annotations
+
+import builtins
+import io
+import logging
+import multiprocessing
+from types import SimpleNamespace
+
+import pytest
+
+from almond_axol.utils import affinity, jetson_diag, proc_diag
+from almond_axol.zed import devices, snapshot
+
+
+class _Connection:
+    def __init__(self, message=None, *, ready: bool = True, eof: bool = False) -> None:
+        self.message = message
+        self.ready = ready
+        self.eof = eof
+        self.closed = False
+        self.sent: list[object] = []
+
+    def poll(self, timeout: float) -> bool:
+        return self.ready
+
+    def recv(self):
+        if self.eof:
+            raise EOFError
+        return self.message
+
+    def send(self, value) -> None:
+        self.sent.append(value)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _Process:
+    def __init__(self, *, alive: bool = False) -> None:
+        self.alive = alive
+        self.started = False
+        self.terminated = False
+
+    def start(self) -> None:
+        self.started = True
+
+    def join(self, timeout: float) -> None:
+        return None
+
+    def is_alive(self) -> bool:
+        return self.alive and not self.terminated
+
+    def terminate(self) -> None:
+        self.terminated = True
+
+
+class _Context:
+    def __init__(self, parent: _Connection, *, alive: bool = False) -> None:
+        self.parent = parent
+        self.child = _Connection()
+        self.proc = _Process(alive=alive)
+
+    def Pipe(self):
+        return self.parent, self.child
+
+    def Process(self, **kwargs):
+        self.process_kwargs = kwargs
+        return self.proc
+
+
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        (("ok", [{"serial": 2, "model": "ZED", "kind": "stereo"}]), 2),
+        (("err", "ImportError", "pyzed missing"), ImportError),
+        (("err", "SDKError", "daemon down"), RuntimeError),
+    ],
+)
+def test_zed_enumeration_process_messages(monkeypatch, message, expected) -> None:
+    context = _Context(_Connection(message), alive=True)
+    monkeypatch.setattr(multiprocessing, "get_context", lambda method: context)
+    if isinstance(expected, int):
+        assert devices.list_zed_devices()[0]["serial"] == expected
+    else:
+        with pytest.raises(expected):
+            devices.list_zed_devices()
+    assert context.proc.started
+    assert context.proc.terminated
+    assert context.parent.closed and context.child.closed
+
+
+def test_zed_enumeration_timeout_and_crash(monkeypatch) -> None:
+    context = _Context(_Connection(ready=False))
+    monkeypatch.setattr(multiprocessing, "get_context", lambda method: context)
+    with pytest.raises(TimeoutError, match="did not respond"):
+        devices.list_zed_devices(timeout_s=0.1)
+
+    context = _Context(_Connection(ready=True, eof=True))
+    monkeypatch.setattr(multiprocessing, "get_context", lambda method: context)
+    with pytest.raises(RuntimeError, match="without a result"):
+        devices.list_zed_devices()
+
+
+def test_zed_worker_and_stereo_serials(monkeypatch) -> None:
+    conn = _Connection()
+    monkeypatch.setattr(
+        devices,
+        "list_zed_devices_inproc",
+        lambda: [{"serial": 9, "model": "X", "kind": "stereo"}],
+    )
+    devices._enumerate_worker(conn)  # type: ignore[arg-type]
+    assert conn.sent[0][0] == "ok"
+    assert conn.closed
+
+    monkeypatch.setattr(
+        devices,
+        "list_zed_devices",
+        lambda: [
+            {"serial": 1, "model": "One", "kind": "mono"},
+            {"serial": 2, "model": "X", "kind": "stereo"},
+        ],
+    )
+    assert devices.stereo_serials() == {2}
+    monkeypatch.setattr(
+        devices,
+        "list_zed_devices",
+        lambda: (_ for _ in ()).throw(ImportError("missing")),
+    )
+    assert devices.stereo_serials() == set()
+    monkeypatch.setattr(
+        devices,
+        "list_zed_devices",
+        lambda: (_ for _ in ()).throw(RuntimeError("down")),
+    )
+    assert devices.stereo_serials() == set()
+
+
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        (("ok", b"jpeg"), b"jpeg"),
+        (("err", "ImportError", "cv2 missing"), ImportError),
+        (("err", "KeyError", "unknown camera"), KeyError),
+        (("err", "ConnectionError", "open failed"), RuntimeError),
+    ],
+)
+def test_snapshot_process_messages(monkeypatch, message, expected) -> None:
+    context = _Context(_Connection(message))
+    monkeypatch.setattr(multiprocessing, "get_context", lambda method: context)
+    if isinstance(expected, bytes):
+        assert snapshot.snapshot_jpeg(123) == expected
+    else:
+        with pytest.raises(expected):
+            snapshot.snapshot_jpeg(123)
+
+
+def test_snapshot_timeout_crash_and_worker(monkeypatch) -> None:
+    context = _Context(_Connection(ready=False), alive=True)
+    monkeypatch.setattr(multiprocessing, "get_context", lambda method: context)
+    with pytest.raises(TimeoutError, match="preview did not complete"):
+        snapshot.snapshot_jpeg(4, timeout_s=0.1)
+    assert context.proc.terminated
+
+    context = _Context(_Connection(eof=True))
+    monkeypatch.setattr(multiprocessing, "get_context", lambda method: context)
+    with pytest.raises(RuntimeError, match="without a result"):
+        snapshot.snapshot_jpeg(4)
+
+    conn = _Connection()
+    monkeypatch.setattr(snapshot, "snapshot_jpeg_inproc", lambda serial: b"image")
+    snapshot._snapshot_worker(conn, 4)  # type: ignore[arg-type]
+    assert conn.sent == [("ok", b"image")]
+
+
+@pytest.mark.parametrize(
+    ("count", "expected"),
+    [
+        (2, None),
+        (
+            4,
+            {
+                "realtime": {0, 1},
+                "ik": {0, 1},
+                "relay": {2, 3},
+                "background": {2, 3},
+            },
+        ),
+        (
+            6,
+            {
+                "realtime": {0, 1},
+                "ik": {0, 1},
+                "relay": {2, 3},
+                "background": {4, 5},
+            },
+        ),
+        (
+            8,
+            {
+                "realtime": {0, 1},
+                "ik": {2},
+                "relay": {3, 4},
+                "background": {5, 6, 7},
+            },
+        ),
+    ],
+)
+def test_affinity_core_groups(monkeypatch, count, expected) -> None:
+    monkeypatch.setattr(affinity.os, "cpu_count", lambda: count)
+    assert affinity.core_groups() == expected
+
+
+def test_affinity_pinners_and_relay_isolation(monkeypatch) -> None:
+    monkeypatch.setattr(affinity.os, "cpu_count", lambda: 8)
+    calls: list[tuple[int, set[int]]] = []
+    monkeypatch.setattr(
+        affinity.os, "sched_setaffinity", lambda pid, cores: calls.append((pid, cores))
+    )
+    assert affinity.pin_realtime()
+    assert affinity.pin_ik()
+    assert affinity.pin_ik_startup()
+    assert affinity.pin_relay()
+    assert affinity.pin_background()
+    assert [cores for _, cores in calls] == [
+        {0, 1},
+        {2},
+        {0, 1, 2},
+        {3, 4},
+        {5, 6, 7},
+    ]
+
+    monkeypatch.setattr(
+        affinity.os,
+        "sched_setaffinity",
+        lambda pid, cores: calls.append((pid, cores)),
+    )
+    monkeypatch.setattr(
+        affinity.os,
+        "listdir",
+        lambda path: ["10", "20", "not-a-thread"],
+    )
+    import threading
+
+    monkeypatch.setattr(
+        threading,
+        "enumerate",
+        lambda: [SimpleNamespace(native_id=10), SimpleNamespace(native_id=None)],
+    )
+    assert affinity.isolate_relay_cpu()
+    assert calls[-2:] == [(10, {3}), (20, {4})]
+
+    def denied(pid, cores):
+        raise OSError("denied")
+
+    monkeypatch.setattr(affinity.os, "sched_setaffinity", denied)
+    assert not affinity.pin_realtime()
+    assert not affinity.isolate_relay_cpu()
+
+
+def test_proc_readers(monkeypatch) -> None:
+    files = {
+        "/proc/stat": "cpu 1 2 3 4\ncpu0 10 2 3 20 5\ncpu1 4 1 1 4\nintr 2\n",
+        "/proc/12/stat": "12 (worker name) S " + " ".join(["0"] * 10 + ["7", "8"]),
+        "/proc/12/statm": "100 3",
+        "/proc/12/task/12/children": "13 14",
+        "/proc/meminfo": "MemAvailable: 1024 kB\nSwapFree: 10 kB\nSwapTotal: 30 kB\n",
+    }
+
+    def fake_open(path, *args, **kwargs):
+        if str(path) not in files:
+            raise OSError("missing")
+        return io.StringIO(files[str(path)])
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+    assert proc_diag.read_percpu() == {"cpu0": (15, 40), "cpu1": (6, 10)}
+    assert proc_diag.read_proc_cpu(12) == (15, "worker name")
+    assert proc_diag.read_proc_rss(12) == 3 * proc_diag.PAGE_SIZE
+    assert proc_diag.read_children(12) == [13, 14]
+    assert proc_diag.read_meminfo() == (1024**2, 10 * 1024, 30 * 1024)
+    assert proc_diag._gib(2 * 1024**3) == "2.0G"
+    assert proc_diag.read_proc_cpu(99) is None
+    assert proc_diag.read_proc_rss(99) == 0
+    assert proc_diag.read_children(99) == []
+
+
+def test_system_diag_scans_labeled_processes(monkeypatch) -> None:
+    diag = proc_diag.SystemDiag({10: "main"}, logging.getLogger("test"))
+    monkeypatch.setattr(proc_diag, "read_proc_cpu", lambda pid: (pid, f"p{pid}"))
+    monkeypatch.setattr(proc_diag, "read_children", lambda pid: [11])
+    assert diag._scan_labeled() == {10: (10, "main"), 11: (11, "main-p11")}
+    assert diag._label(10, "python") == "main"
+    assert diag._label(20, "other") == "other"
+    diag.stop()
+    assert diag._stop.is_set()
+
+
+def test_tegrastats_parser_and_unavailable_run(monkeypatch, caplog) -> None:
+    logger = logging.getLogger("tegra-test")
+    caplog.set_level(logging.DEBUG, logger="tegra-test")
+    diag = jetson_diag.TegraStatsDiag(logger)
+    diag._log_line(
+        "RAM 2048/8192MB SWAP 10/100MB CPU [10%@1000,20%@1500] "
+        "EMC_FREQ 30% GR3D_FREQ 40% NVENC 600 cpu@50C gpu@61.5C throttling"
+    )
+    assert "gr3d=40%" in caplog.text
+    assert "cpufreq=1000-1500MHz" in caplog.text
+    assert "tmax=61.5C" in caplog.text
+    assert "throttle=yes" in caplog.text
+
+    monkeypatch.setattr(jetson_diag.jetson, "_is_jetson", lambda: False)
+    monkeypatch.setattr(jetson_diag.shutil, "which", lambda name: None)
+    diag.run()
+    assert "diag disabled" in caplog.text

--- a/tests/test_recording_ownership.py
+++ b/tests/test_recording_ownership.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from almond_axol.recording import ownership
+
+
+def test_restore_dataset_ownership_adopts_root_created_tree(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakePath:
+        def __init__(self, value: str, uid: int = 0) -> None:
+            self.value = value
+            self.uid = uid
+            self.parents: tuple[FakePath, ...] = ()
+
+        def __fspath__(self) -> str:
+            return self.value
+
+        def __str__(self) -> str:
+            return self.value
+
+        def is_dir(self) -> bool:
+            return True
+
+        def stat(self) -> SimpleNamespace:
+            return SimpleNamespace(st_uid=self.uid, st_gid=1001)
+
+    operator_home = FakePath("/home/operator", uid=1000)
+    lerobot_home = FakePath("/home/operator/lerobot")
+    organization = FakePath("/home/operator/lerobot/org")
+    dataset = FakePath("/home/operator/lerobot/org/dataset")
+    dataset.parents = (organization, lerobot_home, operator_home)
+
+    changes: list[tuple[str, int, int]] = []
+    monkeypatch.setattr(ownership.os, "geteuid", lambda: 0)
+    monkeypatch.setattr(
+        ownership.os,
+        "walk",
+        lambda path: [(path, [], ["episode.mp4"])],
+    )
+    monkeypatch.setattr(
+        ownership.os,
+        "lchown",
+        lambda path, uid, gid: changes.append((os.fspath(path), uid, gid)),
+    )
+
+    ownership.restore_dataset_ownership(dataset)
+    changed_paths = {path for path, uid, gid in changes if (uid, gid) == (1000, 1001)}
+    assert os.fspath(organization) in changed_paths
+    assert os.fspath(dataset) in changed_paths
+    assert "/home/operator/lerobot/org/dataset/episode.mp4" in changed_paths
+
+
+def test_restore_dataset_ownership_noops_and_swallows_filesystem_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dataset = SimpleNamespace(is_dir=lambda: True, parents=())
+    calls: list[object] = []
+    monkeypatch.setattr(ownership.os, "geteuid", lambda: 1000)
+    monkeypatch.setattr(ownership.os, "lchown", lambda *args: calls.append(args))
+    ownership.restore_dataset_ownership(dataset)
+    ownership.restore_dataset_ownership(SimpleNamespace(is_dir=lambda: False))
+    assert calls == []
+
+    monkeypatch.setattr(ownership.os, "geteuid", lambda: 0)
+    broken = SimpleNamespace(
+        is_dir=lambda: (_ for _ in ()).throw(OSError("gone")),
+    )
+    ownership.restore_dataset_ownership(broken)

--- a/tests/test_robot_math.py
+++ b/tests/test_robot_math.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import struct
+
+import numpy as np
+import pytest
+
+from almond_axol.robot.cart import deadzone, mix
+from almond_axol.robot.config import AxolConfig
+from almond_axol.robot.lift import _decode_status
+from almond_axol.teleop.worker import (
+    _quat_xyzw_to_matrix,
+    _scale_rotation_np,
+    _vr_to_flu_np,
+)
+
+
+def test_cart_deadzone_rescales_and_clamps() -> None:
+    assert deadzone(0.1, 0.15) == 0.0
+    assert deadzone(0.15, 0.15) == 0.0
+    assert deadzone(1.0, 0.15) == 1.0
+    assert deadzone(-1.0, 0.15) == -1.0
+    assert deadzone(0.575, 0.15) == pytest.approx(0.5)
+
+
+def test_cart_mix_preserves_limits_and_symmetry() -> None:
+    wheels = mix(vx=1.0, vy=1.0, wz=1.0, max_speed=20.0, turn_scale=1.0)
+    assert len(wheels) == 4
+    assert max(abs(v) for v in wheels) == pytest.approx(20.0)
+    assert mix(0.0, 0.0, 0.0, 20.0, 1.0) == [0.0] * 4
+
+
+def test_lift_status_decodes_wire_flags_and_unhomed_position() -> None:
+    data = struct.pack("<HhBb", 0xFFFF, -120, 0b10101011, -3)
+    status = _decode_status(data)
+
+    assert status.position_permille is None
+    assert status.height_percent is None
+    assert status.velocity == -120
+    assert status.homed and status.moving and status.stall_fault and status.at_upper
+    assert status.jog
+
+
+def test_robot_config_stiffness_is_applied_per_arm() -> None:
+    compliant = AxolConfig(left_stiffness=0.0, right_stiffness=1.0).resolved()
+    assert compliant.left.shoulder_1.kp < compliant.right.shoulder_1.kp
+    with pytest.raises(ValueError):
+        AxolConfig(left_stiffness=1.1).resolved()
+
+
+def test_vr_coordinate_and_quaternion_helpers() -> None:
+    position, rotation = _vr_to_flu_np(1.0, 2.0, 3.0, 0.0, 0.0, 0.0, 1.0)
+    np.testing.assert_allclose(position, [3.0, 2.0, -1.0])
+    np.testing.assert_allclose(rotation @ rotation.T, np.eye(3), atol=1e-7)
+    assert np.linalg.det(rotation) == pytest.approx(1.0)
+    identity = _quat_xyzw_to_matrix(0.0, 0.0, 0.0, 1.0)
+    np.testing.assert_allclose(identity, np.eye(3), atol=1e-7)
+    np.testing.assert_allclose(_scale_rotation_np(identity, 0.5), np.eye(3), atol=1e-7)

--- a/tests/test_runner_lifecycle.py
+++ b/tests/test_runner_lifecycle.py
@@ -216,6 +216,10 @@ def test_runner_camera_helpers_and_attach(monkeypatch) -> None:
     ) == (False, None)
 
     monkeypatch.setattr(runner, "stereo_serials", lambda: {12})
+    # Resolution validation lives behind the optional ``lerobot`` extra. This
+    # test covers the runner's mapping behavior, so keep that package boundary
+    # mocked just like the physical camera enumeration above.
+    monkeypatch.setattr(operation, "_resolution", lambda *args, **kwargs: "SVGA")
     session = Session("teleop", {})
     cfg = SimpleNamespace(cameras={}, camera_eyes={}, resolution=None)
     cameras = {

--- a/tests/test_runner_lifecycle.py
+++ b/tests/test_runner_lifecycle.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import asyncio
+import io
+import logging
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from almond_axol.serve import runner
+from almond_axol.serve.manager import Session
+from almond_axol.serve.settings import SettingsStore
+
+
+class _Thread:
+    def __init__(self, target=None, args=(), **kwargs) -> None:
+        self.target = target
+        self.args = args
+        self.started = False
+        self.joins: list[float | None] = []
+        self.alive = True
+
+    def start(self) -> None:
+        self.started = True
+
+    def join(self, timeout=None) -> None:
+        self.joins.append(timeout)
+
+    def is_alive(self) -> bool:
+        return self.alive
+
+
+class _RobotLink:
+    def __init__(self, *, release_error: bool = False) -> None:
+        self.released = 0
+        self.reacquired = 0
+        self.release_error = release_error
+
+    def release(self) -> None:
+        self.released += 1
+        if self.release_error:
+            raise RuntimeError("link failed")
+
+    def reacquire(self) -> None:
+        self.reacquired += 1
+
+
+def test_output_forwarding_stream_and_logging_filters() -> None:
+    lines: list[str] = []
+    original = io.StringIO()
+    tee = runner._StreamTee(original, lines.append)
+    assert tee.write("one\ntwo") == 7
+    tee.write(" continued\n")
+    tee.flush()
+    assert original.getvalue() == "one\ntwo continued\n"
+    assert lines == ["one", "two continued"]
+    assert not tee.isatty()
+
+    runner._forward_line(lines.append, "\x1b[31mred\x1b[0m")
+    runner._forward_line(lines.append, "INFO:     uvicorn noise")
+    assert lines[-1] == "red"
+
+    handler = runner._SessionLogHandler(lines.append)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    handler.emit(logging.LogRecord("robot", logging.INFO, "", 1, "moving", (), None))
+    handler.emit(
+        logging.LogRecord("uvicorn.access", logging.INFO, "", 1, "GET", (), None)
+    )
+    assert lines[-1] == "moving"
+
+
+def test_operation_start_config_error_and_single_operation_guard(monkeypatch) -> None:
+    fake_threads: list[_Thread] = []
+
+    def make_thread(*args, **kwargs):
+        thread = _Thread(*args, **kwargs)
+        fake_threads.append(thread)
+        return thread
+
+    monkeypatch.setattr(runner.threading, "Thread", make_thread)
+    monkeypatch.setattr(runner.multiprocessing, "active_children", lambda: [])
+    operation = runner.OperationRunner()
+    monkeypatch.setattr(operation, "_build_config", lambda op, args: SimpleNamespace())
+    session = operation.start("teleop", {"sim": True})
+    assert session.status == "running"
+    assert operation.current() is session
+    assert operation.get(session.id) is session
+    assert operation.get("missing") is None
+    assert operation.is_running()
+    assert fake_threads[0].started
+    with pytest.raises(RuntimeError, match="already running"):
+        operation.start("teleop", {"sim": True})
+    with pytest.raises(KeyError):
+        runner.OperationRunner().start("does-not-exist", {})
+
+    broken = runner.OperationRunner()
+
+    def invalid(op, args):
+        raise ValueError("bad option")
+
+    monkeypatch.setattr(broken, "_build_config", invalid)
+    failed = broken.start("teleop", {"sim": True})
+    assert failed.status == "error"
+    assert "bad option" in (failed.error or "")
+    assert not broken.is_running()
+
+
+def test_operation_releases_and_reacquires_robot(monkeypatch) -> None:
+    monkeypatch.setattr(runner.threading, "Thread", _Thread)
+    monkeypatch.setattr(runner.multiprocessing, "active_children", lambda: [])
+    link = _RobotLink()
+    operation = runner.OperationRunner(link)
+    monkeypatch.setattr(operation, "_build_config", lambda op, args: SimpleNamespace())
+    session = operation.start("teleop", {})
+    assert link.released == 1
+    operation._finish(session, needs_robot=True)
+    assert link.reacquired == 1
+    assert session.status == "exited"
+    assert session.exit_code == 0
+    assert session.log[-1] == "[serve] robot link reacquired"
+
+    warning_link = _RobotLink(release_error=True)
+    warning_op = runner.OperationRunner(warning_link)
+    monkeypatch.setattr(warning_op, "_build_config", lambda op, args: SimpleNamespace())
+    warning = warning_op.start("teleop", {})
+    assert any("release warning" in line for line in warning.log)
+
+
+def test_operation_stop_and_episode_control(monkeypatch) -> None:
+    operation = runner.OperationRunner()
+    assert operation.stop() is None
+    session = Session("demo", {})
+    session.status = "running"
+    operation._session = session
+    worker = _Thread()
+    worker.alive = False
+    operation._thread = worker  # type: ignore[assignment]
+    watchdogs: list[_Thread] = []
+
+    def make_thread(*args, **kwargs):
+        item = _Thread(*args, **kwargs)
+        item.alive = False
+        watchdogs.append(item)
+        return item
+
+    monkeypatch.setattr(runner.threading, "Thread", make_thread)
+    stopped = operation.stop()
+    assert stopped is session
+    assert session.status == "stopping"
+    assert operation._stop_event.is_set()
+    assert watchdogs[0].started
+    assert operation.stop() is session
+
+    pushed: list[str] = []
+    operation._policy_control = SimpleNamespace(
+        push=pushed.append, snapshot=lambda: {"phase": "waiting"}
+    )
+    assert operation.episode_command("save")
+    assert pushed == ["save"]
+    assert operation.policy_state() == {"phase": "waiting"}
+    operation._policy_control = None
+    assert not operation.episode_command("save")
+    assert operation.policy_state() is None
+
+
+def test_operation_kills_only_new_children(monkeypatch) -> None:
+    killed: list[int] = []
+
+    def child(pid: int, name: str, *, fails: bool = False):
+        def kill() -> None:
+            if fails:
+                raise OSError("gone")
+            killed.append(pid)
+
+        return SimpleNamespace(pid=pid, name=name, kill=kill)
+
+    old = child(1, "old")
+    recorder = child(2, "dataset-recorder")
+    relay = child(3, "relay")
+    failed = child(4, "failed", fails=True)
+    monkeypatch.setattr(
+        runner.multiprocessing,
+        "active_children",
+        lambda: [old, recorder, relay, failed],
+    )
+    operation = runner.OperationRunner()
+    session = Session("demo", {})
+    operation._session = session
+    operation._baseline_children = {1}
+    assert operation._kill_op_children(session, spare={"dataset-recorder"})
+    assert killed == [3]
+    assert any("failed to kill pid 4" in line for line in session.log)
+    assert not operation._kill_op_children(Session("other", {}))
+
+
+def test_runner_camera_helpers_and_attach(monkeypatch) -> None:
+    operation = runner.OperationRunner()
+    assert operation._camera_serials(None) == {}
+    assert operation._camera_serials(
+        {
+            "serials": {
+                "overhead": " 12 ",
+                "left_arm": "bad",
+                "right_arm": -1,
+                "unknown": 20,
+            }
+        }
+    ) == {"overhead": 12}
+    assert operation._branch(None, "stream", "overhead", True) == (True, None)
+    assert operation._branch(
+        {"stream": {"overhead": "both"}}, "stream", "overhead", True
+    ) == (True, "both")
+    assert operation._branch(
+        {"stream": {"overhead": False}}, "stream", "overhead", True
+    ) == (False, None)
+
+    monkeypatch.setattr(runner, "stereo_serials", lambda: {12})
+    session = Session("teleop", {})
+    cfg = SimpleNamespace(cameras={}, camera_eyes={}, resolution=None)
+    cameras = {
+        "serials": {"overhead": 12, "left_arm": 13},
+        "stream_resolution": "SVGA",
+        "stream": {"overhead": "both", "left_arm": False},
+    }
+    operation._attach_cameras_to_teleop(cfg, cameras, session)
+    assert cfg.cameras == {"overhead": 12}
+    assert cfg.camera_eyes == {"overhead": "both"}
+    assert cfg.resolution == "SVGA"
+    assert "stereo: overhead" in session.log[-1]
+
+
+def test_settings_reset_normalization_and_merged_args(tmp_path: Path) -> None:
+    path = tmp_path / "nested" / "settings.json"
+    path.parent.mkdir()
+    path.write_text("corrupt")
+    store = SettingsStore(path)
+    assert store.snapshot() == {"values": {}, "cameras": None, "advanced": {}}
+    assert store.can_channels() == ("can_alm_axol_l", "can_alm_axol_r")
+    assert store.has_gripper()
+
+    store.update(
+        values={
+            "robot.left_channel": "none",
+            "robot.right_channel": " can7 ",
+            "robot.has_gripper": "false",
+            "robot.left_stiffness": 0.5,
+        },
+        cameras={"serials": {"overhead": "123"}},
+        advanced={"axol.left.elbow.kp": 40},
+    )
+    assert store.can_channels() == (None, "can7")
+    assert not store.has_gripper()
+    assert store.cameras() == {"serials": {"overhead": "123"}}
+    merged = store.merged_args("teleop", {"axol.left_stiffness": 0.9})
+    assert merged["axol.left_stiffness"] == 0.9
+    assert merged["axol.left.elbow.kp"] == 40
+
+    store.update(
+        values={"robot.left_stiffness": None},
+        cameras=None,
+        advanced={"axol.left.elbow.kp": None},
+    )
+    assert store.cameras() is None
+    assert "robot.left_stiffness" not in store.snapshot()["values"]
+    with pytest.raises(KeyError, match="unknown advanced"):
+        store.update(advanced={"unknown.value": 1})
+
+
+def test_runner_shutdown_calls_blocking_stop(monkeypatch) -> None:
+    async def exercise() -> None:
+        operation = runner.OperationRunner()
+        operation._session = Session("demo", {})
+        operation._session.status = "running"
+        called: list[bool] = []
+        monkeypatch.setattr(operation, "_stop_blocking", lambda: called.append(True))
+        await operation.shutdown()
+        assert called == [True]
+
+    asyncio.run(exercise())

--- a/tests/test_sdk_and_cli.py
+++ b/tests/test_sdk_and_cli.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from almond_axol.cli import main as cli_main
+from almond_axol.robot.sim import Sim
+from almond_axol.waypoints import JOINT_VECTOR_LEN, Waypoint, WaypointSet
+
+
+def test_sim_sdk_tracks_both_arms_without_starting_viewer() -> None:
+    async def exercise() -> None:
+        sim = Sim(port=0)
+        left = np.linspace(0.0, 0.7, JOINT_VECTOR_LEN, dtype=np.float32)
+        right = -left
+        await sim.motion_control(left=left, right=right)
+
+        actual_left, actual_right = await sim.get_positions()
+        np.testing.assert_array_equal(actual_left, left)
+        np.testing.assert_array_equal(actual_right, right)
+        np.testing.assert_array_equal(
+            sim._build_q(), np.concatenate([left[:7], right[:7]])
+        )
+
+    asyncio.run(exercise())
+
+
+def test_waypoints_round_trip_atomically(tmp_path: Path) -> None:
+    waypoint = Waypoint(
+        left=np.arange(JOINT_VECTOR_LEN, dtype=np.float32) / 10,
+        right=np.arange(JOINT_VECTOR_LEN, dtype=np.float32) / -10,
+    )
+    waypoints = WaypointSet([waypoint])
+    path = tmp_path / "nested" / "path.json"
+
+    waypoints.save(path)
+    loaded = WaypointSet.load(path)
+
+    assert loaded[0].label == "waypoint 1"
+    np.testing.assert_allclose(loaded[0].left, waypoint.left)
+    assert not path.with_suffix(".json.tmp").exists()
+    assert WaypointSet.load(tmp_path / "missing.json").waypoints == []
+
+
+def test_waypoint_file_rejects_bad_shape_version_and_json(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="left waypoint"):
+        Waypoint(np.zeros(2), np.zeros(JOINT_VECTOR_LEN))
+
+    path = tmp_path / "path.json"
+    path.write_text(json.dumps({"version": 999, "waypoints": []}))
+    with pytest.raises(ValueError, match="version 999"):
+        WaypointSet.load(path)
+    path.write_text("not json")
+    with pytest.raises(ValueError, match="not valid JSON"):
+        WaypointSet.load(path)
+
+
+def test_cli_help_lists_hardware_and_sim_commands(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["axol", "--help"])
+    with pytest.raises(SystemExit) as exc:
+        cli_main()
+
+    assert exc.value.code == 0
+    output = capsys.readouterr().out
+    assert "teleop" in output
+    assert "can.setup" in output
+    assert "serve" in output

--- a/tests/test_self_update.py
+++ b/tests/test_self_update.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from almond_axol.serve import update
+
+
+class _Dist:
+    def __init__(self, direct_url: str | None, version: str = "1.2.3") -> None:
+        self._direct_url = direct_url
+        self.version = version
+
+    def read_text(self, name: str) -> str | None:
+        assert name == "direct_url.json"
+        return self._direct_url
+
+
+class _AsyncProc:
+    def __init__(self, output: bytes = b"", returncode: int = 0) -> None:
+        self.output = output
+        self.returncode = returncode
+
+    async def communicate(self):
+        return self.output, b""
+
+
+def test_version_and_install_metadata(monkeypatch) -> None:
+    assert update.parse_version("v1.2.30") == (1, 2, 30)
+    assert update.parse_version("1.0") == (1, 0)
+    assert update.parse_version("v1.0-rc1") is None
+
+    vcs = json.dumps(
+        {
+            "url": "git+https://example.test/project.git",
+            "vcs_info": {"commit_id": "abc123"},
+        }
+    )
+    monkeypatch.setattr(update, "distribution", lambda name: _Dist(vcs, "2.0"))
+    assert update.installed_origin() == (
+        "https://example.test/project.git",
+        "abc123",
+    )
+    assert not update.installed_from_index()
+    assert update.installed_version() == "2.0"
+
+    monkeypatch.setattr(update, "distribution", lambda name: _Dist(None))
+    assert update.installed_origin() is None
+    assert update.installed_from_index()
+
+    monkeypatch.setattr(update, "distribution", lambda name: _Dist("not json"))
+    assert update.installed_origin() is None
+
+    def missing(name):
+        raise update.PackageNotFoundError(name)
+
+    monkeypatch.setattr(update, "distribution", missing)
+    assert update.installed_origin() is None
+    assert not update.installed_from_index()
+    assert update.installed_version() is None
+
+
+def test_git_helper_and_checkout_commit(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(
+        update.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=0, stdout=b"output\n"),
+    )
+    assert update._git(tmp_path, "status") == b"output\n"
+    monkeypatch.setattr(
+        update.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(returncode=1, stdout=b"bad"),
+    )
+    assert update._git(tmp_path, "status") is None
+
+    def explode(*args, **kwargs):
+        raise OSError("git missing")
+
+    monkeypatch.setattr(update.subprocess, "run", explode)
+    assert update._git(tmp_path, "status") is None
+
+    monkeypatch.setattr(update, "installed_origin", lambda: ("url", "pinned"))
+    assert update.installed_commit() == "pinned"
+
+    monkeypatch.setattr(update, "installed_origin", lambda: None)
+    fake_module = tmp_path / "pkg" / "serve" / "update.py"
+    fake_module.parent.mkdir(parents=True)
+    (tmp_path / ".git").mkdir()
+    monkeypatch.setattr(update, "__file__", str(fake_module))
+    outputs = iter([b"deadbeef\n", b" M file\n", b"diff bytes"])
+    monkeypatch.setattr(update, "_git", lambda *args: next(outputs))
+    digest = hashlib.sha256(b" M file\n" + b"diff bytes").hexdigest()[:8]
+    assert update.installed_commit() == f"deadbeef-dirty.{digest}"
+
+
+def _updater(monkeypatch, *, idle: bool = True, index: bool = True):
+    monkeypatch.setattr(update, "installed_origin", lambda: None)
+    monkeypatch.setattr(update, "installed_from_index", lambda: index)
+    monkeypatch.setattr(update, "installed_version", lambda: "1.0.0")
+    monkeypatch.setattr(update, "installed_commit", lambda: "commit")
+    monkeypatch.setattr(update.shutil, "which", lambda name: f"/bin/{name}")
+    return update.SelfUpdater(lambda: idle)
+
+
+def test_remote_release_resolution_and_status(monkeypatch) -> None:
+    async def exercise() -> None:
+        updater = _updater(monkeypatch)
+        tag_output = (
+            b"a refs/tags/v1.2.0\n"
+            b"b refs/tags/v2.0.0^{}\n"
+            b"c refs/tags/not-a-release\n"
+            b"malformed\n"
+        )
+
+        async def spawn(*args, **kwargs):
+            return _AsyncProc(tag_output)
+
+        monkeypatch.setattr(update.asyncio, "create_subprocess_exec", spawn)
+        assert await updater._resolve_latest_release("origin") == ("v2.0.0", "2.0.0")
+        await updater.refresh_remote()
+        status = await updater.status(force=True)
+        assert status["enabled"] is True
+        assert status["version"] == "1.0.0"
+        assert status["remoteVersion"] == "2.0.0"
+        assert status["updateAvailable"] is True
+        assert status["idle"] is True
+
+        async def bad_spawn(*args, **kwargs):
+            return _AsyncProc(b"", returncode=2)
+
+        monkeypatch.setattr(update.asyncio, "create_subprocess_exec", bad_spawn)
+        assert await updater._resolve_latest_release("origin") is None
+
+        async def missing_spawn(*args, **kwargs):
+            raise OSError("missing")
+
+        monkeypatch.setattr(update.asyncio, "create_subprocess_exec", missing_spawn)
+        assert await updater._resolve_latest_release("origin") is None
+
+    asyncio.run(exercise())
+
+
+def test_start_guards_and_debounced_refresh(monkeypatch) -> None:
+    async def exercise() -> None:
+        disabled = _updater(monkeypatch, index=False)
+        assert disabled.start() == (False, "not a release install")
+
+        updater = _updater(monkeypatch)
+        assert updater.start() == (False, "no update available")
+        updater._remote_tag = "v2.0.0"
+        updater._remote_version = "2.0.0"
+        updater._state = "updating"
+        assert updater.start() == (False, "an update is already in progress")
+
+        busy = update.SelfUpdater(lambda: False)
+        busy._remote_tag = "v2.0.0"
+        busy._remote_version = "2.0.0"
+        assert busy.start() == (
+            False,
+            "server is busy; stop the running operation first",
+        )
+
+        calls: list[str] = []
+
+        async def refreshed() -> None:
+            calls.append("refresh")
+
+        updater._state = "idle"
+        updater.refresh_remote = refreshed  # type: ignore[method-assign]
+        updater._remote_checked_at = 0
+        updater._schedule_remote_refresh()
+        assert updater._remote_task is not None
+        await updater._remote_task
+        assert calls == ["refresh"]
+        updater._remote_checked_at = update.time.monotonic()
+        updater._schedule_remote_refresh()
+        assert calls == ["refresh"]
+
+    asyncio.run(exercise())
+
+
+def test_successful_update_and_provision(monkeypatch) -> None:
+    async def exercise() -> None:
+        updater = _updater(monkeypatch)
+        updater._remote_tag = "v2.0.0"
+        updater._remote_version = "2.0.0"
+        commands: list[tuple[str, ...]] = []
+
+        async def spawn(*args, **kwargs):
+            commands.append(args)
+            return _AsyncProc(b"done")
+
+        monkeypatch.setattr(update.asyncio, "create_subprocess_exec", spawn)
+        exits: list[int] = []
+        monkeypatch.setattr(update.os, "_exit", exits.append)
+        await updater._run_update()
+        assert commands[0][-1] == "almond-axol[lerobot,sim]==2.0.0"
+        assert commands[1] == ("/bin/axol", "provision")
+        assert updater._phase == "restarting"
+        assert updater._restart_pending
+        assert exits == [0]
+
+    asyncio.run(exercise())
+
+
+@pytest.mark.parametrize(
+    ("failure", "message"),
+    [
+        ("missing", "could not run uv"),
+        ("returncode", "uv tool install failed: last line"),
+    ],
+)
+def test_update_failures(monkeypatch, failure: str, message: str) -> None:
+    async def exercise() -> None:
+        updater = _updater(monkeypatch)
+        updater._remote_tag = "v2.0.0"
+        updater._remote_version = "2.0.0"
+
+        async def spawn(*args, **kwargs):
+            if failure == "missing":
+                raise OSError("not found")
+            return _AsyncProc(b"first\nlast line", returncode=1)
+
+        monkeypatch.setattr(update.asyncio, "create_subprocess_exec", spawn)
+        await updater._run_update()
+        assert updater._state == "error"
+        assert message in (updater._error or "")
+        assert updater._phase is None
+
+    asyncio.run(exercise())
+
+
+def test_provision_once_and_failure_paths(monkeypatch) -> None:
+    async def exercise() -> None:
+        updater = _updater(monkeypatch)
+        tasks: list[object] = []
+
+        def capture(coro):
+            tasks.append(coro)
+            coro.close()
+            return SimpleNamespace()
+
+        monkeypatch.setattr(update.asyncio, "create_task", capture)
+        updater.ensure_provisioned()
+        updater.ensure_provisioned()
+        assert len(tasks) == 1
+
+        monkeypatch.setattr(update.shutil, "which", lambda name: None)
+        await updater._provision()
+
+        monkeypatch.setattr(update.shutil, "which", lambda name: "/bin/axol")
+
+        async def failed(*args, **kwargs):
+            return _AsyncProc(b"bad provision", returncode=1)
+
+        monkeypatch.setattr(update.asyncio, "create_subprocess_exec", failed)
+        await updater._provision()
+
+        async def missing(*args, **kwargs):
+            raise OSError("gone")
+
+        monkeypatch.setattr(update.asyncio, "create_subprocess_exec", missing)
+        await updater._provision()
+
+    asyncio.run(exercise())

--- a/tests/test_serve_contracts.py
+++ b/tests/test_serve_contracts.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+from almond_axol.serve import app as app_module
+from almond_axol.serve.commands import _format_value, _truthy, build_argv, command_specs
+from almond_axol.serve.introspect import build_argparse_schema, build_schema
+from almond_axol.serve.settings import SettingsStore
+
+
+@dataclass
+class NestedConfig:
+    enabled: bool = False
+    gains: list[float] = field(default_factory=lambda: [1.0, 2.0])
+
+
+@dataclass
+class ExampleConfig:
+    """Example config.
+
+    Attributes:
+        count: Number of attempts.
+    """
+
+    count: int = 2
+    nested: NestedConfig = field(default_factory=NestedConfig)
+
+
+def test_draccus_schema_preserves_types_defaults_and_help() -> None:
+    schema = build_schema(ExampleConfig)
+    count = next(node for node in schema.nodes if node["key"] == "count")
+    nested = next(node for node in schema.nodes if node["key"] == "nested")
+
+    assert count["type"] == "number"
+    assert count["default"] == 2
+    assert count["help"] == "Number of attempts."
+    assert [child["key"] for child in nested["children"]] == [
+        "nested.enabled",
+        "nested.gains",
+    ]
+    assert nested["children"][1]["type"] == "vector"
+
+
+def test_argparse_schema_understands_required_flags_and_switches() -> None:
+    def add_parser(subparsers: argparse._SubParsersAction) -> None:  # type: ignore[type-arg]
+        parser = subparsers.add_parser("demo")
+        parser.add_argument("name")
+        parser.add_argument("--count", type=int, default=3)
+        parser.add_argument("--verbose", action="store_true")
+
+    schema = build_argparse_schema(add_parser)
+    fields = {node["key"]: node for node in schema.nodes}
+
+    assert fields["name"]["required"] is True
+    assert fields["count"]["type"] == "number"
+    assert fields["verbose"]["type"] == "boolean"
+
+
+def test_settings_store_persists_merges_and_validates(tmp_path: Path) -> None:
+    path = tmp_path / "settings.json"
+    store = SettingsStore(path)
+    snapshot = store.update(
+        values={"robot.has_gripper": False, "robot.left_channel": "can9"},
+        cameras={"serials": {"overhead": "123"}},
+    )
+    assert snapshot["values"]["robot.has_gripper"] is False
+    assert store.can_channels()[0] == "can9"
+    assert store.has_gripper() is False
+    assert SettingsStore(path).snapshot() == snapshot
+    with pytest.raises(KeyError, match="unknown settings"):
+        store.update(values={"does.not.exist": 1})
+
+
+def test_command_catalog_and_argv_contracts() -> None:
+    specs = command_specs()
+    by_id = {spec["id"]: spec for spec in specs}
+    assert {"teleop", "gravity-comp", "waypoints"} <= by_id.keys()
+    assert by_id["teleop"]["simCapable"] is True
+    assert by_id["teleop"]["isOperation"] is True
+
+    argv = build_argv("teleop", {"sim": True, "cart_only": False})
+    assert argv == ["--sim", "true", "--cart_only", "false"]
+    assert _truthy("true") and not _truthy("off")
+    assert _format_value([1, 2]) == "[1, 2]"
+    assert _format_value(None) is None
+
+
+def test_fastapi_read_only_routes_without_hardware(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        app_module, "SettingsStore", lambda: SettingsStore(tmp_path / "settings.json")
+    )
+    app = app_module.create_app(static_dir=tmp_path / "missing-dist")
+    routes = {route.path for route in app.routes}
+    assert {"/api/info", "/api/commands", "/api/settings", "/api/op/start"} <= routes
+
+    with TestClient(app) as client:
+        response = client.get("/__accept")
+        assert response.status_code == 200
+        assert "text/html" in response.headers["content-type"]
+        command_response = client.get("/api/commands")
+        assert command_response.status_code == 200
+        assert any(item["id"] == "teleop" for item in command_response.json())
+
+
+def test_fastapi_control_surface_and_error_contracts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class FakeRobot:
+        def __init__(self, left, right, **kwargs) -> None:
+            self._channels = (left, right)
+            self._state = "disconnected"
+
+        def status(self):
+            return {
+                "state": self._state,
+                "connected": self._state == "connected",
+                "motors": [],
+                "faults": [],
+            }
+
+        def channels(self):
+            return self._channels
+
+        def set_channels(self, left, right) -> None:
+            self._channels = (left, right)
+
+        def connect(self):
+            self._state = "connected"
+            return self.status()
+
+        def disconnect(self):
+            self._state = "disconnected"
+            return self.status()
+
+        def motor_details(self, arm, joint):
+            if joint == "UNKNOWN":
+                raise KeyError(joint)
+            return {"arm": arm, "joint": joint, "status": "OK"}
+
+        def motor_faults(self):
+            return []
+
+        def release(self) -> None:
+            self._state = "busy"
+
+        def reacquire(self) -> None:
+            self._state = "connected"
+
+        def shutdown(self) -> None:
+            self._state = "disconnected"
+
+    class FakeUpdater:
+        version = "1.0.0"
+        commit = "abc"
+        release_install = False
+
+        def __init__(self, is_idle) -> None:
+            self.is_idle = is_idle
+            self.provisioned = False
+
+        def ensure_provisioned(self) -> None:
+            self.provisioned = True
+
+        async def status(self, *, force=False):
+            return {
+                "enabled": False,
+                "version": self.version,
+                "remoteVersion": None,
+                "updateAvailable": False,
+                "idle": self.is_idle(),
+                "state": "idle",
+                "phase": None,
+                "error": None,
+            }
+
+        def start(self):
+            return False, "not a release install"
+
+    settings_path = tmp_path / "settings.json"
+    monkeypatch.setattr(
+        app_module, "SettingsStore", lambda: SettingsStore(settings_path)
+    )
+    monkeypatch.setattr(app_module, "RobotLink", FakeRobot)
+    monkeypatch.setattr(app_module, "SelfUpdater", FakeUpdater)
+    monkeypatch.setattr(
+        app_module, "_list_can_interfaces", lambda: [{"name": "can0", "up": True}]
+    )
+    monkeypatch.setattr(
+        app_module,
+        "_detect_cameras",
+        lambda: {
+            "devices": [{"serial": 7, "model": "ZED X", "kind": "stereo"}],
+            "error": None,
+        },
+    )
+    monkeypatch.setattr(
+        app_module.adb,
+        "status",
+        lambda: SimpleNamespace(
+            installed=True,
+            serial="quest",
+            state="device",
+            reverse_active=True,
+            ready=True,
+        ),
+    )
+    monkeypatch.setattr(app_module.adb, "connect", app_module.adb.status)
+    monkeypatch.setattr(
+        app_module.adb, "set_proximity_disabled", lambda disabled: (True, None)
+    )
+
+    import almond_axol.recording.datasets as datasets_module
+    import almond_axol.zed as zed_module
+    import almond_axol.zed.snapshot as snapshot_module
+
+    monkeypatch.setattr(datasets_module, "list_datasets", lambda base=None: [])
+    monkeypatch.setattr(snapshot_module, "snapshot_jpeg", lambda serial: b"jpeg")
+    monkeypatch.setattr(zed_module, "restart_zed_daemon", lambda: None)
+
+    static = tmp_path / "dist"
+    (static / "assets").mkdir(parents=True)
+    (static / "index.html").write_text("<html>app</html>")
+    (static / "assets" / "bundle.js").write_text("console.log('ok')")
+    app = app_module.create_app(static_dir=static)
+
+    with TestClient(app) as client:
+        assert client.get("/api/info").json()["version"] == "1.0.0"
+        assert client.get("/api/update/status?refresh=true").json()["idle"] is True
+        assert client.post("/api/update/start").status_code == 409
+
+        assert client.get("/api/robot/status").json()["state"] == "disconnected"
+        assert (
+            client.post(
+                "/api/robot/connect",
+                json={"channelsSet": True, "leftChannel": None, "rightChannel": None},
+            ).status_code
+            == 400
+        )
+        connected = client.post(
+            "/api/robot/connect",
+            json={"channelsSet": True, "leftChannel": "can0", "rightChannel": None},
+        )
+        assert connected.json()["state"] == "connected"
+        assert client.post("/api/robot/disconnect").json()["state"] == "disconnected"
+        assert (
+            client.get("/api/can/interfaces").json()["interfaces"][0]["name"] == "can0"
+        )
+        assert client.get("/api/robot/motors/left/ELBOW").status_code == 200
+        assert client.get("/api/robot/motors/left/UNKNOWN").status_code == 404
+
+        assert client.get("/api/telemetry").json()["state"] == "disconnected"
+        assert client.get("/api/telemetry/history?seconds=1&max_frames=5").json() == {
+            "frames": []
+        }
+        with client.websocket_connect("/api/telemetry/ws") as websocket:
+            assert websocket.receive_json()["type"] == "hello"
+
+        assert (
+            client.post("/api/diagnostics/run", json={"command": "missing"}).status_code
+            == 400
+        )
+        assert client.get("/api/diagnostics/runs").json() == {"runs": []}
+        assert client.delete("/api/diagnostics/runs").json() == {"removed": 0}
+        assert client.get("/api/diagnostics/runs/missing").status_code == 404
+        assert client.get("/api/cameras/detect").json()["devices"][0]["serial"] == 7
+        preview = client.get("/api/cameras/preview/7")
+        assert preview.content == b"jpeg"
+        assert preview.headers["cache-control"] == "no-store"
+        assert client.post("/api/cameras/restart-daemon").json()["ok"] is True
+
+        assert client.get("/api/settings").status_code == 200
+        assert (
+            client.put(
+                "/api/settings", json={"values": {"robot.has_gripper": False}}
+            ).json()["values"]["robot.has_gripper"]
+            is False
+        )
+        assert (
+            client.put("/api/settings", json={"values": {"not.real": True}}).status_code
+            == 400
+        )
+        assert client.get("/api/datasets").json() == {"datasets": []}
+        assert client.get("/api/urdf/not-real.stl").status_code == 404
+
+        assert client.get("/api/usb/status").json()["ready"] is True
+        assert client.post("/api/usb/connect").json()["serial"] == "quest"
+        assert client.post("/api/usb/proximity", json={"disabled": True}).json() == {
+            "ok": True
+        }
+        assert client.get("/api/op/status").json()["running"] is False
+        assert client.post("/api/op/start", json={"op": "missing"}).status_code == 400
+        assert client.post("/api/op/stop").status_code == 404
+        assert (
+            client.post("/api/op/episode", json={"command": "save"}).status_code == 409
+        )
+        assert client.get("/api/sessions").json() == []
+        assert client.post("/api/run", json={"command": "missing"}).status_code == 400
+        assert client.post("/api/sessions/missing/stop").status_code == 404
+        assert (
+            client.post("/api/sessions/missing/input", json={"line": ""}).status_code
+            == 404
+        )
+        assert client.get("/api/sessions/missing/log").status_code == 404
+        with client.websocket_connect("/api/sessions/missing/logs") as websocket:
+            assert websocket.receive_json()["type"] == "error"
+
+        assert (
+            client.get("/assets/bundle.js")
+            .headers["cache-control"]
+            .startswith("public")
+        )
+        assert client.get("/some/client/route").text == "<html>app</html>"
+        assert client.get("/api/not-real").status_code == 404

--- a/tests/test_service_lifecycle.py
+++ b/tests/test_service_lifecycle.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from collections import deque
+from pathlib import Path
+from types import SimpleNamespace
+
+from almond_axol.serve import manager, telemetry
+
+
+class _AsyncLines:
+    def __init__(self, *lines: bytes) -> None:
+        self._lines = iter(lines)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> bytes:
+        try:
+            return next(self._lines)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+
+class _Stdin:
+    def __init__(self, *, broken: bool = False) -> None:
+        self.writes: list[bytes] = []
+        self.broken = broken
+
+    def write(self, value: bytes) -> None:
+        if self.broken:
+            raise BrokenPipeError
+        self.writes.append(value)
+
+    async def drain(self) -> None:
+        return None
+
+
+class _Proc:
+    def __init__(self, *lines: bytes, returncode: int | None = None) -> None:
+        self.stdout = _AsyncLines(*lines)
+        self.stdin = _Stdin()
+        self.pid = 1234
+        self.returncode = returncode
+
+    async def wait(self) -> int:
+        return 0 if self.returncode is None else self.returncode
+
+
+def test_session_stream_input_and_resumable_log() -> None:
+    async def exercise() -> None:
+        session = manager.Session("demo", {"speed": 2})
+        proc = _Proc(b"first\n", b"bad-utf8-\xff\n")
+        session.proc = proc  # type: ignore[assignment]
+        queue = asyncio.Queue(maxsize=1)
+        session.subscribers.add(queue)
+
+        seen: list[str] = []
+        assert await manager.pump_into(proc, session, "child", seen.append) == 0
+        assert seen == ["first", "bad-utf8-�"]
+        assert await session.send_input("continue")
+        assert proc.stdin.writes == [b"continue\n"]
+        assert await queue.get() == "[child] first"
+
+        lines, offset = session.read_log(1)
+        assert lines == ["[child] bad-utf8-�"]
+        assert offset == 2
+        assert session.to_dict()["pid"] == 1234
+
+        proc.returncode = 0
+        assert not await session.send_input("ignored")
+        session.proc = None
+        assert not await session.send_input("ignored")
+
+    asyncio.run(exercise())
+
+
+def test_session_threadsafe_fanout_and_broken_input() -> None:
+    class ImmediateLoop:
+        def call_soon_threadsafe(self, callback, *args) -> None:
+            callback(*args)
+
+    async def exercise() -> None:
+        session = manager.Session("demo", {})
+        session.loop = ImmediateLoop()  # type: ignore[assignment]
+        queue = asyncio.Queue(maxsize=2)
+        session.subscribers.add(queue)
+        session.emit("hello")
+        session.close_stream()
+        assert await queue.get() == "hello"
+        assert await queue.get() is None
+
+        proc = _Proc()
+        proc.stdin = _Stdin(broken=True)
+        session.proc = proc  # type: ignore[assignment]
+        assert not await session.send_input("answer")
+
+    asyncio.run(exercise())
+
+
+def test_session_manager_launch_error_and_completed_process(monkeypatch) -> None:
+    async def exercise() -> None:
+        sessions = manager.SessionManager()
+
+        async def fail_spawn(*args, **kwargs):
+            raise OSError("no executable")
+
+        monkeypatch.setattr(manager, "spawn_proc", fail_spawn)
+        failed = await sessions.start_raw("broken", ["broken"])
+        assert failed.status == "error"
+        assert "no executable" in (failed.error or "")
+
+        proc = _Proc(b"ready\n", returncode=7)
+
+        async def fake_spawn(*args, **kwargs):
+            return proc
+
+        spawned: list[object] = []
+
+        def capture_task(coro):
+            spawned.append(coro)
+            coro.close()
+            return SimpleNamespace()
+
+        monkeypatch.setattr(manager, "spawn_proc", fake_spawn)
+        monkeypatch.setattr(manager.asyncio, "create_task", capture_task)
+        running = await sessions.start_raw("demo", ["demo", "--flag"])
+        assert running.status == "running"
+        assert running in [sessions.get(running.id)]
+        assert sessions.list()[-1]["command"] == "demo"
+        assert spawned
+
+        await sessions._pump(running)
+        assert running.status == "exited"
+        assert running.exit_code == 7
+        assert running.log[-1].endswith("code 7")
+        assert await sessions.stop(running.id)
+        assert not await sessions.stop("missing")
+
+    asyncio.run(exercise())
+
+
+def test_session_manager_custom_teardown_and_shutdown() -> None:
+    async def exercise() -> None:
+        sessions = manager.SessionManager()
+        called: list[str] = []
+        session = manager.Session("inline", {})
+
+        async def teardown() -> None:
+            called.append("done")
+
+        session.teardown = teardown
+        sessions._sessions[session.id] = session
+        queue = sessions.subscribe(session)
+        sessions.unsubscribe(session, queue)
+        await sessions.shutdown()
+        assert called == ["done"]
+
+    asyncio.run(exercise())
+
+
+def test_telemetry_hub_snapshot_history_and_subscription(monkeypatch) -> None:
+    times = iter([100.0, 101.0, 102.0, 103.0])
+    monkeypatch.setattr(telemetry.time, "time", lambda: next(times))
+    hub = telemetry.TelemetryHub()
+
+    async def exercise() -> None:
+        queue = hub.subscribe()
+        hub.push_frame({"left:J1": [1.0, 2.0, 3.0]})
+        hub.push_slow({"left:J1": {"temperature": 30}})
+        hub.push_state("ready")
+        hub.push_state("ready")
+
+        assert (await queue.get())["type"] == "frame"
+        assert (await queue.get())["type"] == "slow"
+        assert await queue.get() == {"type": "state", "state": "ready"}
+        assert queue.empty()
+        snapshot = hub.snapshot()
+        assert snapshot["state"] == "ready"
+        assert snapshot["latest"]["t"] == 100.0
+        assert snapshot["slow"]["left:J1"]["temperature"] == 30
+        hub.unsubscribe(queue)
+
+    asyncio.run(exercise())
+    hub._frames = deque(({"t": float(i), "m": {}} for i in range(10)), maxlen=20)
+    monkeypatch.setattr(telemetry.time, "time", lambda: 10.0)
+    assert [f["t"] for f in hub.history(5, max_frames=3)] == [5.0, 6.0, 8.0]
+    assert [f["t"] for f in hub.frames_between(2.0, 4.0)] == [2.0, 3.0, 4.0]
+    hub.clear_slow()
+    assert hub.snapshot()["slow"] == {}
+
+
+def test_diagnostics_store_round_trip_csv_and_clear(
+    tmp_path: Path, monkeypatch
+) -> None:
+    now = iter([10.0, 20.0])
+    monkeypatch.setattr(telemetry.time, "time", lambda: next(now))
+    hub = telemetry.TelemetryHub()
+    hub._frames.extend(
+        [{"t": 12.0, "m": {}}, {"t": 18.0, "m": {}}, {"t": 30.0, "m": {}}]
+    )
+    store = telemetry.DiagnosticsRunStore(hub, tmp_path / "runs")
+    meta = store.begin("session", "rom-test", {"arm": "left"})
+
+    capture = tmp_path / "capture.csv"
+    capture.write_text(
+        "t,left:J1:pos,left:J1:vel,left:J1:tq,ignored\n1.0,1,2,3,x\n2.0,4,,6,x\n"
+    )
+    store.finalize(meta, "exited", 0, [f"[telemetry] csv={capture}", "ok"])
+    assert meta["frameCount"] == 2
+    assert store.list() == [meta]
+
+    loaded = store.load(meta["id"], max_frames=1)
+    assert loaded is not None
+    assert loaded["frames"] == [{"t": 1.0, "m": {"left:J1": [1.0, 2.0, 3.0]}}]
+    assert loaded["log"][-1] == "ok"
+    assert store.load("missing") is None
+
+    assert store.clear() == 1
+    assert not capture.exists()
+    assert store.list() == []
+    assert store.clear() == 0
+
+
+def test_diagnostics_store_tolerates_corrupt_files(tmp_path: Path) -> None:
+    runs = tmp_path / "runs"
+    runs.mkdir()
+    (runs / "bad.meta.json").write_text("not json")
+    (runs / "ok.meta.json").write_text(json.dumps({"id": "ok", "startedAt": 1}))
+    (runs / "ok.data.json").write_text("bad")
+    store = telemetry.DiagnosticsRunStore(telemetry.TelemetryHub(), runs)
+    assert store.list() == [{"id": "ok", "startedAt": 1}]
+    assert store.load("ok") == {
+        "meta": {"id": "ok", "startedAt": 1},
+        "frames": [],
+        "log": [],
+    }
+
+    malformed = tmp_path / "bad.csv"
+    malformed.write_text("wrong,header\n1,2\n")
+    assert telemetry._read_csv_frames(malformed) == []
+    malformed.write_text("t,left:J1:pos\nnot-a-time,1\n")
+    assert telemetry._read_csv_frames(malformed) == []

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import multiprocessing
+import queue
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
 
+from almond_axol.video import gst_zed
 from almond_axol.video.gst_zed import _split_nals
 from almond_axol.video.hw_video import (
     _bitrate_for,
@@ -88,3 +91,278 @@ def test_shared_memory_raw_frame_round_trip() -> None:
     finally:
         reader.close()
         writer.close()
+
+
+def test_gst_availability_checks_optional_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        gst_zed, "_require_gst", lambda: (_ for _ in ()).throw(ImportError())
+    )
+    assert not gst_zed._gi_available()
+    assert not gst_zed._element_available("zedsrc")
+
+    class Factory:
+        @staticmethod
+        def find(name: str) -> object | None:
+            return object() if name == "zedsrc" else None
+
+    class Gst:
+        ElementFactory = Factory
+
+    monkeypatch.setattr(gst_zed, "_require_gst", lambda: (Gst, object()))
+    assert gst_zed._gi_available()
+    assert gst_zed._element_available("zedsrc")
+    assert not gst_zed._element_available("zedxonesrc")
+
+    monkeypatch.setattr(gst_zed, "_gi_available", lambda: True)
+    monkeypatch.setattr(gst_zed, "hw_h264_available", lambda: True)
+    monkeypatch.setattr(gst_zed, "_element_available", lambda name: name == "zedsrc")
+    assert not gst_zed.zed_gst_available()
+    assert gst_zed.zed_stereo_gst_available()
+
+    monkeypatch.setattr(gst_zed, "_gi_available", lambda: False)
+    assert not gst_zed.zed_gst_available()
+    assert not gst_zed.zed_stereo_gst_available()
+
+
+def test_gst_typelib_path_adds_only_existing_directories(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    existing = "/custom/typelibs"
+    monkeypatch.setenv("GI_TYPELIB_PATH", existing)
+    monkeypatch.setattr(
+        gst_zed.os.path,
+        "isdir",
+        lambda path: path.endswith("x86_64-linux-gnu/girepository-1.0"),
+    )
+    gst_zed._set_typelib_path()
+    parts = gst_zed.os.environ["GI_TYPELIB_PATH"].split(gst_zed.os.pathsep)
+    assert parts == [existing, "/usr/lib/x86_64-linux-gnu/girepository-1.0"]
+
+    gst_zed._set_typelib_path()
+    assert gst_zed.os.environ["GI_TYPELIB_PATH"].split(gst_zed.os.pathsep) == parts
+
+
+def test_encoded_channel_fans_out_and_drops_stale_units() -> None:
+    channel = gst_zed._AUChannel(lambda: True)
+    first = channel.subscribe()
+    second = channel.subscribe()
+    assert channel.alive
+
+    for value in range(gst_zed._SUBSCRIBER_QUEUE_DEPTH + 2):
+        channel.broadcast([bytes([value])])
+
+    assert channel.first_au.is_set()
+    assert first.qsize() == gst_zed._SUBSCRIBER_QUEUE_DEPTH
+    assert first.get_nowait() == [b"\x02"]
+    assert second.get_nowait() == [b"\x02"]
+
+    while not first.empty():
+        first.get_nowait()
+    channel.unsubscribe(first)
+    channel.unsubscribe(first)
+    channel.broadcast([b"latest"])
+    with pytest.raises(queue.Empty):
+        first.get_nowait()
+
+
+def test_raw_gst_buffer_returns_rgb_and_enforces_freshness(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    raw = gst_zed._RawBuffer(width=2, height=1)
+    with pytest.raises(RuntimeError, match="has not captured"):
+        raw.read_latest_with_ts()
+    with pytest.raises(TimeoutError, match="waiting for frame"):
+        raw.read_at_or_after(1.0, timeout_ms=0)
+
+    rgba = np.arange(8, dtype=np.uint8).reshape(1, 2, 4)
+    raw.set(rgba, cap_ts=4.0, recv_ts=5.0)
+    frame, cap, recv = raw.read_at_or_after(3.0)
+    np.testing.assert_array_equal(frame, rgba[:, :, :3])
+    assert frame.flags.c_contiguous
+    assert (cap, recv) == (4.0, 5.0)
+
+    monkeypatch.setattr(gst_zed.time, "perf_counter", lambda: 5.01)
+    np.testing.assert_array_equal(raw.read_latest(max_age_ms=20), frame)
+    with pytest.raises(TimeoutError, match="old"):
+        raw.read_latest(max_age_ms=5)
+
+
+def test_gst_stream_consumer_delegates_to_available_branches() -> None:
+    consumer = gst_zed._GstStreamConsumer()
+    consumer._alive_fn = lambda: True
+    consumer._enc = None
+    consumer._raw = None
+    assert consumer.alive
+    with pytest.raises(RuntimeError, match="no encoded"):
+        consumer.subscribe()
+    with pytest.raises(RuntimeError, match="no raw"):
+        consumer.read_latest()
+    with pytest.raises(RuntimeError, match="no raw"):
+        consumer.read_latest_with_ts()
+    with pytest.raises(RuntimeError, match="no raw"):
+        consumer.read_at_or_after(0.0)
+
+    channel = gst_zed._AUChannel(lambda: True)
+    raw = gst_zed._RawBuffer(1, 1)
+    raw.set(np.array([[[1, 2, 3, 4]]], dtype=np.uint8), 1.0, 1.0)
+    consumer._enc = channel
+    consumer._raw = raw
+    subscribed = consumer.subscribe()
+    channel.broadcast([b"au"])
+    assert subscribed.get_nowait() == [b"au"]
+    consumer.unsubscribe(subscribed)
+    np.testing.assert_array_equal(consumer.read(), np.array([[[1, 2, 3]]]))
+    assert consumer.read_latest_with_ts()[1:] == (1.0, 1.0)
+
+
+def test_gst_pipeline_fragments_include_transport_and_encoder_settings() -> None:
+    assert "name=encoded" in gst_zed._enc_appsink("encoded")
+    assert "drop=true" in gst_zed._raw_appsink("raw")
+    assert "socket-path=/tmp/raw.sock" in gst_zed._raw_shmsink("/tmp/raw.sock")
+
+    dataset = gst_zed._dataset_enc_shmsink("/tmp/data.sock", 960, 600, 60, "data")
+    assert "name=data" in dataset
+    assert "idrinterval=15" in dataset
+    assert "socket-path=/tmp/data.sock" in dataset
+    assert "peak-bitrate=" in dataset
+
+    encoded = gst_zed._enc_branch(4_000_000, 30, "head")
+    assert "name=head" in encoded
+    assert "bitrate=4000000" in encoded
+    assert "idrinterval=30" in encoded
+
+
+def test_gst_pipeline_timestamps_latency_and_lifecycle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    base = gst_zed._GstPipelineBase()
+    assert not base.alive
+    assert not base.is_connected
+
+    class State:
+        NULL = "null"
+
+    class Query:
+        @staticmethod
+        def new_latency() -> object:
+            return object()
+
+    Gst = SimpleNamespace(CLOCK_TIME_NONE=-1, State=State, Query=Query)
+
+    class Clock:
+        def get_time(self) -> int:
+            return 6_000_000_000
+
+    class Pipeline:
+        state = "playing"
+
+        def get_state(self, timeout: int) -> tuple[None, str, None]:
+            return None, self.state, None
+
+        def get_base_time(self) -> int:
+            return 1_000_000_000
+
+        def query(self, query: object) -> bool:
+            return True
+
+        def set_state(self, state: str) -> None:
+            self.state = state
+
+    base._gst = Gst
+    base._pipeline = Pipeline()
+    base._clock = Clock()
+    assert base.alive
+    assert base.is_connected
+    assert base._cap_perf_from_pts(4_000_000_000, 10.0) == 9.0
+    assert base._cap_perf_from_pts(Gst.CLOCK_TIME_NONE, 10.0) == 10.0
+
+    query_result = SimpleNamespace(parse_latency=lambda: (True, 20_000_000, None))
+    monkeypatch.setattr(Query, "new_latency", lambda: query_result)
+    assert base._measure_raw_latency_s(60) == 0.02
+    base._pipeline.query = lambda query: False  # type: ignore[method-assign]
+    assert base._measure_raw_latency_s(50) == 0.02
+    assert base._measure_raw_latency_s(0) == 0.0
+
+    thread = SimpleNamespace(join=lambda timeout: None)
+    base._threads.append(thread)  # type: ignore[arg-type]
+    base.disconnect()
+    assert base._pipeline is None
+    assert base._threads == []
+    assert not base.is_connected
+
+
+def test_gst_buffer_handlers_unmap_and_publish_frames(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Gst:
+        class MapFlags:
+            READ = "read"
+
+    class Buffer:
+        def __init__(self, data: bytes, *, ok: bool = True) -> None:
+            self.data = data
+            self.ok = ok
+            self.pts = 4
+            self.unmapped = 0
+
+        def map(self, flags: str) -> tuple[bool, SimpleNamespace]:
+            return self.ok, SimpleNamespace(data=self.data, size=len(self.data))
+
+        def unmap(self, mapinfo: SimpleNamespace) -> None:
+            self.unmapped += 1
+
+    base = gst_zed._GstPipelineBase()
+    base._gst = Gst
+    base._cap_perf_from_pts = lambda pts, recv: recv - 0.1  # type: ignore[method-assign]
+    channel = gst_zed._AUChannel(lambda: True)
+    subscriber = channel.subscribe()
+    monkeypatch.setattr(gst_zed.time, "perf_counter", lambda: 1.0)
+    encoded = base._make_au_handler(channel, "head")
+
+    rejected = Buffer(b"ignored", ok=False)
+    encoded(rejected, 1.0)
+    with pytest.raises(queue.Empty):
+        subscriber.get_nowait()
+
+    accepted = Buffer(b"\x00\x00\x01\x65frame")
+    encoded(accepted, 1.0)
+    assert subscriber.get_nowait() == [b"\x65frame"]
+    assert accepted.unmapped == 1
+
+    received: list[tuple[np.ndarray, float, float]] = []
+    raw_handler = base._make_raw_handler(
+        lambda rgba, cap, recv: received.append((rgba.copy(), cap, recv)), 2, 1
+    )
+    short = Buffer(b"\x00" * 7)
+    raw_handler(short, 5.0)
+    assert received == []
+    assert short.unmapped == 1
+
+    complete = Buffer(bytes(range(8)))
+    raw_handler(complete, 5.0)
+    np.testing.assert_array_equal(received[0][0], np.arange(8).reshape(1, 2, 4))
+    assert received[0][1:] == (4.9, 5.0)
+    assert complete.unmapped == 1
+
+    raw = gst_zed._RawBuffer(2, 1)
+    sink = base._buffer_sink(raw)
+    source = np.arange(8, dtype=np.uint8).reshape(1, 2, 4)
+    sink(source, 2.0, 3.0)
+    source.fill(0)
+    np.testing.assert_array_equal(
+        raw.read_latest_with_ts()[0], [[[0, 1, 2], [4, 5, 6]]]
+    )
+
+
+def test_encoder_bitrate_update_is_best_effort() -> None:
+    encoder = SimpleNamespace(
+        values=[], set_property=lambda name, value: encoder.values.append((name, value))
+    )
+    pipeline = SimpleNamespace(
+        get_by_name=lambda name: encoder if name == "present" else None
+    )
+    gst_zed._set_enc_bitrate(pipeline, "present", 4.5)
+    gst_zed._set_enc_bitrate(pipeline, "missing", 10)
+    assert encoder.values == [("bitrate", 4)]

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import multiprocessing
+
+import numpy as np
+import pytest
+
+from almond_axol.video.gst_zed import _split_nals
+from almond_axol.video.hw_video import (
+    _bitrate_for,
+    _drain_complete_nals,
+    _gst_argv,
+    _strip_start_code,
+    dataset_vbr_bitrate,
+)
+from almond_axol.video.shm_frames import (
+    RawFrameReader,
+    RawFrameWriter,
+    _au_has_coded_slice,
+    _block_size,
+)
+from almond_axol.video.video_proc import _eye_plan, _plan, _pyshm_meta, _raw_plan
+
+
+def test_bitrate_budgets_are_bounded() -> None:
+    assert _bitrate_for(320, 240, 15) == 4_000_000
+    assert _bitrate_for(8000, 8000, 120) == 20_000_000
+    target, peak = dataset_vbr_bitrate(960, 600, 60)
+    assert 3_000_000 <= target <= 16_000_000
+    assert peak == target * 2
+
+
+def test_gstreamer_command_is_shell_free_and_dimensioned() -> None:
+    argv = _gst_argv(640, 480, 30, 5_000_000)
+    assert argv[:2] == ["gst-launch-1.0", "-q"]
+    assert "width=640" in argv
+    assert "height=480" in argv
+    assert "bitrate=5000000" in argv
+    assert "!" in argv
+
+
+def test_annex_b_nal_helpers_handle_three_and_four_byte_prefixes() -> None:
+    assert _strip_start_code(b"\x00\x00\x01\x65abc") == b"\x65abc"
+    assert _strip_start_code(b"\x00\x00\x00\x01\x67abc") == b"\x67abc"
+    assert _strip_start_code(b"plain") is None
+
+    buf = bytearray(b"\x00\x00\x00\x01\x67aa\x00\x00\x01\x68bb\x00\x00\x01\x65tail")
+    assert _drain_complete_nals(buf) == [b"\x67aa", b"\x68bb"]
+    assert bytes(buf).endswith(b"\x00\x00\x01\x65tail")
+
+    assert _split_nals(b"\x00\x00\x01\x67aa\x00\x00\x00\x01\x68bb") == [
+        b"\x67aa",
+        b"\x68bb",
+    ]
+    assert _au_has_coded_slice(b"\x00\x00\x01\x65frame")
+    assert not _au_has_coded_slice(b"\x00\x00\x01\x67sps")
+
+
+def test_camera_eye_plans_keep_stream_and_record_independent() -> None:
+    assert _plan("head", ["left", "right"], True) == [
+        ("left", "head_left"),
+        ("right", "head_right"),
+    ]
+    spec = {
+        "stream_eyes": ["left", "right"],
+        "stream_suffix": True,
+        "record_eyes": ["left"],
+        "record_suffix": False,
+    }
+    assert _eye_plan("head", spec) == [("left", "head_left"), ("right", "head_right")]
+    assert _raw_plan("head", spec) == [("left", "head")]
+    assert _pyshm_meta("block", 10, 20, 30)["transport"] == "pyshm"
+
+
+def test_shared_memory_raw_frame_round_trip() -> None:
+    assert _block_size(2, 3) > 2 * 3 * 3
+    condition = multiprocessing.Condition()
+    writer = RawFrameWriter.create(2, 3, condition)
+    reader = RawFrameReader(writer.name, 2, 3, 60, condition)
+    rgba = np.arange(3 * 2 * 4, dtype=np.uint8).reshape(3, 2, 4)
+    try:
+        with pytest.raises(RuntimeError, match="no frames"):
+            reader.read_latest_with_ts()
+        writer.publish(rgba, cap_ts=10.0, recv_ts=11.0)
+        frame, cap, recv = reader.read_latest_with_ts()
+        np.testing.assert_array_equal(frame, rgba[:, :, :3])
+        assert (cap, recv) == (10.0, 11.0)
+    finally:
+        reader.close()
+        writer.close()

--- a/tests/test_vr.py
+++ b/tests/test_vr.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+
+import pytest
+
+from almond_axol.vr import ice
+from almond_axol.vr.interp import PoseInterpolator
+from almond_axol.vr.models import VRFrame, VRState
+
+
+def test_vr_frame_defaults_and_validation(
+    frame_factory: Callable[..., VRFrame],
+) -> None:
+    frame = frame_factory()
+
+    assert frame.state is VRState.TELEOP
+    assert frame.l_grip == frame.r_grip == 1.0
+    assert frame.l_tracked and frame.r_tracked
+    assert frame.model_dump(mode="json")["state"] == "teleop"
+
+    with pytest.raises(ValueError):
+        frame_factory(state="not-a-state")
+
+
+def test_pose_interpolator_latest_wins(frame_factory: Callable[..., VRFrame]) -> None:
+    interpolator = PoseInterpolator(enabled=False)
+    first = frame_factory(seq=1)
+    latest = frame_factory(seq=2, l_lock=True)
+
+    interpolator.push(first, now=1.0)
+    interpolator.push(latest, now=2.0)
+
+    assert interpolator.sample(now=2.0) is latest
+    interpolator.reset()
+    assert interpolator.sample(now=3.0) is None
+
+
+def test_pose_interpolator_blends_motion_but_keeps_latest_controls(
+    frame_factory: Callable[..., VRFrame],
+) -> None:
+    first = frame_factory(t=0.0, seq=1)
+    second = frame_factory(t=100.0, seq=2, l_lock=True, reset=True)
+    second.l_ee.position.x = 1.0
+    interpolator = PoseInterpolator(
+        min_delay_s=0.05,
+        max_delay_s=0.05,
+        smooth_window_s=0.0,
+    )
+
+    interpolator.push(first, now=10.0)
+    interpolator.push(second, now=10.1)
+    result = interpolator.sample(now=10.1)
+
+    assert result is not None
+    assert result.l_ee.position.x == pytest.approx(0.5, abs=0.02)
+    assert result.l_lock is True
+    assert result.reset is True
+
+
+def test_ice_configuration_and_candidate_summary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AXOL_TURN_URL", "turn:a.example, turns:b.example")
+    monkeypatch.setenv("AXOL_TURN_USERNAME", "user")
+    monkeypatch.setenv("AXOL_TURN_PASSWORD", "secret")
+
+    browser = ice.client_ice_servers()
+    server = ice.ice_servers()
+    assert browser == [
+        {
+            "urls": ["turn:a.example", "turns:b.example"],
+            "username": "user",
+            "credential": "secret",
+        }
+    ]
+    assert server[0].urls == ["turn:a.example", "turns:b.example"]
+
+    sdp = "\r\n".join(
+        [
+            "v=0",
+            "a=candidate:1 1 udp 1 10.0.0.1 1000 typ host",
+            "a=candidate:2 1 udp 1 1.2.3.4 2000 typ relay",
+        ]
+    )
+    assert ice.summarize_candidates(sdp) == "candidates: host=1 relay=1"
+    assert ice.summarize_candidates("v=0") == "candidates: none"
+
+
+def test_candidates_are_replicated_to_each_media_section() -> None:
+    candidate = "a=candidate:1 1 udp 1 10.0.0.1 1000 typ host"
+    sdp = f"v=0\nm=audio 9 UDP/TLS/RTP/SAVPF 111\n{candidate}\nm=video 9 UDP/TLS/RTP/SAVPF 96\n"
+
+    replicated = ice.replicate_candidates_across_mlines(sdp)
+
+    assert replicated.count(candidate) == 2
+    assert ice.replicate_candidates_across_mlines("v=0\nm=audio 9 RTP/AVP 0\n") == (
+        "v=0\nm=audio 9 RTP/AVP 0\n"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -194,6 +194,12 @@ sim = [
     { name = "viser" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "aiortc", specifier = ">=1.9" },
@@ -214,6 +220,12 @@ requires-dist = [
     { name = "yourdfpy", specifier = ">=0.0.60" },
 ]
 provides-extras = ["gamepad", "lerobot", "sim"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.3" },
+    { name = "pytest-cov", specifier = ">=6.0" },
+]
 
 [[package]]
 name = "almond-jaxls"
@@ -609,6 +621,105 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/f5/deb1a27aa20746c0278ac998c4179e272004699b2d33959ce020c5ac1615/coverage-7.16.0.tar.gz", hash = "sha256:077f0964087883176ff6ab9b074694cae29f8c708273b13ca62c183c6ed716cd", size = 945620, upload-time = "2026-08-28T21:54:37.74Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/9c/8d2688694f53dc0b0f0e4783c7eb3c4bb1e79beaf1411879f6dabedf4607/coverage-7.16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d1c77c3579ac42798f8b7eed6d3dd258debacca32c8753fc8a1f6eaf1db644f5", size = 223194, upload-time = "2026-08-28T21:51:27.767Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/11/f002163dd688aa3fa49ac6a424b7c2705c7fcf80fba18ec9f586d77827ca/coverage-7.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1f81cb1554c3712e41649ed5dc98656b50b958e4da12f0f5adb681ce3db92831", size = 223553, upload-time = "2026-08-28T21:51:29.46Z" },
+    { url = "https://files.pythonhosted.org/packages/81/65/f9d469e97c4554372a710650a109004a2434dfc56f577142e5d6057fa0cc/coverage-7.16.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6e701938ec9081d3e400a0c9a9a8ae0f7ca44214741daeac4454b1c6ef6dbd19", size = 255054, upload-time = "2026-08-28T21:51:31.54Z" },
+    { url = "https://files.pythonhosted.org/packages/95/29/dd89fd39af1a3b6e9a9c3eddeaf03f6376ba517d43d6cbf8b519177e2a10/coverage-7.16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:719a3feb6220dd32ed932d4c3676d17fb8739e2643b29c0e7c3af400ff80ac44", size = 257790, upload-time = "2026-08-28T21:51:33.374Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/64/208d26cedc525d6b5db9c492cf9130784c42d9eb08d22badaa7b806005ad/coverage-7.16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:87771ecf986cff55e87413238cd5e4f54d949c2074bd6fc1657d26a56314ee24", size = 258904, upload-time = "2026-08-28T21:51:35.096Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/98/28e2752aa9a8baee5798edade9c95602ca200f4e7eeb503eb64df42e5921/coverage-7.16.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:47d5e1fc0b321c8308a2aacee0497c435b08acaa629b7059798fdf6fc3006352", size = 261165, upload-time = "2026-08-28T21:51:36.744Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/77/fa6ae699a0ea2bc12acb38a85d96b786fea0f833c12b5756056350e0e547/coverage-7.16.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:01b18b8a6c9cec8d5f45550e2501426ed982cf2c35016b0acd2ba9b5d8b2fb06", size = 255416, upload-time = "2026-08-28T21:51:38.495Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c8/5ee46d1de7d34cb00ba08b5c50da1971114dbc09ca9898ccc32975ec74dd/coverage-7.16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:32c56b5b47c50635081445ac404dd08c2d591b9c837c22570aa9e182c3b42cd4", size = 256825, upload-time = "2026-08-28T21:51:40.27Z" },
+    { url = "https://files.pythonhosted.org/packages/15/f6/d59e1c0693ad48855fe20169fbf6ee5befefe5887a7fabf5f0bcb464a2dc/coverage-7.16.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:6ad3bbad240ab937512156bc944fdee63ac4dd34a7558a3094548fd4c1150c02", size = 254970, upload-time = "2026-08-28T21:51:43.136Z" },
+    { url = "https://files.pythonhosted.org/packages/df/7b/b51bbe05b3a7565927fccfb1be42b8b3c1f4ab15e53d91b303e9923969aa/coverage-7.16.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4c1f16d5555a195295d0dc9c902612270e3dfed6a11f3bf7bc470b7b6a79ed3c", size = 259039, upload-time = "2026-08-28T21:51:44.983Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/04/d513f816456a8a43c1859abe88a37d01d7d2515b6c3e24ebb3c9b1dd44ec/coverage-7.16.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:f6c9c21a8bf0d19788f3c5f3e020c90317a0a63ef60521b376003801e21250fb", size = 254539, upload-time = "2026-08-28T21:51:46.733Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/54/5542190ceb97e0d1333a4ce0c8f95b2ef2efe790f1ad018a4b61766f849e/coverage-7.16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:06f20145a9eb5bf1fd1dde3c0bc2af2e7c22135ab07ca6284d6ada7cc3904c4e", size = 256410, upload-time = "2026-08-28T21:51:48.363Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/28/78643f361ff6bb5b2ade90f8bfc8395fe9ca367a18c101f8991215b4c65b/coverage-7.16.0-cp312-cp312-win32.whl", hash = "sha256:916cf8d25c1ce148f7eceb1d45afc9724841200110adc4e53250391852debd91", size = 225239, upload-time = "2026-08-28T21:51:50.22Z" },
+    { url = "https://files.pythonhosted.org/packages/67/61/8e76b36c36b1a033dc933dd2480db96b04ce3be975793ce3fad122e7174d/coverage-7.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:78f8b56261d608be102c62edd3a60b66bcd0b581f3f86fdcabaf8b8d95adc950", size = 225775, upload-time = "2026-08-28T21:51:51.912Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/f3/bb4787a4b81c1792ca69b502f5f730dbbb609f73fed552ab074c6b92cb8b/coverage-7.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:577c2ac8c0036f6f8edd3a7783a9e67302b17771d1abf0fd2ed246e3158be51b", size = 225159, upload-time = "2026-08-28T21:51:53.667Z" },
+    { url = "https://files.pythonhosted.org/packages/54/c5/e62c87f4799d1e3647d5b2ae16ea1d12205d72fde1ea8529e13fe050f678/coverage-7.16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1545c52ce756b8a97007f439a220297f1cd72a2cbbcdffccdf1c1f70e74f9a42", size = 223215, upload-time = "2026-08-28T21:51:55.628Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e9/5e62fda9397175fb206f75368b6e85da06d831c181b6d0f67ca073cd2f89/coverage-7.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0598aadae641f30a0796b75b45c0b9c5de8619bd5cfb251bb0cc254e86e6dd13", size = 223585, upload-time = "2026-08-28T21:51:57.355Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/40/bede08621b1ba67e88c4d3336c22b52cb7911ff1fa4ef055344b6670e58a/coverage-7.16.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:4080ad6bad9f14690e6b2104f5e8d137ccc65a4b5427a36662090637d4bd16d5", size = 254575, upload-time = "2026-08-28T21:51:59.233Z" },
+    { url = "https://files.pythonhosted.org/packages/12/d8/ab0bdaa45dfd6b8cbf1a3ec548fdf827684b1997f9724375c5b3e89144fb/coverage-7.16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e9883a2f8206ce3af59117dc278e5d043fea06912bca3f199816129e5e2de354", size = 257172, upload-time = "2026-08-28T21:52:01.015Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/bb/135de81784bbd7dfedcab2b92b03d71d75b09b0815b42d6dabb052def5a6/coverage-7.16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:984e5430fc6f858385009e92549955157d79335b1f3e13e1031e0f89d1284261", size = 258410, upload-time = "2026-08-28T21:52:02.76Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/72/ce44ecc062fb2e43d9447bb76154d091c2139232f20c125297c4b58f4c6a/coverage-7.16.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b1374099dd1ad0d31fbb6c95d00a56a3c5e85fb3343dca14fc12f78323a2b42a", size = 260539, upload-time = "2026-08-28T21:52:04.821Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c4/9389c36a41e59406ca2bba493807c2294d2e5186a7e9ebcc2e63a0f2a711/coverage-7.16.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:34d8686bce035c8465b318a8c2890e69ba14a00801a27f4eb6bdc97c23944d87", size = 254756, upload-time = "2026-08-28T21:52:06.68Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/0f/7762447b15e01fb84263608540123c4d9941f06303265ee74d801ccbec0e/coverage-7.16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:857fceba6ff4b507ee0ad98798a33d544a8473df0c542bf04251ee4ed5ee6292", size = 256540, upload-time = "2026-08-28T21:52:08.529Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/fa/c60dc75a8346c1dbebebc7279b19971c88f70dd575f0bc10bc0cb16f92d5/coverage-7.16.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:bbf08d951abaa1ce89e28c998361d56b952413846b459cd017f116ad4c9adbfa", size = 254508, upload-time = "2026-08-28T21:52:10.323Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/4e0834f3a1fccaa8bf625a2a1d73bde0fa32577dc3249853c0dd0e7f2b20/coverage-7.16.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:1a03e78f53e4d2ab13adac19958a89322d1829913e5623d642627bf60b35da21", size = 258659, upload-time = "2026-08-28T21:52:12.124Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/ec/fe712d3a11fd6e874565a5fa5497c48b8ece561d9611da040b44cdcf8386/coverage-7.16.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:dcd3dafcdd78305d27c59a1006b53a4990acb89e68d8fbe0992f4f83503c827f", size = 254326, upload-time = "2026-08-28T21:52:14.181Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/78/093e12072e01034c65ff380f76c74b79dd83e44fa92b689a2154389be734/coverage-7.16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c1bcfe470a796fbea6234accd81d258a31574dc0b7bf569e16be757572c4de17", size = 256102, upload-time = "2026-08-28T21:52:16.003Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/c0/265176117ca5d06e3f65575842884cdda96cf213350a31e9d41c80d65854/coverage-7.16.0-cp313-cp313-win32.whl", hash = "sha256:1420370276f1694b663207b8245c3628aafb9624fe3cebf313a13d860e55ee67", size = 225250, upload-time = "2026-08-28T21:52:17.82Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/01/8a87f2c04fde322430b45d16d8f543693e9894c5b2d2ca238a287c00beca/coverage-7.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:496277c8d7beed695e02c7be53516a0152e4caef8738a0feab6a638546cce449", size = 225790, upload-time = "2026-08-28T21:52:19.641Z" },
+    { url = "https://files.pythonhosted.org/packages/23/40/c21feacd9edfe7063195bf9cc84d650e9938fc6a23063e4f027199b160e1/coverage-7.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:181c2906b9b3759955c1c33c51fbb91c754fbd0b82ea49e2c81061f5a052082c", size = 225180, upload-time = "2026-08-28T21:52:21.613Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/850675f262391b322c4c988b6cdc32cdc6629288f0fb158687b587a393a8/coverage-7.16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:54b7fba6a74d010de34319a0419d5b65af8c00f539ad0b6f39fc6f342ab99697", size = 223258, upload-time = "2026-08-28T21:52:23.558Z" },
+    { url = "https://files.pythonhosted.org/packages/61/c1/4f54c6d47c80d1cc58ef8fe6b74e6eb50f9e2c0f6e2de6cf38dbca2937b8/coverage-7.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fa4ff0b3dd52208d2b30903022d5087f82000507b504753dfeee83e4f32d6883", size = 223587, upload-time = "2026-08-28T21:52:25.627Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/be/298f2456230fb44e272a4e53a41b3f3c39f0821c242d7b7daa9787b4d6f7/coverage-7.16.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:35a9676bf86097f790113ebd9fb67681804ef54d40941d2f10ba68c02239e575", size = 254632, upload-time = "2026-08-28T21:52:27.689Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9c/a1bda6439c19c4783d50df896142b67b9e7d432db36675d339a32778669d/coverage-7.16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f98d438add63546745e5e847192e3e9ab897ed6f2ca96f8281e2f5a15958ae62", size = 257139, upload-time = "2026-08-28T21:52:29.741Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/cd/cd735c9be757f97237c305f36897a5e5b348bdbc12ebed3b2b80060dd8a9/coverage-7.16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:151855767480be14db595cbc2040f6a4db965cdfeebd354d79b0256742b029e0", size = 258484, upload-time = "2026-08-28T21:52:31.68Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/04/84b2e1e8aae9db3f549782f28ce25bba5fd6a9c7bfba3782ffe8b4cd2559/coverage-7.16.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:183613f664718b340589d7f005c7e92b4b601cffd20a8a4117cfda3e983b080f", size = 260798, upload-time = "2026-08-28T21:52:33.642Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/4f/e04cf52483619a4dc5dd6367b30c9a8ac52243567fdfacec9b11a441565c/coverage-7.16.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:785b114356c99c0dd5b3f57b9696cfd57b7704f4c53847df8dc88c6cc0d9bcb6", size = 254612, upload-time = "2026-08-28T21:52:35.543Z" },
+    { url = "https://files.pythonhosted.org/packages/da/33/627c4113f66bfffd43807f54dbf080c4632ecf12e4ef7a3bdd4ec38e46a2/coverage-7.16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:30f5aee6d1d517abcdfd4f9cad027969ff79a1440a22da263f9514e31b5b66e9", size = 256495, upload-time = "2026-08-28T21:52:37.485Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/38/aaca432f4e008a88f2bc4d1459aa7016d8d1bbbe801f7e4fa3cf2746557b/coverage-7.16.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:190ffa0f5af966254c249fb3aeaca2cef389785e3e287fd577d39e134d20f8a3", size = 254454, upload-time = "2026-08-28T21:52:39.425Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/db/8430aa87ef0a508f4c17c1b8fa7e0cf80231988d9081aa36c194036592d6/coverage-7.16.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:0ccc37c00e1a5d30840902c54557e104d04aead872cedf6d2281c8725a467e06", size = 258728, upload-time = "2026-08-28T21:52:41.32Z" },
+    { url = "https://files.pythonhosted.org/packages/76/88/cd8aa8c82493ffbd291d3ef5554452fffc634c6c6098a04ac848c79c98f3/coverage-7.16.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6c60cde430c0e7e3be612973af39b4cff90ec2e2defe7b2b701daea3a0ffff04", size = 254271, upload-time = "2026-08-28T21:52:43.278Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/49/fe16c811ea9314a84b48f34e4bf5a3d9013091093b285a74b2272fc863d7/coverage-7.16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c5297028c8df849a61b29129cadfe682f90b5b396f528eb319a57d7678eefdad", size = 255927, upload-time = "2026-08-28T21:52:45.461Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/45/d0bd410e78cfbf768acc8099b335e1d5c0d5c26103c796d2bebdee001715/coverage-7.16.0-cp314-cp314-win32.whl", hash = "sha256:136988df5bc5a48795d9c42c75c4bbda5d9a78e750a080c1233010edff93a1af", size = 225424, upload-time = "2026-08-28T21:52:47.658Z" },
+    { url = "https://files.pythonhosted.org/packages/17/78/1ce6ce4646822e9308dcdb1942eaf31bfd7da43247b8886338b0d6fe3767/coverage-7.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:ce2ba5e9f1842fe09165825abfb3bc6b527c71a27bc2eb3a10f2284ced64506d", size = 225918, upload-time = "2026-08-28T21:52:49.692Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/cd/e1323fe3a7dfcdd709451a43fe708ca1dfd36a7fc07b34eb7bd1dfdfb52d/coverage-7.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:a89d07e48d9baead9a15599923a02f62c6df6c3d85aa84ef34be3c9fd6aeb91f", size = 225344, upload-time = "2026-08-28T21:52:51.665Z" },
+    { url = "https://files.pythonhosted.org/packages/39/fb/1c15460d4cf915f09ae3ad3862fef4f901838991c5641b0cec545050d810/coverage-7.16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:6e2854b62601c89a63814ad5def3b90d99c6724cc4cb977f75b725e5fca4b1e3", size = 223986, upload-time = "2026-08-28T21:52:53.572Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/73/347d2d0009ac211f79ee2a2364fd2aa19d6b9628dc22ed13a9b9386097ab/coverage-7.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f093faf23df888518d273be6da65f0ec5a25b5d8b670231e4d87de07361042e7", size = 224254, upload-time = "2026-08-28T21:52:55.59Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/2f/51442e6ad9d705369596f08496021647e276d5b57311818fd4312d93509b/coverage-7.16.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:b7dbbbf6551eb94618e7bc76ab61cc2740a5b3d13294171bd6adb36e12346c3c", size = 265619, upload-time = "2026-08-28T21:52:57.645Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/8e/0f752276f6d13efbd019ab6d90792e20d6272c44cda039dc5c6d27b91e7f/coverage-7.16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:51e7d0e311d2fba3915f971236cbdd4ad821fc7a23988221c0b33c964b0eba22", size = 267734, upload-time = "2026-08-28T21:52:59.611Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/02/4df3baef8029881c9d1a380859f2be73f90080d430def567d182e8566a35/coverage-7.16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0bb04ee77e557d7476471969d35fbbfb5fc8a4152e9409aa5811780c36d9b23e", size = 270156, upload-time = "2026-08-28T21:53:01.658Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/30/ce10fdb74055ebbfb5c8a025d8845dc19c76e4b2c42bb5c755b56678990c/coverage-7.16.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c72c9b201dc0e8c2c8821d49858fd865010d08181bf877d2320971b6464ebfd5", size = 271279, upload-time = "2026-08-28T21:53:03.698Z" },
+    { url = "https://files.pythonhosted.org/packages/71/19/c7e1fc9504d90da848493bad4018dd235c713a80633e48c5f0a41b63d45e/coverage-7.16.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0fca700cae4635656668ba6e2b66a85aac9f2622d7b2bcf82e844c409eaa1313", size = 264677, upload-time = "2026-08-28T21:53:05.741Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/f3/4021519dd41583ab396c81955387f927779641f6bac26818b6918a45aafc/coverage-7.16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:584896fb8b650e999e24ef57e9513e482c12f8e15a73ee9d4584e23c99465867", size = 267610, upload-time = "2026-08-28T21:53:07.763Z" },
+    { url = "https://files.pythonhosted.org/packages/55/fc/df65aac93938d8f506434c8e96440c1d696f6be0a6a01d3c6bfe5d49403e/coverage-7.16.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:949eae7e0f562b1518355aaef4b03523e49a6d3fea12aa3542d9e36c863f8267", size = 265217, upload-time = "2026-08-28T21:53:09.786Z" },
+    { url = "https://files.pythonhosted.org/packages/32/2d/dc9a5e62715165fcb4c715f965f411e324917c9daeddde16536e9d36ce3f/coverage-7.16.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:64f0611ee05364fc85cc3e5bc371804117a76fd337720e6017332fc7c534257a", size = 268948, upload-time = "2026-08-28T21:53:11.866Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/4e/fe73a5560f25fca52acda76fc1554f30de081793ae4de97e920f8ab161d7/coverage-7.16.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:050a291b3cfe5e0df5999ef2fa5a7aff6e2db329f069d47eb63f02bde2e7e96b", size = 264061, upload-time = "2026-08-28T21:53:13.996Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/f7/bb78cc4b97085ebbd77fa18cbc25abfab462814efa3e2363b4e50885c775/coverage-7.16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a336b1e2990a64f5c356a9b8380fb9c029d56c832b801255250c44d603271bfd", size = 266371, upload-time = "2026-08-28T21:53:16.233Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ec/84b4af5cd4ad498477b3bfb2217e47b048da919451053790efda66f7383c/coverage-7.16.0-cp314-cp314t-win32.whl", hash = "sha256:058631257350b31784ed43ceb808298b6f074edf4ebca4c7ce5082e6bf873a61", size = 225736, upload-time = "2026-08-28T21:53:18.632Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/43/50fc0e6c675c3ef14895a74bab2d6120cb5d6f4b562a3d3f5046797758dc/coverage-7.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:ed35097438dfa980c1ec75bc83edf8acbe7a374d7007e571957a257fbd0e2fb3", size = 226570, upload-time = "2026-08-28T21:53:20.754Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/24/9effce7bcd3c6eeb4da3561905837509e582dcdde7a7f07d6ef2c8512f76/coverage-7.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0466f4a5c0370461b7d8c7eb259d7d1db0b5756f13d66230b04d22a1d380ee11", size = 225879, upload-time = "2026-08-28T21:53:22.747Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/2c/318e4379106bc8047ba235e3732ddc87d1b393ac3db9776f5405ff14f322/coverage-7.16.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:80d7d5d744a041f08637df743ac086204ec5acbcd8432a42b00b49e607358024", size = 223257, upload-time = "2026-08-28T21:53:25.376Z" },
+    { url = "https://files.pythonhosted.org/packages/81/4d/a5c54d9144e9db6505749758ba50a28be624148873751728a59cbb72d27a/coverage-7.16.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:c5feffce90c3d602e149de1c477578efc34dee5f069f9764cc15808ce01ee15c", size = 223596, upload-time = "2026-08-28T21:53:27.461Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/97/38e93a10899c9315964c0a4e729b3e5867f8f46e977808f9c6fbda52525a/coverage-7.16.0-cp315-cp315-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:acadbf2f2a18d7f9c7f119ac798c00c540d7c79c93abd71ed648c87891303633", size = 254699, upload-time = "2026-08-28T21:53:29.715Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/7a/acddda030b4630f68167f3daa94b41d22071847822a70d8178d43dcf678e/coverage-7.16.0-cp315-cp315-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4212cec9b42fd9929e70b462732fefd8b13406371871c82f3c14397499d6550b", size = 257614, upload-time = "2026-08-28T21:53:31.948Z" },
+    { url = "https://files.pythonhosted.org/packages/15/7e/225b182497c1ce6d3f0d76a3074a4dbc9f272300e92bb100df53b03de0aa/coverage-7.16.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c5a43cc0ef101637ae920a9eed24cf0549ef815621eae68b3ad577ec5a7ad2f", size = 259236, upload-time = "2026-08-28T21:53:34.291Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/19/76641ddc50cb2410ebbd0ed7fe1052614d0e5612e802a2817521adb9febb/coverage-7.16.0-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c76a9b50a344261fe4a9bd20c322b48d3913cc48e8c37f78c21a596008296e68", size = 261433, upload-time = "2026-08-28T21:53:36.401Z" },
+    { url = "https://files.pythonhosted.org/packages/12/9e/5f89de8b7c2017f36b68b4e4a25940723a748b21474820bf61e8bce0891c/coverage-7.16.0-cp315-cp315-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:80cf547379ad6b1878fd03b033b51188beab4b41824c96e7839e014a4cb947be", size = 255182, upload-time = "2026-08-28T21:53:38.496Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c1/ce94b2ec502e79775efb5efa22c741ebb0bd2be10bdd29650825ff57bdcb/coverage-7.16.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:4b1d09cb5d8dc2c7164450f5217e6f0717497de9c588806a0780d352abef904a", size = 257329, upload-time = "2026-08-28T21:53:40.87Z" },
+    { url = "https://files.pythonhosted.org/packages/86/8d/3f5374df3a6ca19ee5f98a6bd21dbb05f1e9d399bd9978e9821d260eab5e/coverage-7.16.0-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:cd1e85abed2d2499c16664137ac802356316f92b4e2bf3c150bdf0c45f5dd9ae", size = 255210, upload-time = "2026-08-28T21:53:43.393Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/b8/1bc5751496d0be6fd9dde8ca547d9a8a9f07847856aba3f3ae5ac594cd81/coverage-7.16.0-cp315-cp315-musllinux_1_2_ppc64le.whl", hash = "sha256:360967a6fd77794c167529eec2d16ff8e38216110619d23acc3fd466a1648bee", size = 259442, upload-time = "2026-08-28T21:53:45.725Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/dc/8aca78e47e1e6fcc761cd28a20daf4a84bd847a7369e2701a93ccfc3d1fd/coverage-7.16.0-cp315-cp315-musllinux_1_2_riscv64.whl", hash = "sha256:92cbc2bf4f7f67c79f1d3ca4fe8c50faddf48e852a3d07eaaf02dc014889832f", size = 254618, upload-time = "2026-08-28T21:53:48.292Z" },
+    { url = "https://files.pythonhosted.org/packages/73/fd/787842cdf6ce16ac5c1bd8a26549bab3b3f27b02500075bc540dc7853bca/coverage-7.16.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:cce4dc8528453128c6fae523b15f3887fbea1d4d7c9eb9639d3d4fdcbe570c73", size = 256541, upload-time = "2026-08-28T21:53:50.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/79/8df302cbef373dd1f3401044cdb94dfc74517e5af2af27b4d0e721557e0e/coverage-7.16.0-cp315-cp315-win32.whl", hash = "sha256:5205baea687133613dced668a3d0168ea1479349615bfc255849a7944988c889", size = 225429, upload-time = "2026-08-28T21:53:53.177Z" },
+    { url = "https://files.pythonhosted.org/packages/85/87/5bad7ac45f76b3728ca211028ee561c2ede3ba44da401129e28bb8737291/coverage-7.16.0-cp315-cp315-win_amd64.whl", hash = "sha256:4fcb5f07a9b7083bfb715115d27ce263ba2b5b89dddeee536b295ba0e3c2c627", size = 225903, upload-time = "2026-08-28T21:53:55.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/ea/67d84b11caf240f059ec313f616d82212df5004e8bc85802c1edfc50bb3d/coverage-7.16.0-cp315-cp315-win_arm64.whl", hash = "sha256:d568a8adcec0eda42ec23e5e65dfb8c184fc255120f9e99b484f7c869d923fb9", size = 225334, upload-time = "2026-08-28T21:53:57.769Z" },
+    { url = "https://files.pythonhosted.org/packages/65/21/a88349cce3ff720729b754916ac47e2e3646a8137552e4fa7cdd5967cc7f/coverage-7.16.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:3e8037e8213adf882e9d7eedd2c5c557933ab0b9632c42d98fe98ec9bcdb4025", size = 223980, upload-time = "2026-08-28T21:54:00.082Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/02/4d54abf3e6a4d8b7675921b20e91163b1064a5a9dbefebb71c05065dd136/coverage-7.16.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:289f2ed4d56eebf029b649e7dfc3c1153b111962a75e294cdd8e4a1598a04cc3", size = 224276, upload-time = "2026-08-28T21:54:02.381Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/39/10dbc96d95d20b9b041045d293480bd49e536180e93af62dd7662376284d/coverage-7.16.0-cp315-cp315t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:9b83f6ac575530783771c8dcf05284f7c8b5b12f1e7cb226d63445aac4497a3a", size = 265135, upload-time = "2026-08-28T21:54:04.558Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/3b/6b326544afd1a8aef3a495bbae109a7ab5baf23e04a2741d8d64e2df2ba2/coverage-7.16.0-cp315-cp315t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2c3ff6580f2dfc5bec34717b85b2e6cf5ec993b721e7bb58a794babd525a8178", size = 268216, upload-time = "2026-08-28T21:54:06.97Z" },
+    { url = "https://files.pythonhosted.org/packages/54/34/1dc8265f3ed990690e24d5f31ff79bc9fb9b25d54f9f89bebad5a6a8b7a1/coverage-7.16.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:507596cee23e9968b1934fe86d799b76166541af0a293930918b1b48a5c84bd2", size = 270772, upload-time = "2026-08-28T21:54:09.234Z" },
+    { url = "https://files.pythonhosted.org/packages/66/a7/3a8463713a402b44044ec832f4a76e442ce4b3a207804303f4d1dc1a9bb4/coverage-7.16.0-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:edc2be98e6c55ccc5ff7832bb64f023a4b03dba39dfa84b850046cf08a8249b0", size = 271752, upload-time = "2026-08-28T21:54:11.701Z" },
+    { url = "https://files.pythonhosted.org/packages/25/3b/dd5e795cfbe1842f69899189089ae289a96d6a68de312960ea668542e33c/coverage-7.16.0-cp315-cp315t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9c0690994b84a15a53bdd39e0b2fdb539b22533820623eb86ba75b93760c645b", size = 265589, upload-time = "2026-08-28T21:54:14.12Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/b6/fd90636cbd95cb018312f6ca1ca2bbd70fbe8e4ee6f3992fc36a4230364e/coverage-7.16.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:de24c62bf798940a14674a47489a81b79915ec4134f556d5199830e065225dd0", size = 268596, upload-time = "2026-08-28T21:54:16.303Z" },
+    { url = "https://files.pythonhosted.org/packages/91/10/ef2d59264f3b3b358cc5885ca375e6cdbda7c195e78304d5aae800a72d9d/coverage-7.16.0-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:69474d81f198774c9d2937599ca5da04c9e1c5de5032da23c607ce4960ce360e", size = 265072, upload-time = "2026-08-28T21:54:18.597Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/5b/400891c364c0170408d172501b340b18611800f4c42d8fbb16f9f5497c24/coverage-7.16.0-cp315-cp315t-musllinux_1_2_ppc64le.whl", hash = "sha256:72a0795cc6d34acc2b03dfeabdc82b61b72087f2737018b56ac92c1cf5446c54", size = 269768, upload-time = "2026-08-28T21:54:20.985Z" },
+    { url = "https://files.pythonhosted.org/packages/98/93/9792c80271df04d287d21ed5d662fd8fa58b1737888d817679b1ce5d2fab/coverage-7.16.0-cp315-cp315t-musllinux_1_2_riscv64.whl", hash = "sha256:d9a218d3f9c7d6916684ed5ba94f620661117a730e733cd6ef5e87accc5872eb", size = 265211, upload-time = "2026-08-28T21:54:23.344Z" },
+    { url = "https://files.pythonhosted.org/packages/81/67/5b8f827cfa6616e6bd7ba9397acfe7e3c4fd5b9fca4125511d5089f55d5a/coverage-7.16.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:49fa72ead28c8216f8916398a4f3c4669acb30a061822810ee20a727a1be2897", size = 267170, upload-time = "2026-08-28T21:54:25.85Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ee/c135d2d2cb617d744bc3e13c922f2fae66964494176ddef225dc4656bd2c/coverage-7.16.0-cp315-cp315t-win32.whl", hash = "sha256:27461af9f3ed7d2cf2411eb083784f87055ebf42211789ae3a216c48609bc743", size = 225731, upload-time = "2026-08-28T21:54:28.151Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/4d/dc3d53eadf155916e183bf5dfacbfc4aa5bfb7f13b7da11c01caa7a05cbc/coverage-7.16.0-cp315-cp315t-win_amd64.whl", hash = "sha256:c5612cc20ca76abc883e50269af47c1494b42958bb63dbb9aa79729a1ab5f7d3", size = 226562, upload-time = "2026-08-28T21:54:30.42Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/00/ac9da1a60a4e84c3ad0f7db4723fd327154a8f9add210c0dcd2db3ec5156/coverage-7.16.0-cp315-cp315t-win_arm64.whl", hash = "sha256:2ddaa9e2af4760a329d80008b7a3b4762fbb0dbcb169199360f9a5179c32f2dc", size = 225872, upload-time = "2026-08-28T21:54:32.806Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5a/234e8fadf85c3cc48cb31c247b9e8e0c7f06ece80f5b29f9b8c241f9da4c/coverage-7.16.0-py3-none-any.whl", hash = "sha256:245f7de6d023a5bba375dbec9f2e0869bfa26ac0cc639bbb7b4c814884000b73", size = 214977, upload-time = "2026-08-28T21:54:35.189Z" },
+]
+
+[[package]]
 name = "cryptography"
 version = "49.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -663,7 +774,7 @@ name = "cuda-bindings"
 version = "12.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "(platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/c1/dabe88f52c3e3760d861401bb994df08f672ec893b8f7592dc91626adcf3/cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fda147a344e8eaeca0c6ff113d2851ffca8f7dfc0a6c932374ee5c47caa649c8", size = 12151019, upload-time = "2025-10-21T14:51:43.167Z" },
@@ -771,7 +882,7 @@ name = "embreex"
 version = "2.17.7.post7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "(platform_machine != 'arm64' and sys_platform == 'darwin') or (platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "numpy" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/01/ed299e72f62731be03c383ee4e13191d28afd7e73a8a30012e5b12c61916/embreex-2.17.7.post7-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b10cddba4cc294122e5a76c6df8b042fcb291b352220ecc72b2d9559fc45c48b", size = 10738000, upload-time = "2025-10-22T20:07:29.599Z" },
@@ -1271,6 +1382,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/84/93bcd1300216ea50811cee96873b84a1bebf8d0489ffaf7f2a3756bab866/imageio-2.37.3.tar.gz", hash = "sha256:bbb37efbfc4c400fcd534b367b91fcd66d5da639aaa138034431a1c5e0a41451", size = 389673, upload-time = "2026-03-09T11:31:12.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/fa/391e437a34e55095173dca5f24070d89cbc233ff85bf1c29c93248c6588d/imageio-2.37.3-py3-none-any.whl", hash = "sha256:46f5bb8522cd421c0f5ae104d8268f569d856b29eb1a13b92829d1970f32c9f0", size = 317646, upload-time = "2026-03-09T11:31:10.771Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -2191,7 +2311,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "(platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cublas-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -2202,7 +2322,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -2229,9 +2349,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "(platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-cusparse-cu12", marker = "(platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -2242,7 +2362,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -2438,6 +2558,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/01/4a/9202e8d11714c1fc5951f2e1ef362f2d7fbc595e1f6717971d5dd750e969/pillow-12.1.1-cp314-cp314t-win32.whl", hash = "sha256:d2912fd8114fc5545aa3a4b5576512f64c55a03f3ebcca4c10194d593d43ea36", size = 6438736, upload-time = "2026-02-11T04:22:46.347Z" },
     { url = "https://files.pythonhosted.org/packages/f3/ca/cbce2327eb9885476b3957b2e82eb12c866a8b16ad77392864ad601022ce/pillow-12.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:4ceb838d4bd9dab43e06c363cab2eebf63846d6a4aeaea283bbdfd8f1a8ed58b", size = 7182894, upload-time = "2026-02-11T04:22:48.114Z" },
     { url = "https://files.pythonhosted.org/packages/ec/d2/de599c95ba0a973b94410477f8bf0b6f0b5e67360eb89bcb1ad365258beb/pillow-12.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:7b03048319bfc6170e93bd60728a1af51d3dd7704935feb228c4d4faab35d334", size = 2546446, upload-time = "2026-02-11T04:22:50.342Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -2795,6 +2924,36 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+coverage
 *.local
 
 # Generated at build time from @webxr-input-profiles/assets (see

--- a/web/.prettierignore
+++ b/web/.prettierignore
@@ -1,0 +1,6 @@
+app/dist/
+app/public/webxr-profiles/
+coverage/
+node_modules/
+package-lock.json
+packages/*/dist/

--- a/web/app/eslint.config.js
+++ b/web/app/eslint.config.js
@@ -19,5 +19,17 @@ export default defineConfig([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      // Vite's default treats colocated hooks/variants and entry-point-local
+      // components as errors even though they are safe; keep the diagnostics
+      // visible without making those established patterns fail CI.
+      'react-refresh/only-export-components': [
+        'warn',
+        { allowConstantExport: true, allowExportNames: ['useToast'] },
+      ],
+      // Clearing a stream immediately when its session id changes is the
+      // intended external-subscription reset, not derived-state mirroring.
+      'react-hooks/set-state-in-effect': 'warn',
+    },
   },
 ])

--- a/web/app/src/components/diagnostics/run-history.tsx
+++ b/web/app/src/components/diagnostics/run-history.tsx
@@ -311,8 +311,8 @@ function RunDetail({ id }: { id: string }) {
         </div>
       ) : (
         <p className="text-sm text-white/35">
-          No telemetry was captured for this run (the script owned the CAN bus and did not write
-          its own capture).
+          No telemetry was captured for this run (the script owned the CAN bus and did not write its
+          own capture).
         </p>
       )}
       <div>

--- a/web/app/src/components/diagnostics/telemetry-chart.tsx
+++ b/web/app/src/components/diagnostics/telemetry-chart.tsx
@@ -414,17 +414,13 @@ export function TelemetryChart({
 
   // Tooltip placement: clamp inside the plot, flip sides near the right edge.
   const tooltipLeft =
-    hover && size.w > 0
-      ? PAD.left + ((hover.t - view.t0) / (view.t1 - view.t0 || 1)) * plotW
-      : 0
+    hover && size.w > 0 ? PAD.left + ((hover.t - view.t0) / (view.t1 - view.t0 || 1)) * plotW : 0
   const flip = tooltipLeft > size.w - 190
 
   const card = (
     // The Card surface is normally a translucent wash; full screen needs a
     // solid one so the page behind doesn't bleed through the plot.
-    <Card
-      className={cn("gap-3 p-4", expanded && "h-full w-full bg-[#161618]", className)}
-    >
+    <Card className={cn("gap-3 p-4", expanded && "h-full w-full bg-[#161618]", className)}>
       <div className="flex items-baseline gap-2">
         <h3 className="font-heading text-sm font-semibold">{title}</h3>
         <span className="text-xs text-white/35">{unit}</span>
@@ -469,9 +465,7 @@ export function TelemetryChart({
             className="pointer-events-none absolute top-2 z-10 w-44 rounded-md border border-white/10 bg-[#1c1c1c]/95 px-2.5 py-2 text-xs shadow-xl"
             style={flip ? { right: size.w - tooltipLeft + 8 } : { left: tooltipLeft + 8 }}
           >
-            <div className="mb-1 font-mono text-[0.65rem] text-white/40">
-              {fmtClock(hover.t)}
-            </div>
+            <div className="mb-1 font-mono text-[0.65rem] text-white/40">{fmtClock(hover.t)}</div>
             {series.map((s, i) => (
               <div key={s.key} className="flex items-center gap-2 leading-5">
                 <span

--- a/web/app/src/components/ui/toast.tsx
+++ b/web/app/src/components/ui/toast.tsx
@@ -52,16 +52,13 @@ export function ToastProvider({ children }: { children: ReactNode }) {
     setToasts((prev) => prev.filter((t) => t.id !== id))
   }, [])
 
-  const show = useCallback(
-    (message: string, variant: ToastVariant = "info", duration?: number) => {
-      const id = nextId.current++
-      setToasts((prev) => [
-        ...prev,
-        { id, message, variant, duration: duration ?? DEFAULT_DURATION[variant] },
-      ])
-    },
-    []
-  )
+  const show = useCallback((message: string, variant: ToastVariant = "info", duration?: number) => {
+    const id = nextId.current++
+    setToasts((prev) => [
+      ...prev,
+      { id, message, variant, duration: duration ?? DEFAULT_DURATION[variant] },
+    ])
+  }, [])
 
   const api = useMemo<ToastApi>(
     () => ({
@@ -88,10 +85,7 @@ export function useToast(): ToastApi {
   return ctx
 }
 
-const VARIANT_STYLES: Record<
-  ToastVariant,
-  { wrap: string; icon: ReactNode }
-> = {
+const VARIANT_STYLES: Record<ToastVariant, { wrap: string; icon: ReactNode }> = {
   error: {
     wrap: "border-red-400/30 bg-red-400/[0.08] text-red-100",
     icon: <AlertTriangle className="size-4 shrink-0 text-red-400" />,

--- a/web/app/src/lib/api-clients.test.ts
+++ b/web/app/src/lib/api-clients.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import * as api from "./supervisor"
+import * as telemetry from "./telemetry"
+
+const session = {
+  id: "s1",
+  command: "teleop",
+  args: {},
+  status: "running",
+  exitCode: null,
+  error: null,
+  startedAt: 1,
+  pid: 2,
+}
+
+function response(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+describe("supervisor API client", () => {
+  const requests: Array<{ url: string; init?: RequestInit }> = []
+
+  beforeEach(() => {
+    requests.length = 0
+    api.setServerBase("robot.local")
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input)
+        requests.push({ url, init })
+        if (url.endsWith("/api/info")) return response({ hostname: "axol" })
+        if (url.includes("/api/update/status")) return response({ enabled: true })
+        if (url.endsWith("/api/update/start")) return response({ started: true })
+        if (url.endsWith("/api/host/shutdown") || url.endsWith("/api/host/restart")) {
+          return response({ ok: true })
+        }
+        if (url.endsWith("/api/robot/status")) return response({ state: "connected" })
+        if (url.endsWith("/api/robot/connect") || url.endsWith("/api/robot/disconnect")) {
+          return response({ state: "connected" })
+        }
+        if (url.endsWith("/api/can/interfaces")) return response({ interfaces: [] })
+        if (url.endsWith("/api/cameras/detect")) return response({ devices: [], error: null })
+        if (url.endsWith("/api/cameras/restart-daemon")) return response({ ok: true, error: null })
+        if (url.endsWith("/api/usb/status") || url.endsWith("/api/usb/connect")) {
+          return response({ ready: true })
+        }
+        if (url.endsWith("/api/usb/proximity")) return response({ ok: true })
+        if (url.endsWith("/api/op/status")) return response({ running: false, policy: null })
+        if (url.endsWith("/api/op/start") || url.endsWith("/api/op/stop")) return response(session)
+        if (url.endsWith("/api/op/episode")) return response({ ok: true })
+        if (url.endsWith("/api/datasets")) return response({ datasets: [{ repoId: "org/data" }] })
+        if (url.endsWith("/api/commands")) return response([])
+        if (url.endsWith("/api/sessions")) return response([session])
+        if (url.endsWith("/api/run") || url.includes("/api/sessions/s1/stop")) {
+          return response(session)
+        }
+        if (url.includes("/api/sessions/s1/input")) return response({ ok: true })
+        if (url.endsWith("/api/settings")) {
+          return response({ values: {}, cameras: null, advanced: {} })
+        }
+        return response({})
+      })
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    api.setServerBase("")
+  })
+
+  it("calls read-only status endpoints and normalizes their payloads", async () => {
+    expect(await api.fetchInfo()).toEqual({ hostname: "axol" })
+    expect(await api.fetchUpdateStatus(true)).toEqual({ enabled: true })
+    expect(await api.fetchRobotStatus()).toEqual({ state: "connected" })
+    expect(await api.fetchCanInterfaces()).toEqual({ interfaces: [] })
+    expect(await api.detectCameras()).toEqual({ devices: [], error: null })
+    expect(await api.fetchUsbStatus()).toEqual({ ready: true })
+    expect(await api.fetchOpStatus()).toEqual({ running: false, policy: null })
+    expect(await api.fetchDatasets()).toEqual([{ repoId: "org/data" }])
+    expect(await api.fetchCommands()).toEqual([])
+    expect(await api.fetchSessions()).toEqual([session])
+    expect(await api.fetchSettings()).toEqual({ values: {}, cameras: null, advanced: {} })
+    expect(requests.every((item) => item.url.startsWith("https://robot.local:8001"))).toBe(true)
+  })
+
+  it("sends the complete mutation contract", async () => {
+    await api.startUpdate()
+    await api.shutdownHost()
+    await api.restartHost()
+    await api.robotConnect({ left: "can0", right: null })
+    await api.robotDisconnect()
+    await api.restartCameraDaemon()
+    await api.usbConnect()
+    await api.setQuestProximityDisabled(true)
+    await api.startOperation("teleop", { sim: true })
+    await api.stopOperation()
+    await api.sendEpisodeCommand("save")
+    await api.runCommand("motor.info", { arm: "left" })
+    await api.stopSession("s1")
+    await api.sendSessionInput("s1", "continue")
+    const saved = await api.saveSettings({ values: { "robot.has_gripper": false } })
+
+    expect(saved.schema).toEqual([])
+    expect(saved.advancedSchema).toEqual([])
+    expect(
+      requests.every((item) => item.init?.method === "POST" || item.init?.method === "PUT")
+    ).toBe(true)
+    expect(requests.find((item) => item.url.endsWith("/api/robot/connect"))?.init?.body).toContain(
+      '"channelsSet":true'
+    )
+    expect(requests.find((item) => item.url.endsWith("/api/op/start"))?.init?.body).toContain(
+      '"cameras":null'
+    )
+  })
+
+  it("surfaces server and invalid-host responses as useful errors", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => response({ error: "robot busy" }, 409))
+    )
+    await expect(api.fetchInfo()).rejects.toThrow("robot busy")
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("not json"))
+    )
+    await expect(api.fetchInfo()).rejects.toThrow("did not answer like an axol serve host")
+  })
+
+  it("turns connection probe timeouts into a concise offline error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => Promise.reject(new DOMException("late", "TimeoutError")))
+    )
+    await expect(api.fetchCommands()).rejects.toThrow("no response from the host after 2s")
+  })
+
+  it("builds URLs and fault labels", () => {
+    expect(api.apiUrl("/api/info")).toBe("https://robot.local:8001/api/info")
+    expect(api.wsBaseUrl()).toBe("wss://robot.local:8001")
+    expect(api.urdfUrl().endsWith("/api/urdf/axol.urdf")).toBe(true)
+    expect(
+      api.motorFaultLabel({
+        arm: "left",
+        joint: "SHOULDER_1",
+        problem: "over temperature",
+        temperature: 77.6,
+      })
+    ).toBe("L shoulder 1 — over temperature (78°C)")
+  })
+})
+
+describe("telemetry API client", () => {
+  beforeEach(() => {
+    api.setServerBase("")
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = String(input)
+        if (url.includes("/history")) return response({ frames: [] })
+        if (url.includes("/motors/")) return response({ arm: "left", joint: "ELBOW" })
+        if (url.endsWith("/api/diagnostics/run")) return response({ run: null, session })
+        if (url.endsWith("/api/diagnostics/runs")) return response({ runs: [], removed: 2 })
+        if (url.includes("/api/diagnostics/runs/")) {
+          return response({ meta: { id: "run1" }, frames: [], log: [] })
+        }
+        return response({ state: "connected", sampleHz: 10, slow: {}, slowT: null, latest: null })
+      })
+    )
+  })
+
+  afterEach(() => vi.unstubAllGlobals())
+
+  it("covers telemetry, motor, and diagnostic run endpoints", async () => {
+    expect((await telemetry.fetchTelemetry()).sampleHz).toBe(10)
+    expect(await telemetry.fetchTelemetryHistory(60, 20)).toEqual({ frames: [] })
+    expect(await telemetry.fetchMotorDetails("left", "ELBOW")).toMatchObject({ joint: "ELBOW" })
+    expect(await telemetry.startDiagnosticsRun("rom-test", { arm: "left" })).toMatchObject({
+      run: null,
+    })
+    expect(await telemetry.fetchDiagnosticsRuns()).toEqual({ runs: [], removed: 2 })
+    expect(await telemetry.clearDiagnosticsRuns()).toEqual({ runs: [], removed: 2 })
+    expect((await telemetry.fetchDiagnosticsRun("run1")).meta.id).toBe("run1")
+  })
+
+  it("surfaces telemetry HTTP failures", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => response({}, 503))
+    )
+    await expect(telemetry.fetchTelemetry()).rejects.toThrow("HTTP 503")
+  })
+})

--- a/web/app/src/lib/camera-spec.test.ts
+++ b/web/app/src/lib/camera-spec.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  defaultEyes,
+  eyesLeft,
+  eyesRight,
+  materializeCameraSpec,
+  selEnabled,
+  selEyes,
+} from "./camera-spec"
+import type { CameraSpec } from "./supervisor"
+
+const spec: CameraSpec = {
+  serials: { overhead: " 101 ", left_arm: "202", right_arm: "" },
+  stream_resolution: "HD1200",
+  record_resolution: "SVGA",
+  stream: { left_arm: false },
+  record: { overhead: "right" },
+}
+
+describe("camera specification", () => {
+  it("applies slot-specific stereo defaults", () => {
+    expect(defaultEyes("overhead")).toBe("both")
+    expect(defaultEyes("left_arm")).toBe("left")
+    expect(eyesLeft("both")).toBe(true)
+    expect(eyesLeft("right")).toBe(false)
+    expect(eyesRight("left")).toBe(false)
+    expect(selEnabled(undefined)).toBe(true)
+    expect(selEnabled(false)).toBe(false)
+    expect(selEyes(true, "overhead")).toBe("both")
+  })
+
+  it("materializes UI defaults based on detected camera kind", () => {
+    expect(
+      materializeCameraSpec(spec, [
+        { serial: 101, model: "ZED X", kind: "stereo" },
+        { serial: 202, model: "ZED X One", kind: "mono" },
+      ])
+    ).toEqual({
+      serials: { overhead: "101", left_arm: "202", right_arm: "" },
+      stream_resolution: "HD1200",
+      record_resolution: "SVGA",
+      stream: { overhead: "both", left_arm: false },
+      record: { overhead: "right", left_arm: true },
+    })
+  })
+})

--- a/web/app/src/lib/headset.test.ts
+++ b/web/app/src/lib/headset.test.ts
@@ -1,0 +1,21 @@
+import { afterEach, describe, expect, it } from "vitest"
+
+import { isHeadsetBrowser } from "./headset"
+
+const originalUserAgent = navigator.userAgent
+
+afterEach(() => {
+  Object.defineProperty(navigator, "userAgent", { configurable: true, value: originalUserAgent })
+})
+
+describe("headset detection", () => {
+  it.each(["OculusBrowser/32", "Mozilla Quest 3", "PicoBrowser VR"])("recognizes %s", (ua) => {
+    Object.defineProperty(navigator, "userAgent", { configurable: true, value: ua })
+    expect(isHeadsetBrowser()).toBe(true)
+  })
+
+  it("does not classify a desktop browser as a headset", () => {
+    Object.defineProperty(navigator, "userAgent", { configurable: true, value: "Mozilla Chrome" })
+    expect(isHeadsetBrowser()).toBe(false)
+  })
+})

--- a/web/app/src/lib/supervisor.test.ts
+++ b/web/app/src/lib/supervisor.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it } from "vitest"
+
+import {
+  cameraCount,
+  computeArgs,
+  configuredSerials,
+  filterSchema,
+  flattenFields,
+  isModified,
+  isRobotFreeRun,
+  missingCameraSerials,
+  missingRequired,
+  operationsFromCommands,
+  serverHttpBase,
+  type CameraSpec,
+  type CommandSpec,
+  type SchemaField,
+  type SchemaNode,
+} from "./supervisor"
+
+const required: SchemaField = {
+  kind: "field",
+  key: "repo_id",
+  label: "Repo ID",
+  type: "text",
+  default: null,
+  required: true,
+}
+const optional: SchemaField = {
+  kind: "field",
+  key: "sim",
+  label: "Sim",
+  type: "boolean",
+  default: false,
+  required: false,
+}
+const schema: SchemaNode[] = [
+  required,
+  { kind: "group", key: "advanced", label: "Advanced", children: [optional] },
+]
+
+describe("supervisor pure helpers", () => {
+  beforeEach(() => localStorage.clear())
+
+  it.each([
+    ["robot.local", "https://robot.local:8001"],
+    ["http://robot.local:9000/path", "http://robot.local:9000"],
+    ["", ""],
+    ["http://[", ""],
+  ])("normalizes server address %s", (input, expected) => {
+    expect(serverHttpBase(input)).toBe(expected)
+  })
+
+  it("counts, trims, and checks configured cameras", () => {
+    const cameras: CameraSpec = {
+      serials: { overhead: " 1 ", left_arm: "2", right_arm: " " },
+      stream_resolution: "SVGA",
+      record_resolution: "SVGA",
+    }
+    expect(cameraCount(cameras)).toBe(2)
+    expect(configuredSerials(cameras)).toEqual(["1", "2"])
+    expect(missingCameraSerials(cameras, [{ serial: 2, model: "one", kind: "mono" }])).toEqual([
+      "1",
+    ])
+  })
+
+  it("flattens and filters nested schemas", () => {
+    expect(flattenFields(schema).map((field) => field.key)).toEqual(["repo_id", "sim"])
+    expect(flattenFields(filterSchema(schema, new Set(["repo_id"])))).toEqual([optional])
+    expect(filterSchema(schema, new Set(["repo_id", "sim"]))).toEqual([])
+  })
+
+  it("sends required and changed values only", () => {
+    expect(missingRequired([required, optional], {})).toEqual(["repo_id"])
+    expect(missingRequired([required], { repo_id: "org/data" })).toEqual([])
+    expect(isModified(optional, false)).toBe(false)
+    expect(isModified(optional, true)).toBe(true)
+    expect(computeArgs([required, optional], { repo_id: "org/data", sim: false })).toEqual({
+      repo_id: "org/data",
+    })
+    expect(computeArgs([required, optional], { repo_id: "org/data", sim: true })).toEqual({
+      repo_id: "org/data",
+      sim: true,
+    })
+  })
+
+  it("derives operation metadata and robot-free flags", () => {
+    const command = {
+      id: "custom",
+      label: "Custom",
+      description: "Custom operation",
+      simCapable: true,
+      requiresHardware: false,
+      available: true,
+      error: null,
+      schema: [],
+      required: [],
+      cli: "custom",
+      category: "Operate",
+      isOperation: true,
+      simFlag: "simulate",
+      robotFreeFlags: ["cart_only"],
+      perRunFields: ["simulate"],
+    } satisfies CommandSpec
+    const [meta] = operationsFromCommands([command])
+    expect(meta.fields).toEqual(["simulate"])
+    expect(isRobotFreeRun(meta, { simulate: true })).toBe(true)
+    expect(isRobotFreeRun(meta, { cart_only: true })).toBe(true)
+    expect(isRobotFreeRun(meta, {})).toBe(false)
+  })
+})

--- a/web/app/src/lib/telemetry.test.ts
+++ b/web/app/src/lib/telemetry.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest"
+
+import { JOINTS, jointLabel, jointsFor, motorKey } from "./telemetry"
+
+describe("telemetry labels", () => {
+  it("drops only the gripper for a gripperless robot", () => {
+    expect(jointsFor(false)).toHaveLength(JOINTS.length - 1)
+    expect(jointsFor(false)).not.toContain("GRIPPER")
+    expect(jointsFor(undefined)).toBe(JOINTS)
+  })
+
+  it("builds stable labels and keys", () => {
+    expect(jointLabel("SHOULDER_1")).toBe("shoulder 1")
+    expect(motorKey("left", "ELBOW")).toBe("left:ELBOW")
+  })
+})

--- a/web/app/src/lib/utils.test.ts
+++ b/web/app/src/lib/utils.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest"
+
+import { cn, sentenceCase } from "./utils"
+
+describe("UI utilities", () => {
+  it("uses canonical acronym casing", () => {
+    expect(sentenceCase("repo id")).toBe("Repo ID")
+    expect(sentenceCase("teleop hz")).toBe("Teleop Hz")
+    expect(sentenceCase("com x offset")).toBe("CoM x offset")
+  })
+
+  it("merges conflicting Tailwind classes", () => {
+    expect(cn("p-2 text-red-500", undefined, "p-4")).toBe("text-red-500 p-4")
+  })
+})

--- a/web/app/src/lib/version.test.ts
+++ b/web/app/src/lib/version.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest"
+
+import { versionMismatch } from "./version"
+
+describe("version mismatch", () => {
+  it("accepts identical commits", () => {
+    expect(
+      versionMismatch({
+        hostname: "x",
+        lanIp: "x",
+        viewerPort: 1,
+        vrPort: 2,
+        commit: "test-ui-commit",
+      })
+    ).toBeNull()
+  })
+
+  it("allows a hosted release on the same version", () => {
+    expect(
+      versionMismatch({
+        hostname: "x",
+        lanIp: "x",
+        viewerPort: 1,
+        vrPort: 2,
+        commit: "release-commit",
+        version: "1.2.0",
+        releaseInstall: true,
+      })
+    ).toBeNull()
+  })
+
+  it("reports an older backend release", () => {
+    const mismatch = versionMismatch({
+      hostname: "x",
+      lanIp: "x",
+      viewerPort: 1,
+      vrPort: 2,
+      commit: "old-commit",
+      version: "1.1.9",
+      releaseInstall: true,
+    })
+    expect(mismatch?.serverOlder).toBe(true)
+    expect(mismatch?.serverDev).toBe(false)
+  })
+})

--- a/web/app/src/troika-three-text.d.ts
+++ b/web/app/src/troika-three-text.d.ts
@@ -10,6 +10,6 @@ declare module "troika-three-text" {
 
   export function preloadFont(
     options: { font?: string; characters?: string | string[]; sdfGlyphSize?: number },
-    callback: () => void,
+    callback: () => void
   ): void
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,7 +10,10 @@
         "packages/*"
       ],
       "devDependencies": {
-        "prettier": "^3.8.1"
+        "@vitest/coverage-v8": "^3.2.4",
+        "jsdom": "^26.1.0",
+        "prettier": "^3.8.1",
+        "vitest": "^3.2.4"
       }
     },
     "app": {
@@ -59,14 +62,49 @@
       "resolved": "packages/axol-vr-client",
       "link": true
     },
-    "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -75,9 +113,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -85,21 +123,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -116,14 +154,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -133,14 +171,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -150,9 +188,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -160,29 +198,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -192,9 +230,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -202,9 +240,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -212,9 +250,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -222,27 +260,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -261,33 +299,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -295,17 +333,27 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@bufbuild/protobuf": {
@@ -313,6 +361,121 @@
       "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.0.tgz",
       "integrity": "sha512-B/XlCaFIP8LOwzo+bz5uFzATYokcwCKQcghqnlfwSmM5eX/qTkvDBnDPs+gXtX/RyjxJ4DRikECcPJbyALA8FA==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@dimforge/rapier3d-compat": {
       "version": "0.12.0",
@@ -1074,6 +1237,34 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@iwer/devui": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@iwer/devui/-/devui-1.1.2.tgz",
@@ -1185,6 +1376,17 @@
       },
       "peerDependencies": {
         "three": ">= 0.159.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@pmndrs/handle": {
@@ -1822,6 +2024,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1839,6 +2042,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1856,6 +2060,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1873,6 +2078,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1890,6 +2096,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1907,6 +2114,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1924,6 +2132,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1941,6 +2150,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1958,6 +2168,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1975,6 +2186,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1992,6 +2204,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -2009,6 +2222,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -2308,6 +2522,24 @@
       "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
       "license": "MIT"
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/draco3d": {
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
@@ -2598,16 +2830,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -2742,6 +2974,155 @@
         "vite": "^4 || ^5 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.7.tgz",
+      "integrity": "sha512-NEGWJS2XNu2PfRLQwOO3CTKj1tTETxNBdk454vDxVBhxJYhPaA/eS0nAI0c+1El1P7a60z8+i+ZrQoGESweGKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.7",
+        "vitest": "3.2.7"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@webgpu/types": {
       "version": "0.1.69",
       "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.69.tgz",
@@ -2777,6 +3158,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -2794,6 +3185,32 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -2807,6 +3224,35 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/axol-vr-app": {
       "resolved": "app",
@@ -2840,9 +3286,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.24",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.24.tgz",
-      "integrity": "sha512-I2NkZOOrj2XuguvWCK6OVh9GavsNjZjK908Rq3mIBK25+GD8vPX5w2WdxVqnQ7xx3SrZJiCiZFu+/Oz50oSYSA==",
+      "version": "2.11.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.20.tgz",
+      "integrity": "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2862,9 +3308,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2873,9 +3319,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "dev": true,
       "funding": [
         {
@@ -2893,11 +3339,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2989,9 +3435,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001791",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
-      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+      "version": "1.0.30001810",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001810.tgz",
+      "integrity": "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==",
       "dev": true,
       "funding": [
         {
@@ -3019,6 +3465,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -3052,6 +3515,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -3207,11 +3680,39 @@
         "postcss-value-parser": "^4.0.2"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -3229,6 +3730,23 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -3274,12 +3792,26 @@
       "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.345",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.345.tgz",
-      "integrity": "sha512-F9JXQGiMrz6yVNPI2qOVPvB9HzjH5cGzhs8oJ6A28V5L/YnzN/0KsuiibqF+F1Fd9qxFzD1BUnYSd8JfULxTwg==",
+      "version": "1.5.416",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.416.tgz",
+      "integrity": "sha512-K6bvB2BjnNrugtIih6ewlbBI9DXa976jIdiIlRLHhBoEI9a4JaQjjHyF+A1IQI543aQYR4LnmOrT/K5fZj0aPA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.22.2",
@@ -3294,6 +3826,26 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -3534,6 +4086,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3542,6 +4104,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3652,6 +4224,23 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3683,6 +4272,28 @@
       "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
       "license": "MIT"
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -3694,6 +4305,32 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -3754,6 +4391,67 @@
       "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz",
       "integrity": "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -3828,6 +4526,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -3841,6 +4549,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
@@ -3852,6 +4567,60 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/its-fine": {
       "version": "2.0.0",
@@ -3873,6 +4642,22 @@
       "dependencies": {
         "gl-matrix": "^3.4.3",
         "webxr-layers-polyfill": "^1.1.0"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/jiti": {
@@ -3902,16 +4687,66 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -4037,6 +4872,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4058,6 +4894,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4079,6 +4916,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4100,6 +4938,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4121,6 +4960,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4142,6 +4982,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4163,6 +5004,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4184,6 +5026,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4205,6 +5048,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4226,6 +5070,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4247,6 +5092,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4330,6 +5176,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4369,6 +5222,47 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/meshline": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
@@ -4395,6 +5289,16 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mlly": {
@@ -4430,9 +5334,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -4456,9 +5360,19 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
-      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "version": "2.0.54",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.54.tgz",
+      "integrity": "sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.25",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.25.tgz",
+      "integrity": "sha512-kktSgNDIbyEIs/LrE6dtEMnfzxSDpXViFl6c4gFjz/CgtnL4GDCR3wyZXzjvAXsNB8dXU4dAfvIOgLMH2/vwLg==",
       "dev": true,
       "license": "MIT"
     },
@@ -4521,6 +5435,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -4532,6 +5453,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/path-exists": {
@@ -4553,12 +5487,46 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4603,9 +5571,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -4623,7 +5591,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -4771,9 +5739,9 @@
       "license": "MIT"
     },
     "node_modules/react-router": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
-      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.3.tgz",
+      "integrity": "sha512-gyXgtdr5uACJ5b1Q4udzjVV+tb/rlHIMJKuJ0e89R4Kzgz47z/rgP0dIKxktqIEUhDHluGTPJJH/wRha7CyqsA==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -4793,12 +5761,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
-      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.3.tgz",
+      "integrity": "sha512-ytVbyBBM7vMfRCam25r0WMhSVSom909A8p+8m0/f1w853dz/xfFu6etAT2SEbVoSnI+ZoPRDqIsQXVT89gp7kg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.17.0"
+        "react-router": "7.18.3"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -4901,6 +5869,33 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -4944,6 +5939,26 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -4963,6 +5978,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stats-gl": {
       "version": "2.4.2",
@@ -4990,6 +6012,117 @@
       "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
       "license": "MIT"
     },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -5002,6 +6135,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/styled-components": {
       "version": "6.4.1",
@@ -5100,6 +6253,13 @@
         "react": ">=17.0"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwind-merge": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
@@ -5129,6 +6289,60 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/thenify": {
@@ -5192,6 +6406,20 @@
       "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -5207,6 +6435,82 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tree-kill": {
@@ -5365,13 +6669,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/tsup/node_modules/tinyexec": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/tunnel-rat": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/tunnel-rat/-/tunnel-rat-0.1.2.tgz",
@@ -5475,9 +6772,9 @@
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.2.tgz",
+      "integrity": "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==",
       "dev": true,
       "funding": [
         {
@@ -5543,13 +6840,13 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
@@ -5617,6 +6914,115 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/webgl-constants": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
@@ -5628,6 +7034,16 @@
       "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
       "license": "MIT"
     },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/webxr-layers-polyfill": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/webxr-layers-polyfill/-/webxr-layers-polyfill-1.1.0.tgz",
@@ -5635,6 +7051,44 @@
       "license": "Apache-2.0",
       "dependencies": {
         "gl-matrix": "^3.4.3"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {
@@ -5652,6 +7106,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -5661,6 +7132,143 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/web/package.json
+++ b/web/package.json
@@ -7,9 +7,15 @@
   ],
   "scripts": {
     "build": "npm run build -w @almond/axol-vr-client && npm run build -w axol-vr-app",
-    "format": "prettier --write \"**/*.{ts,tsx,json,css}\""
+    "format": "prettier --write \"**/*.{ts,tsx,json,css}\"",
+    "format:check": "prettier --check \"**/*.{ts,tsx,json,css}\"",
+    "lint": "npm run lint -w axol-vr-app",
+    "test": "vitest run --coverage"
   },
   "devDependencies": {
-    "prettier": "^3.8.1"
+    "@vitest/coverage-v8": "^3.2.4",
+    "jsdom": "^26.1.0",
+    "prettier": "^3.8.1",
+    "vitest": "^3.2.4"
   }
 }

--- a/web/packages/axol-vr-client/src/serverUrl.test.ts
+++ b/web/packages/axol-vr-client/src/serverUrl.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest"
+
+import { axolHttpsOrigin, axolWsUrl, resolveAuthority } from "./serverUrl"
+
+describe("server URL helpers", () => {
+  it.each([
+    ["robot.local", "robot.local:8000"],
+    [" 192.168.1.20 ", "192.168.1.20:8000"],
+    ["robot.local:9000", "robot.local:9000"],
+    ["https://robot.example/path", "robot.example:443"],
+    ["wss://robot.example/ws", "robot.example:443"],
+  ])("resolves %s", (input, expected) => {
+    expect(resolveAuthority(input, 8000)).toBe(expected)
+  })
+
+  it("builds matching secure HTTP and websocket endpoints", () => {
+    expect(axolWsUrl("robot.local", 8000)).toBe("wss://robot.local:8000/ws")
+    expect(axolHttpsOrigin("robot.local", 8000)).toBe("https://robot.local:8000")
+  })
+})

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,36 @@
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { defineConfig } from "vitest/config"
+
+const root = path.dirname(fileURLToPath(import.meta.url))
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(root, "app/src"),
+    },
+  },
+  define: {
+    __AXOL_BUILD_COMMIT__: JSON.stringify("test-ui-commit"),
+    __AXOL_BUILD_VERSION__: JSON.stringify("1.2.0"),
+  },
+  test: {
+    environment: "jsdom",
+    include: ["**/*.test.{ts,tsx}"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json-summary"],
+      include: [
+        "app/src/lib/{camera-spec,headset,supervisor,telemetry,utils,version}.ts",
+        "packages/axol-vr-client/src/serverUrl.ts",
+      ],
+      thresholds: {
+        statements: 75,
+        branches: 75,
+        functions: 75,
+        lines: 75,
+      },
+    },
+  },
+})


### PR DESCRIPTION
## Summary
- add 89 hardware-independent Python unit and integration tests
- add 34 frontend and SDK client tests
- add GitHub Actions jobs for Python and Web gates
- enforce 30% branch-aware Python coverage and 75% frontend coverage
- add Dependabot configuration and testing documentation

## Verification
- Python: 89 passed, 30.08% aggregate coverage
- Web: 34 passed, 79.46% coverage
- Ruff lint and formatting passed
- Python package and LeRobot plugin builds passed
- Frontend production build and high-severity dependency audit passed

Branch protection is intentionally disabled until this workflow lands on main; the Python and Web required checks can be restored afterward.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly additive tests and CI wiring; production code changes are minimal (formatting, ESLint warnings). Residual risk is only that new coverage floors or audit gates could block merges until thresholds are met.
> 
> **Overview**
> Introduces **hardware-independent automated testing** and **CI enforcement** where the repo previously had no pytest suite or merge gates.
> 
> **Python:** Adds a `tests/` suite (CAN bus resilience, serve/FastAPI contracts, VR/ICE, telemetry, self-update, motor protocols, and more) wired through `pytest`/`pytest-cov` in `pyproject.toml` with a **30% branch coverage floor** on `almond_axol` (excluding `lerobot`). Dev deps land in `uv.lock` via a `dev` dependency group.
> 
> **Web:** Adds Vitest unit tests for control-panel helpers (`supervisor`, telemetry clients, camera spec, version mismatch, etc.), minor ESLint rule tweaks so existing patterns don’t fail CI, and ignores `coverage/` in git/prettier.
> 
> **Automation:** New `.github/workflows/ci.yml` runs parallel **Python** (ruff, pytest, `uv build` for main + LeRobot plugin) and **Web** (`npm ci`, format/lint, test with coverage, build, high-severity audit) on PRs/pushes to `main`. **Dependabot** weekly groups updates for uv, npm (`web/`), and GitHub Actions. Docs (`README`, `AGENTS.md`) and a CI badge describe how to run tests locally; `.gitignore` adds coverage artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d33c4e124ff3f31216982e954fcdfae37f3c0048. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->