### PR TITLE
Prevent ZED startup stalls and isolate realtime trace writers

### DIFF
--- a/almond_axol/cli/collect_data.py
+++ b/almond_axol/cli/collect_data.py
@@ -1002,11 +1002,15 @@ def _run(
             deadline += teleop_interval
             t0 = time.perf_counter()
             _maybe_log_rate(t0)
-            # Record only robot-driving windows, never camera/JAX startup or
-            # an idle pre-record wait. Keeping the gate open across the last
-            # tracking command and a following reset captures the transition
-            # that previously oscillated during collection.
-            robot.set_control_trace_active(teleop.is_tracking or teleop.is_resetting)
+            # Keep a recording's trace open after the headset drops tracking:
+            # its terminate/SAVING state can arrive before we consume the event
+            # below. The outer guarded-return path then continues that same
+            # segment and closes it after the arm settles. Without ``recording``
+            # here, reopening for the return resets both RT/measured recorders
+            # and replaces the useful take with a tiny return/fault capture.
+            robot.set_control_trace_active(
+                recording or teleop.is_tracking or teleop.is_resetting
+            )
 
             # Camera reads happen on the capture thread; the control loop only
             # ever touches joint state.

--- a/almond_axol/rt/link.py
+++ b/almond_axol/rt/link.py
@@ -99,6 +99,17 @@ class RtLink:
         groups = core_groups()
         if groups is not None:
             can_cores = sorted(groups["can"])
+            background_cores = sorted(groups["background"])
+            if background_cores:
+                # The Rust trace writers are spawned by the CAN threads. Give
+                # them an explicit throughput-safe destination so trace file
+                # flush/truncate work runs with the dataset recorder instead
+                # of inheriting either a CAN core or this process's realtime
+                # core. Rust validates and applies the mask before opening or
+                # writing the trace.
+                env["AXOL_RT_BACKGROUND_CPUS"] = ",".join(
+                    str(core) for core in background_cores
+                )
             if len(can_cores) >= 2 and groups["can"].isdisjoint(groups["realtime"]):
                 env["AXOL_RT_CPU_LEFT"] = str(can_cores[0])
                 env["AXOL_RT_CPU_RIGHT"] = str(can_cores[1])

--- a/almond_axol/video/gst_zed.py
+++ b/almond_axol/video/gst_zed.py
@@ -471,8 +471,11 @@ def _dataset_enc_shmsink(
     header only once; if shmsink discarded that header before the recorder's
     late ``gdpdepay`` connection, the consumer could never parse the stream.
     Waiting parks this branch's first GDP packet until the recorder attaches.
-    The branch has its own leaky queue before its rate limiter/valve/encoder, so
-    this wait cannot block camera capture or the independent headset branch.
+    A leaky queue after the encoder keeps NVENC draining (and releases its NVMM
+    input surfaces) while that packet is parked; the queue must stay before
+    ``gdppay`` so it can never discard GDP's one-shot stream/caps header. The
+    branch's earlier queue still decouples it from camera capture and the
+    independent headset branch.
     The rate limiter deliberately stays upstream of the valve: it must continue
     tracking the source timeline between episodes, otherwise reopening a stale
     ``videorate`` can briefly pass capture-rate frames into a lower-rate dataset.
@@ -492,7 +495,7 @@ def _dataset_enc_shmsink(
         f"bitrate={target} peak-bitrate={peak} preset-level=1 "
         f"insert-sps-pps=true insert-aud=true idrinterval={idr} maxperf-enable=true "
         "! video/x-h264,stream-format=byte-stream,alignment=au "
-        "! gdppay "
+        f"! {_QUEUE} ! gdppay "
         f"! shmsink socket-path={socket_path} wait-for-connection=true "
         "sync=false async=false"
     )

--- a/almond_axol/video/shm_frames.py
+++ b/almond_axol/video/shm_frames.py
@@ -506,9 +506,10 @@ class EncodedAuReader:
     stream cannot drop frames: every P-frame depends on its predecessors. So this
     reader delivers **every** AU strictly **in order** via :meth:`read_next_au`,
     and the capture loop is frame-driven (one AU consumed per dataset row). A
-    dedicated pull thread drains the (non-leaky) appsink into an in-process queue
-    so a momentarily slow consumer grows the queue rather than dropping AUs and
-    corrupting the stream.
+    dedicated pull thread drains the (non-leaky) appsink. Before the first
+    episode flush it discards validated startup AUs; afterwards it fills an
+    in-process queue so a momentarily slow consumer grows the queue rather than
+    dropping AUs and corrupting the stream.
 
     Each episode's mp4 must start on a keyframe (a leading P-frame is
     undecodable), so after :meth:`flush` the reader drops AUs until the next IDR.
@@ -787,6 +788,17 @@ class EncodedAuReader:
                     or capture_perf <= self._minimum_capture_perf
                     or self._error is not None
                 ):
+                    continue
+                # Before the first episode boundary, the relay's output queue
+                # may intentionally shed AUs while shmsink waits for this late
+                # reader. GStreamer marks the resumed stream DISCONT, and there
+                # may be more than one such buffer. These startup AUs are never
+                # recorded: the initial closed-valve flush below establishes a
+                # strictly newer PTS cutoff and re-arms the first-IDR gate. Drain
+                # them here so their expected discontinuities and volume cannot
+                # fail connect() or overflow the bounded episode queue. Transport
+                # and timestamp validation above remains fail-closed.
+                if not self._episode_cutoff_active:
                     continue
                 if self._await_keyframe:
                     if not is_idr:

--- a/rust/axol-rt/src/serve.rs
+++ b/rust/axol-rt/src/serve.rs
@@ -317,6 +317,15 @@ impl TimingHealth {
         }
         self.consecutive_late >= 3 || self.recent_late.count_ones() >= MAX_RECENT_LATE_TICKS
     }
+
+    /// Record this tick before applying the immediate full-cycle limit.  The
+    /// ordering matters: the fault diagnostic must include the tick that
+    /// triggered it, even when `lateness >= period` is already sufficient to
+    /// stop the loop.
+    fn record_lateness(&mut self, lateness: Duration, period: Duration) -> bool {
+        let clustered_lateness = self.record(lateness <= LATE_TICK);
+        lateness >= period || clustered_lateness
+    }
 }
 
 type BusStartGate = (Mutex<Option<Instant>>, Condvar);
@@ -442,6 +451,66 @@ fn write_trace_row(out: &mut io::BufWriter<std::fs::File>, r: TraceRow) -> io::R
     )
 }
 
+fn parse_cpu_set(raw: &str, source: &str) -> io::Result<libc::cpu_set_t> {
+    if raw.trim().is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("invalid {source}: CPU set is empty"),
+        ));
+    }
+    let mut set = unsafe { std::mem::zeroed::<libc::cpu_set_t>() };
+    unsafe { libc::CPU_ZERO(&mut set) };
+    for item in raw.split(',') {
+        let item = item.trim();
+        let cpu: usize = item.parse().map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("invalid {source}={raw:?}: expected comma-separated CPU numbers"),
+            )
+        })?;
+        if cpu >= libc::CPU_SETSIZE as usize {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("invalid {source}={raw:?}: CPU {cpu} is out of range"),
+            ));
+        }
+        unsafe { libc::CPU_SET(cpu, &mut set) };
+    }
+    Ok(set)
+}
+
+/// A trace writer is throughput work, never realtime work. Writer threads
+/// are spawned before their parent bus thread changes its affinity, and this
+/// is a second fail-safe against a future call-site move: shed any inherited
+/// realtime policy and move to the launcher's background cores before opening
+/// or writing the trace file.
+fn configure_trace_writer_scheduling(affinity: Option<&libc::cpu_set_t>) -> io::Result<()> {
+    let param = libc::sched_param { sched_priority: 0 };
+    let rc = unsafe { libc::sched_setscheduler(0, libc::SCHED_OTHER, &param) };
+    if rc != 0 {
+        return Err(io::Error::other(format!(
+            "could not put trace writer under SCHED_OTHER: {}",
+            io::Error::last_os_error()
+        )));
+    }
+    if let Some(set) = affinity {
+        let rc = unsafe {
+            libc::sched_setaffinity(
+                0,
+                std::mem::size_of::<libc::cpu_set_t>(),
+                set as *const libc::cpu_set_t,
+            )
+        };
+        if rc != 0 {
+            return Err(io::Error::other(format!(
+                "could not pin trace writer to background CPUs: {}",
+                io::Error::last_os_error()
+            )));
+        }
+    }
+    Ok(())
+}
+
 fn start_trace_writer(
     side: u8,
 ) -> io::Result<Option<(mpsc::SyncSender<TraceMsg>, TraceHandle, PathBuf)>> {
@@ -456,11 +525,32 @@ fn start_trace_writer(
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
     }
+    let affinity = match std::env::var("AXOL_RT_BACKGROUND_CPUS") {
+        Ok(raw) => Some(parse_cpu_set(&raw, "AXOL_RT_BACKGROUND_CPUS")?),
+        Err(std::env::VarError::NotPresent) => None,
+        Err(std::env::VarError::NotUnicode(_)) => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "AXOL_RT_BACKGROUND_CPUS is not valid UTF-8",
+            ));
+        }
+    };
     // About 17 seconds of headroom per arm at 240 Hz x 7 joints. A full
     // channel never blocks the control loop: samples are dropped and counted.
     let (tx, rx) = mpsc::sync_channel::<TraceMsg>(28_000);
+    // Do not report tracing as active until the writer has shed any inherited
+    // realtime policy and moved off the control CPUs. Failure disables the
+    // optional trace rather than weakening motor-loop isolation.
+    let (setup_tx, setup_rx) = mpsc::sync_channel::<io::Result<()>>(0);
     let writer_path = path.clone();
     let handle = std::thread::spawn(move || -> io::Result<()> {
+        if let Err(err) = configure_trace_writer_scheduling(affinity.as_ref()) {
+            let _ = setup_tx.send(Err(err));
+            return Ok(());
+        }
+        if setup_tx.send(Ok(())).is_err() {
+            return Ok(());
+        }
         let mut out = trace_file(&writer_path)?;
         for msg in rx {
             match msg {
@@ -473,6 +563,24 @@ fn start_trace_writer(
         }
         out.flush()
     });
+    match setup_rx.recv() {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => {
+            let _ = handle.join();
+            return Err(err);
+        }
+        Err(_) => {
+            return match handle.join() {
+                Ok(Err(err)) => Err(err),
+                Ok(Ok(())) => Err(io::Error::other(
+                    "trace writer exited before configuring its scheduler",
+                )),
+                Err(_) => Err(io::Error::other(
+                    "trace writer panicked while configuring its scheduler",
+                )),
+            };
+        }
+    }
     Ok(Some((tx, handle, path)))
 }
 
@@ -757,6 +865,48 @@ mod tests {
             assert!(!health.record(true));
         }
         assert!(health.record(false));
+    }
+
+    #[test]
+    fn timing_health_counts_immediate_full_cycle_fault() {
+        let mut health = TimingHealth::default();
+        let period = Duration::from_micros(4_167);
+        assert!(health.record_lateness(period, period));
+        assert_eq!(health.recent_late.count_ones(), 1);
+        assert_eq!(health.consecutive_late, 1);
+    }
+
+    #[test]
+    fn trace_writer_forces_normal_scheduling_and_requested_affinity() {
+        let (policy, affinity_ok) = std::thread::spawn(|| {
+            let mut available = unsafe { std::mem::zeroed::<libc::cpu_set_t>() };
+            let rc = unsafe {
+                libc::sched_getaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &mut available)
+            };
+            assert_eq!(rc, 0, "{}", io::Error::last_os_error());
+            let cpu = (0..libc::CPU_SETSIZE as usize)
+                .find(|&cpu| unsafe { libc::CPU_ISSET(cpu, &available) })
+                .expect("test thread has no available CPU");
+            let requested = parse_cpu_set(&cpu.to_string(), "test CPU set").unwrap();
+
+            configure_trace_writer_scheduling(Some(&requested)).unwrap();
+
+            let mut applied = unsafe { std::mem::zeroed::<libc::cpu_set_t>() };
+            let rc = unsafe {
+                libc::sched_getaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &mut applied)
+            };
+            assert_eq!(rc, 0, "{}", io::Error::last_os_error());
+            let only_requested_cpu = (0..libc::CPU_SETSIZE as usize)
+                .filter(|&candidate| unsafe { libc::CPU_ISSET(candidate, &applied) })
+                .eq(std::iter::once(cpu));
+            (unsafe { libc::sched_getscheduler(0) }, only_requested_cpu)
+        })
+        .join()
+        .unwrap();
+        assert_eq!(policy, libc::SCHED_OTHER);
+        assert!(affinity_ok);
+        assert!(parse_cpu_set("", "test CPU set").is_err());
+        assert!(parse_cpu_set("0,nope", "test CPU set").is_err());
     }
 
     /// Live stall-detection check against a real interface whose bus has no
@@ -1162,6 +1312,29 @@ fn bus_loop(
     ready_tx: &mpsc::Sender<io::Result<()>>,
     start_gate: &BusStartGate,
 ) -> io::Result<()> {
+    // Spawn throughput helpers before this thread pins itself to the CAN CPU
+    // and enters SCHED_FIFO. Linux threads inherit their creator's scheduler
+    // and affinity, so moving this below `configure_bus_scheduling` would let
+    // trace flush/truncate work contend directly with the control loop.
+    let (trace_tx, trace_handle) = match start_trace_writer(side) {
+        Ok(Some((tx, handle, path))) => {
+            send_text(
+                out_tx,
+                b'L',
+                &format!("{iface}: RT control trace -> {}", path.display()),
+            );
+            (Some(tx), Some(handle))
+        }
+        Ok(None) => (None, None),
+        Err(err) => {
+            send_text(
+                out_tx,
+                b'L',
+                &format!("{iface}: RT control trace disabled: {err}"),
+            );
+            (None, None)
+        }
+    };
     if let Err(err) = configure_bus_scheduling(iface, side, out_tx) {
         let _ = ready_tx.send(Err(err));
         return Ok(());
@@ -1185,25 +1358,6 @@ fn bus_loop(
         let _ = ready_tx.send(Err(err));
         return Ok(());
     }
-    let (trace_tx, trace_handle) = match start_trace_writer(side) {
-        Ok(Some((tx, handle, path))) => {
-            send_text(
-                out_tx,
-                b'L',
-                &format!("{iface}: RT control trace -> {}", path.display()),
-            );
-            (Some(tx), Some(handle))
-        }
-        Ok(None) => (None, None),
-        Err(err) => {
-            send_text(
-                out_tx,
-                b'L',
-                &format!("{iface}: RT control trace disabled: {err}"),
-            );
-            (None, None)
-        }
-    };
     let _ = ready_tx.send(Ok(()));
 
     // Play state, indexed by target slot: the latest adopted command per
@@ -1341,7 +1495,7 @@ fn bus_loop(
             // has been lost. Stop before issuing another impedance command.
             // Smaller isolated late ticks are tolerated with host damping
             // suppressed below; clustered lateness also fails closed.
-            if lateness >= period || timing_health.record(timing_on_time) {
+            if timing_health.record_lateness(lateness, period) {
                 fault.store(1, Ordering::SeqCst);
                 stop.store(true, Ordering::SeqCst);
                 return Err(io::Error::other(format!(

--- a/tests/test_encoded_au_reader.py
+++ b/tests/test_encoded_au_reader.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import types
+import unittest
+from collections.abc import Iterable
+from unittest.mock import patch
+
+from almond_axol.video.shm_frames import EncodedAuReader
+
+
+_IDR = b"\x00\x00\x00\x01\x65\x88"
+_P_FRAME = b"\x00\x00\x00\x01\x41\x9a"
+
+
+class _FakeBuffer:
+    def __init__(self, au: bytes, pts: int, *, discont: bool = False) -> None:
+        self._au = au
+        self.pts = pts
+        self._discont = discont
+
+    def has_flags(self, _flags: int) -> bool:
+        return self._discont
+
+    def map(self, _flags: int) -> tuple[bool, types.SimpleNamespace]:
+        return True, types.SimpleNamespace(data=self._au)
+
+    def unmap(self, _mapinfo: types.SimpleNamespace) -> None:
+        pass
+
+
+class _FakeSample:
+    def __init__(self, buffer: _FakeBuffer) -> None:
+        self._buffer = buffer
+
+    def get_buffer(self) -> _FakeBuffer:
+        return self._buffer
+
+
+class _FakePipeline:
+    def get_bus(self) -> None:
+        return None
+
+
+class _FakeGst:
+    SECOND = 1_000_000_000
+    CLOCK_TIME_NONE = -1
+    BufferFlags = types.SimpleNamespace(DISCONT=1)
+    MapFlags = types.SimpleNamespace(READ=1)
+    MessageType = types.SimpleNamespace(ERROR=1, EOS=2)
+
+    def parse_launch(self, _pipeline: str) -> _FakePipeline:
+        return _FakePipeline()
+
+
+class _FakeSink:
+    def __init__(self, reader: EncodedAuReader, buffers: Iterable[_FakeBuffer]) -> None:
+        self._reader = reader
+        self._samples = iter(_FakeSample(buffer) for buffer in buffers)
+
+    def emit(self, _signal: str, _timeout: int) -> _FakeSample | None:
+        sample = next(self._samples, None)
+        if sample is None:
+            self._reader._stop.set()
+        return sample
+
+
+def _reader() -> EncodedAuReader:
+    gst = _FakeGst()
+    with patch("almond_axol.video.gst_zed._require_gst", return_value=(gst, None)):
+        return EncodedAuReader(
+            "/tmp/test-encoded-au.sock",
+            width=960,
+            height=600,
+            fps=60,
+            name="test-camera",
+            pts_perf_offset_s=0.0,
+        )
+
+
+def _pull(reader: EncodedAuReader, buffers: Iterable[_FakeBuffer]) -> None:
+    reader._stop.clear()
+    reader._sink = _FakeSink(reader, buffers)
+    reader._pull_loop()
+
+
+class EncodedAuReaderDiscontinuityTest(unittest.TestCase):
+    def test_startup_discontinuities_are_validated_and_drained(self) -> None:
+        reader = _reader()
+
+        _pull(
+            reader,
+            [
+                _FakeBuffer(_IDR, 1_000_000_000),
+                _FakeBuffer(_P_FRAME, 1_016_000_000, discont=True),
+                _FakeBuffer(_P_FRAME, 1_032_000_000, discont=True),
+            ],
+        )
+
+        self.assertTrue(reader._first_sample.is_set())
+        self.assertEqual(reader._latest_capture_perf, 1.032)
+        self.assertEqual(reader.pending, 0)
+        self.assertEqual(reader._delivered, 0)
+        self.assertFalse(reader._seen_first_au)
+        self.assertIsNone(reader._error)
+
+    def test_episode_discontinuity_after_first_idr_remains_fatal(self) -> None:
+        reader = _reader()
+        reader._flush_requested.set()
+        reader._complete_flush()
+
+        _pull(
+            reader,
+            [
+                _FakeBuffer(_P_FRAME, 1_000_000_000, discont=True),
+                _FakeBuffer(_IDR, 1_016_000_000, discont=True),
+                _FakeBuffer(_P_FRAME, 1_032_000_000),
+            ],
+        )
+
+        self.assertEqual(reader.pending, 2)
+        self.assertEqual(reader._delivered, 2)
+        self.assertIsNone(reader._error)
+
+        _pull(
+            reader,
+            [_FakeBuffer(_P_FRAME, 1_048_000_000, discont=True)],
+        )
+
+        self.assertEqual(reader.pending, 0)
+        with self.assertRaisesRegex(
+            RuntimeError, "encoded-AU discontinuity.*near frame 2"
+        ):
+            reader.read_next_au(timeout_ms=0)
+
+    def test_invalid_startup_timestamp_remains_fatal(self) -> None:
+        reader = _reader()
+
+        _pull(reader, [_FakeBuffer(_IDR, _FakeGst.CLOCK_TIME_NONE)])
+
+        self.assertFalse(reader._first_sample.is_set())
+        self.assertEqual(reader.pending, 0)
+        self.assertIn("has no PTS", reader._permanent_error or "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gst_dataset_transport.py
+++ b/tests/test_gst_dataset_transport.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import unittest
+
+from almond_axol.video.gst_zed import ZedGstCamera, ZedGstStereoCamera
+
+
+_H264_OUTPUT = (
+    "video/x-h264,stream-format=byte-stream,alignment=au ! "
+    "queue leaky=downstream max-size-buffers=2 ! gdppay ! shmsink"
+)
+
+
+class GstDatasetTransportTest(unittest.TestCase):
+    def assert_dataset_branch_is_backpressure_safe(
+        self, pipeline: str, valve_name: str, encoder_name: str, socket_path: str
+    ) -> None:
+        start = pipeline.index(f"valve name={valve_name} drop=false")
+        sink = f"shmsink socket-path={socket_path} wait-for-connection=true"
+        end = pipeline.index(sink, start) + len(sink)
+        branch = pipeline[start:end]
+
+        self.assertIn(f"name={encoder_name}", branch)
+        self.assertIn(_H264_OUTPUT, branch)
+        self.assertIn(sink, branch)
+
+    def test_mono_dataset_encoder_drains_before_recorder_connects(self) -> None:
+        camera = ZedGstCamera(
+            serial=1,
+            resolution="SVGA",
+            raw_socket_path="/tmp/mono-dataset.sock",
+        )
+
+        pipeline = camera._pipeline_str()
+
+        self.assertIn("valve name=rawvalve drop=false", pipeline)
+        self.assert_dataset_branch_is_backpressure_safe(
+            pipeline, "rawvalve", "dsenc", "/tmp/mono-dataset.sock"
+        )
+        self.assertEqual(camera._raw_gates(), (("rawvalve", "dsenc"),))
+
+    def test_both_stereo_dataset_encoders_drain_before_recorder_connects(
+        self,
+    ) -> None:
+        camera = ZedGstStereoCamera(
+            serial=2,
+            resolution="SVGA",
+            left_raw_socket_path="/tmp/left-dataset.sock",
+            right_raw_socket_path="/tmp/right-dataset.sock",
+        )
+
+        pipeline = camera._pipeline_str()
+
+        self.assertIn("valve name=rawvalve_l drop=false", pipeline)
+        self.assertIn("valve name=rawvalve_r drop=false", pipeline)
+        self.assert_dataset_branch_is_backpressure_safe(
+            pipeline, "rawvalve_l", "dsenc_l", "/tmp/left-dataset.sock"
+        )
+        self.assert_dataset_branch_is_backpressure_safe(
+            pipeline, "rawvalve_r", "dsenc_r", "/tmp/right-dataset.sock"
+        )
+        self.assertEqual(
+            camera._raw_gates(),
+            (("rawvalve_l", "dsenc_l"), ("rawvalve_r", "dsenc_r")),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- isolate each dataset NVENC output from a late shared-memory reader
- preserve the GDP stream header/caps by keeping the leaky queue before `gdppay`
- drain validated, intentionally lossy startup access units until the first episode flush, then enforce strict in-episode continuity
- keep one collection trace across recording termination, save, and guarded return
- run Rust trace writers under SCHED_OTHER on background CPUs instead of inheriting the realtime CAN scheduler and core
- include an immediate full-cycle overrun in the rolling timing diagnostic
- cover mono/stereo dataset transport, recorder startup resynchronization, and Rust scheduling/accounting with regression tests

## Root causes

### Camera and recorder startup

The dataset `shmsink` intentionally waits for the recorder so GDP's one-shot stream header and caps are not lost. The existing leaky queue was upstream of NVENC, so a blocked encoder output retained NVMM surfaces until Argus timed out and restarted. A second queue on the encoded side lets NVENC drain through arbitrarily long recorder/JAX startup delays.

That queue makes pre-recorder encoded AUs intentionally lossy. Depending on which in-flight buffer arrives first, GStreamer can mark a later startup AU `DISCONT`; the reader previously accepted that marker only on AU zero and could abort before an episode began. The reader now validates and drains every AU before the first completed recorder flush. Strict continuity starts at the episode boundary: the valve-close handshake phase-aligns each encoder, flushes to quiet, and reopens on a fresh SPS/PPS-bearing IDR for row zero. A later in-episode discontinuity still fails closed.

### Realtime timing and traces

The trace writer was spawned after each CAN thread entered SCHED_FIFO and pinned itself, so the writer inherited both the realtime policy and CAN core. Buffered trace work could therefore contend directly with the 240 Hz loop. Writers now shed realtime scheduling and move to the launcher's background CPU set before opening the trace.

Collection could also drop the trace gate in the headset's SAVING transition and reopen it for return-to-rest, truncating the useful take. The gate now stays active for the full recording and guarded return. Finally, whole-cycle overruns are recorded before the fail-closed check so diagnostics no longer report zero late ticks for the tick that caused the fault.

## Validation

- 56 Python unit tests pass
- Ruff 0.9.7 lint and format checks pass
- 25 Rust tests pass; one hardware-only CAN test remains ignored
- Cargo format, release build, protocol check, and new-code Clippy checks pass
- delayed-reader GStreamer probe: encoder remained at 90 buffers over 3 seconds before attachment, and the late GDP reader negotiated and received access units

A full on-robot collect-data run remains the final validation for the Jetson camera, recorder startup, and trace scheduling changes.
