### PR TITLE
Keep recording boundaries responsive and camera-safe

### DIFF
--- a/almond_axol/cli/collect_dagger.py
+++ b/almond_axol/cli/collect_dagger.py
@@ -97,6 +97,7 @@ from ..recording import (
     RecorderDatasetSaveError,
     default_vcodec,
 )
+from ..utils.control_loop import run_blocking_with_sync_control_ticks
 from .collect_data import (
     _existing_dataset_resolution,
     _start_video_relay,
@@ -525,6 +526,12 @@ class _DaggerControlLoop(threading.Thread):
             while not self.shutdown_event.is_set():
                 t0 = time.perf_counter()
 
+                capture_error = self.recorder.poll_capture_error()
+                if capture_error is not None:
+                    raise RuntimeError(
+                        f"recorder capture failed: {capture_error}; episode discarded"
+                    )
+
                 # --- episode end requested from the VR record button?
                 events = self.teleop.get_teleop_events()
                 if events[TeleopEvents.TERMINATE_EPISODE]:
@@ -653,6 +660,27 @@ class _DaggerControlLoop(threading.Thread):
             )
             self.fatal_error = exc
             self.shutdown_event.set()
+
+
+def _stop_dagger_control_thread(
+    control_thread: _DaggerControlLoop,
+    timeout_s: float = 5.0,
+) -> bool:
+    """Signal and join the sole episode command producer.
+
+    The supervisor calls this both on the normal episode boundary and from its
+    outermost cleanup. That second call closes the Ctrl+C window between
+    ``Thread.start()`` and the normal shutdown block: recorder/relay/robot
+    teardown must never race a controller that was never told to stop.
+
+    Returns:
+        True when the thread is stopped. False means it is wedged in a backend
+        call; the caller must disconnect the robot before releasing resources.
+    """
+    control_thread.shutdown_event.set()
+    if control_thread.is_alive():
+        control_thread.join(timeout=timeout_s)
+    return not control_thread.is_alive()
 
 
 # ----------------------------------------------------------------------
@@ -945,6 +973,29 @@ def _run(
             wait_retry=wait_retry,
         )
 
+    def _measured_joint_hold_action() -> dict[str, float]:
+        """Snapshot measured joints as a direct, IK-free impedance target."""
+        left, right = robot.positions
+        # These package-private lists are AxolRobot's canonical direct-action
+        # keys (and already omit the gripper on a gripperless SKU). Using them
+        # intentionally bypasses Cartesian policy action space and its IK/
+        # shaper: a boundary heartbeat must hold, never continue a trajectory.
+        return {
+            **{
+                key: float(left[index])
+                for index, key in enumerate(robot._left_pos_keys)
+            },
+            **{
+                key: float(right[index])
+                for index, key in enumerate(robot._right_pos_keys)
+            },
+        }
+
+    # The normal policy cadence is already much faster than the Rust target
+    # watchdog. Keep at least 20 Hz of headroom at lifecycle boundaries even
+    # if someone configures an unusually low dataset/policy frame rate.
+    boundary_period = min(1.0 / float(fps), 1.0 / float(teleop_hz), 0.05)
+
     def _gate_retry() -> bool:
         """Contact-hold retry via the continue gate (terminal Enter / panel)."""
         return control.await_continue(
@@ -1119,9 +1170,45 @@ def _run(
             policy.set_instruction(task)
             # Arm the recorder before opening the relay branch. Today DAgger
             # forces raw pyshm, but this ordering also preserves row-zero IDR
-            # semantics if it later adopts the encoded transport.
-            recorder.start_episode(task)
-            relay.set_raw_enabled(True)
+            # semantics if it later adopts the encoded transport. Both calls
+            # are bounded IPC transactions, but together they can exceed the
+            # Rust target watchdog; hold the just-measured post-rest pose while
+            # they run off-thread. Policy inference deliberately has not
+            # started yet, so camera setup cannot advance the trajectory.
+            start_hold_action = _measured_joint_hold_action()
+
+            def _start_capture() -> None:
+                recorder.start_episode(task)
+                relay.set_raw_enabled(True)
+
+            def _hold_start_pose() -> None:
+                robot.send_action(start_hold_action)
+
+            run_blocking_with_sync_control_ticks(
+                _start_capture,
+                _hold_start_pose,
+                boundary_period,
+                drain_tick=_hold_start_pose,
+            )
+
+            if stop_event.is_set():
+                # Stop may arrive from the panel while the bounded start IPC
+                # drains. Never launch a policy controller after that request;
+                # close the just-opened capture under the same measured hold.
+                def _finish_cancelled_start() -> int:
+                    try:
+                        return recorder.finish_episode()
+                    finally:
+                        relay.set_raw_enabled(False)
+
+                run_blocking_with_sync_control_ticks(
+                    _finish_cancelled_start,
+                    _hold_start_pose,
+                    boundary_period,
+                    drain_tick=_hold_start_pose,
+                )
+                recorder.cancel_episode()
+                break
 
             control_thread = _DaggerControlLoop(
                 robot=robot,
@@ -1195,11 +1282,10 @@ def _run(
                 interrupted = True
 
             control.end_episode()
-            control_thread.shutdown_event.set()
-            control_thread.join(timeout=5.0)
+            control_stopped = _stop_dagger_control_thread(control_thread)
             teleop.set_intervention_allowed(False)
             teleop.force_disengage()
-            if control_thread.is_alive():
+            if not control_stopped:
                 # A policy call wedged past shutdown can otherwise wake later
                 # and issue one more command while the supervisor homes/saves.
                 # Disconnect first, then discard capture; never race a second
@@ -1224,9 +1310,34 @@ def _run(
             # Freeze and join capture at an exact row count before closing the
             # relay. A mere pause acknowledgement can leave one raw camera read
             # in flight; closing its valve then turns a normal episode end into
-            # a capture timeout.
-            final_rows = recorder.finish_episode()
-            relay.set_raw_enabled(False)
+            # a capture timeout. The only controller has been joined, so there
+            # is no race: snapshot and hold measured joints while the bounded
+            # recorder + relay IPC runs on a worker thread. A direct joint hold
+            # also bypasses Cartesian IK/shaping, so a Cartesian policy's last
+            # desired pose cannot keep advancing during shutdown.
+            finish_hold_action = _measured_joint_hold_action()
+
+            def _finish_capture() -> int:
+                try:
+                    final_rows = recorder.finish_episode()
+                except BaseException as exc:
+                    try:
+                        relay.set_raw_enabled(False)
+                    except BaseException as gate_exc:
+                        exc.add_note(f"relay close also failed: {gate_exc!r}")
+                    raise
+                relay.set_raw_enabled(False)
+                return final_rows
+
+            def _hold_finish_pose() -> None:
+                robot.send_action(finish_hold_action)
+
+            final_rows = run_blocking_with_sync_control_ticks(
+                _finish_capture,
+                _hold_finish_pose,
+                boundary_period,
+                drain_tick=_hold_finish_pose,
+            )
             # Close a span still open when the loop exited (the episode ended
             # mid-intervention) at the final row count — exact, since capture
             # is paused — so intervention_spans is complete for any consumer.
@@ -1308,7 +1419,13 @@ def _run(
             pass
 
         log_say("Stopping.")
-        if control_thread is None or not control_thread.is_alive():
+        # Ctrl+C can land immediately after control_thread.start(), before the
+        # normal episode shutdown block. Always signal and drain that sole
+        # command producer before policy/robot/recorder/relay teardown.
+        control_stopped = control_thread is None or _stop_dagger_control_thread(
+            control_thread
+        )
+        if control_stopped:
             try:
                 policy.close()
             except Exception:  # noqa: BLE001

--- a/almond_axol/cli/collect_data.py
+++ b/almond_axol/cli/collect_data.py
@@ -72,6 +72,7 @@ from ..robot.control import ContactWatchdog
 from ..teleop.recorder import resolve_prefix
 from ..teleop_activity import TeleopActivityMarker
 from ..utils import affinity
+from ..utils.control_loop import run_blocking_with_control_ticks
 from ..utils.jetson_diag import TegraStatsDiag
 from ..utils.proc_diag import SystemDiag
 from .config import DatasetResolution, LogLevel, parse
@@ -955,9 +956,12 @@ def _run(
     # interleaved with CAN telemetry on one thread, exactly like `axol teleop`.
     # The main thread drives the episode lifecycle (dataset writes, rest-pose
     # moves) and blocks on each coroutine until the episode (or reset) finishes.
-    async def _episode_loop() -> tuple[bool, bool, bool]:
+    async def _episode_loop() -> tuple[bool, bool, bool, int]:
         recording = False
+        capture_ready = False
         rerecord = False
+        contact = False
+        captured_rows = 0
         # perf_counter deadline of a panel-started record countdown, or None.
         pending_start: float | None = None
         # Tracking-phase contact watchdog (opt-in — the threshold defaults
@@ -970,6 +974,96 @@ def _run(
             if vrt_cfg.teleop_torque_threshold > 0
             else None
         )
+        last_robot_act: dict[str, Any] | None = None
+        last_dataset_act: dict[str, Any] | None = None
+
+        class _TrackingContact(RuntimeError):
+            pass
+
+        async def _tracking_tick() -> None:
+            """Run one normal teleop tick without consuming boundary events."""
+            nonlocal last_robot_act, last_dataset_act
+            if _stopped() and last_robot_act is not None:
+                # Ctrl+C/Stop during recorder startup must drain the bounded
+                # worker before teardown, but must not keep following a moving
+                # controller while it does so.
+                await _hold_tick()
+                return
+            t0 = time.perf_counter()
+            _maybe_log_rate(t0)
+            # Keep a recording's trace open after the headset drops tracking:
+            # terminate/SAVING may arrive before the outer loop consumes it.
+            robot.set_control_trace_active(
+                recording or teleop.is_tracking or teleop.is_resetting
+            )
+
+            joint_obs = robot.get_joint_observation()
+            t_obs = time.perf_counter()
+            teleop.send_feedback(joint_obs)
+            act = teleop.get_action()
+            t_act = time.perf_counter()
+            act_processed = teleop_action_proc((act, joint_obs))
+            robot_act = robot_action_proc((act_processed, joint_obs))
+            dataset_act = robot.action_to_dataset(act_processed)
+            t_proc = time.perf_counter()
+            await robot.send_action_async(robot_act)
+            t_send = time.perf_counter()
+            sect["obs"] += t_obs - t0
+            sect["act"] += t_act - t_obs
+            sect["proc"] += t_proc - t_act
+            sect["send"] += t_send - t_proc
+
+            last_robot_act = robot_act
+            last_dataset_act = dataset_act
+            recorder.publish(joint_obs, dataset_act, t0)
+
+            # start_episode resets the subprocess's dedicated error pipe on a
+            # worker thread. Do not inspect that pipe from this event-loop
+            # heartbeat until the start transaction has completed.
+            if recording and capture_ready:
+                capture_error = recorder.poll_capture_error()
+                if capture_error is not None:
+                    raise RuntimeError(
+                        f"recorder capture failed: {capture_error}; episode discarded"
+                    )
+
+            if watchdog is not None:
+                tripped = watchdog.update(robot.torque_residuals())
+                if tripped is not None:
+                    joint, residual = tripped
+                    _logger.warning(
+                        "teleop contact: %s torque residual %.1f exceeds %.1f — going limp",
+                        joint,
+                        residual,
+                        vrt_cfg.teleop_torque_threshold,
+                    )
+                    raise _TrackingContact
+
+        async def _hold_tick() -> None:
+            """Refresh the last command while recorder/gate shutdown blocks."""
+            if last_robot_act is None or last_dataset_act is None:
+                return
+            t0 = time.perf_counter()
+            _maybe_log_rate(t0)
+            robot.set_control_trace_active(True)
+            joint_obs = robot.get_joint_observation()
+            teleop.send_feedback(joint_obs)
+            await robot.send_action_async(last_robot_act)
+            # Capture is already being stopped on the worker thread. Publishing
+            # keeps the nearest-state history fresh for any final in-flight AU.
+            recorder.publish(joint_obs, last_dataset_act, t0)
+
+        def _start_capture() -> None:
+            recorder.start_episode(task)
+            if relay is not None:
+                relay.set_raw_enabled(True)
+
+        def _finish_capture() -> int:
+            try:
+                return recorder.finish_episode()
+            finally:
+                if relay is not None:
+                    relay.set_raw_enabled(False)
 
         # Absolute-deadline pacing (mirrors `axol teleop`): late wakeups are
         # corrected on the next cycle instead of stretching the command interval.
@@ -1000,52 +1094,11 @@ def _run(
                 prev_t0["v"] = 0.0
                 continue
             deadline += teleop_interval
-            t0 = time.perf_counter()
-            _maybe_log_rate(t0)
-            # Keep a recording's trace open after the headset drops tracking:
-            # its terminate/SAVING state can arrive before we consume the event
-            # below. The outer guarded-return path then continues that same
-            # segment and closes it after the arm settles. Without ``recording``
-            # here, reopening for the return resets both RT/measured recorders
-            # and replaces the useful take with a tiny return/fault capture.
-            robot.set_control_trace_active(
-                recording or teleop.is_tracking or teleop.is_resetting
-            )
-
-            # Camera reads happen on the capture thread; the control loop only
-            # ever touches joint state.
-            joint_obs = robot.get_joint_observation()
-            t_obs = time.perf_counter()
-            teleop.send_feedback(joint_obs)
-            act = teleop.get_action()
-            t_act = time.perf_counter()
-            act_processed = teleop_action_proc((act, joint_obs))
-            robot_act = robot_action_proc((act_processed, joint_obs))
-            t_proc = time.perf_counter()
-            await robot.send_action_async(robot_act)
-            t_send = time.perf_counter()
-            sect["obs"] += t_obs - t0
-            sect["act"] += t_act - t_obs
-            sect["proc"] += t_proc - t_act
-            sect["send"] += t_send - t_proc
-
-            if watchdog is not None:
-                tripped = watchdog.update(robot.torque_residuals())
-                if tripped is not None:
-                    joint, residual = tripped
-                    _logger.warning(
-                        "teleop contact: %s torque residual %.1f exceeds %.1f — going limp",
-                        joint,
-                        residual,
-                        vrt_cfg.teleop_torque_threshold,
-                    )
-                    return recording, rerecord, True
-
-            # Record the action in the configured action space: identity for
-            # joint datasets, FK-to-Cartesian when observe_cartesian is set. The
-            # arm is still commanded with the teleop joint targets above, so its
-            # motion is unchanged — only the stored representation differs.
-            recorder.publish(joint_obs, robot.action_to_dataset(act_processed), t0)
+            try:
+                await _tracking_tick()
+            except _TrackingContact:
+                contact = True
+                break
 
             events = teleop.get_teleop_events()
             panel_cmd = control.poll_command()
@@ -1074,11 +1127,25 @@ def _run(
                 pending_start = None
                 recording = True
                 # Arm recorder cutoffs before opening the poised-before-IDR
-                # dataset valves. This preserves the first reopened IDR as row
-                # zero instead of flushing it in a startup race.
-                recorder.start_episode(task)
-                if relay is not None:
-                    relay.set_raw_enabled(True)
+                # dataset valves. Both calls can wait for transport/GOP
+                # boundaries, so run them off-loop while normal teleop ticks
+                # continue feeding the Rust target watchdog.
+                await asyncio.sleep(max(0.0, deadline - time.perf_counter()))
+                try:
+                    await run_blocking_with_control_ticks(
+                        _start_capture,
+                        _tracking_tick,
+                        teleop_interval,
+                        drain_tick=_guard_gravity_step,
+                    )
+                except _TrackingContact:
+                    contact = True
+                    break
+                capture_ready = True
+                # Do not repay the blocking worker's elapsed time with a burst
+                # of zero-sleep commands on the absolute-deadline scheduler.
+                deadline = time.perf_counter()
+                prev_t0["v"] = 0.0
                 control.note_recording()
                 log_say("Recording started.")
 
@@ -1107,7 +1174,18 @@ def _run(
             if slip > max_slip["v"]:
                 max_slip["v"] = slip
 
-        return recording, rerecord, False
+        if recording:
+            # A contact abort must never resume the last tracked target while
+            # the bounded capture close drains. Keep the arm limp instead;
+            # normal episode ends refresh the frozen command pose.
+            boundary_tick = _guard_gravity_step if contact else _hold_tick
+            captured_rows = await run_blocking_with_control_ticks(
+                _finish_capture,
+                boundary_tick,
+                teleop_interval,
+                drain_tick=_guard_gravity_step,
+            )
+        return recording, rerecord, contact, captured_rows
 
     # Guarded return-to-rest: the sequencing (torque watchdog, gravity-comp
     # fallback, reset-press retry) lives in the shared engine
@@ -1201,6 +1279,26 @@ def _run(
         finally:
             robot.set_control_trace_active(False)
 
+    def _drain_robot_future(fut: Any) -> None:
+        """Wait through repeated Ctrl+C until an on-robot coroutine is done.
+
+        Recorder boundary helpers deliberately keep their heartbeat alive until
+        their bounded worker finishes. Cancelling after an arbitrary timeout
+        would let that heartbeat race robot.disconnect() during teardown.
+        """
+        while True:
+            try:
+                fut.result()
+                return
+            except KeyboardInterrupt:
+                # A second Ctrl+C still must not make concurrent motor commands
+                # and teardown possible. The hardware e-stop remains immediate.
+                continue
+            except BaseException:
+                # The coroutine is done and its caller's original exception
+                # remains primary; only command quiescence matters here.
+                return
+
     def _run_on_robot_loop(coro: Any) -> Any:
         """Run ``coro`` on the robot's event loop and block until it returns.
 
@@ -1210,13 +1308,10 @@ def _run(
         fut = asyncio.run_coroutine_threadsafe(coro, robot.event_loop)
         try:
             return fut.result()
-        except KeyboardInterrupt:
+        except KeyboardInterrupt as interrupted:
             loop_stop.set()
-            try:
-                fut.result(timeout=5.0)
-            except BaseException:
-                fut.cancel()
-            raise
+            _drain_robot_future(fut)
+            raise interrupted
 
     def _wrap_up_episode(recording: bool, rerecord: bool, captured_rows: int) -> None:
         """Save or discard the just-ended episode and announce the result."""
@@ -1266,15 +1361,9 @@ def _run(
                 f"Episode {episode_idx + 1}: robot is at rest pose. Press record on the VR controller when ready."
             )
 
-            recording, rerecord, contact = _run_on_robot_loop(_episode_loop())
-
-            # Freeze capture exactly at the operator boundary while the final
-            # state snapshot still brackets every accepted exposure. Only then
-            # wait for the relay's next natural IDR and close its dataset branch;
-            # tail AUs are drained and discarded at the next reader flush.
-            captured_rows = recorder.finish_episode() if recording else 0
-            if relay is not None:
-                relay.set_raw_enabled(False)
+            recording, rerecord, contact, captured_rows = _run_on_robot_loop(
+                _episode_loop()
+            )
 
             if _stopped():
                 if recording:
@@ -1319,10 +1408,7 @@ def _run(
                 # Ctrl+C or a failed save: unwind the guarded return so it
                 # stops commanding the robot before teardown.
                 loop_stop.set()
-                try:
-                    home_future.result(timeout=5.0)
-                except BaseException:
-                    home_future.cancel()
+                _drain_robot_future(home_future)
                 raise
             # Drain VR events fired during the return, then unblock the
             # headset for the next take.

--- a/almond_axol/recording/record_proc.py
+++ b/almond_axol/recording/record_proc.py
@@ -64,6 +64,7 @@ _SAVE_TIMEOUT_S = 180.0
 # How long a lightweight episode command (pause/resume/frame_count) may take —
 # these only flip an event / read a counter in the recorder's command thread.
 _CMD_TIMEOUT_S = 10.0
+_CAPTURE_STOP_TIMEOUT_S = 10.0
 
 # --- Encoded (relay-side H.264) capture-loop tuning ---
 # How long the first row waits for each camera's first access unit (relay valve
@@ -1845,13 +1846,27 @@ class InProcessRecorder:
     def _stop_capture(self) -> None:
         if self._thread is not None and self._stop is not None:
             self._stop.set()
-            self._thread.join()
+            self._thread.join(timeout=_CAPTURE_STOP_TIMEOUT_S)
+            if self._thread.is_alive():
+                raise RuntimeError(
+                    "capture thread did not stop within 10s; refusing to "
+                    "finalize while dataset writes may still be in flight"
+                )
             self._thread = None
 
     def finish_episode(self) -> int:
         """Freeze capture without saving and return the exact buffered rows."""
         self._stop_capture()
+        if self._capture_error is not None:
+            self._dataset.clear_episode_buffer()
+            raise RuntimeError(
+                f"recorder capture failed: {self._capture_error}; episode discarded"
+            )
         return self._frames["n"]
+
+    def poll_capture_error(self) -> str | None:
+        """Return an episode-local capture failure without blocking."""
+        return self._capture_error
 
     def save_episode(self) -> None:
         from ..lerobot.nvenc_encoder import dropped_frames
@@ -1898,8 +1913,16 @@ class InProcessRecorder:
 
     def close(self) -> None:
         self._stop_capture()
-        _finalize_dataset(self._dataset, self._config, self._episodes_recorded)
-        self._verifier.close()
+        try:
+            # close() is also the Ctrl+C / panel-Stop escape hatch. The caller
+            # may never have reached finish/cancel, so always tear down a live
+            # streaming encoder and discard uncommitted rows before dataset
+            # finalization. This is idempotent after save_episode(), which
+            # creates a fresh buffer.
+            self._dataset.clear_episode_buffer()
+            _finalize_dataset(self._dataset, self._config, self._episodes_recorded)
+        finally:
+            self._verifier.close()
 
 
 # ---------------------------------------------------------------------------
@@ -1909,6 +1932,7 @@ class InProcessRecorder:
 
 def _recorder_main(
     conn: multiprocessing.connection.Connection,
+    error_conn: multiprocessing.connection.Connection,
     raw_cond: Any,
     config: dict,
 ) -> None:
@@ -2028,11 +2052,19 @@ def _recorder_main(
     record_event = threading.Event()
     frame_counter: dict[str, int] = {"n": 0}
 
+    def report_capture_error(message: str) -> None:
+        """Publish the first capture failure without corrupting command replies."""
+        if capture_error["v"] is not None:
+            return
+        capture_error["v"] = message
+        with contextlib.suppress(OSError, EOFError, ValueError):
+            error_conn.send(message)
+
     def stop_capture() -> None:
         nonlocal thread
         if thread is not None and stop is not None:
             stop.set()
-            thread.join(timeout=10.0)
+            thread.join(timeout=_CAPTURE_STOP_TIMEOUT_S)
             if thread.is_alive():
                 raise RuntimeError(
                     "capture thread did not stop within 10s; refusing to "
@@ -2074,7 +2106,7 @@ def _recorder_main(
                     task=task,
                     rerun_ip=config["rerun_ip"],
                     stop_event=stop,
-                    on_error=lambda m: capture_error.__setitem__("v", m),
+                    on_error=report_capture_error,
                 )
                 loop_kwargs["frame_counter"] = frame_counter
                 if not encoded_mode:
@@ -2104,6 +2136,8 @@ def _recorder_main(
                 except RuntimeError as exc:
                     conn.send(("error", str(exc)))
                 else:
+                    if capture_error["v"] is not None:
+                        dataset.clear_episode_buffer()
                     conn.send(("finished", frame_counter["n"]))
             elif kind == "pause_episode":
                 if encoded_mode:
@@ -2223,23 +2257,39 @@ def _recorder_main(
             stop.set()
             thread.join()
             thread = None
+        # EOF, shutdown, and KeyboardInterrupt may all bypass the explicit
+        # cancel command. Always discard any uncommitted rows and cancel a live
+        # streaming encoder before finalizing; after a successful save this is
+        # an idempotent clear of the newly-created empty episode buffer.
+        buffer_discarded = False
         try:
-            finalize_config = config
-            if save_poisoned:
-                # Preserve a fresh first-save failure for inspection/repair and
-                # never upload a dataset whose writer indices may be partial.
-                finalize_config = {
-                    **config,
-                    "is_complete": True,
-                    "push_to_hub": False,
-                }
-            _finalize_dataset(dataset, finalize_config, episodes_recorded)
+            dataset.clear_episode_buffer()
+            buffer_discarded = True
         except Exception:
-            # Never let this take the subprocess down before the cameras are
-            # released, but do not swallow it either: a failed finalize is how
-            # a session's episode metadata ends up unreadable, and suppressing
-            # it left the operator with only the downstream parquet error.
-            _logger.exception("recorder failed to finalize the dataset")
+            _logger.exception(
+                "recorder failed to discard its unsaved episode; refusing "
+                "dataset finalization"
+            )
+        if buffer_discarded:
+            try:
+                finalize_config = config
+                if save_poisoned:
+                    # Preserve a fresh first-save failure for inspection/repair
+                    # and never upload a dataset whose writer indices may be
+                    # partial.
+                    finalize_config = {
+                        **config,
+                        "is_complete": True,
+                        "push_to_hub": False,
+                    }
+                _finalize_dataset(dataset, finalize_config, episodes_recorded)
+            except Exception:
+                # Never let this take the subprocess down before the cameras are
+                # released, but do not swallow it either: a failed finalize is
+                # how a session's episode metadata ends up unreadable, and
+                # suppressing it left the operator with only the downstream
+                # parquet error.
+                _logger.exception("recorder failed to finalize the dataset")
         # After finalize (the dataset is already consistent on disk either
         # way), give the verifier a bounded window to finish its ~1-episode
         # backlog so a bad last take is still reported before exit.
@@ -2249,6 +2299,8 @@ def _recorder_main(
                 cam.close()
         with contextlib.suppress(Exception):
             snap_reader.close()
+        with contextlib.suppress(Exception):
+            error_conn.close()
 
 
 class DatasetRecorderProcess:
@@ -2278,6 +2330,10 @@ class DatasetRecorderProcess:
         self._snapshot_lock = ctx.Lock()
         self._snap = SnapshotWriter(obs_keys, action_keys, self._snapshot_lock)
         self._conn, child_conn = ctx.Pipe()
+        # Capture runs on a child thread while command/reply messages use
+        # ``_conn``. Keep failures on a dedicated one-way pipe so the hot
+        # control loop can poll them without stealing an expected command reply.
+        self._error_conn, child_error_conn = ctx.Pipe(duplex=False)
         full_config = {
             **config,
             "raw_meta": raw_meta,
@@ -2288,14 +2344,16 @@ class DatasetRecorderProcess:
         }
         self._proc = ctx.Process(
             target=_recorder_main,
-            args=(child_conn, raw_cond, full_config),
+            args=(child_conn, child_error_conn, raw_cond, full_config),
             daemon=True,
             name="dataset-recorder",
         )
         self._proc.start()
         child_conn.close()
+        child_error_conn.close()
         self._lock = threading.Lock()
         self._episode_count = 0
+        self._capture_error: str | None = None
         try:
             deadline = time.perf_counter() + _READY_TIMEOUT_S
             while True:
@@ -2328,6 +2386,8 @@ class DatasetRecorderProcess:
             with contextlib.suppress(Exception):
                 self._conn.close()
             with contextlib.suppress(Exception):
+                self._error_conn.close()
+            with contextlib.suppress(Exception):
                 self._snap.close()
             raise
 
@@ -2344,6 +2404,14 @@ class DatasetRecorderProcess:
         return self._episode_count
 
     def start_episode(self, task: str) -> None:
+        # Discard a failure already consumed by the previous episode. The child
+        # clears its matching local value before it starts this capture thread.
+        try:
+            while self._error_conn.poll():
+                self._error_conn.recv()
+        except (EOFError, OSError, ValueError):
+            pass
+        self._capture_error = None
         with self._lock:
             self._conn.send(("start_episode", task))
             if not self._conn.poll(_CMD_TIMEOUT_S):
@@ -2363,7 +2431,21 @@ class DatasetRecorderProcess:
         if msg[0] != "finished":
             detail = msg[1] if len(msg) > 1 else repr(msg)
             raise RuntimeError(f"recorder finish_episode failed: {detail}")
+        capture_error = self.poll_capture_error()
+        if capture_error is not None:
+            raise RuntimeError(
+                f"recorder capture failed: {capture_error}; episode discarded"
+            )
         return int(msg[1])
+
+    def poll_capture_error(self) -> str | None:
+        """Return the first capture-thread failure for this episode, if any."""
+        try:
+            while self._error_conn.poll():
+                self._capture_error = str(self._error_conn.recv())
+        except (EOFError, OSError, ValueError):
+            pass
+        return self._capture_error
 
     def _episode_gate(self, command: str, expect: str) -> int:
         """Send a pause/resume/frame-count command; return the row count.
@@ -2461,5 +2543,7 @@ class DatasetRecorderProcess:
             )
         with contextlib.suppress(Exception):
             self._conn.close()
+        with contextlib.suppress(Exception):
+            self._error_conn.close()
         with contextlib.suppress(Exception):
             self._snap.close()

--- a/almond_axol/teleop/worker.py
+++ b/almond_axol/teleop/worker.py
@@ -27,15 +27,15 @@ from .trajectory import plan_collision_aware_trajectory
 
 _logger = logging.getLogger(__name__)
 
-# Freeze detection (see IKWorker._note_solve): warn when the solver keeps
-# returning its seed unchanged while the tracked targets move away — the
-# operator experiences the arm as stuck, then lurching once the solve breaks
-# free. Thresholds: how long the output must be frozen before warning, how far
-# the targets must have moved (so a still hand doesn't warn), and how often to
-# re-warn while the freeze persists.
+# Freeze handling (see IKWorker._note_solve): when one arm's solver output keeps
+# returning its seed unchanged while that arm's tracked target moves away, the
+# operator experiences a hold followed by a catch-up lurch. After a confirmed
+# run, automatically clutch that controller at the held IK pose: the snap frame
+# itself cannot move, future hand deltas retain the normal relative mapping, and
+# only the unexecuted motion accumulated during the freeze is discarded.
 _FREEZE_WARN_AFTER_S = 0.5
 _FREEZE_MIN_TARGET_DRIFT_M = 0.005
-_FREEZE_REWARN_EVERY_S = 2.0
+_FREEZE_MIN_TARGET_DRIFT_RAD = math.radians(5.0)
 
 # Tracking glitch rejection (see IKWorker._frame_snap_verdict): the VR pose
 # stream carries two kinds of both-hand discontinuity that the operator's
@@ -210,14 +210,14 @@ class IKWorker:
         self._active: dict[str, bool] = {"left": False, "right": False}
         self._hold_fk: dict[str, tuple[np.ndarray, np.ndarray]] = {}
         self._hold_elbow_fk: dict[str, np.ndarray] = {}
-        # Freeze detection state: when the last solve returned its seed
-        # unchanged, `_freeze_since` holds the wall time the freeze started and
-        # `_freeze_targets` the EE/elbow target positions at that moment, so a
-        # warning fires only when the targets kept moving away (a still hand
-        # legitimately produces an unchanged solution).
-        self._freeze_since: float | None = None
-        self._freeze_targets: np.ndarray | None = None
-        self._freeze_next_warn: float = _FREEZE_WARN_AFTER_S
+        # Per-arm freeze state. A bimanual solve can leave one arm's joint slice
+        # bit-identical while the other progresses, so whole-vector detection
+        # both misses real freezes and cannot clutch only the affected mapping.
+        # Each target snapshot is (EE position, EE rotation, optional elbow).
+        self._freeze_since: dict[str, float] = {}
+        self._freeze_targets: dict[
+            str, tuple[np.ndarray, np.ndarray, np.ndarray | None]
+        ] = {}
         # Snap poses as (pos_3, rot_3x3) numpy tuples — no jaxlie overhead
         self._snap_ctrl: dict[str, tuple[np.ndarray, np.ndarray]] = {}
         self._snap_fk: dict[str, tuple[np.ndarray, np.ndarray]] = {}
@@ -553,13 +553,88 @@ class IKWorker:
             q_new[self._solver.left_indices] = q_current[self._solver.left_indices]
         if not self._active["right"]:
             q_new[self._solver.right_indices] = q_current[self._solver.right_indices]
-        targets = [tl_pos, tr_pos]
-        if elbow_l is not None and elbow_r is not None:
-            targets += [elbow_l, elbow_r]
-        self._note_solve(
-            bool(np.array_equal(q_new, q_current)),
-            np.concatenate(targets),
-        )
+        # Detect and resolve seed-return stalls per arm. Re-snapshot only a
+        # stalled arm whose target actually moved: a still controller can
+        # legitimately sit at a collision or joint boundary, and the healthy
+        # arm must retain both its solved output and its controller mapping.
+        #
+        # Re-anchoring uses the *current filtered* controller pose and FK of the
+        # unchanged joint slice. At this sample _relative_target_np therefore
+        # returns that FK exactly (zero translation, identity rotation), so the
+        # clutch cannot introduce a command step. Motion after this sample is
+        # once again relative 1:1 (or with the configured multipliers); motion
+        # accumulated while the solver was unable to move is deliberately
+        # discarded instead of being released later as a lurch.
+        reanchor: list[
+            tuple[
+                str,
+                np.ndarray,
+                np.ndarray,
+                np.ndarray | None,
+                list[int],
+            ]
+        ] = []
+        for (
+            side,
+            ctrl_pos,
+            ctrl_rot,
+            ctrl_e,
+            target_pos,
+            target_rot,
+            target_e,
+            indices,
+        ) in (
+            (
+                "left",
+                left_pos,
+                left_rot,
+                left_e,
+                tl_pos,
+                tl_rot,
+                elbow_l,
+                self._solver.left_indices,
+            ),
+            (
+                "right",
+                right_pos,
+                right_rot,
+                right_e,
+                tr_pos,
+                tr_rot,
+                elbow_r,
+                self._solver.right_indices,
+            ),
+        ):
+            if not self._active[side]:
+                self._clear_freeze(side)
+                continue
+            arm_frozen = bool(np.array_equal(q_new[indices], q_current[indices]))
+            if self._note_solve(
+                side,
+                arm_frozen,
+                target_pos,
+                target_rot,
+                target_e,
+            ):
+                reanchor.append((side, ctrl_pos, ctrl_rot, ctrl_e, indices))
+
+        if reanchor:
+            # Keep the persistent posture attractor consistent with the new
+            # clutch origin, but update only re-anchored joint slices. Re-pinning
+            # the whole vector would unnecessarily perturb a healthy arm that
+            # made progress in this same bimanual solve.
+            posture = self._solver.posture_pose
+            for side, ctrl_pos, ctrl_rot, ctrl_e, indices in reanchor:
+                self._snap_arm(
+                    side,
+                    ctrl_pos,
+                    ctrl_rot,
+                    ctrl_e,
+                    _ee(side),
+                    _elbow(side) if self._use_elbow else None,
+                )
+                posture[indices] = q_current[indices]
+            self._solver.set_posture_pose(posture)
         if self._rec is not None:
             self._rec.record(
                 raw_l=np.array(
@@ -756,48 +831,89 @@ class IKWorker:
         self._note_raw(raw_l, raw_r, t_eff)
         return ("ok", None, None)
 
-    def _clear_freeze(self) -> None:
-        """Forget any in-progress freeze run (disengage / engage / reset)."""
-        self._freeze_since = None
-        self._freeze_targets = None
-        self._freeze_next_warn = _FREEZE_WARN_AFTER_S
+    def _clear_freeze(self, side: str | None = None) -> None:
+        """Forget one or all in-progress freeze runs."""
+        if side is None:
+            self._freeze_since.clear()
+            self._freeze_targets.clear()
+            return
+        self._freeze_since.pop(side, None)
+        self._freeze_targets.pop(side, None)
 
-    def _note_solve(self, frozen: bool, targets: np.ndarray) -> None:
-        """Track seed-returning solves; WARN when the output freezes.
+    def _note_solve(
+        self,
+        side: str,
+        frozen: bool,
+        target_pos: np.ndarray,
+        target_rot: np.ndarray,
+        target_elbow: np.ndarray | None,
+    ) -> bool:
+        """Track one arm's seed-returning solves; request a safe clutch.
 
         A single unchanged solution is normal (e.g. the hand is still, or the
-        target is held against a constraint). The failure mode worth flagging is
-        a *run* of solves that return the seed while the EE/elbow targets keep
-        moving away — the operator sees the arm stop responding, and the
-        accumulated error is released as a lurch once a solve finally makes
-        progress (see ``KinematicsConfig`` for the tuning that minimises this).
+        target is held against a constraint). The failure mode worth handling
+        is a *run* of solves that returns this arm's seed while its EE/elbow
+        target keeps moving away. Once confirmed, the caller re-snapshots the
+        controller against FK of the held joints, acting like an automatic
+        clutch: no command step now, no accumulated catch-up later.
 
         Args:
-            frozen: True when this solve returned ``q_current`` bit-identically.
-            targets: Concatenated EE + elbow target positions (m) of this solve,
-                used to measure how far the targets drifted during the freeze.
+            side: ``"left"`` or ``"right"``.
+            frozen: True when this arm's solved joint slice returned its
+                ``q_current`` slice bit-identically.
+            target_pos: Current EE target position in metres.
+            target_rot: Current EE target rotation matrix.
+            target_elbow: Optional elbow target position in metres.
+
+        Returns:
+            True once the freeze duration and target-motion thresholds are met;
+            the caller should re-anchor this arm at the current sample.
         """
         if not frozen:
-            self._clear_freeze()
-            return
+            self._clear_freeze(side)
+            return False
         now = time.monotonic()
-        if self._freeze_since is None or self._freeze_targets is None:
-            self._freeze_since = now
-            self._freeze_targets = targets
-            return
-        duration = now - self._freeze_since
-        drift = float(np.max(np.abs(targets - self._freeze_targets)))
-        if duration >= self._freeze_next_warn and drift >= _FREEZE_MIN_TARGET_DRIFT_M:
-            _logger.warning(
-                "IK frozen for %.1fs: solver keeps returning its seed while the "
-                "EE/elbow targets moved %.0f mm — it cannot make progress "
-                "(target likely conflicts with the self-collision margin or "
-                "joint limits); the arm holds, then catches up in a lurch when "
-                "the solve breaks free.",
-                duration,
-                drift * 1e3,
+        start = self._freeze_targets.get(side)
+        if side not in self._freeze_since or start is None:
+            self._freeze_since[side] = now
+            self._freeze_targets[side] = (
+                target_pos.copy(),
+                target_rot.copy(),
+                None if target_elbow is None else target_elbow.copy(),
             )
-            self._freeze_next_warn = duration + _FREEZE_REWARN_EVERY_S
+            return False
+
+        duration = now - self._freeze_since[side]
+        start_pos, start_rot, start_elbow = start
+        pos_drift = float(np.linalg.norm(target_pos - start_pos))
+        if target_elbow is not None and start_elbow is not None:
+            pos_drift = max(
+                pos_drift,
+                float(np.linalg.norm(target_elbow - start_elbow)),
+            )
+        relative_rot = start_rot.T @ target_rot
+        cos_angle = float(np.clip((np.trace(relative_rot) - 1.0) * 0.5, -1.0, 1.0))
+        rot_drift = math.acos(cos_angle)
+        moved = (
+            pos_drift >= _FREEZE_MIN_TARGET_DRIFT_M
+            or rot_drift >= _FREEZE_MIN_TARGET_DRIFT_RAD
+        )
+        if duration < _FREEZE_WARN_AFTER_S or not moved:
+            return False
+
+        _logger.warning(
+            "IK %s arm frozen for %.1fs: its solver output stayed at the seed "
+            "while the EE/elbow target moved %.0f mm / %.1f deg (likely a "
+            "self-collision or joint-limit conflict). Re-anchoring the "
+            "controller at the held pose; motion accumulated during the "
+            "freeze is discarded to prevent a catch-up lurch.",
+            side,
+            duration,
+            pos_drift * 1e3,
+            math.degrees(rot_drift),
+        )
+        self._clear_freeze(side)
+        return True
 
     def _reset_pose_filters(self) -> None:
         """Clear the pose-filter state for every controller and elbow stream."""

--- a/almond_axol/utils/control_loop.py
+++ b/almond_axol/utils/control_loop.py
@@ -1,0 +1,283 @@
+"""Helpers for keeping robot command loops alive across blocking work."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import signal
+import threading
+import time
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+async def run_blocking_with_control_ticks(
+    operation: Callable[[], T],
+    tick: Callable[[], Awaitable[None]],
+    period_s: float,
+    *,
+    drain_tick: Callable[[], Awaitable[None]] | None = None,
+) -> T:
+    """Run blocking ``operation`` off-loop while awaiting ``tick`` regularly.
+
+    This is for bounded lifecycle calls which cannot safely interrupt a robot's
+    command stream (for example, recorder IPC at an episode boundary). Merely
+    awaiting :func:`asyncio.to_thread` is not enough when the awaiting coroutine
+    is itself the only command producer, so this helper continues calling
+    ``tick`` on the caller's event loop until the worker finishes. If ``tick``
+    fails and ``drain_tick`` is provided, the first error is retained while the
+    safer fallback tick keeps the command stream alive until the worker drains.
+
+    Tick pacing is relative to the start of each tick. A slow tick therefore
+    delays the next one instead of accruing an absolute-deadline debt and
+    emitting a burst of catch-up commands. Caller cancellation is delayed until
+    the blocking worker has completed: Python cannot cancel work already running
+    in a thread, and abandoning such a worker could let it keep using an IPC pipe
+    while teardown or a later command races it. The operation must consequently
+    be bounded internally (for example, its IPC call must have a finite timeout);
+    the helper deliberately does not pretend it can kill a stuck Python thread.
+
+    Args:
+        operation: Bounded synchronous callable to execute in a worker thread.
+        tick: Async control/hold step, run serially on the caller's event loop.
+        period_s: Minimum target period between the starts of normal-duration
+            ticks. Must be positive.
+        drain_tick: Optional safe hold/fallback step used after ``tick`` raises.
+            If it also raises, the worker is still drained but no further ticks
+            are attempted; the original tick error remains primary.
+
+    Returns:
+        The value returned by ``operation``.
+
+    Raises:
+        ValueError: If ``period_s`` is not positive.
+        BaseException: Any exception from ``operation`` or ``tick``. A tick
+            error takes precedence over a concurrent operation error. If the
+            caller cancels this coroutine, cancellation wins after the worker
+            has been drained.
+    """
+    if period_s <= 0:
+        raise ValueError("period_s must be positive")
+
+    loop = asyncio.get_running_loop()
+
+    async def drive() -> T:
+        worker = asyncio.create_task(asyncio.to_thread(operation))
+        active_tick = tick
+        tick_error: BaseException | None = None
+        drain_error: BaseException | None = None
+        try:
+            while not worker.done():
+                tick_started = loop.time()
+                try:
+                    await active_tick()
+                except BaseException as exc:
+                    if tick_error is None:
+                        tick_error = exc
+                        if drain_tick is None:
+                            break
+                        active_tick = drain_tick
+                    else:
+                        drain_error = exc
+                        break
+                remaining = period_s - (loop.time() - tick_started)
+                if remaining > 0 and not worker.done():
+                    # Unlike wait_for(), asyncio.wait() does not cancel the
+                    # non-cancellable thread-backed task when the period ends.
+                    await asyncio.wait((worker,), timeout=remaining)
+            if not worker.done():
+                # No fallback exists, or the fallback itself failed. Preserve
+                # IPC sequencing even though there is no longer a useful tick.
+                with contextlib.suppress(BaseException):
+                    await asyncio.shield(worker)
+
+            operation_error: BaseException | None = None
+            result: T | None = None
+            try:
+                result = worker.result()
+            except BaseException as exc:
+                operation_error = exc
+
+            if tick_error is not None:
+                if drain_error is not None:
+                    tick_error.add_note(f"drain tick also failed: {drain_error!r}")
+                if operation_error is not None:
+                    tick_error.add_note(
+                        f"blocking operation also failed: {operation_error!r}"
+                    )
+                raise tick_error
+            if operation_error is not None:
+                raise operation_error
+            return result  # type: ignore[return-value]
+        except BaseException:
+            # A failed tick must not orphan a thread which may still hold an IPC
+            # lock. There is no useful heartbeat after the heartbeat itself has
+            # failed, but draining the bounded operation preserves sequencing.
+            if not worker.done():
+                with contextlib.suppress(BaseException):
+                    await asyncio.shield(worker)
+            else:
+                # Retrieve a worker exception so asyncio does not report an
+                # unobserved task while the tick exception remains primary.
+                with contextlib.suppress(BaseException):
+                    worker.result()
+            raise
+
+    # Shield a dedicated driver so cancellation of this public coroutine does
+    # not stop its heartbeat while the underlying thread continues to run.
+    driver = asyncio.create_task(drive())
+    cancellation: asyncio.CancelledError | None = None
+    while True:
+        try:
+            result = await asyncio.shield(driver)
+        except asyncio.CancelledError as exc:
+            # ``shield`` also raises CancelledError when the *driver* finished
+            # cancelled (for example, operation() itself raised it). That is
+            # an outcome, not a new caller cancellation: retrying await on the
+            # already-cancelled task would spin forever.
+            if driver.done() and driver.cancelled():
+                if cancellation is not None:
+                    raise cancellation
+                raise
+            if cancellation is None:
+                cancellation = exc
+            # Keep waiting through repeated cancellation requests. The shielded
+            # driver continues ticking until its bounded worker has completed.
+            continue
+        except BaseException:
+            if cancellation is not None:
+                # The await above retrieved the driver's exception; preserve
+                # the caller's earlier cancellation as the primary outcome.
+                raise cancellation
+            raise
+        if cancellation is not None:
+            raise cancellation
+        return result
+
+
+def run_blocking_with_sync_control_ticks(
+    operation: Callable[[], T],
+    tick: Callable[[], None],
+    period_s: float,
+    *,
+    drain_tick: Callable[[], None] | None = None,
+) -> T:
+    """Synchronous counterpart to :func:`run_blocking_with_control_ticks`.
+
+    ``operation`` runs on one non-daemon worker thread while the calling thread
+    invokes ``tick`` at a relative cadence. This is intended for synchronous
+    robot supervisors whose command API itself hops to the robot event loop.
+
+    A ``KeyboardInterrupt`` is remembered but delayed until the operation has
+    completed; ticks continue in the meantime so Ctrl+C cannot turn a bounded
+    recorder transition into a lost target stream. A regular tick failure uses
+    ``drain_tick`` when supplied. As with the async form, ``operation`` must
+    enforce its own finite timeout because a running Python thread cannot be
+    killed safely.
+    """
+    if period_s <= 0:
+        raise ValueError("period_s must be positive")
+
+    worker_done = threading.Event()
+    result: T | None = None
+    operation_error: BaseException | None = None
+
+    def run_operation() -> None:
+        nonlocal result, operation_error
+        try:
+            result = operation()
+        except BaseException as exc:
+            operation_error = exc
+        finally:
+            worker_done.set()
+
+    worker = threading.Thread(
+        target=run_operation,
+        name="axol-blocking-control-work",
+        daemon=False,
+    )
+    active_tick = tick
+    tick_error: BaseException | None = None
+    drain_error: BaseException | None = None
+    cancellation: KeyboardInterrupt | None = None
+
+    # On Linux, defer SIGINT across the complete worker lifetime. CPython can
+    # deliver it between any two bytecodes (including a finally clause's loop
+    # condition), and no arrangement of Python-level try blocks can make every
+    # one of those gaps atomic. Restoring the mask only after join delivers a
+    # pending Ctrl+C at the first point where abandoning this function is safe.
+    previous_mask: set[signal.Signals] | None = None
+    if threading.current_thread() is threading.main_thread() and hasattr(
+        signal, "pthread_sigmask"
+    ):
+        previous_mask = signal.pthread_sigmask(signal.SIG_BLOCK, {signal.SIGINT})
+    worker_started = False
+    try:
+        worker.start()
+        worker_started = True
+
+        while True:
+            try:
+                # Keep the condition inside the handler: CPython can deliver
+                # SIGINT between any two bytecodes, including loop bookkeeping.
+                if worker_done.is_set():
+                    break
+                tick_started = time.perf_counter()
+                active_tick()
+                remaining = period_s - (time.perf_counter() - tick_started)
+                if remaining > 0 and not worker_done.is_set():
+                    worker_done.wait(remaining)
+            except KeyboardInterrupt as exc:
+                if cancellation is None:
+                    cancellation = exc
+                # Ctrl+C is external to the tick itself. Continue the same safe
+                # target stream while the bounded worker drains.
+            except BaseException as exc:
+                if tick_error is None:
+                    tick_error = exc
+                    if drain_tick is None:
+                        break
+                    active_tick = drain_tick
+                else:
+                    drain_error = exc
+                    break
+    finally:
+        # A failed tick or a signal anywhere after Thread.start() cannot justify
+        # abandoning a worker which may still own an IPC transaction. Keep every
+        # loop condition inside its KeyboardInterrupt handler and drain the
+        # operation's internally bounded timeout before returning to teardown.
+        try:
+            if worker_started:
+                while True:
+                    try:
+                        if worker_done.is_set():
+                            break
+                        worker_done.wait(period_s)
+                    except KeyboardInterrupt as exc:
+                        if cancellation is None:
+                            cancellation = exc
+                while True:
+                    try:
+                        worker.join(period_s)
+                        if not worker.is_alive():
+                            break
+                    except KeyboardInterrupt as exc:
+                        if cancellation is None:
+                            cancellation = exc
+        finally:
+            if previous_mask is not None:
+                signal.pthread_sigmask(signal.SIG_SETMASK, previous_mask)
+
+    if cancellation is not None:
+        raise cancellation
+    if tick_error is not None:
+        if drain_error is not None:
+            tick_error.add_note(f"drain tick also failed: {drain_error!r}")
+        if operation_error is not None:
+            tick_error.add_note(f"blocking operation also failed: {operation_error!r}")
+        raise tick_error
+    if operation_error is not None:
+        raise operation_error
+    return result  # type: ignore[return-value]

--- a/almond_axol/video/gst_zed.py
+++ b/almond_axol/video/gst_zed.py
@@ -44,6 +44,7 @@ gate use; without them callers fall back to the SDK ``ZedCamera``.
 from __future__ import annotations
 
 import logging
+import math
 import os
 import queue
 import threading
@@ -423,6 +424,12 @@ def _raw_shmsink(socket_path: str) -> str:
 # encoder immediately before a periodic IDR, so reopening emits that IDR as row
 # zero; the reader verifies this and defensively drops any leading P-frames.
 _DATASET_IDR_INTERVAL_S = 0.25
+# Opening every camera with a sequence of host-side property writes can straddle
+# multiple source frames. Arm a timestamp probe on every branch first, then let
+# each one open itself on its first exposure at/after one shared future instant.
+# 100 ms is ample time to install the handful of probes without making a record
+# press feel sluggish; the relay caller performs this wait away from control.
+_DATASET_ENABLE_LEAD_S = 0.100
 # A disable observes a complete GOP and closes immediately before the following
 # IDR. Two seconds leaves a full-frame margin even at the supported 1 fps
 # minimum; a timeout therefore indicates a stalled encoder, not scheduler jitter.
@@ -548,6 +555,22 @@ class _GstPipelineBase:
         # physical camera first, then waits for all of them, so their encoder
         # GOP counters restart from the same phase at the next episode.
         self._dataset_disable: list[tuple[Any, int, threading.Event, Any, str]] = []
+        # One ``(sink_pad, probe_id, opened, cancelled, lock, status, valve,
+        # label)`` per dataset branch waiting for a common exposure boundary.
+        # ``lock`` serializes an opening callback with fail-close so a callback
+        # can never reopen a valve after an aborted multi-camera transaction.
+        self._dataset_enable: list[
+            tuple[
+                Any,
+                int,
+                threading.Event,
+                threading.Event,
+                threading.Lock,
+                dict[str, str | None],
+                Any,
+                str,
+            ]
+        ] = []
 
     def _cancel_dataset_disable(self) -> None:
         """Remove any outstanding natural-IDR probes (best effort)."""
@@ -560,15 +583,189 @@ class _GstPipelineBase:
             except Exception:  # noqa: BLE001 - pipeline may be tearing down
                 pass
 
-    def _enable_dataset_valves(self, gates: tuple[tuple[str, str | None], ...]) -> None:
-        """Open every named dataset valve and cancel a pending close."""
-        self._cancel_dataset_disable()
+    def _cancel_dataset_enable(self) -> None:
+        """Cancel a pending common-frame open and leave every valve closed."""
+        pending, self._dataset_enable = self._dataset_enable, []
+        for pad, probe_id, opened, cancelled, lock, status, valve, label in pending:
+            # The callback checks ``cancelled`` and changes the valve under this
+            # same lock. If it won the race, fail-close runs second and closes
+            # the valve; if cancellation won, the callback cannot reopen it.
+            with lock:
+                cancelled.set()
+                if status["error"] is None:
+                    status["error"] = f"dataset source {label!r} opening was cancelled"
+                valve.set_property("drop", True)
+                # Wake a concurrent finish waiter so abort/disconnect never
+                # leaves it sleeping until the full gate timeout.
+                opened.set()
+            try:
+                pad.remove_probe(probe_id)
+            except Exception:  # noqa: BLE001 - callback/pipeline may be exiting
+                pass
+
+    def _abort_dataset_enable(self, gates: tuple[tuple[str, str | None], ...]) -> None:
+        """Fail a multi-camera open closed, including branches already opened."""
+        self._cancel_dataset_enable()
         if self._pipeline is None:
             return
         for valve_name, _encoder_name in gates:
             valve = self._pipeline.get_by_name(valve_name)
             if valve is not None:
-                valve.set_property("drop", False)
+                valve.set_property("drop", True)
+
+    def _begin_dataset_enable(
+        self,
+        gates: tuple[tuple[str, str | None], ...],
+        target_perf_s: float,
+    ) -> None:
+        """Arm every branch to open on its first exposure at/after one instant.
+
+        Dataset valves receive sensor-exposure PTS even while dropping buffers.
+        Installing probes on all cameras before ``target_perf_s`` avoids the
+        one/two-frame phase error caused by sequential property writes. Each
+        camera has a different pipeline running-time origin, so the shared
+        system-wide ``perf_counter`` target is converted with that pipeline's
+        calibrated PTS offset.
+        """
+        self._cancel_dataset_disable()
+        self._cancel_dataset_enable()
+        if self._pipeline is None:
+            return
+        if not math.isfinite(target_perf_s):
+            raise ValueError("dataset enable target must be finite")
+        if self._pts_perf_offset_s is None:
+            raise RuntimeError(
+                "camera pipeline PTS/perf_counter mapping is unavailable"
+            )
+
+        # Round upward: a sub-nanosecond conversion error must not admit an
+        # exposure infinitesimally before the shared boundary.
+        target_pts = math.ceil((target_perf_s - self._pts_perf_offset_s) * 1e9)
+        armed: list[
+            tuple[
+                Any,
+                int,
+                threading.Event,
+                threading.Event,
+                threading.Lock,
+                dict[str, str | None],
+                Any,
+                str,
+            ]
+        ] = []
+        try:
+            for valve_name, encoder_name in gates:
+                valve = self._pipeline.get_by_name(valve_name)
+                if valve is None:
+                    raise RuntimeError(f"missing dataset valve {valve_name!r}")
+                # A common-frame open is valid only from the known closed state.
+                # Closing here also makes repeated/partially failed requests
+                # deterministic instead of leaking an already-open frame.
+                valve.set_property("drop", True)
+                pad = valve.get_static_pad("sink")
+                if pad is None:
+                    raise RuntimeError(f"missing dataset valve pad {valve_name!r}")
+                opened = threading.Event()
+                cancelled = threading.Event()
+                transition_lock = threading.Lock()
+                status: dict[str, str | None] = {"error": None}
+                label = encoder_name or valve_name
+
+                def open_at_common_exposure(
+                    _pad: Any,
+                    info: Any,
+                    *,
+                    branch_valve: Any = valve,
+                    branch_opened: threading.Event = opened,
+                    branch_cancelled: threading.Event = cancelled,
+                    branch_lock: threading.Lock = transition_lock,
+                    branch_status: dict[str, str | None] = status,
+                    branch_label: str = label,
+                    threshold_pts: int = target_pts,
+                ) -> Any:
+                    buf = info.get_buffer()
+                    if buf is None:
+                        return self._gst.PadProbeReturn.OK
+                    if buf.pts == self._gst.CLOCK_TIME_NONE:
+                        with branch_lock:
+                            if not branch_cancelled.is_set():
+                                branch_status["error"] = (
+                                    f"dataset source {branch_label!r} has no exposure PTS"
+                                )
+                                branch_opened.set()
+                        return self._gst.PadProbeReturn.REMOVE
+                    if int(buf.pts) < threshold_pts:
+                        return self._gst.PadProbeReturn.OK
+                    with branch_lock:
+                        if branch_cancelled.is_set():
+                            return self._gst.PadProbeReturn.REMOVE
+                        # This is a sink-pad probe: changing ``drop`` before the
+                        # valve handles the current buffer admits this exposure,
+                        # not merely the following one.
+                        branch_valve.set_property("drop", False)
+                        branch_opened.set()
+                    return self._gst.PadProbeReturn.REMOVE
+
+                probe_id = pad.add_probe(
+                    self._gst.PadProbeType.BUFFER, open_at_common_exposure
+                )
+                if not probe_id:
+                    raise RuntimeError(
+                        f"could not install dataset enable probe on {valve_name!r}"
+                    )
+                armed.append(
+                    (
+                        pad,
+                        probe_id,
+                        opened,
+                        cancelled,
+                        transition_lock,
+                        status,
+                        valve,
+                        label,
+                    )
+                )
+        except Exception:
+            self._dataset_enable = armed
+            self._abort_dataset_enable(gates)
+            raise
+        self._dataset_enable = armed
+
+    def _finish_dataset_enable(self, deadline: float) -> None:
+        """Wait for all common-frame probes, failing the whole camera closed."""
+        # Keep the list published while waiting so a concurrent abort/disconnect
+        # can mark every transition cancelled and close its valve. Swapping it
+        # out here would let a later streaming callback reopen after fail-close.
+        pending = self._dataset_enable
+        failures: list[str] = []
+        for (
+            _pad,
+            _probe_id,
+            opened,
+            cancelled,
+            _lock,
+            status,
+            _valve,
+            label,
+        ) in pending:
+            remaining = max(0.0, deadline - time.perf_counter())
+            if not opened.wait(remaining) and not opened.is_set():
+                failures.append(f"{label}: timed out waiting for exposure boundary")
+                continue
+            error = status["error"]
+            if error is not None:
+                failures.append(error)
+            elif cancelled.is_set():
+                failures.append(f"{label}: exposure-boundary opening was cancelled")
+        if failures:
+            # Cancel only if this is still the transaction we waited on. A
+            # concurrent abort already closed it; a later begin owns a new list
+            # which this failed waiter must not touch.
+            if self._dataset_enable is pending:
+                self._cancel_dataset_enable()
+            raise RuntimeError("; ".join(failures))
+        if self._dataset_enable is pending:
+            self._dataset_enable = []
 
     def _begin_dataset_disable(self, gates: tuple[tuple[str, str | None], ...]) -> None:
         """Arm every encoded branch to stop one frame before its next IDR.
@@ -578,6 +775,7 @@ class _GstPipelineBase:
         that GOP, and close after its final P-frame. Every encoder is therefore
         poised to emit an IDR on the first frame after the valve next opens.
         """
+        self._cancel_dataset_enable()
         self._cancel_dataset_disable()
         if self._pipeline is None:
             return
@@ -874,6 +1072,7 @@ class _GstPipelineBase:
 
     def disconnect(self) -> None:
         self._stop.set()
+        self._cancel_dataset_enable()
         self._cancel_dataset_disable()
         for thread in self._threads:
             thread.join(timeout=2.0)
@@ -1018,6 +1217,18 @@ class ZedGstCamera(_GstPipelineBase, _GstStreamConsumer):
         """Complete a close previously armed by :meth:`begin_raw_disable`."""
         self._finish_dataset_disable(deadline)
 
+    def begin_raw_enable(self, target_perf_s: float) -> None:
+        """Arm this camera to open on a shared future exposure boundary."""
+        self._begin_dataset_enable(self._raw_gates(), target_perf_s)
+
+    def finish_raw_enable(self, deadline: float) -> None:
+        """Wait for a common-boundary open armed by :meth:`begin_raw_enable`."""
+        self._finish_dataset_enable(deadline)
+
+    def abort_raw_enable(self) -> None:
+        """Cancel an opening transaction and immediately close every branch."""
+        self._abort_dataset_enable(self._raw_gates())
+
     def set_raw_enabled(self, enabled: bool) -> None:
         """Open or close the dataset branch at runtime (no pipeline reconfig).
 
@@ -1031,7 +1242,9 @@ class ZedGstCamera(_GstPipelineBase, _GstStreamConsumer):
         if not self._want_raw or self._pipeline is None:
             return
         if enabled:
-            self._enable_dataset_valves(self._raw_gates())
+            target = time.perf_counter() + _DATASET_ENABLE_LEAD_S
+            self.begin_raw_enable(target)
+            self.finish_raw_enable(target + _DATASET_GATE_TIMEOUT_S)
             return
         self.begin_raw_disable()
         self.finish_raw_disable(time.perf_counter() + _DATASET_GATE_TIMEOUT_S)
@@ -1386,6 +1599,18 @@ class ZedGstStereoCamera(_GstPipelineBase):
         """Complete a close previously armed by :meth:`begin_raw_disable`."""
         self._finish_dataset_disable(deadline)
 
+    def begin_raw_enable(self, target_perf_s: float) -> None:
+        """Arm both eyes to open on a shared future exposure boundary."""
+        self._begin_dataset_enable(self._raw_gates(), target_perf_s)
+
+    def finish_raw_enable(self, deadline: float) -> None:
+        """Wait for a common-boundary open armed by :meth:`begin_raw_enable`."""
+        self._finish_dataset_enable(deadline)
+
+    def abort_raw_enable(self) -> None:
+        """Cancel an opening transaction and immediately close every eye."""
+        self._abort_dataset_enable(self._raw_gates())
+
     def set_raw_enabled(self, enabled: bool) -> None:
         """Open or close both eyes' dataset branches at runtime.
 
@@ -1396,7 +1621,9 @@ class ZedGstStereoCamera(_GstPipelineBase):
         if not self._want_raw or self._pipeline is None:
             return
         if enabled:
-            self._enable_dataset_valves(self._raw_gates())
+            target = time.perf_counter() + _DATASET_ENABLE_LEAD_S
+            self.begin_raw_enable(target)
+            self.finish_raw_enable(target + _DATASET_GATE_TIMEOUT_S)
             return
         self.begin_raw_disable()
         self.finish_raw_disable(time.perf_counter() + _DATASET_GATE_TIMEOUT_S)

--- a/almond_axol/video/gst_zed.py
+++ b/almond_axol/video/gst_zed.py
@@ -424,6 +424,13 @@ def _raw_shmsink(socket_path: str) -> str:
 # encoder immediately before a periodic IDR, so reopening emits that IDR as row
 # zero; the reader verifies this and defensively drops any leading P-frames.
 _DATASET_IDR_INTERVAL_S = 0.25
+# Before the recorder connects, a tiny leaky output queue is intentional: it
+# keeps NVENC returning its NVMM surfaces while shmsink parks GDP's one-shot
+# header. Once an episode opens, two seconds of bounded compressed-AU headroom
+# absorbs scheduler jitter without making predictive H.264 silently lossy.
+_DATASET_STARTUP_QUEUE_BUFFERS = 2
+_DATASET_ACTIVE_QUEUE_MIN_BUFFERS = 60
+_DATASET_ACTIVE_QUEUE_SECONDS = 2
 # Opening every camera with a sequence of host-side property writes can straddle
 # multiple source frames. Arm a timestamp probe on every branch first, then let
 # each one open itself on its first exposure at/after one shared future instant.
@@ -502,8 +509,11 @@ def _dataset_enc_shmsink(
         f"bitrate={target} peak-bitrate={peak} preset-level=1 "
         f"insert-sps-pps=true insert-aud=true idrinterval={idr} maxperf-enable=true "
         "! video/x-h264,stream-format=byte-stream,alignment=au "
-        f"! {_QUEUE} ! gdppay "
-        f"! shmsink socket-path={socket_path} wait-for-connection=true "
+        f"! queue name={name}_outq leaky=downstream "
+        f"max-size-buffers={_DATASET_STARTUP_QUEUE_BUFFERS} "
+        "max-size-bytes=0 max-size-time=0 ! gdppay "
+        f"! shmsink name={name}_shmsink socket-path={socket_path} "
+        "wait-for-connection=true "
         "sync=false async=false"
     )
 
@@ -571,6 +581,7 @@ class _GstPipelineBase:
                 str,
             ]
         ] = []
+        self._dataset_enabled = False
 
     def _cancel_dataset_disable(self) -> None:
         """Remove any outstanding natural-IDR probes (best effort)."""
@@ -606,12 +617,52 @@ class _GstPipelineBase:
     def _abort_dataset_enable(self, gates: tuple[tuple[str, str | None], ...]) -> None:
         """Fail a multi-camera open closed, including branches already opened."""
         self._cancel_dataset_enable()
+        self._dataset_enabled = False
         if self._pipeline is None:
             return
         for valve_name, _encoder_name in gates:
             valve = self._pipeline.get_by_name(valve_name)
             if valve is not None:
                 valve.set_property("drop", True)
+        self._set_dataset_output_queue_depth(gates, active=False)
+
+    def _set_dataset_output_queue_depth(
+        self,
+        gates: tuple[tuple[str, str | None], ...],
+        *,
+        active: bool,
+    ) -> None:
+        """Select bounded startup or active-episode H.264 queue headroom.
+
+        Startup must remain aggressively leaky because GDP's header is parked
+        at ``shmsink wait-for-connection=true`` before the recorder exists.
+        During an episode the reader is connected and flushed, so retain two
+        seconds of compressed AUs before failing with DISCONT. Keeping the
+        queue bounded and leaky still isolates camera capture/NVENC if the
+        recorder process dies outright.
+        """
+        if self._pipeline is None:
+            return
+        dataset_fps = max(1, int(getattr(self, "dataset_fps", 1)))
+        active_buffers = max(
+            _DATASET_ACTIVE_QUEUE_MIN_BUFFERS,
+            _DATASET_ACTIVE_QUEUE_SECONDS * dataset_fps,
+        )
+        depth = active_buffers if active else _DATASET_STARTUP_QUEUE_BUFFERS
+        for _valve_name, encoder_name in gates:
+            if encoder_name is None:
+                continue
+            output_queue = self._pipeline.get_by_name(f"{encoder_name}_outq")
+            if output_queue is None:
+                raise RuntimeError(
+                    f"missing dataset encoder output queue {encoder_name}_outq"
+                )
+            output_queue.set_property("leaky", 2)  # downstream
+            output_queue.set_property("max-size-buffers", depth)
+            # Explicitly disable the queue defaults (10 MB / 1 s); otherwise
+            # either can undercut the intended frame-count bound.
+            output_queue.set_property("max-size-bytes", 0)
+            output_queue.set_property("max-size-time", 0)
 
     def _begin_dataset_enable(
         self,
@@ -628,6 +679,11 @@ class _GstPipelineBase:
         calibrated PTS offset.
         """
         self._cancel_dataset_disable()
+        if self._dataset_enabled:
+            # Relay commands are idempotent. Re-arming an already-open branch
+            # would close it until the next future boundary, dropping H.264 AUs
+            # from the live episode for no semantic state change.
+            return
         self._cancel_dataset_enable()
         if self._pipeline is None:
             return
@@ -654,6 +710,7 @@ class _GstPipelineBase:
             ]
         ] = []
         try:
+            self._set_dataset_output_queue_depth(gates, active=True)
             for valve_name, encoder_name in gates:
                 valve = self._pipeline.get_by_name(valve_name)
                 if valve is None:
@@ -766,6 +823,7 @@ class _GstPipelineBase:
             raise RuntimeError("; ".join(failures))
         if self._dataset_enable is pending:
             self._dataset_enable = []
+        self._dataset_enabled = True
 
     def _begin_dataset_disable(self, gates: tuple[tuple[str, str | None], ...]) -> None:
         """Arm every encoded branch to stop one frame before its next IDR.
@@ -851,10 +909,12 @@ class _GstPipelineBase:
         except Exception:
             self._dataset_disable = armed
             self._cancel_dataset_disable()
+            self._dataset_enabled = False
             for valve_name, _encoder_name in gates:
                 valve = self._pipeline.get_by_name(valve_name)
                 if valve is not None:
                     valve.set_property("drop", True)
+            self._set_dataset_output_queue_depth(gates, active=False)
             raise
         self._dataset_disable = armed
 
@@ -876,10 +936,12 @@ class _GstPipelineBase:
                 valve.set_property("drop", True)
                 timed_out.append(label)
         if timed_out:
+            self._dataset_enabled = False
             raise RuntimeError(
                 "timed out aligning dataset encoder before IDR on "
                 + ", ".join(timed_out)
             )
+        self._dataset_enabled = False
 
     @property
     def alive(self) -> bool:
@@ -1073,6 +1135,7 @@ class _GstPipelineBase:
     def disconnect(self) -> None:
         self._stop.set()
         self._cancel_dataset_enable()
+        self._dataset_enabled = False
         self._cancel_dataset_disable()
         for thread in self._threads:
             thread.join(timeout=2.0)
@@ -1215,7 +1278,10 @@ class ZedGstCamera(_GstPipelineBase, _GstStreamConsumer):
 
     def finish_raw_disable(self, deadline: float) -> None:
         """Complete a close previously armed by :meth:`begin_raw_disable`."""
-        self._finish_dataset_disable(deadline)
+        try:
+            self._finish_dataset_disable(deadline)
+        finally:
+            self._set_dataset_output_queue_depth(self._raw_gates(), active=False)
 
     def begin_raw_enable(self, target_perf_s: float) -> None:
         """Arm this camera to open on a shared future exposure boundary."""
@@ -1597,7 +1663,10 @@ class ZedGstStereoCamera(_GstPipelineBase):
 
     def finish_raw_disable(self, deadline: float) -> None:
         """Complete a close previously armed by :meth:`begin_raw_disable`."""
-        self._finish_dataset_disable(deadline)
+        try:
+            self._finish_dataset_disable(deadline)
+        finally:
+            self._set_dataset_output_queue_depth(self._raw_gates(), active=False)
 
     def begin_raw_enable(self, target_perf_s: float) -> None:
         """Arm both eyes to open on a shared future exposure boundary."""

--- a/almond_axol/video/video_proc.py
+++ b/almond_axol/video/video_proc.py
@@ -86,6 +86,100 @@ def _open_sdk_camera(name: str, spec: dict) -> object | None:
     return None
 
 
+def _set_dataset_branches_enabled(owned: list[object], enabled: bool) -> None:
+    """Gate every dataset branch as one fail-closed camera transaction.
+
+    Opening uses one future ``perf_counter`` instant for every physical camera.
+    Each gst camera installs all of its valve probes before any caller waits, so
+    the first admitted exposure is selected by sensor PTS instead of by a series
+    of host-side property writes which can straddle multiple 60 Hz frames.
+    """
+    if enabled:
+        from .gst_zed import _DATASET_ENABLE_LEAD_S, _DATASET_GATE_TIMEOUT_S
+
+        target = time.perf_counter() + _DATASET_ENABLE_LEAD_S
+        armed: list[object] = []
+        legacy: list[object] = []
+        errors: list[str] = []
+        for cam in owned:
+            if hasattr(cam, "begin_raw_enable") and hasattr(cam, "finish_raw_enable"):
+                try:
+                    cam.begin_raw_enable(target)
+                    armed.append(cam)
+                except Exception as exc:  # noqa: BLE001 - fail all branches below
+                    errors.append(f"{cam}: {exc}")
+            elif hasattr(cam, "set_raw_enabled"):
+                legacy.append(cam)
+
+        if not errors and armed and time.perf_counter() >= target:
+            errors.append(
+                "missed the shared dataset exposure boundary while arming cameras"
+            )
+
+        # A begin failure means the common barrier was not installed everywhere;
+        # do not admit frames on the cameras which did arm successfully.
+        if not errors:
+            for cam in legacy:
+                try:
+                    cam.set_raw_enabled(True)
+                except Exception as exc:  # noqa: BLE001 - fail all branches below
+                    errors.append(f"{cam}: {exc}")
+
+        if not errors:
+            deadline = target + _DATASET_GATE_TIMEOUT_S
+            for cam in armed:
+                try:
+                    cam.finish_raw_enable(deadline)
+                except Exception as exc:  # noqa: BLE001 - collect every failure
+                    errors.append(f"{cam}: {exc}")
+
+        if errors:
+            # Some peers may already have crossed the timestamp boundary. Abort
+            # all cameras, including completed ones whose local pending list is
+            # now empty, so the relay never acknowledges a partially open set.
+            close_errors: list[str] = []
+            for cam in owned:
+                try:
+                    if hasattr(cam, "abort_raw_enable"):
+                        cam.abort_raw_enable()
+                    elif hasattr(cam, "set_raw_enabled"):
+                        cam.set_raw_enabled(False)
+                except Exception as exc:  # noqa: BLE001 - report original too
+                    close_errors.append(f"{cam}: fail-close failed: {exc}")
+            raise RuntimeError("; ".join([*errors, *close_errors]))
+        return
+
+    # Two phases are intentional: install the IDR probes on every physical
+    # camera before waiting on any one of them. Sequential arm+wait would stop
+    # cameras at different GOP phases and their episode-opening IDRs could be
+    # hundreds of milliseconds apart.
+    armed = []
+    errors = []
+    for cam in owned:
+        if hasattr(cam, "begin_raw_disable") and hasattr(cam, "finish_raw_disable"):
+            try:
+                cam.begin_raw_disable()
+                armed.append(cam)
+            except Exception as exc:  # noqa: BLE001 - finish other cameras
+                errors.append(f"{cam}: {exc}")
+        elif hasattr(cam, "set_raw_enabled"):
+            try:
+                cam.set_raw_enabled(False)
+            except Exception as exc:  # noqa: BLE001 - finish other cameras
+                errors.append(f"{cam}: {exc}")
+    # Matches gst_zed's gate bound. At the supported 1 fps minimum a valid next
+    # encoder output can arrive almost exactly one second later, so a 1.0 s
+    # deadline spuriously fails under any scheduling load.
+    deadline = time.perf_counter() + 2.0
+    for cam in armed:
+        try:
+            cam.finish_raw_disable(deadline)
+        except Exception as exc:  # noqa: BLE001 - collect every failure
+            errors.append(f"{cam}: {exc}")
+    if errors:
+        raise RuntimeError("; ".join(errors))
+
+
 def _gsth264_meta(
     socket_path: str,
     width: int,
@@ -612,48 +706,7 @@ def _relay_main(
 
     def _set_raw_enabled(enabled: bool) -> None:
         """Gate every dataset branch, coordinating encoded GOP phase."""
-        if enabled:
-            errors: list[str] = []
-            for cam in owned:
-                if not hasattr(cam, "set_raw_enabled"):
-                    continue
-                try:
-                    cam.set_raw_enabled(True)
-                except Exception as exc:  # noqa: BLE001 - report all branches
-                    errors.append(f"{cam}: {exc}")
-            if errors:
-                raise RuntimeError("; ".join(errors))
-            return
-
-        # Two phases are intentional: install the IDR probes on every physical
-        # camera before waiting on any one of them. Sequential arm+wait would
-        # stop cameras at different GOP phases and their episode-opening IDRs
-        # could be hundreds of milliseconds apart.
-        armed: list[object] = []
-        errors = []
-        for cam in owned:
-            if hasattr(cam, "begin_raw_disable") and hasattr(cam, "finish_raw_disable"):
-                try:
-                    cam.begin_raw_disable()
-                    armed.append(cam)
-                except Exception as exc:  # noqa: BLE001 - finish other cameras
-                    errors.append(f"{cam}: {exc}")
-            elif hasattr(cam, "set_raw_enabled"):
-                try:
-                    cam.set_raw_enabled(False)
-                except Exception as exc:  # noqa: BLE001 - finish other cameras
-                    errors.append(f"{cam}: {exc}")
-        # Matches gst_zed's gate bound. At the supported 1 fps minimum a valid
-        # next encoder output can arrive almost exactly one second later, so a
-        # 1.0 s deadline spuriously fails under any scheduling load.
-        deadline = time.perf_counter() + 2.0
-        for cam in armed:
-            try:
-                cam.finish_raw_disable(deadline)
-            except Exception as exc:  # noqa: BLE001 - collect every failure
-                errors.append(f"{cam}: {exc}")
-        if errors:
-            raise RuntimeError("; ".join(errors))
+        _set_dataset_branches_enabled(owned, bool(enabled))
 
     async def serve() -> None:
         loop = asyncio.get_running_loop()

--- a/tests/test_control_loop.py
+++ b/tests/test_control_loop.py
@@ -1,0 +1,415 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+import unittest
+from unittest.mock import patch
+
+from almond_axol.utils.control_loop import (
+    run_blocking_with_control_ticks,
+    run_blocking_with_sync_control_ticks,
+)
+
+
+class RunBlockingWithControlTicksTest(unittest.IsolatedAsyncioTestCase):
+    async def test_ticks_continue_until_blocking_operation_returns(self) -> None:
+        release = threading.Event()
+        ticks = 0
+
+        def operation() -> int:
+            if not release.wait(1.0):
+                raise TimeoutError("test did not release operation")
+            return 42
+
+        async def tick() -> None:
+            nonlocal ticks
+            ticks += 1
+            if ticks == 3:
+                release.set()
+
+        result = await run_blocking_with_control_ticks(operation, tick, 0.001)
+
+        self.assertEqual(result, 42)
+        self.assertGreaterEqual(ticks, 3)
+
+    async def test_operation_exception_propagates_after_ticks(self) -> None:
+        release = threading.Event()
+        ticks = 0
+
+        def operation() -> None:
+            if not release.wait(1.0):
+                raise TimeoutError("test did not release operation")
+            raise RuntimeError("recorder failed")
+
+        async def tick() -> None:
+            nonlocal ticks
+            ticks += 1
+            if ticks == 2:
+                release.set()
+
+        with self.assertRaisesRegex(RuntimeError, "recorder failed"):
+            await run_blocking_with_control_ticks(operation, tick, 0.001)
+
+        self.assertGreaterEqual(ticks, 2)
+
+    async def test_cancellation_drains_worker_while_ticks_continue(self) -> None:
+        release = threading.Event()
+        operation_done = threading.Event()
+        first_tick = asyncio.Event()
+        finish_first_tick = asyncio.Event()
+        ticks = 0
+
+        def operation() -> None:
+            try:
+                if not release.wait(1.0):
+                    raise TimeoutError("test did not release operation")
+            finally:
+                operation_done.set()
+
+        async def tick() -> None:
+            nonlocal ticks
+            ticks += 1
+            if ticks == 1:
+                first_tick.set()
+                await finish_first_tick.wait()
+            elif ticks == 3:
+                release.set()
+
+        task = asyncio.create_task(
+            run_blocking_with_control_ticks(operation, tick, 0.001)
+        )
+        await asyncio.wait_for(first_tick.wait(), 1.0)
+        task.cancel()
+        finish_first_tick.set()
+
+        with self.assertRaises(asyncio.CancelledError):
+            await asyncio.wait_for(task, 1.0)
+
+        self.assertTrue(operation_done.is_set())
+        self.assertGreaterEqual(ticks, 3)
+
+    async def test_slow_tick_does_not_create_catch_up_burst(self) -> None:
+        release = threading.Event()
+        starts: list[float] = []
+        loop = asyncio.get_running_loop()
+        period_s = 0.02
+
+        def operation() -> None:
+            if not release.wait(1.0):
+                raise TimeoutError("test did not release operation")
+
+        async def tick() -> None:
+            starts.append(loop.time())
+            if len(starts) == 1:
+                await asyncio.sleep(3 * period_s)
+            elif len(starts) == 4:
+                release.set()
+
+        await run_blocking_with_control_ticks(operation, tick, period_s)
+
+        self.assertGreaterEqual(len(starts), 4)
+        self.assertGreaterEqual(starts[1] - starts[0], 3 * period_s * 0.8)
+        # An absolute-deadline loop would run ticks 2-4 back-to-back to repay
+        # the first tick's delay. Relative pacing leaves each later gap intact.
+        self.assertGreaterEqual(starts[2] - starts[1], period_s * 0.8)
+        self.assertGreaterEqual(starts[3] - starts[2], period_s * 0.8)
+
+    async def test_driver_cancelled_error_does_not_spin_forever(self) -> None:
+        ticks = 0
+
+        def operation() -> None:
+            raise asyncio.CancelledError
+
+        async def tick() -> None:
+            nonlocal ticks
+            ticks += 1
+
+        with self.assertRaises(asyncio.CancelledError):
+            await asyncio.wait_for(
+                run_blocking_with_control_ticks(operation, tick, 0.001),
+                timeout=1.0,
+            )
+
+        self.assertGreaterEqual(ticks, 1)
+
+    async def test_tick_cancelled_error_does_not_spin_forever(self) -> None:
+        release = threading.Event()
+
+        def operation() -> None:
+            if not release.wait(1.0):
+                raise TimeoutError("test did not release operation")
+
+        async def tick() -> None:
+            release.set()
+            raise asyncio.CancelledError
+
+        with self.assertRaises(asyncio.CancelledError):
+            await asyncio.wait_for(
+                run_blocking_with_control_ticks(operation, tick, 0.001),
+                timeout=1.0,
+            )
+
+    async def test_tick_error_uses_drain_tick_until_worker_finishes(self) -> None:
+        release = threading.Event()
+        drain_ticks = 0
+
+        def operation() -> None:
+            if not release.wait(1.0):
+                raise TimeoutError("test did not release operation")
+
+        async def tick() -> None:
+            raise RuntimeError("tracking contact")
+
+        async def drain_tick() -> None:
+            nonlocal drain_ticks
+            drain_ticks += 1
+            if drain_ticks == 3:
+                release.set()
+
+        with self.assertRaisesRegex(RuntimeError, "tracking contact"):
+            await run_blocking_with_control_ticks(
+                operation,
+                tick,
+                0.001,
+                drain_tick=drain_tick,
+            )
+
+        self.assertGreaterEqual(drain_ticks, 3)
+
+    async def test_drain_tick_error_still_drains_worker(self) -> None:
+        release = threading.Event()
+        operation_done = threading.Event()
+
+        def operation() -> None:
+            try:
+                if not release.wait(1.0):
+                    raise TimeoutError("test did not release operation")
+            finally:
+                operation_done.set()
+
+        async def tick() -> None:
+            raise RuntimeError("tracking contact")
+
+        async def drain_tick() -> None:
+            release.set()
+            raise OSError("hold failed")
+
+        with self.assertRaisesRegex(RuntimeError, "tracking contact") as raised:
+            await run_blocking_with_control_ticks(
+                operation,
+                tick,
+                0.001,
+                drain_tick=drain_tick,
+            )
+
+        self.assertTrue(operation_done.is_set())
+        self.assertTrue(
+            any("hold failed" in note for note in raised.exception.__notes__)
+        )
+
+
+class RunBlockingWithSyncControlTicksTest(unittest.TestCase):
+    def test_interrupt_from_loop_condition_is_drained(self) -> None:
+        release = threading.Event()
+        operation_done = threading.Event()
+        ticks = 0
+        real_event = threading.Event
+
+        class InterruptOnceEvent:
+            def __init__(self) -> None:
+                self._event = real_event()
+                self._interrupted = False
+
+            def is_set(self) -> bool:
+                if not self._interrupted:
+                    self._interrupted = True
+                    raise KeyboardInterrupt
+                return self._event.is_set()
+
+            def set(self) -> None:
+                self._event.set()
+
+            def wait(self, timeout: float | None = None) -> bool:
+                return self._event.wait(timeout)
+
+        events = 0
+
+        def make_event():
+            nonlocal events
+            events += 1
+            return InterruptOnceEvent() if events == 1 else real_event()
+
+        def operation() -> None:
+            try:
+                if not release.wait(1.0):
+                    raise TimeoutError("test did not release operation")
+            finally:
+                operation_done.set()
+
+        def tick() -> None:
+            nonlocal ticks
+            ticks += 1
+            if ticks == 3:
+                release.set()
+
+        with (
+            patch("almond_axol.utils.control_loop.threading.Event", make_event),
+            self.assertRaises(KeyboardInterrupt),
+        ):
+            run_blocking_with_sync_control_ticks(operation, tick, 0.001)
+
+        self.assertTrue(operation_done.is_set())
+        self.assertGreaterEqual(ticks, 3)
+
+    def test_interrupt_delivered_after_worker_start_is_drained(self) -> None:
+        release = threading.Event()
+        operation_done = threading.Event()
+        ticks = 0
+
+        def operation() -> None:
+            try:
+                if not release.wait(1.0):
+                    raise TimeoutError("test did not release operation")
+            finally:
+                operation_done.set()
+
+        def tick() -> None:
+            nonlocal ticks
+            ticks += 1
+            if ticks == 3:
+                release.set()
+
+        # Model SIGINT becoming pending while Thread.start() is protected and
+        # being delivered as soon as the main thread restores its old mask.
+        with (
+            patch(
+                "almond_axol.utils.control_loop.signal.pthread_sigmask",
+                side_effect=(set(), KeyboardInterrupt()),
+            ),
+            self.assertRaises(KeyboardInterrupt),
+        ):
+            run_blocking_with_sync_control_ticks(operation, tick, 0.001)
+
+        self.assertTrue(operation_done.is_set())
+        self.assertGreaterEqual(ticks, 3)
+
+    def test_ticks_continue_until_blocking_operation_returns(self) -> None:
+        release = threading.Event()
+        ticks = 0
+
+        def operation() -> int:
+            if not release.wait(1.0):
+                raise TimeoutError("test did not release operation")
+            return 42
+
+        def tick() -> None:
+            nonlocal ticks
+            ticks += 1
+            if ticks == 3:
+                release.set()
+
+        result = run_blocking_with_sync_control_ticks(operation, tick, 0.001)
+
+        self.assertEqual(result, 42)
+        self.assertGreaterEqual(ticks, 3)
+
+    def test_operation_exception_propagates_after_ticks(self) -> None:
+        release = threading.Event()
+        ticks = 0
+
+        def operation() -> None:
+            if not release.wait(1.0):
+                raise TimeoutError("test did not release operation")
+            raise RuntimeError("recorder failed")
+
+        def tick() -> None:
+            nonlocal ticks
+            ticks += 1
+            if ticks == 2:
+                release.set()
+
+        with self.assertRaisesRegex(RuntimeError, "recorder failed"):
+            run_blocking_with_sync_control_ticks(operation, tick, 0.001)
+
+        self.assertGreaterEqual(ticks, 2)
+
+    def test_tick_error_uses_drain_tick_until_worker_finishes(self) -> None:
+        release = threading.Event()
+        drain_ticks = 0
+
+        def operation() -> None:
+            if not release.wait(1.0):
+                raise TimeoutError("test did not release operation")
+
+        def tick() -> None:
+            raise RuntimeError("command failed")
+
+        def drain_tick() -> None:
+            nonlocal drain_ticks
+            drain_ticks += 1
+            if drain_ticks == 3:
+                release.set()
+
+        with self.assertRaisesRegex(RuntimeError, "command failed"):
+            run_blocking_with_sync_control_ticks(
+                operation,
+                tick,
+                0.001,
+                drain_tick=drain_tick,
+            )
+
+        self.assertGreaterEqual(drain_ticks, 3)
+
+    def test_keyboard_interrupt_is_delayed_while_ticks_continue(self) -> None:
+        release = threading.Event()
+        operation_done = threading.Event()
+        ticks = 0
+
+        def operation() -> None:
+            try:
+                if not release.wait(1.0):
+                    raise TimeoutError("test did not release operation")
+            finally:
+                operation_done.set()
+
+        def tick() -> None:
+            nonlocal ticks
+            ticks += 1
+            if ticks == 1:
+                raise KeyboardInterrupt
+            if ticks == 3:
+                release.set()
+
+        with self.assertRaises(KeyboardInterrupt):
+            run_blocking_with_sync_control_ticks(operation, tick, 0.001)
+
+        self.assertTrue(operation_done.is_set())
+        self.assertGreaterEqual(ticks, 3)
+
+    def test_slow_tick_does_not_create_catch_up_burst(self) -> None:
+        release = threading.Event()
+        starts: list[float] = []
+        period_s = 0.02
+
+        def operation() -> None:
+            if not release.wait(1.0):
+                raise TimeoutError("test did not release operation")
+
+        def tick() -> None:
+            starts.append(time.perf_counter())
+            if len(starts) == 1:
+                time.sleep(3 * period_s)
+            elif len(starts) == 4:
+                release.set()
+
+        run_blocking_with_sync_control_ticks(operation, tick, period_s)
+
+        self.assertGreaterEqual(len(starts), 4)
+        self.assertGreaterEqual(starts[1] - starts[0], 3 * period_s * 0.8)
+        self.assertGreaterEqual(starts[2] - starts[1], period_s * 0.8)
+        self.assertGreaterEqual(starts[3] - starts[2], period_s * 0.8)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_dagger_control_cleanup.py
+++ b/tests/test_dagger_control_cleanup.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import threading
+import unittest
+
+from almond_axol.cli.collect_dagger import _stop_dagger_control_thread
+
+
+class _BlockingControlThread(threading.Thread):
+    def __init__(self) -> None:
+        super().__init__(daemon=True)
+        self.shutdown_event = threading.Event()
+        self.stopped = threading.Event()
+
+    def run(self) -> None:
+        self.shutdown_event.wait(1.0)
+        self.stopped.set()
+
+
+class DaggerControlCleanupTest(unittest.TestCase):
+    def test_outer_cleanup_signals_and_joins_started_control_thread(self) -> None:
+        control_thread = _BlockingControlThread()
+        control_thread.start()
+
+        stopped = _stop_dagger_control_thread(control_thread, timeout_s=1.0)
+
+        self.assertTrue(stopped)
+        self.assertTrue(control_thread.shutdown_event.is_set())
+        self.assertTrue(control_thread.stopped.is_set())
+        self.assertFalse(control_thread.is_alive())
+
+    def test_cleanup_accepts_thread_that_was_constructed_but_not_started(
+        self,
+    ) -> None:
+        control_thread = _BlockingControlThread()
+
+        stopped = _stop_dagger_control_thread(control_thread, timeout_s=0.0)
+
+        self.assertTrue(stopped)
+        self.assertTrue(control_thread.shutdown_event.is_set())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gst_dataset_transport.py
+++ b/tests/test_gst_dataset_transport.py
@@ -7,17 +7,11 @@ import unittest
 from unittest.mock import patch
 
 from almond_axol.video.gst_zed import (
-    _GstPipelineBase,
     ZedGstCamera,
     ZedGstStereoCamera,
+    _GstPipelineBase,
 )
 from almond_axol.video.video_proc import _set_dataset_branches_enabled
-
-
-_H264_OUTPUT = (
-    "video/x-h264,stream-format=byte-stream,alignment=au ! "
-    "queue leaky=downstream max-size-buffers=2 ! gdppay ! shmsink"
-)
 
 
 class _FakeGst:
@@ -67,6 +61,22 @@ class _FakeValve:
         return self.sink if name == "sink" else None
 
 
+class _FakeQueue:
+    def __init__(self) -> None:
+        self.properties = {
+            "leaky": 2,
+            "max-size-buffers": 2,
+            "max-size-bytes": 0,
+            "max-size-time": 0,
+        }
+
+    def set_property(self, name: str, value: int) -> None:
+        self.properties[name] = int(value)
+
+    def get_property(self, name: str) -> int:
+        return self.properties[name]
+
+
 class _FakePipeline:
     def __init__(self, elements: dict[str, object]) -> None:
         self._elements = elements
@@ -80,10 +90,16 @@ def _fake_gate_base(
 ) -> tuple[_GstPipelineBase, dict[str, _FakeValve]]:
     gst = _FakeGst()
     valves = {name: _FakeValve(gst) for name in valve_names}
+    queues = {
+        ("dsenc" if name == "rawvalve" else f"dsenc_{name.rsplit('_', 1)[1]}")
+        + "_outq": _FakeQueue()
+        for name in valve_names
+    }
     base = _GstPipelineBase()
     base._gst = gst
-    base._pipeline = _FakePipeline(valves)
+    base._pipeline = _FakePipeline({**valves, **queues})
     base._pts_perf_offset_s = offset_s
+    base.dataset_fps = 30
     return base, valves
 
 
@@ -115,12 +131,20 @@ class GstDatasetTransportTest(unittest.TestCase):
         self, pipeline: str, valve_name: str, encoder_name: str, socket_path: str
     ) -> None:
         start = pipeline.index(f"valve name={valve_name} drop=false")
-        sink = f"shmsink socket-path={socket_path} wait-for-connection=true"
+        sink = (
+            f"shmsink name={encoder_name}_shmsink socket-path={socket_path} "
+            "wait-for-connection=true"
+        )
         end = pipeline.index(sink, start) + len(sink)
         branch = pipeline[start:end]
 
         self.assertIn(f"name={encoder_name}", branch)
-        self.assertIn(_H264_OUTPUT, branch)
+        self.assertIn(
+            "video/x-h264,stream-format=byte-stream,alignment=au ! "
+            f"queue name={encoder_name}_outq leaky=downstream "
+            "max-size-buffers=2 max-size-bytes=0 max-size-time=0 ! gdppay",
+            branch,
+        )
         self.assertIn(sink, branch)
 
     def test_mono_dataset_encoder_drains_before_recorder_connects(self) -> None:
@@ -176,6 +200,45 @@ class GstDatasetEnableBarrierTest(unittest.TestCase):
         valve.sink.push(10_000_000_000)
         self.assertFalse(valve.drop)
         base._finish_dataset_enable(0.0)
+
+    def test_active_episode_expands_bounded_predictive_queue(self) -> None:
+        base, _valves = _fake_gate_base()
+        output_queue = base._pipeline.get_by_name("dsenc_outq")
+
+        base._begin_dataset_enable((("rawvalve", "dsenc"),), 100.0)
+
+        self.assertEqual(output_queue.get_property("leaky"), 2)
+        self.assertEqual(output_queue.get_property("max-size-buffers"), 60)
+        self.assertEqual(output_queue.get_property("max-size-bytes"), 0)
+        self.assertEqual(output_queue.get_property("max-size-time"), 0)
+
+        base._abort_dataset_enable((("rawvalve", "dsenc"),))
+        self.assertEqual(output_queue.get_property("max-size-buffers"), 2)
+
+    def test_active_queue_depth_scales_with_capture_rate(self) -> None:
+        base, _valves = _fake_gate_base()
+        base.dataset_fps = 60
+        output_queue = base._pipeline.get_by_name("dsenc_outq")
+
+        base._begin_dataset_enable((("rawvalve", "dsenc"),), 100.0)
+
+        self.assertEqual(output_queue.get_property("max-size-buffers"), 120)
+
+    def test_repeated_enable_does_not_reclose_live_episode(self) -> None:
+        base, valves = _fake_gate_base(offset_s=90.0)
+        gates = (("rawvalve", "dsenc"),)
+        valve = valves["rawvalve"]
+
+        base._begin_dataset_enable(gates, 100.0)
+        valve.sink.push(10_000_000_000)
+        base._finish_dataset_enable(0.0)
+        self.assertFalse(valve.drop)
+
+        base._begin_dataset_enable(gates, 101.0)
+        base._finish_dataset_enable(0.0)
+
+        self.assertFalse(valve.drop)
+        self.assertEqual(base._dataset_enable, [])
 
     def test_failed_eye_recloses_sibling_which_already_opened(self) -> None:
         base, valves = _fake_gate_base(

--- a/tests/test_gst_dataset_transport.py
+++ b/tests/test_gst_dataset_transport.py
@@ -1,14 +1,113 @@
 from __future__ import annotations
 
+import threading
+import time
+import types
 import unittest
+from unittest.mock import patch
 
-from almond_axol.video.gst_zed import ZedGstCamera, ZedGstStereoCamera
+from almond_axol.video.gst_zed import (
+    _GstPipelineBase,
+    ZedGstCamera,
+    ZedGstStereoCamera,
+)
+from almond_axol.video.video_proc import _set_dataset_branches_enabled
 
 
 _H264_OUTPUT = (
     "video/x-h264,stream-format=byte-stream,alignment=au ! "
     "queue leaky=downstream max-size-buffers=2 ! gdppay ! shmsink"
 )
+
+
+class _FakeGst:
+    CLOCK_TIME_NONE = -1
+    PadProbeType = types.SimpleNamespace(BUFFER=1)
+    PadProbeReturn = types.SimpleNamespace(OK="ok", REMOVE="remove")
+
+
+class _FakePad:
+    def __init__(self, gst: _FakeGst) -> None:
+        self._gst = gst
+        self._next_probe = 1
+        self._probes: dict[int, object] = {}
+
+    def add_probe(self, _probe_type: int, callback: object) -> int:
+        probe_id = self._next_probe
+        self._next_probe += 1
+        self._probes[probe_id] = callback
+        return probe_id
+
+    def remove_probe(self, probe_id: int) -> None:
+        self._probes.pop(probe_id, None)
+
+    def push(self, pts: int) -> None:
+        buffer = types.SimpleNamespace(pts=pts)
+        info = types.SimpleNamespace(get_buffer=lambda: buffer)
+        for probe_id, callback in list(self._probes.items()):
+            result = callback(self, info)
+            if result == self._gst.PadProbeReturn.REMOVE:
+                self._probes.pop(probe_id, None)
+
+
+class _FakeValve:
+    def __init__(self, gst: _FakeGst) -> None:
+        self.drop = True
+        self.sink = _FakePad(gst)
+
+    def get_property(self, name: str) -> bool:
+        assert name == "drop"
+        return self.drop
+
+    def set_property(self, name: str, value: bool) -> None:
+        assert name == "drop"
+        self.drop = bool(value)
+
+    def get_static_pad(self, name: str) -> _FakePad | None:
+        return self.sink if name == "sink" else None
+
+
+class _FakePipeline:
+    def __init__(self, elements: dict[str, object]) -> None:
+        self._elements = elements
+
+    def get_by_name(self, name: str) -> object | None:
+        return self._elements.get(name)
+
+
+def _fake_gate_base(
+    *, offset_s: float = 90.0, valve_names: tuple[str, ...] = ("rawvalve",)
+) -> tuple[_GstPipelineBase, dict[str, _FakeValve]]:
+    gst = _FakeGst()
+    valves = {name: _FakeValve(gst) for name in valve_names}
+    base = _GstPipelineBase()
+    base._gst = gst
+    base._pipeline = _FakePipeline(valves)
+    base._pts_perf_offset_s = offset_s
+    return base, valves
+
+
+class _FakeCoordinatedCamera:
+    def __init__(
+        self, name: str, calls: list[tuple], *, finish_error: str | None = None
+    ) -> None:
+        self.name = name
+        self.calls = calls
+        self.finish_error = finish_error
+
+    def __repr__(self) -> str:
+        return self.name
+
+    def begin_raw_enable(self, target: float) -> None:
+        self.calls.append(("begin", self.name, target))
+
+    def finish_raw_enable(self, deadline: float) -> None:
+        self.calls.append(("finish", self.name, deadline))
+        if self.finish_error is not None:
+            raise RuntimeError(self.finish_error)
+
+    def abort_raw_enable(self) -> None:
+        self.calls.append(("abort", self.name))
 
 
 class GstDatasetTransportTest(unittest.TestCase):
@@ -63,6 +162,132 @@ class GstDatasetTransportTest(unittest.TestCase):
             camera._raw_gates(),
             (("rawvalve_l", "dsenc_l"), ("rawvalve_r", "dsenc_r")),
         )
+
+
+class GstDatasetEnableBarrierTest(unittest.TestCase):
+    def test_valve_opens_on_first_exposure_at_or_after_shared_target(self) -> None:
+        base, valves = _fake_gate_base(offset_s=90.0)
+        valve = valves["rawvalve"]
+
+        base._begin_dataset_enable((("rawvalve", "dsenc"),), 100.0)
+        valve.sink.push(9_999_999_999)
+        self.assertTrue(valve.drop)
+
+        valve.sink.push(10_000_000_000)
+        self.assertFalse(valve.drop)
+        base._finish_dataset_enable(0.0)
+
+    def test_failed_eye_recloses_sibling_which_already_opened(self) -> None:
+        base, valves = _fake_gate_base(
+            offset_s=90.0, valve_names=("rawvalve_l", "rawvalve_r")
+        )
+        gates = (("rawvalve_l", "dsenc_l"), ("rawvalve_r", "dsenc_r"))
+
+        base._begin_dataset_enable(gates, 100.0)
+        valves["rawvalve_l"].sink.push(10_000_000_000)
+        self.assertFalse(valves["rawvalve_l"].drop)
+
+        with self.assertRaisesRegex(RuntimeError, "dsenc_r.*timed out"):
+            base._finish_dataset_enable(0.0)
+        self.assertTrue(valves["rawvalve_l"].drop)
+        self.assertTrue(valves["rawvalve_r"].drop)
+
+    def test_missing_exposure_pts_fails_closed(self) -> None:
+        base, valves = _fake_gate_base()
+        valve = valves["rawvalve"]
+
+        base._begin_dataset_enable((("rawvalve", "dsenc"),), 100.0)
+        valve.sink.push(_FakeGst.CLOCK_TIME_NONE)
+
+        with self.assertRaisesRegex(RuntimeError, "dsenc.*has no exposure PTS"):
+            base._finish_dataset_enable(0.0)
+        self.assertTrue(valve.drop)
+
+    def test_abort_wakes_pending_finish_and_cannot_reopen(self) -> None:
+        base, valves = _fake_gate_base()
+        valve = valves["rawvalve"]
+        gates = (("rawvalve", "dsenc"),)
+
+        base._begin_dataset_enable(gates, 100.0)
+        opened = base._dataset_enable[0][2]
+        wait_entered = threading.Event()
+        original_wait = opened.wait
+
+        def tracked_wait(timeout: float | None = None) -> bool:
+            wait_entered.set()
+            return original_wait(timeout)
+
+        opened.wait = tracked_wait  # type: ignore[method-assign]
+        failures: list[BaseException] = []
+
+        def finish() -> None:
+            try:
+                base._finish_dataset_enable(time.perf_counter() + 1.0)
+            except BaseException as exc:
+                failures.append(exc)
+
+        waiter = threading.Thread(target=finish)
+        waiter.start()
+        self.assertTrue(wait_entered.wait(1.0))
+        base._abort_dataset_enable(gates)
+        waiter.join(1.0)
+
+        self.assertFalse(waiter.is_alive())
+        self.assertEqual(len(failures), 1)
+        self.assertRegex(str(failures[0]), "opening was cancelled")
+        valve.sink.push(10_000_000_000)
+        self.assertTrue(valve.drop)
+
+    def test_relay_arms_every_camera_with_same_target_before_waiting(self) -> None:
+        calls: list[tuple] = []
+        cameras = [
+            _FakeCoordinatedCamera("overhead", calls),
+            _FakeCoordinatedCamera("left_arm", calls),
+            _FakeCoordinatedCamera("right_arm", calls),
+        ]
+
+        with patch("almond_axol.video.video_proc.time.perf_counter", return_value=50.0):
+            _set_dataset_branches_enabled(cameras, True)
+
+        self.assertEqual([call[0] for call in calls], ["begin"] * 3 + ["finish"] * 3)
+        targets = [call[2] for call in calls if call[0] == "begin"]
+        self.assertEqual(targets, [50.1, 50.1, 50.1])
+
+    def test_relay_failure_aborts_completed_peer_cameras(self) -> None:
+        calls: list[tuple] = []
+        cameras = [
+            _FakeCoordinatedCamera("overhead", calls),
+            _FakeCoordinatedCamera("left_arm", calls, finish_error="no exposure"),
+        ]
+
+        with (
+            patch("almond_axol.video.video_proc.time.perf_counter", return_value=50.0),
+            self.assertRaisesRegex(RuntimeError, "left_arm: no exposure"),
+        ):
+            _set_dataset_branches_enabled(cameras, True)
+
+        self.assertIn(("abort", "overhead"), calls)
+        self.assertIn(("abort", "left_arm"), calls)
+
+    def test_relay_fails_closed_if_arming_misses_future_boundary(self) -> None:
+        calls: list[tuple] = []
+        cameras = [
+            _FakeCoordinatedCamera("overhead", calls),
+            _FakeCoordinatedCamera("left_arm", calls),
+        ]
+
+        with (
+            patch(
+                "almond_axol.video.video_proc.time.perf_counter",
+                side_effect=(50.0, 50.11),
+            ),
+            self.assertRaisesRegex(RuntimeError, "missed the shared.*boundary"),
+        ):
+            _set_dataset_branches_enabled(cameras, True)
+
+        self.assertNotIn("finish", [call[0] for call in calls])
+        self.assertIn(("abort", "overhead"), calls)
+        self.assertIn(("abort", "left_arm"), calls)
 
 
 if __name__ == "__main__":

--- a/tests/test_ik_freeze_clutch.py
+++ b/tests/test_ik_freeze_clutch.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import math
+import types
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+
+from almond_axol.teleop.worker import IKWorker, _relative_target_np
+from almond_axol.vr.models import VRFrame, VRPose, VRPosition, VRQuaternion
+
+
+def _rot_y(angle: float) -> np.ndarray:
+    c = math.cos(angle)
+    s = math.sin(angle)
+    return np.array(((c, 0.0, s), (0.0, 1.0, 0.0), (-s, 0.0, c)), np.float32)
+
+
+def _rot_z(angle: float) -> np.ndarray:
+    c = math.cos(angle)
+    s = math.sin(angle)
+    return np.array(((c, -s, 0.0), (s, c, 0.0), (0.0, 0.0, 1.0)), np.float32)
+
+
+def _freeze_tracker() -> IKWorker:
+    worker = object.__new__(IKWorker)
+    worker._freeze_since = {}
+    worker._freeze_targets = {}
+    return worker
+
+
+class _IdentityFilter:
+    def update(self, value: np.ndarray, t: float | None = None) -> np.ndarray:
+        del t
+        return np.asarray(value, dtype=np.float32).copy()
+
+    def nudge(self, delta: np.ndarray) -> None:
+        del delta
+
+    def reset(self, seed: np.ndarray | None = None) -> None:
+        del seed
+
+
+class _SeedLeftSolver:
+    left_indices = list(range(7))
+    right_indices = list(range(7, 14))
+    num_joints = 14
+
+    def __init__(self) -> None:
+        self.left_pose = (
+            np.array((0.40, 0.20, 0.30), np.float32),
+            np.eye(3, dtype=np.float32),
+        )
+        self.right_pose = (
+            np.array((0.40, -0.20, 0.30), np.float32),
+            np.eye(3, dtype=np.float32),
+        )
+        self.left_elbow = np.array((0.10, 0.20, 0.30), np.float32)
+        self.right_elbow = np.array((0.10, -0.20, 0.30), np.float32)
+        self._posture = np.arange(14, dtype=np.float32)
+
+    @property
+    def posture_pose(self) -> np.ndarray:
+        return self._posture.copy()
+
+    def set_posture_pose(self, q: np.ndarray) -> None:
+        self._posture = np.asarray(q, dtype=np.float32).copy()
+
+    def fk(
+        self, q: np.ndarray
+    ) -> tuple[
+        tuple[np.ndarray, np.ndarray],
+        tuple[np.ndarray, np.ndarray],
+    ]:
+        del q
+        return self.left_pose, self.right_pose
+
+    def elbow_positions(self, q: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        del q
+        return self.left_elbow, self.right_elbow
+
+    def ik(self, q: np.ndarray, **kwargs: object) -> np.ndarray:
+        del kwargs
+        out = np.asarray(q, dtype=np.float32).copy()
+        # The left arm is stuck at its seed while the right arm remains healthy.
+        out[self.right_indices[0]] += 0.01
+        return out
+
+
+def _step_worker() -> IKWorker:
+    worker = object.__new__(IKWorker)
+    worker._config = types.SimpleNamespace(
+        ik_frequency=120.0,
+        position_multiplier=1.0,
+        rotation_multiplier=1.0,
+    )
+    worker._solver = _SeedLeftSolver()
+    worker._use_elbow = False
+    worker._active = {"left": True, "right": True}
+    worker._hold_fk = {}
+    worker._hold_elbow_fk = {}
+    worker._freeze_since = {}
+    worker._freeze_targets = {}
+    worker._snap_ctrl = {
+        "left": (np.zeros(3, np.float32), np.eye(3, dtype=np.float32)),
+        "right": (np.zeros(3, np.float32), np.eye(3, dtype=np.float32)),
+    }
+    worker._snap_fk = {
+        "left": worker._solver.left_pose,
+        "right": worker._solver.right_pose,
+    }
+    worker._snap_elbow_ctrl = {}
+    worker._snap_elbow_fk = {}
+    worker._prev_raw = {}
+    worker._prev_raw_t = None
+    worker._raw_vel = {}
+    worker._suspect = None
+    worker._last_solve_t = None
+    worker._rec = None
+    worker._f_l_pos = _IdentityFilter()
+    worker._f_l_quat = _IdentityFilter()
+    worker._f_r_pos = _IdentityFilter()
+    worker._f_r_quat = _IdentityFilter()
+    worker._f_l_elbow = _IdentityFilter()
+    worker._f_r_elbow = _IdentityFilter()
+    return worker
+
+
+def _frame(*, left_forward: float, t_ms: float) -> VRFrame:
+    identity = VRQuaternion(x=0.0, y=0.0, z=0.0, w=1.0)
+    zero = VRPosition(x=0.0, y=0.0, z=0.0)
+    return VRFrame(
+        # VR +z is robot +x (forward).
+        l_ee=VRPose(
+            position=VRPosition(x=0.0, y=0.0, z=left_forward),
+            quaternion=identity,
+        ),
+        r_ee=VRPose(position=zero, quaternion=identity),
+        l_elbow=zero,
+        r_elbow=zero,
+        l_lock=True,
+        r_lock=True,
+        t=t_ms,
+    )
+
+
+class RelativeTargetReanchorTest(unittest.TestCase):
+    def test_current_controller_pose_maps_exactly_to_reanchored_fk(self) -> None:
+        ctrl_pos = np.array((0.2, -0.1, 0.7), np.float32)
+        ctrl_rot = _rot_z(0.4)
+        fk_pos = np.array((0.5, 0.25, 0.35), np.float32)
+        fk_rot = _rot_y(-0.3)
+
+        target_pos, target_rot = _relative_target_np(
+            ctrl_pos,
+            ctrl_rot,
+            ctrl_pos,
+            ctrl_rot,
+            fk_pos,
+            fk_rot,
+            position_multiplier=2.0,
+            rotation_multiplier=1.5,
+        )
+
+        np.testing.assert_allclose(target_pos, fk_pos, atol=1e-7)
+        np.testing.assert_allclose(target_rot, fk_rot, atol=1e-7)
+
+        # A new controller delta starts from the new origin; no old backlog is
+        # hidden in the mapping. Controller-local +x maps to EE-local +z.
+        moved_ctrl = ctrl_pos + ctrl_rot @ np.array((0.01, 0.0, 0.0), np.float32)
+        moved_pos, _ = _relative_target_np(
+            moved_ctrl,
+            ctrl_rot,
+            ctrl_pos,
+            ctrl_rot,
+            fk_pos,
+            fk_rot,
+            position_multiplier=2.0,
+            rotation_multiplier=1.5,
+        )
+        np.testing.assert_allclose(moved_pos, fk_pos + 0.02 * fk_rot[:, 2], atol=1e-7)
+
+
+class FreezeTrackerTest(unittest.TestCase):
+    def test_duration_and_translation_thresholds_gate_clutch(self) -> None:
+        worker = _freeze_tracker()
+        pos = np.zeros(3, np.float32)
+        rot = np.eye(3, dtype=np.float32)
+
+        with patch(
+            "almond_axol.teleop.worker.time.monotonic",
+            side_effect=(10.0, 10.49, 10.51),
+        ):
+            self.assertFalse(worker._note_solve("left", True, pos, rot, None))
+            self.assertFalse(
+                worker._note_solve(
+                    "left", True, pos + np.array((0.006, 0.0, 0.0)), rot, None
+                )
+            )
+            self.assertTrue(
+                worker._note_solve(
+                    "left", True, pos + np.array((0.006, 0.0, 0.0)), rot, None
+                )
+            )
+
+        self.assertNotIn("left", worker._freeze_since)
+        self.assertNotIn("left", worker._freeze_targets)
+
+    def test_rotation_only_freeze_requests_clutch(self) -> None:
+        worker = _freeze_tracker()
+        pos = np.zeros(3, np.float32)
+        rot = np.eye(3, dtype=np.float32)
+
+        with patch("almond_axol.teleop.worker.time.monotonic", side_effect=(3.0, 3.51)):
+            self.assertFalse(worker._note_solve("right", True, pos, rot, None))
+            self.assertTrue(
+                worker._note_solve("right", True, pos, _rot_z(math.radians(6)), None)
+            )
+
+    def test_elbow_motion_counts_and_progress_clears_only_one_arm(self) -> None:
+        worker = _freeze_tracker()
+        pos = np.zeros(3, np.float32)
+        rot = np.eye(3, dtype=np.float32)
+        elbow = np.zeros(3, np.float32)
+
+        with patch(
+            "almond_axol.teleop.worker.time.monotonic", side_effect=(1.0, 1.0, 1.51)
+        ):
+            self.assertFalse(worker._note_solve("left", True, pos, rot, elbow))
+            self.assertFalse(worker._note_solve("right", True, pos, rot, elbow))
+            worker._note_solve("left", False, pos, rot, elbow)
+            self.assertTrue(
+                worker._note_solve(
+                    "right",
+                    True,
+                    pos,
+                    rot,
+                    elbow + np.array((0.0, 0.006, 0.0)),
+                )
+            )
+
+        self.assertNotIn("left", worker._freeze_since)
+        self.assertNotIn("right", worker._freeze_since)
+
+    def test_clear_without_side_resets_all_arms(self) -> None:
+        worker = _freeze_tracker()
+        worker._freeze_since = {"left": 1.0, "right": 2.0}
+        pose = (np.zeros(3), np.eye(3), None)
+        worker._freeze_targets = {"left": pose, "right": pose}
+
+        worker._clear_freeze()
+
+        self.assertEqual(worker._freeze_since, {})
+        self.assertEqual(worker._freeze_targets, {})
+
+
+class FreezeClutchStepTest(unittest.TestCase):
+    def test_stalled_arm_reanchors_without_blocking_healthy_arm(self) -> None:
+        worker = _step_worker()
+        right_snap_ctrl = tuple(value.copy() for value in worker._snap_ctrl["right"])
+        right_snap_fk = tuple(value.copy() for value in worker._snap_fk["right"])
+        right_posture = worker._solver.posture_pose[7:].copy()
+        q0 = np.zeros(14, np.float32)
+
+        with patch(
+            "almond_axol.teleop.worker.time.monotonic", side_effect=(20.0, 20.51)
+        ):
+            q1 = worker.step(_frame(left_forward=0.0, t_ms=0.0), q0)
+            q2 = worker.step(_frame(left_forward=0.006, t_ms=8.33), q1)
+
+        # The stalled arm has no command step on the clutch frame. The healthy
+        # arm's result from that same bimanual solve is retained.
+        np.testing.assert_array_equal(q2[:7], q1[:7])
+        self.assertAlmostEqual(float(q2[7] - q1[7]), 0.01, places=6)
+
+        np.testing.assert_array_equal(worker._snap_ctrl["right"][0], right_snap_ctrl[0])
+        np.testing.assert_array_equal(worker._snap_ctrl["right"][1], right_snap_ctrl[1])
+        np.testing.assert_array_equal(worker._snap_fk["right"][0], right_snap_fk[0])
+        np.testing.assert_array_equal(worker._snap_fk["right"][1], right_snap_fk[1])
+        np.testing.assert_array_equal(worker._solver.posture_pose[7:], right_posture)
+
+        # The current filtered left-controller sample now maps exactly to FK of
+        # the held left joints; the six millimetres accumulated while frozen is
+        # absent from the next solve target.
+        np.testing.assert_allclose(
+            worker._snap_ctrl["left"][0], np.array((0.006, 0.0, 0.0)), atol=1e-7
+        )
+        target_pos, target_rot = _relative_target_np(
+            *worker._snap_ctrl["left"],
+            *worker._snap_ctrl["left"],
+            *worker._snap_fk["left"],
+        )
+        np.testing.assert_allclose(target_pos, worker._solver.left_pose[0], atol=1e-7)
+        np.testing.assert_allclose(target_rot, worker._solver.left_pose[1], atol=1e-7)
+
+    def test_snap_arm_reanchors_elbow_origin_too(self) -> None:
+        worker = _freeze_tracker()
+        worker._snap_ctrl = {}
+        worker._snap_fk = {}
+        worker._snap_elbow_ctrl = {}
+        worker._snap_elbow_fk = {}
+        ctrl_pos = np.array((0.1, 0.2, 0.3), np.float32)
+        ctrl_rot = _rot_z(0.2)
+        ctrl_elbow = np.array((0.0, 0.3, 0.4), np.float32)
+        fk_pose = (np.array((0.4, 0.2, 0.3), np.float32), _rot_y(0.2))
+        fk_elbow = np.array((0.2, 0.3, 0.4), np.float32)
+
+        worker._snap_arm("left", ctrl_pos, ctrl_rot, ctrl_elbow, fk_pose, fk_elbow)
+
+        np.testing.assert_array_equal(worker._snap_elbow_ctrl["left"], ctrl_elbow)
+        np.testing.assert_array_equal(worker._snap_elbow_fk["left"], fk_elbow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_recorder_capture_error.py
+++ b/tests/test_recorder_capture_error.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import multiprocessing
+import unittest
+from unittest.mock import patch
+
+from almond_axol.recording.record_proc import (
+    DatasetRecorderProcess,
+    InProcessRecorder,
+)
+
+
+class _FakeDataset:
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+
+    def clear_episode_buffer(self) -> None:
+        self.events.append("clear")
+
+
+class _FakeVerifier:
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+
+    def close(self) -> None:
+        self.events.append("verifier-close")
+
+
+class DatasetRecorderCaptureErrorTest(unittest.TestCase):
+    def test_in_process_close_discards_normal_unsaved_episode_before_finalize(
+        self,
+    ) -> None:
+        events: list[str] = []
+        recorder = InProcessRecorder.__new__(InProcessRecorder)
+        recorder._thread = None
+        recorder._stop = None
+        recorder._capture_error = None
+        recorder._dataset = _FakeDataset(events)
+        recorder._config = {}
+        recorder._episodes_recorded = 0
+        recorder._verifier = _FakeVerifier(events)
+
+        def finalize(*_args: object) -> None:
+            events.append("finalize")
+
+        with patch(
+            "almond_axol.recording.record_proc._finalize_dataset",
+            side_effect=finalize,
+        ):
+            recorder.close()
+
+        self.assertEqual(events, ["clear", "finalize", "verifier-close"])
+
+    def test_capture_error_uses_separate_nonblocking_channel(self) -> None:
+        ctx = multiprocessing.get_context("spawn")
+        recv_conn, send_conn = ctx.Pipe(duplex=False)
+        recorder = DatasetRecorderProcess.__new__(DatasetRecorderProcess)
+        recorder._error_conn = recv_conn
+        recorder._capture_error = None
+        try:
+            self.assertIsNone(recorder.poll_capture_error())
+
+            send_conn.send("camera alignment failed")
+
+            self.assertEqual(recorder.poll_capture_error(), "camera alignment failed")
+            # The first failure stays visible after the pipe has been drained.
+            self.assertEqual(recorder.poll_capture_error(), "camera alignment failed")
+        finally:
+            send_conn.close()
+            recv_conn.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- open every dataset camera on one sensor-exposure boundary while preserving the existing natural-IDR close protocol
- keep the post-NVENC queue small and leaky between episodes, then give active capture two seconds of bounded AU headroom
- run recorder and relay boundary IPC off the sole robot command loop while continuously refreshing safe targets; drain Ctrl+C and DAgger control threads before teardown
- surface capture failures immediately and always discard unfinished recorder state before finalization
- clutch only an IK arm that repeatedly returns its exact seed while its tracked target moves, preventing the later catch-up lurch

## Why

The field logs showed three separate failures: boundary IPC exceeded the Rust target watchdog, sequential camera opens selected exposures 33.3 ms apart, and Pyroki sometimes returned an unchanged seed for 0.5-2.5 seconds. The prior two-buffer post-encoder queue also had only about 33 ms of active headroom and could mark the encoded stream discontinuous under a scheduling hiccup.

The Rust control core itself remains unchanged in this branch. Its traces stayed at zero late ticks; it was correctly holding when Python stopped producing targets.

## Safety properties

- camera/NVENC streaming stays in GStreamer with no new per-frame Python work
- encoder output remains bounded and downstream-leaky if the recorder dies, so camera capture cannot backpressure into Argus
- normal recording expands only the compressed-AU queue and resets it after gate close
- boundary workers have finite internal timeouts and cannot outlive robot/IPC teardown, including Ctrl+C
- DAgger always signals and joins its episode command producer before policy, robot, recorder, or relay cleanup
- the IK clutch is per-arm, thresholded by both time and target motion, and produces no command step on its re-anchor frame

## Validation

- Python: 92 passed
- Rust: 25 passed, 1 live-CAN hardware test ignored
- Ruff lint and format checks passed on all changed files
- git diff --check passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes episode-boundary robot commanding, recorder subprocess IPC, and live camera gating—safety-critical paths—but behavior is defensive (holds, joins, fail-closed) with broad test coverage.
> 
> **Overview**
> Hardens **data collection and DAgger** so recorder/relay IPC at episode start and finish no longer starves the Rust target watchdog. New `run_blocking_with_control_ticks` helpers run bounded `start_episode` / `finish_episode` / relay gating on a worker thread while the main or robot loop keeps sending hold or teleop ticks; DAgger uses measured joint holds and always stops its control thread before teardown (including early Ctrl+C).
> 
> **Recorder and capture errors** get a dedicated one-way error pipe with `poll_capture_error`, bounded capture-thread joins, and stricter discard-before-finalize on `close()` and failed finishes. Control loops in collect-data and DAgger abort the episode when capture fails mid-take.
> 
> **GStreamer dataset branches** open on a shared future exposure timestamp (probes on all cameras before wait) instead of sequential valve toggles; post-NVENC queues stay tiny/leaky until recording, then expand to ~2s of bounded AU headroom. The video relay coordinates multi-camera enable/disable fail-closed.
> 
> **VR teleop IK** switches from freeze warnings to **per-arm automatic clutch**: when one arm’s solver keeps returning its seed while targets move, that arm re-anchors to the held pose so accumulated error is not released as a lurch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50de20428c78d021886f303b2bd35ab153dc4d01. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->