### PR TITLE
Fix encoded camera row-zero recovery

### DIFF
--- a/almond_axol/cli/collect_dagger.py
+++ b/almond_axol/cli/collect_dagger.py
@@ -94,6 +94,7 @@ from ..lerobot.rollout import (
 from ..lerobot.teleop.config_vr import AxolVRTeleopConfig
 from ..recording import (
     DatasetRecorderProcess,
+    RecorderCaptureError,
     RecorderDatasetSaveError,
     default_vcodec,
 )
@@ -462,6 +463,11 @@ class _DaggerControlLoop(threading.Thread):
         self.teleop_hz = teleop_hz
         self.shutdown_event = threading.Event()
         self.fatal_error: BaseException | None = None
+        # A capture-integrity rejection is scoped to this episode. The
+        # supervisor joins the controller/capture thread, discards the buffer,
+        # homes, and retries the same episode index. Lifecycle/IPC/control
+        # failures continue to use fatal_error.
+        self.capture_error: str | None = None
         # Episode outcome signalled from the VR record button: 's' (terminate)
         # or 'r' (reset+stop). Read by the supervisor.
         self.vr_choice: str | None = None
@@ -528,9 +534,12 @@ class _DaggerControlLoop(threading.Thread):
 
                 capture_error = self.recorder.poll_capture_error()
                 if capture_error is not None:
-                    raise RuntimeError(
-                        f"recorder capture failed: {capture_error}; episode discarded"
+                    self.capture_error = str(capture_error)
+                    log_say(
+                        f"Camera capture failed; ending and discarding this "
+                        f"episode: {capture_error}"
                     )
+                    return
 
                 # --- episode end requested from the VR record button?
                 events = self.teleop.get_teleop_events()
@@ -1197,7 +1206,12 @@ def _run(
                 # close the just-opened capture under the same measured hold.
                 def _finish_cancelled_start() -> int:
                     try:
-                        return recorder.finish_episode()
+                        try:
+                            return recorder.finish_episode()
+                        except RecorderCaptureError:
+                            # The session is already stopping and the rejected
+                            # buffer was cleared by finish_episode.
+                            return 0
                     finally:
                         relay.set_raw_enabled(False)
 
@@ -1270,6 +1284,8 @@ def _run(
                     if time.perf_counter() >= deadline:
                         timed_out = True
                         break
+                    if control_thread.capture_error is not None:
+                        break
                     if control_thread.fatal_error is not None:
                         log_say(
                             f"Fatal error in DAgger control loop: "
@@ -1317,27 +1333,28 @@ def _run(
             # desired pose cannot keep advancing during shutdown.
             finish_hold_action = _measured_joint_hold_action()
 
-            def _finish_capture() -> int:
+            def _finish_capture() -> tuple[int, str | None]:
                 try:
-                    final_rows = recorder.finish_episode()
-                except BaseException as exc:
                     try:
-                        relay.set_raw_enabled(False)
-                    except BaseException as gate_exc:
-                        exc.add_note(f"relay close also failed: {gate_exc!r}")
-                    raise
-                relay.set_raw_enabled(False)
-                return final_rows
+                        return recorder.finish_episode(), None
+                    except RecorderCaptureError as exc:
+                        return 0, str(exc)
+                finally:
+                    # A gate-close failure is session-fatal and deliberately
+                    # overrides an episode-local capture rejection: continuing
+                    # with the relay branch open is not a valid recovery.
+                    relay.set_raw_enabled(False)
 
             def _hold_finish_pose() -> None:
                 robot.send_action(finish_hold_action)
 
-            final_rows = run_blocking_with_sync_control_ticks(
+            final_rows, finish_capture_error = run_blocking_with_sync_control_ticks(
                 _finish_capture,
                 _hold_finish_pose,
                 boundary_period,
                 drain_tick=_hold_finish_pose,
             )
+            capture_error = control_thread.capture_error or finish_capture_error
             # Close a span still open when the loop exited (the episode ended
             # mid-intervention) at the final row count — exact, since capture
             # is paused — so intervention_spans is complete for any consumer.
@@ -1353,6 +1370,20 @@ def _run(
             if control_thread.fatal_error is not None:
                 recorder.cancel_episode()
                 break
+
+            if capture_error is not None:
+                # finish_episode has joined capture and cleared its rejected
+                # buffer. Home exactly like a normal episode boundary before
+                # retrying the unchanged dataset episode index.
+                recorder.cancel_episode()
+                teleop.send_feedback_state(VRState.SAVING)
+                log_say(
+                    f"Episode discarded because camera capture failed: {capture_error}"
+                )
+                log_say("Returning to rest pose.")
+                if not _return_to_rest_guarded(_gate_retry):
+                    break
+                continue
 
             choice = control.poll_choice() or control_thread.vr_choice
             if timed_out and choice is None:
@@ -1392,9 +1423,10 @@ def _run(
                 # Writer indices/parquet rows may already have changed. A
                 # retry in this process could compound the damage.
                 raise
-            except RuntimeError as exc:
-                # e.g. the recorder refused a video/row-misaligned episode
-                # (encoder frame drops). Discarded — keep the session up.
+            except RecorderCaptureError as exc:
+                # An encoder/capture integrity rejection is pre-commit and
+                # already cleared its episode buffer. Other recorder RuntimeErrors
+                # are IPC/lifecycle failures and must stop the session.
                 log_say(f"Episode NOT saved: {exc}")
                 continue
             episode_idx += 1

--- a/almond_axol/cli/collect_data.py
+++ b/almond_axol/cli/collect_data.py
@@ -65,6 +65,7 @@ from ..lerobot.teleop.config_vr import AxolVRTeleopConfig
 from ..recording import (
     DatasetRecorderProcess,
     InProcessRecorder,
+    RecorderCaptureError,
     default_vcodec,
     restore_dataset_ownership,
 )
@@ -956,12 +957,13 @@ def _run(
     # interleaved with CAN telemetry on one thread, exactly like `axol teleop`.
     # The main thread drives the episode lifecycle (dataset writes, rest-pose
     # moves) and blocks on each coroutine until the episode (or reset) finishes.
-    async def _episode_loop() -> tuple[bool, bool, bool, int]:
+    async def _episode_loop() -> tuple[bool, bool, bool, int, str | None]:
         recording = False
         capture_ready = False
         rerecord = False
         contact = False
         captured_rows = 0
+        capture_failure: str | None = None
         # perf_counter deadline of a panel-started record countdown, or None.
         pending_start: float | None = None
         # Tracking-phase contact watchdog (opt-in — the threshold defaults
@@ -982,7 +984,7 @@ def _run(
 
         async def _tracking_tick() -> None:
             """Run one normal teleop tick without consuming boundary events."""
-            nonlocal last_robot_act, last_dataset_act
+            nonlocal capture_failure, last_robot_act, last_dataset_act
             if _stopped() and last_robot_act is not None:
                 # Ctrl+C/Stop during recorder startup must drain the bounded
                 # worker before teardown, but must not keep following a moving
@@ -1023,9 +1025,8 @@ def _run(
             if recording and capture_ready:
                 capture_error = recorder.poll_capture_error()
                 if capture_error is not None:
-                    raise RuntimeError(
-                        f"recorder capture failed: {capture_error}; episode discarded"
-                    )
+                    capture_failure = str(capture_error)
+                    return
 
             if watchdog is not None:
                 tripped = watchdog.update(robot.torque_residuals())
@@ -1058,10 +1059,16 @@ def _run(
             if relay is not None:
                 relay.set_raw_enabled(True)
 
-        def _finish_capture() -> int:
+        def _finish_capture() -> tuple[int, str | None]:
             try:
-                return recorder.finish_episode()
+                try:
+                    return recorder.finish_episode(), None
+                except RecorderCaptureError as exc:
+                    return 0, str(exc)
             finally:
+                # A relay-close failure is a camera lifecycle failure, not an
+                # episode rejection. Let it override the recoverable capture
+                # result so the session cannot continue with an open branch.
                 if relay is not None:
                     relay.set_raw_enabled(False)
 
@@ -1099,6 +1106,12 @@ def _run(
             except _TrackingContact:
                 contact = True
                 break
+            if capture_failure is not None:
+                # The capture thread has already stopped. End the take now
+                # instead of letting the operator finish an episode that is
+                # guaranteed to be discarded.
+                teleop.send_feedback_state(VRState.SAVING)
+                break
 
             events = teleop.get_teleop_events()
             panel_cmd = control.poll_command()
@@ -1126,10 +1139,10 @@ def _run(
             if start_requested and not recording:
                 pending_start = None
                 recording = True
-                # Arm recorder cutoffs before opening the poised-before-IDR
-                # dataset valves. Both calls can wait for transport/GOP
-                # boundaries, so run them off-loop while normal teleop ticks
-                # continue feeding the Rust target watchdog.
+                # Arm recorder cutoffs before opening the shared-timestamp
+                # dataset valves. Both calls can wait for transport boundaries,
+                # so run them off-loop while normal teleop ticks continue
+                # feeding the Rust target watchdog.
                 await asyncio.sleep(max(0.0, deadline - time.perf_counter()))
                 try:
                     await run_blocking_with_control_ticks(
@@ -1179,13 +1192,18 @@ def _run(
             # the bounded capture close drains. Keep the arm limp instead;
             # normal episode ends refresh the frozen command pose.
             boundary_tick = _guard_gravity_step if contact else _hold_tick
-            captured_rows = await run_blocking_with_control_ticks(
+            (
+                captured_rows,
+                finish_capture_failure,
+            ) = await run_blocking_with_control_ticks(
                 _finish_capture,
                 boundary_tick,
                 teleop_interval,
                 drain_tick=_guard_gravity_step,
             )
-        return recording, rerecord, contact, captured_rows
+            if finish_capture_failure is not None:
+                capture_failure = capture_failure or finish_capture_failure
+        return recording, rerecord, contact, captured_rows, capture_failure
 
     # Guarded return-to-rest: the sequencing (torque watchdog, gravity-comp
     # fallback, reset-press retry) lives in the shared engine
@@ -1313,10 +1331,24 @@ def _run(
             _drain_robot_future(fut)
             raise interrupted
 
-    def _wrap_up_episode(recording: bool, rerecord: bool, captured_rows: int) -> None:
+    def _wrap_up_episode(
+        recording: bool,
+        rerecord: bool,
+        captured_rows: int,
+        capture_failure: str | None,
+    ) -> None:
         """Save or discard the just-ended episode and announce the result."""
         nonlocal episodes_recorded
-        if rerecord:
+        if capture_failure is not None:
+            log_say(
+                f"Episode discarded because camera capture failed: {capture_failure}"
+            )
+            # finish_episode already joined capture and cleared the rejected
+            # buffer. cancel_episode is an idempotent lifecycle reset and also
+            # covers a future recorder implementation that reports the live
+            # poll before its finish reply carries the same rejection.
+            recorder.cancel_episode()
+        elif rerecord:
             log_say("Re-recording episode.")
             if recording:
                 recorder.cancel_episode()
@@ -1328,7 +1360,14 @@ def _run(
             recorder.cancel_episode()
         elif recording:
             log_say("Saving episode…")
-            recorder.save_episode()
+            try:
+                recorder.save_episode()
+            except RecorderCaptureError as exc:
+                # Encoder drops are detected only during the pre-commit save
+                # check on raw fallback transports. The typed contract means
+                # the buffer is already cleared and this take alone is invalid.
+                log_say(f"Episode NOT saved: {exc}")
+                return
             # The serve unit records as root into the operator's home; hand the
             # tree back after every save so a crash never leaves a root-owned
             # dataset behind (no-op off the root service).
@@ -1344,8 +1383,8 @@ def _run(
 
     try:
         # Keep the relay's dataset branch closed until an episode records. This
-        # lives inside the cleanup scope because an acknowledged IDR-alignment
-        # failure is now surfaced synchronously.
+        # lives inside the cleanup scope because an acknowledged camera-gate
+        # failure is surfaced synchronously.
         if relay is not None:
             relay.set_raw_enabled(False)
 
@@ -1361,9 +1400,13 @@ def _run(
                 f"Episode {episode_idx + 1}: robot is at rest pose. Press record on the VR controller when ready."
             )
 
-            recording, rerecord, contact, captured_rows = _run_on_robot_loop(
-                _episode_loop()
-            )
+            (
+                recording,
+                rerecord,
+                contact,
+                captured_rows,
+                capture_failure,
+            ) = _run_on_robot_loop(_episode_loop())
 
             if _stopped():
                 if recording:
@@ -1384,7 +1427,12 @@ def _run(
                 teleop.send_feedback_state(VRState.DATA_COLLECTION)
                 continue
 
-            if recording and not rerecord and captured_rows > 0:
+            if (
+                recording
+                and not rerecord
+                and capture_failure is None
+                and captured_rows > 0
+            ):
                 # Mirror the headset's SAVING state in the panel for the whole
                 # rest-pose + save stretch (recording controls are blocked).
                 control.note_saving()
@@ -1402,7 +1450,12 @@ def _run(
                 _return_home_loop(), robot.event_loop
             )
             try:
-                _wrap_up_episode(recording, rerecord, captured_rows)
+                _wrap_up_episode(
+                    recording,
+                    rerecord,
+                    captured_rows,
+                    capture_failure,
+                )
                 home_future.result()
             except BaseException:
                 # Ctrl+C or a failed save: unwind the guarded return so it

--- a/almond_axol/lerobot/h264_mux_encoder.py
+++ b/almond_axol/lerobot/h264_mux_encoder.py
@@ -30,35 +30,32 @@ the physical capture PTS across ``shmsink``/``shmsrc`` for state association;
 this muxer independently assigns the dataset timeline: the *k*-th access unit is
 muxed at ``pts = k / fps`` (``dts`` and ``duration`` match). The caller
 (:func:`~almond_axol.recording.record_proc.run_encoded_capture_loop`) requires
-one fresh AU per camera per row and aborts on a stall—predictive AUs are never
-replayed—so frame-count == row-count by construction. The concat step reasserts
+one fresh AU per camera per row and aborts on a stall—encoded exposures are
+never replayed—so frame-count == row-count by construction. The concat step reasserts
 that exact grid across episodes (see
 :func:`~almond_axol.recording.record_proc._concatenate_video_files_rebased`).
 
 Because the frames arrive pre-encoded, the first muxed AU of an episode must be
-an IDR or the mp4 is undecodable from frame 0. Between episodes the relay closes
-each dataset branch immediately before its next natural IDR, keeping encoder
-GOP phases aligned. On reopen,
-:class:`~almond_axol.video.shm_frames.EncodedAuReader` verifies that first AU is
-an actual type-5 IDR.
+an IDR or the mp4 is undecodable from frame 0. The relay's dataset stream is
+all-intra: every AU is an actual type-5 IDR, which removes hidden Jetson encoder
+GOP phase from episode boundaries and permits timestamp-based row-zero
+alignment. :class:`~almond_axol.video.shm_frames.EncodedAuReader` verifies that
+contract before delivering any AU.
 
 Image stats
 -----------
 LeRobot folds a sampled subset of frames into running image-normalization stats.
-Here the recorder no longer has raw frames, so each camera decodes its **IDR
-access units as they are fed** on a per-camera background thread
-(:class:`_StatsWorker`): an IDR is self-contained (the relay muxes SPS/PPS into
-every keyframe), so a plain software decoder fed only keyframes (~4/s given the
-relay's IDR cadence) yields the same sampled subset the old post-finalize file
-decode produced, but the cost is amortized across the episode instead of being
-paid as a lump inside ``save_episode``. The worker folds decoded frames into the
-same ``RunningQuantileStats`` the raw path uses (batched updates — the per-call
-histogram build dominates otherwise); :meth:`_CameraH264Muxer.finish` just joins
-the worker and reads the result. If the worker produced nothing (deps missing,
-decode errors), finish falls back to decoding the finalized file's keyframes
-(:meth:`_CameraH264Muxer._compute_stats_from_file`); if that fails too the
-encoder still records correctly and returns ``None`` stats (recomputable
-offline).
+Here the recorder no longer has raw frames, so each camera samples its all-intra
+AUs at a fixed low rate and decodes those on a per-camera background thread
+(:class:`_StatsWorker`). Sampling is time-based rather than "every IDR" because
+every dataset frame is now an IDR; this preserves the old ~4 Hz stats workload
+instead of accidentally decoding four 60 Hz feeds in software. The worker folds
+decoded frames into the same ``RunningQuantileStats`` the raw path uses (batched
+updates — the per-call histogram build dominates otherwise);
+:meth:`_CameraH264Muxer.finish` just joins the worker and reads the result. If
+the worker produced nothing (deps missing, decode errors), finish falls back to
+sampling the finalized file; if that fails too the encoder still records
+correctly and returns ``None`` stats (recomputable offline).
 """
 
 from __future__ import annotations
@@ -95,6 +92,9 @@ _STATS_QUEUE_MAX = 64
 # frames: per-update overhead (histogram build) dominates single-frame updates,
 # while batching everything to the end would move the whole cost into finish().
 _STATS_BATCH_FRAMES = 48
+# Match the former quarter-second GOP's image-stats sampling density without
+# coupling CPU work to keyframe frequency. Dataset AUs are now all keyframes.
+_STATS_SAMPLE_HZ = 4
 
 
 def _au_is_idr(au: bytes) -> bool:
@@ -119,10 +119,10 @@ def _au_is_idr(au: bytes) -> bool:
 class _StatsWorker:
     """Decode a camera's IDR AUs on a background thread and fold image stats.
 
-    ``feed`` is called from the capture path with keyframe AUs only; the actual
+    ``feed`` is called from the capture path with sampled IDR AUs only; the actual
     decode/convert/downsample/update runs on this worker's thread (PyAV and
     numpy release the GIL for the heavy parts), so the per-row cost on the
-    capture loop is one non-blocking queue put every IDR interval. ``result``
+    capture loop is one non-blocking queue put about four times a second. ``result``
     joins the worker and returns the LeRobot-shaped stats dict, or ``None`` if
     nothing was decoded (caller falls back to the post-finalize file decode).
     """
@@ -262,6 +262,7 @@ class _CameraH264Muxer:
         # compounded across the concat, breaks LeRobot's 1e-4 s per-row lookup.
         self._mux_timescale = fps * 1000
         self._count = 0
+        self._stats_stride = max(1, round(fps / _STATS_SAMPLE_HZ))
         self._error: str | None = None
 
         # Live per-keyframe stats decode (see _StatsWorker); create it only after
@@ -337,18 +338,23 @@ class _CameraH264Muxer:
                 f"frame {self._count} — pipeline is flushing/errored, aborting "
                 "the episode"
             )
+        frame_index = self._count
         self._count += 1
-        if self._stats_worker is not None and _au_is_idr(au):
+        if (
+            self._stats_worker is not None
+            and frame_index % self._stats_stride == 0
+            and _au_is_idr(au)
+        ):
             self._stats_worker.feed(au)
 
     def _compute_stats_from_file(self) -> dict | None:
         """Decode the finalized mp4's keyframes for image-normalization stats.
 
         Runs once per episode after the file is written (recording paused between
-        episodes), so it never competes with the live capture loop. Keyframes
-        only (``skip_frame=NONKEY``): the relay emits an IDR every ~0.25 s, so
-        this still samples ~4 frames/s while the decoder skips every P-frame —
-        the bulk of a full decode's cost. All sampled frames are folded in one
+        episodes), so it never competes with the live capture loop. Every packet
+        is independently decodable, so demux all packets but send only the same
+        ~4 Hz stride used by the live worker into the decoder. All sampled frames
+        are folded in one
         batched ``RunningQuantileStats.update`` (as stock LeRobot's
         ``sample_images`` path does; the per-call histogram build dominates when
         updating frame by frame), using the same downsample + (H*W, C) layout so
@@ -384,13 +390,24 @@ class _CameraH264Muxer:
             with av.open(str(self.video_path)) as container:
                 stream = container.streams.video[0]
                 stream.thread_type = "AUTO"
-                stream.codec_context.skip_frame = "NONKEY"
-                for frame in container.decode(stream):
-                    rgb = frame.to_ndarray(format="rgb24")  # H, W, C
-                    ds = auto_downsample_height_width(
-                        np.ascontiguousarray(rgb).transpose(2, 0, 1)  # -> C, H, W
-                    )
-                    batches.append(ds.transpose(1, 2, 0).reshape(-1, ds.shape[0]))
+                frame_index = 0
+                for packet in container.demux(stream):
+                    if packet.dts is None:
+                        continue
+                    sample = frame_index % self._stats_stride == 0
+                    frame_index += 1
+                    if not sample:
+                        continue
+                    if not packet.is_keyframe:
+                        raise RuntimeError(
+                            "all-intra dataset contains a predictive packet"
+                        )
+                    for frame in packet.decode():
+                        rgb = frame.to_ndarray(format="rgb24")  # H, W, C
+                        ds = auto_downsample_height_width(
+                            np.ascontiguousarray(rgb).transpose(2, 0, 1)  # -> C, H, W
+                        )
+                        batches.append(ds.transpose(1, 2, 0).reshape(-1, ds.shape[0]))
         except Exception as exc:  # noqa: BLE001 - never fail the save over stats
             _logger.warning(
                 "post-finalize stats decode failed for %s: %s",

--- a/almond_axol/recording/__init__.py
+++ b/almond_axol/recording/__init__.py
@@ -7,6 +7,7 @@ Public API
 ──────────
     DatasetRecorderProcess     Recorder running in a dedicated subprocess
     InProcessRecorder          Degraded fallback (recorder in the control process)
+    RecorderCaptureError       Safely discarded pre-commit episode capture
     default_vcodec             Pick a video codec that can open on this machine
     make_episode_durable       Flush a just-saved episode so a kill can't lose it
     restore_dataset_ownership  Hand a root-recorded dataset back to the operator
@@ -16,6 +17,7 @@ from .ownership import restore_dataset_ownership
 from .record_proc import (
     DatasetRecorderProcess,
     InProcessRecorder,
+    RecorderCaptureError,
     RecorderDatasetSaveError,
     default_vcodec,
     make_episode_durable,
@@ -24,6 +26,7 @@ from .record_proc import (
 __all__ = [
     "DatasetRecorderProcess",
     "InProcessRecorder",
+    "RecorderCaptureError",
     "RecorderDatasetSaveError",
     "default_vcodec",
     "make_episode_durable",

--- a/almond_axol/recording/record_proc.py
+++ b/almond_axol/recording/record_proc.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import math
 import multiprocessing
 import multiprocessing.connection
 import os
@@ -67,13 +68,13 @@ _CMD_TIMEOUT_S = 10.0
 _CAPTURE_STOP_TIMEOUT_S = 10.0
 
 # --- Encoded (relay-side H.264) capture-loop tuning ---
-# How long the first row waits for each camera's first access unit (relay valve
-# open + poised IDR + shmsrc delivery). If a camera produces nothing in this
-# window its dataset branch never came up, so the episode is aborted.
+# How long the first row waits for each camera's first access unit (shared valve
+# open + all-intra NVENC + shmsrc delivery). If a camera produces nothing in
+# this window its dataset branch never came up, so the episode is aborted.
 _ENCODED_START_TIMEOUT_S = 15.0
-# Row-wide budget shared by all cameras. A timeout aborts the episode: replaying
-# a previous predictive AU corrupts decoder reference state until the next IDR.
-# Shared (not per-camera) so serial reads cannot compound the wait.
+# Row-wide budget shared by all cameras. A timeout aborts the episode rather
+# than fabricating an exposure. Shared (not per-camera) so serial reads cannot
+# compound the wait.
 _ENCODED_ROW_TIMEOUT_S = 1.0
 # How often the blocking AU read wakes to re-check stop_event.
 _ENCODED_POLL_MS = 100
@@ -98,6 +99,16 @@ class RecorderDatasetSaveError(RuntimeError):
     The recorder/session must stop: LeRobot may already have appended parquet
     rows or advanced writer indices, and clearing the in-memory episode buffer
     cannot make a subsequent save safe.
+    """
+
+
+class RecorderCaptureError(RuntimeError):
+    """An episode was rejected before commit because capture lost integrity.
+
+    The capture thread has stopped and the in-memory episode buffer has been
+    cleared before this is raised, so the caller may safely retry the same
+    episode.  Recorder lifecycle, IPC, mux preparation, and dataset-writer
+    failures deliberately use other exception paths and remain session-fatal.
     """
 
 
@@ -864,6 +875,103 @@ def _camera_alignment_limit(fps: int) -> float:
     return max(0.010, 1.5 / fps) if fps > 0 else 0.050
 
 
+def _validate_encoded_cadence_step(
+    name: str,
+    *,
+    first_ts: float,
+    previous_ts: float,
+    capture_ts: float,
+    intervals: int,
+    fps: int,
+    capture_fps: int,
+) -> None:
+    """Fail closed when one encoded exposure is missing or off cadence."""
+    if not math.isfinite(capture_ts):
+        raise RuntimeError(f"camera {name!r} produced an invalid capture timestamp")
+    delta = capture_ts - previous_ts
+    if delta <= 0:
+        raise RuntimeError(
+            f"camera {name!r} capture PTS did not advance "
+            f"({delta * 1e3:.2f}ms); episode discarded"
+        )
+    # A non-divisor decimation (e.g. 60 -> 50) legitimately alternates
+    # source-frame spacings. Allow its largest planned spacing plus a quarter
+    # source interval. A whole extra source interval means a selected frame was
+    # lost.
+    planned_steps = (capture_fps + fps - 1) // fps
+    gap_limit = (planned_steps + 0.25) / capture_fps
+    if delta > gap_limit:
+        raise RuntimeError(
+            f"camera {name!r} dropped an encoded frame: capture PTS jumped "
+            f"{delta * 1e3:.2f}ms (limit {gap_limit * 1e3:.2f}ms); "
+            "episode discarded"
+        )
+    elapsed = capture_ts - first_ts
+    # videorate preserves the selected source PTS. Its phase may differ from
+    # an ideal dataset-rate grid by roughly one source interval, but sustained
+    # capture-rate output (for example after reopening a stale downstream
+    # videorate) must not be silently stretched onto the dataset timeline.
+    cadence_slack = 1.5 / capture_fps
+    minimum_elapsed = intervals / fps - cadence_slack
+    maximum_elapsed = intervals / fps + cadence_slack
+    if elapsed < minimum_elapsed or elapsed > maximum_elapsed:
+        direction = "too fast" if elapsed < minimum_elapsed else "too slow"
+        raise RuntimeError(
+            f"camera {name!r} encoded cadence is {direction}: "
+            f"{intervals + 1} frames span {elapsed * 1e3:.2f}ms at requested "
+            f"{fps}fps (allowed {max(0.0, minimum_elapsed) * 1e3:.2f}–"
+            f"{maximum_elapsed * 1e3:.2f}ms); episode discarded"
+        )
+
+
+def _align_independent_encoded_start(
+    packets: dict[str, tuple[bytes, float, float]],
+    read_next: Callable[[str], tuple[bytes, float, float] | None],
+    *,
+    fps: int,
+    capture_fps: dict[str, int],
+) -> tuple[dict[str, tuple[bytes, float, float]], dict[str, int]]:
+    """Advance lagging all-intra streams to one fixed row-zero boundary.
+
+    The shared raw-valve target is the primary synchronization barrier. A
+    dataset input queue can nevertheless shed a leading exposure, and NVENC can
+    deliver a stale in-flight tail after a prior close. Because the dataset
+    stream is explicitly all-intra, advancing a lagging camera here is safe: the
+    retained AU is still a self-contained frame-zero. The newest initial
+    exposure is a fixed boundary; moving it on overshoot could chase forever
+    when unsynchronized sensors have different phases. Predictive streams must
+    never call this helper.
+    """
+    dropped: dict[str, int] = {}
+    if len(packets) <= 1:
+        return packets, dropped
+    boundary = max(packet[1] for packet in packets.values())
+    first_ts = {name: packet[1] for name, packet in packets.items()}
+    intervals = dict.fromkeys(packets, 0)
+    for name in packets:
+        while packets[name][1] < boundary:
+            previous_ts = packets[name][1]
+            packet = read_next(name)
+            if packet is None:
+                raise TimeoutError(
+                    f"camera {name!r} did not catch up to the row-zero exposure window"
+                )
+            next_interval = intervals[name] + 1
+            _validate_encoded_cadence_step(
+                name,
+                first_ts=first_ts[name],
+                previous_ts=previous_ts,
+                capture_ts=packet[1],
+                intervals=next_interval,
+                fps=fps,
+                capture_fps=capture_fps[name],
+            )
+            intervals[name] = next_interval
+            packets[name] = packet
+            dropped[name] = dropped.get(name, 0) + 1
+    return packets, dropped
+
+
 def _warn_timestamp_skew(
     label: str, state_skew_s: float, camera_skew_s: float, fps: int
 ) -> bool:
@@ -1172,19 +1280,18 @@ def run_encoded_capture_loop(
 
     ``frame_counter`` mirrors :func:`run_capture_loop`'s (a mutable
     ``{"n": int}`` incremented per appended row). There is no ``record_event``
-    on this path: an encoded stream cannot gate mid-episode — every dropped
-    access unit is referenced by later P-frames.
+    on this path: capture rows remain continuous within an episode even though
+    each all-intra AU is independently decodable.
 
     Unlike :func:`run_capture_loop` (real-time paced, *selecting* the camera
-    frame nearest each tick and dropping the rest), an encoded stream cannot drop
-    frames — every P-frame depends on its predecessor — so this loop is driven by
-    the **arrival** of access units: it consumes exactly one AU per camera per
-    dataset row. GDP preserves each AU's sensor-exposure PTS; the row is paired
-    with the joint/action snapshot nearest the median camera exposure,
+    frame nearest each tick), this loop is driven by the **arrival** of access
+    units: after a one-time row-zero alignment it consumes exactly one AU per
+    camera per dataset row. GDP preserves each AU's sensor-exposure PTS; the row
+    is paired with the joint/action snapshot nearest the median camera exposure,
     independent of encoder, shm, and scheduler latency. The blocking per-camera
     read naturally paces the loop to the dataset cadence. A timeout, missing PTS,
     dropped frame, cross-camera phase error, or excessive state skew aborts the
-    episode; predictive H.264 AUs are never dropped or duplicated silently.
+    episode; exposures are never duplicated or silently omitted mid-episode.
 
     The muxer assigns each AU a constant-fps PTS (``k / fps``), so the mp4
     timeline is exact regardless of arrival jitter; its physical exposure PTS is
@@ -1200,10 +1307,9 @@ def run_encoded_capture_loop(
 
         tag_intervention = "intervention" in dataset.features
 
-        # Flush before the relay valve opens. Between episodes each encoder is
-        # frozen immediately before an IDR; arming the cutoff first guarantees
-        # that first reopened IDR survives into row zero instead of being
-        # cleared by a racing flush (which would lose a whole GOP of motion).
+        # Flush before the relay valve opens. Arming the cutoff first guarantees
+        # that a newly admitted all-intra AU survives into row zero instead of
+        # being cleared by a racing flush.
         split_flush = [
             cam
             for cam in cameras.values()
@@ -1273,8 +1379,7 @@ def run_encoded_capture_loop(
             # deadline keeps all cameras on the same clock; read_au's final
             # non-blocking attempt still accepts an AU already queued.
             row_deadline = time.perf_counter() + budget
-            aus: dict[str, bytes] = {}
-            capture_ts: dict[str, float] = {}
+            packets: dict[str, tuple[bytes, float, float]] = {}
             for cam_key, cam in cameras.items():
                 packet = read_au(cam, row_deadline)
                 if packet is None:
@@ -1285,19 +1390,68 @@ def run_encoded_capture_loop(
                         f"camera {cam_key!r} produced no fresh encoded frame "
                         f"within {budget:.1f}s during {phase}; episode discarded"
                     )
-                au, cap_ts, _recv_ts = packet
+                _au, cap_ts, _recv_ts = packet
                 if not np.isfinite(cap_ts):
                     raise RuntimeError(
                         f"camera {cam_key!r} produced an invalid capture timestamp"
                     )
-                aus[cam_key] = au
-                capture_ts[cam_key] = cap_ts
+                packets[cam_key] = packet
                 pending = cam.pending
                 if pending > max_pending:
                     max_pending = pending
 
             if stop_event.is_set():
                 return
+
+            # Trust but verify the raw-valve barrier using the timestamps that
+            # actually reached the recorder. A two-buffer leaky input queue or
+            # a stale NVENC tail can make one first AU later/earlier even though
+            # every valve crossed the same target. All-intra makes it safe to
+            # advance only the lagging streams until their first retained
+            # exposures form one valid camera cluster.
+            if not primed and len(packets) > 1:
+                start_times = [packet[1] for packet in packets.values()]
+                camera_limit = _camera_alignment_limit(fps)
+                if max(start_times) - min(start_times) > camera_limit:
+                    non_independent = [
+                        name
+                        for name, cam in cameras.items()
+                        if not bool(getattr(cam, "frames_are_independent", False))
+                    ]
+                    if non_independent:
+                        raise RuntimeError(
+                            "cannot align encoded row zero by dropping predictive "
+                            "frames from " + ", ".join(sorted(non_independent))
+                        )
+                    try:
+                        packets, startup_drops = _align_independent_encoded_start(
+                            packets,
+                            lambda name: read_au(cameras[name], row_deadline),
+                            fps=fps,
+                            capture_fps={
+                                name: max(
+                                    fps,
+                                    int(getattr(camera, "capture_fps", fps)),
+                                )
+                                for name, camera in cameras.items()
+                            },
+                        )
+                    except TimeoutError as exc:
+                        raise RuntimeError(f"{exc}; episode discarded") from exc
+                    if startup_drops:
+                        _logger.info(
+                            "aligned encoded row zero by discarding independent "
+                            "startup AUs: %s",
+                            ", ".join(
+                                f"{name}={count}"
+                                for name, count in sorted(startup_drops.items())
+                            ),
+                        )
+                    for cam in cameras.values():
+                        max_pending = max(max_pending, cam.pending)
+
+            aus = {name: packet[0] for name, packet in packets.items()}
+            capture_ts = {name: packet[1] for name, packet in packets.items()}
             primed = True
 
             for cam_key, cap_ts in capture_ts.items():
@@ -1306,46 +1460,16 @@ def run_encoded_capture_loop(
                     fps, int(getattr(cameras[cam_key], "capture_fps", fps))
                 )
                 if previous is not None:
-                    delta = cap_ts - previous
-                    if delta <= 0:
-                        raise RuntimeError(
-                            f"camera {cam_key!r} capture PTS did not advance "
-                            f"({delta * 1e3:.2f}ms); episode discarded"
-                        )
-                    # A non-divisor decimation (e.g. 60 -> 50) legitimately
-                    # alternates source-frame spacings. Allow its largest
-                    # planned spacing plus a quarter source interval. A whole
-                    # extra source interval means a selected frame was lost.
-                    planned_steps = (capture_fps + fps - 1) // fps
-                    gap_limit = (planned_steps + 0.25) / capture_fps
-                    if delta > gap_limit:
-                        raise RuntimeError(
-                            f"camera {cam_key!r} dropped an encoded frame: "
-                            f"capture PTS jumped {delta * 1e3:.2f}ms "
-                            f"(limit {gap_limit * 1e3:.2f}ms); episode discarded"
-                        )
                     intervals = capture_intervals[cam_key] + 1
-                    elapsed = cap_ts - first_capture_ts[cam_key]
-                    # videorate preserves the selected source PTS. Its phase
-                    # may differ from an ideal dataset-rate grid by roughly one
-                    # source interval, but sustained capture-rate output (for
-                    # example after reopening a stale downstream videorate)
-                    # must not be silently stretched onto the dataset timeline.
-                    cadence_slack = 1.5 / capture_fps
-                    minimum_elapsed = intervals / fps - cadence_slack
-                    maximum_elapsed = intervals / fps + cadence_slack
-                    if elapsed < minimum_elapsed or elapsed > maximum_elapsed:
-                        direction = (
-                            "too fast" if elapsed < minimum_elapsed else "too slow"
-                        )
-                        raise RuntimeError(
-                            f"camera {cam_key!r} encoded cadence is {direction}: "
-                            f"{intervals + 1} frames span {elapsed * 1e3:.2f}ms "
-                            f"at requested {fps}fps (allowed "
-                            f"{max(0.0, minimum_elapsed) * 1e3:.2f}–"
-                            f"{maximum_elapsed * 1e3:.2f}ms); "
-                            "episode discarded"
-                        )
+                    _validate_encoded_cadence_step(
+                        cam_key,
+                        first_ts=first_capture_ts[cam_key],
+                        previous_ts=previous,
+                        capture_ts=cap_ts,
+                        intervals=intervals,
+                        fps=fps,
+                        capture_fps=capture_fps,
+                    )
                     capture_intervals[cam_key] = intervals
                 else:
                     first_capture_ts[cam_key] = cap_ts
@@ -1859,7 +1983,7 @@ class InProcessRecorder:
         self._stop_capture()
         if self._capture_error is not None:
             self._dataset.clear_episode_buffer()
-            raise RuntimeError(
+            raise RecorderCaptureError(
                 f"recorder capture failed: {self._capture_error}; episode discarded"
             )
         return self._frames["n"]
@@ -1874,7 +1998,7 @@ class InProcessRecorder:
         self._stop_capture()
         if self._capture_error is not None:
             self._dataset.clear_episode_buffer()
-            raise RuntimeError(
+            raise RecorderCaptureError(
                 f"recorder capture failed: {self._capture_error}; episode discarded"
             )
         n_dropped = dropped_frames()
@@ -1882,7 +2006,7 @@ class InProcessRecorder:
             # Mirrors the recorder subprocess: a dropped frame's row still
             # exists, so the video is misaligned — never save it silently.
             self._dataset.clear_episode_buffer()
-            raise RuntimeError(
+            raise RecorderCaptureError(
                 f"{n_dropped} video frame(s) were dropped by the encoder "
                 "(feed queue overflow) — the episode's video is misaligned "
                 "with its rows; episode discarded."
@@ -1964,11 +2088,11 @@ def _recorder_main(
     # (recorder encodes). Pick the matching encoder + capture loop from that.
     raw_meta = config["raw_meta"]
     transports = {str(meta["transport"]) for meta in raw_meta.values()}
-    # Capture is either access-unit-driven (every predictive H.264 AU becomes a
-    # row) or raw-frame-driven (one independently selectable image per tick).
-    # Combining those contracts in one episode would require dropping H.264
-    # dependencies or duplicating raw frames, so reject an unsupported mixed
-    # construction explicitly instead of failing later on a missing reader API.
+    # Capture is either access-unit-driven (every H.264 exposure becomes a row)
+    # or raw-frame-driven (one independently selectable image per tick). Combining
+    # those contracts in one episode would require two pacing models, so reject an
+    # unsupported mixed construction explicitly instead of failing later on a
+    # missing reader API.
     if "gstshm-h264" in transports and len(transports) != 1:
         raise RuntimeError(
             "recorder camera transports must be uniformly gstshm-h264 or raw; "
@@ -2136,9 +2260,14 @@ def _recorder_main(
                 except RuntimeError as exc:
                     conn.send(("error", str(exc)))
                 else:
-                    if capture_error["v"] is not None:
+                    finished_capture_error = capture_error["v"]
+                    if finished_capture_error is not None:
                         dataset.clear_episode_buffer()
-                    conn.send(("finished", frame_counter["n"]))
+                    # Carry the post-join result on the command channel.  The
+                    # notification pipe makes live polling prompt, but cannot
+                    # be the finish authority: its delivery may race this
+                    # reply even though the capture thread has already exited.
+                    conn.send(("finished", frame_counter["n"], finished_capture_error))
             elif kind == "pause_episode":
                 if encoded_mode:
                     conn.send(
@@ -2178,7 +2307,7 @@ def _recorder_main(
                 n_dropped = dropped_frames()
                 if capture_error["v"] is not None:
                     dataset.clear_episode_buffer()
-                    conn.send(("error", capture_error["v"]))
+                    conn.send(("capture_error", capture_error["v"]))
                 elif n_dropped:
                     # A dropped frame was never encoded but its row exists, so
                     # the episode's video is misaligned with its rows (and
@@ -2187,7 +2316,7 @@ def _recorder_main(
                     dataset.clear_episode_buffer()
                     conn.send(
                         (
-                            "error",
+                            "capture_error",
                             f"{n_dropped} video frame(s) were dropped by the "
                             "encoder (feed queue overflow) — the episode's "
                             "video is misaligned with its rows; episode "
@@ -2428,12 +2557,17 @@ class DatasetRecorderProcess:
             if not self._conn.poll(_CMD_TIMEOUT_S + 1.0):
                 raise RuntimeError("recorder did not stop episode capture in time")
             msg = self._conn.recv()
-        if msg[0] != "finished":
-            detail = msg[1] if len(msg) > 1 else repr(msg)
+        if not isinstance(msg, tuple) or not msg or msg[0] != "finished":
+            detail = msg[1] if isinstance(msg, tuple) and len(msg) > 1 else repr(msg)
             raise RuntimeError(f"recorder finish_episode failed: {detail}")
-        capture_error = self.poll_capture_error()
-        if capture_error is not None:
+        if len(msg) != 3:
             raise RuntimeError(
+                f"recorder finish_episode sent unexpected reply: {msg!r}"
+            )
+        capture_error = msg[2]
+        if capture_error is not None:
+            self._capture_error = str(capture_error)
+            raise RecorderCaptureError(
                 f"recorder capture failed: {capture_error}; episode discarded"
             )
         return int(msg[1])
@@ -2487,8 +2621,15 @@ class DatasetRecorderProcess:
             if not self._conn.poll(_SAVE_TIMEOUT_S):
                 raise RuntimeError("recorder did not finish save_episode in time")
             msg = self._conn.recv()
+        if not isinstance(msg, tuple) or not msg:
+            raise RuntimeError(f"recorder save_episode sent unexpected reply: {msg!r}")
         if msg[0] == "saved":
             self._episode_count = int(msg[1])
+        elif msg[0] == "capture_error":
+            self._capture_error = str(msg[1])
+            raise RecorderCaptureError(
+                f"recorder capture failed: {msg[1]}; episode discarded"
+            )
         elif msg[0] == "error":
             raise RuntimeError(f"recorder save_episode failed: {msg[1]}")
         elif msg[0] == "fatal":

--- a/almond_axol/video/gst_zed.py
+++ b/almond_axol/video/gst_zed.py
@@ -416,18 +416,22 @@ def _raw_shmsink(socket_path: str) -> str:
     )
 
 
-# The dataset branch keeps a short keyframe interval (~0.25s): frequent IDRs let
-# LeRobot seek/decode the recorded video cheaply, and bound how long the recorder
-# waits for the first keyframe when an episode's valve opens. The encoder can't
-# be force-keyframed on demand on this L4T (the ``force-IDR`` signal segfaults and
-# force-key-unit events are ignored). Between episodes the relay freezes each
-# encoder immediately before a periodic IDR, so reopening emits that IDR as row
-# zero; the reader verifies this and defensively drops any leading P-frames.
-_DATASET_IDR_INTERVAL_S = 0.25
+# Dataset AUs are all-intra. The Jetson encoder cannot be force-keyframed on
+# demand on this L4T (the ``force-IDR`` signal segfaults and force-key-unit
+# events are ignored), and its input/VIC pipeline retains a variable number of
+# frames after an upstream valve closes. With a predictive GOP that hidden tail
+# advances each encoder by a different amount, so the first recorder-visible
+# IDRs can describe exposures several camera ticks apart even though the raw
+# valves reopen on one shared timestamp. Making every dataset frame an IDR
+# removes that unobservable phase state and also lets the recorder discard a
+# leading independently-decodable AU when forming its row-zero camera cluster.
+# Both ``iframeinterval`` and ``idrinterval`` must be one: nvv4l2h264enc exposes
+# them as separate READY-only controls.
+_DATASET_GOP_FRAMES = 1
 # Before the recorder connects, a tiny leaky output queue is intentional: it
 # keeps NVENC returning its NVMM surfaces while shmsink parks GDP's one-shot
 # header. Once an episode opens, two seconds of bounded compressed-AU headroom
-# absorbs scheduler jitter without making predictive H.264 silently lossy.
+# absorbs scheduler jitter without silently losing encoded exposures.
 _DATASET_STARTUP_QUEUE_BUFFERS = 2
 _DATASET_ACTIVE_QUEUE_MIN_BUFFERS = 60
 _DATASET_ACTIVE_QUEUE_SECONDS = 2
@@ -437,9 +441,8 @@ _DATASET_ACTIVE_QUEUE_SECONDS = 2
 # 100 ms is ample time to install the handful of probes without making a record
 # press feel sluggish; the relay caller performs this wait away from control.
 _DATASET_ENABLE_LEAD_S = 0.100
-# A disable observes a complete GOP and closes immediately before the following
-# IDR. Two seconds leaves a full-frame margin even at the supported 1 fps
-# minimum; a timeout therefore indicates a stalled encoder, not scheduler jitter.
+# The shared gate still has a bounded acknowledgement wait. A timeout means a
+# source stopped producing exposure timestamps, not ordinary scheduler jitter.
 _DATASET_GATE_TIMEOUT_S = 2.0
 
 
@@ -500,14 +503,15 @@ def _dataset_enc_shmsink(
     and uniformly sized across cameras even when one sensor is very noisy (see
     ``dataset_vbr_bitrate``).
     """
-    idr = max(1, round(dataset_fps * _DATASET_IDR_INTERVAL_S))
     target, peak = dataset_vbr_bitrate(w, h, dataset_fps)
     return (
         "nvvidconv ! "
         f"video/x-raw(memory:NVMM),format=NV12,width={w},height={h} "
         f"! nvv4l2h264enc name={name} control-rate=0 "
         f"bitrate={target} peak-bitrate={peak} preset-level=1 "
-        f"insert-sps-pps=true insert-aud=true idrinterval={idr} maxperf-enable=true "
+        f"insert-sps-pps=true insert-aud=true "
+        f"iframeinterval={_DATASET_GOP_FRAMES} "
+        f"idrinterval={_DATASET_GOP_FRAMES} maxperf-enable=true "
         "! video/x-h264,stream-format=byte-stream,alignment=au "
         f"! queue name={name}_outq leaky=downstream "
         f"max-size-buffers={_DATASET_STARTUP_QUEUE_BUFFERS} "
@@ -560,10 +564,9 @@ class _GstPipelineBase:
         self._pts_perf_offset_s: float | None = None
         self._threads: list[threading.Thread] = []
         self._stop = threading.Event()
-        # One ``(src_pad, probe_id, event, valve, label)`` per encoded dataset
-        # branch while an IDR-phase-aligned close is in flight. The relay arms every
-        # physical camera first, then waits for all of them, so their encoder
-        # GOP counters restart from the same phase at the next episode.
+        # Kept as a list for cancellation compatibility with an in-flight close.
+        # Dataset encoders are all-intra now, so current closes are immediate and
+        # never populate it.
         self._dataset_disable: list[tuple[Any, int, threading.Event, Any, str]] = []
         # One ``(sink_pad, probe_id, opened, cancelled, lock, status, valve,
         # label)`` per dataset branch waiting for a common exposure boundary.
@@ -584,7 +587,7 @@ class _GstPipelineBase:
         self._dataset_enabled = False
 
     def _cancel_dataset_disable(self) -> None:
-        """Remove any outstanding natural-IDR probes (best effort)."""
+        """Remove any outstanding legacy dataset-close probes (best effort)."""
         pending, self._dataset_disable = self._dataset_disable, []
         for pad, probe_id, event, _valve, _label in pending:
             if event.is_set():
@@ -826,89 +829,23 @@ class _GstPipelineBase:
         self._dataset_enabled = True
 
     def _begin_dataset_disable(self, gates: tuple[tuple[str, str | None], ...]) -> None:
-        """Arm every encoded branch to stop one frame before its next IDR.
+        """Close every dataset input valve immediately.
 
-        Raw/appsink branches have no predictive codec state and close
-        immediately. Encoded branches observe one natural IDR, count through
-        that GOP, and close after its final P-frame. Every encoder is therefore
-        poised to emit an IDR on the first frame after the valve next opens.
+        Every encoded AU is an IDR, so there is no predictive GOP phase to park.
+        NVENC may still emit a small in-flight tail after the close; the reader's
+        quiet flush drains it before the next shared-timestamp open.
         """
         self._cancel_dataset_enable()
         self._cancel_dataset_disable()
         if self._pipeline is None:
             return
-
-        armed: list[tuple[Any, int, threading.Event, Any, str]] = []
         try:
-            for valve_name, encoder_name in gates:
+            for valve_name, _encoder_name in gates:
                 valve = self._pipeline.get_by_name(valve_name)
                 if valve is None:
                     raise RuntimeError(f"missing dataset valve {valve_name!r}")
-                if bool(valve.get_property("drop")):
-                    continue
-                if encoder_name is None:
-                    valve.set_property("drop", True)
-                    continue
-                encoder = self._pipeline.get_by_name(encoder_name)
-                pad = None if encoder is None else encoder.get_static_pad("src")
-                if pad is None:
-                    raise RuntimeError(f"missing dataset encoder {encoder_name!r}")
-                event = threading.Event()
-                idr_interval = max(1, int(encoder.get_property("idrinterval")))
-                phase: dict[str, int | None] = {"since_idr": None}
-
-                def close_before_idr(
-                    _pad: Any,
-                    info: Any,
-                    *,
-                    branch_valve: Any = valve,
-                    closed: threading.Event = event,
-                    interval: int = idr_interval,
-                    branch_phase: dict[str, int | None] = phase,
-                ) -> Any:
-                    buf = info.get_buffer()
-                    if buf is None:
-                        return self._gst.PadProbeReturn.OK
-                    ok, mapinfo = buf.map(self._gst.MapFlags.READ)
-                    if not ok:
-                        return self._gst.PadProbeReturn.OK
-                    try:
-                        is_idr = any(
-                            (nal[0] & 0x1F) == 5
-                            for nal in _split_nals(bytes(mapinfo.data))
-                        )
-                    finally:
-                        buf.unmap(mapinfo)
-                    if is_idr:
-                        branch_phase["since_idr"] = 0
-                        if interval > 1:
-                            return self._gst.PadProbeReturn.OK
-                    elif branch_phase["since_idr"] is None:
-                        # Probe may have been installed mid-GOP. Observe one
-                        # real IDR before trusting the frame count.
-                        return self._gst.PadProbeReturn.OK
-                    else:
-                        branch_phase["since_idr"] += 1
-                        if branch_phase["since_idr"] < interval - 1:
-                            return self._gst.PadProbeReturn.OK
-                    # Let the final P-frame (or, for all-IDR encoding, this IDR)
-                    # continue downstream, then stop new raw frames. The first
-                    # encoded frame after reopening is a self-contained IDR.
-                    branch_valve.set_property("drop", True)
-                    closed.set()
-                    return self._gst.PadProbeReturn.REMOVE
-
-                probe_id = pad.add_probe(
-                    self._gst.PadProbeType.BUFFER, close_before_idr
-                )
-                if not probe_id:
-                    raise RuntimeError(
-                        f"could not install IDR probe on {encoder_name!r}"
-                    )
-                armed.append((pad, probe_id, event, valve, encoder_name))
+                valve.set_property("drop", True)
         except Exception:
-            self._dataset_disable = armed
-            self._cancel_dataset_disable()
             self._dataset_enabled = False
             for valve_name, _encoder_name in gates:
                 valve = self._pipeline.get_by_name(valve_name)
@@ -916,31 +853,12 @@ class _GstPipelineBase:
                     valve.set_property("drop", True)
             self._set_dataset_output_queue_depth(gates, active=False)
             raise
-        self._dataset_disable = armed
+        self._dataset_disable = []
 
     def _finish_dataset_disable(self, deadline: float) -> None:
-        """Wait for all probes armed by :meth:`_begin_dataset_disable`."""
-        pending, self._dataset_disable = self._dataset_disable, []
-        timed_out: list[str] = []
-        for pad, probe_id, event, valve, label in pending:
-            remaining = max(0.0, deadline - time.perf_counter())
-            if event.wait(remaining):
-                continue
-            # Fail closed. Saving an episode after a phase-align timeout would
-            # be unsafe, so the relay reports this error to the parent.
-            if not event.is_set():
-                try:
-                    pad.remove_probe(probe_id)
-                except Exception:  # noqa: BLE001 - race with a REMOVE callback
-                    pass
-                valve.set_property("drop", True)
-                timed_out.append(label)
-        if timed_out:
-            self._dataset_enabled = False
-            raise RuntimeError(
-                "timed out aligning dataset encoder before IDR on "
-                + ", ".join(timed_out)
-            )
+        """Complete an immediate all-intra dataset close."""
+        del deadline
+        self._dataset_disable = []
         self._dataset_enabled = False
 
     @property
@@ -1273,7 +1191,7 @@ class ZedGstCamera(_GstPipelineBase, _GstStreamConsumer):
         return (("rawvalve", "dsenc" if self._raw_socket_path else None),)
 
     def begin_raw_disable(self) -> None:
-        """Arm this camera's dataset encoder to stop before a subsequent IDR."""
+        """Close this camera's all-intra dataset input."""
         self._begin_dataset_disable(self._raw_gates())
 
     def finish_raw_disable(self, deadline: float) -> None:
@@ -1658,7 +1576,7 @@ class ZedGstStereoCamera(_GstPipelineBase):
         return tuple(gates)
 
     def begin_raw_disable(self) -> None:
-        """Arm every dataset eye to stop before a subsequent IDR."""
+        """Close every all-intra dataset-eye input."""
         self._begin_dataset_disable(self._raw_gates())
 
     def finish_raw_disable(self, deadline: float) -> None:

--- a/almond_axol/video/shm_frames.py
+++ b/almond_axol/video/shm_frames.py
@@ -501,26 +501,19 @@ class EncodedAuReader:
     :class:`~almond_axol.lerobot.h264_mux_encoder.H264MuxStreamingEncoder`, which
     just muxes them (no re-encode).
 
-    Unlike the raw :class:`GstShmFrameReader` (which serves ``read_at_or_after`` —
-    *selecting* the frame nearest a target time and dropping the rest), an encoded
-    stream cannot drop frames: every P-frame depends on its predecessors. So this
-    reader delivers **every** AU strictly **in order** via :meth:`read_next_au`,
-    and the capture loop is frame-driven (one AU consumed per dataset row). A
-    dedicated pull thread drains the (non-leaky) appsink. Before the first
-    episode flush it discards validated startup AUs; afterwards it fills an
-    in-process queue so a momentarily slow consumer grows the queue rather than
-    dropping AUs and corrupting the stream.
+    The dataset encoder is all-intra, so every AU is independently decodable.
+    This reader still delivers AUs strictly in order via :meth:`read_next_au`;
+    the capture loop consumes one per dataset row after it discards any leading
+    AUs needed to form a synchronized row-zero cluster. A dedicated pull thread
+    drains the (non-leaky) appsink. Before the first episode flush it discards
+    validated startup AUs; afterwards it fills an in-process bounded queue.
 
-    Each episode's mp4 must start on a keyframe (a leading P-frame is
-    undecodable), so after :meth:`flush` the reader drops AUs until the next IDR.
-    The relay can't force a keyframe on demand (the ``nvv4l2h264enc`` ``force-IDR``
-    signal segfaults and force-key-unit events are ignored on L4T), so the dataset
-    encoder runs a short ``idrinterval``; the episode's rows simply begin at the
-    first IDR after the valve opens. GDP restores the original sensor-exposure
-    PTS after shm; ``pts_perf_offset_s`` maps that pipeline running-time onto the
-    system-wide ``perf_counter`` clock used by joint/action snapshots. The mp4's
-    own timeline remains the constant-fps PTS the muxer assigns, independent of
-    this physical capture timestamp.
+    Each episode's mp4 starts on an IDR, and every following picture is also an
+    IDR. GDP restores the original sensor-exposure PTS after shm;
+    ``pts_perf_offset_s`` maps that pipeline running-time onto the system-wide
+    ``perf_counter`` clock used by joint/action snapshots. The mp4's own timeline
+    remains the constant-fps PTS the muxer assigns, independent of this physical
+    capture timestamp.
     """
 
     def __init__(
@@ -534,7 +527,7 @@ class EncodedAuReader:
         pts_perf_offset_s: float,
         capture_fps: int | None = None,
     ) -> None:
-        from .gst_zed import _DATASET_IDR_INTERVAL_S, _require_gst
+        from .gst_zed import _DATASET_GOP_FRAMES, _require_gst
 
         self._gst, _ = _require_gst()
         self.width = width
@@ -553,8 +546,8 @@ class EncodedAuReader:
         self._queue: deque[tuple[bytes, float, float]] = deque()
         # Never let a capture-loop failure turn into unbounded compressed-frame
         # growth while the operator continues moving before ending the take.
-        # Overflow is fatal for the episode because dropping one predictive AU
-        # invalidates every dependent P-frame until the next IDR.
+        # Overflow is fatal because it loses exposure/row alignment, even though
+        # every retained all-intra frame remains independently decodable.
         self._queue_limit = max(60, 2 * fps)
         self._cond = threading.Condition()
         # Episode-start drain handshake. While the relay valve is closed the
@@ -573,16 +566,10 @@ class EncodedAuReader:
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
         self._sink: Any = None
-        # Keyframe-cadence integrity guard. The relay emits an IDR every
-        # ``_DATASET_IDR_INTERVAL_S`` (see gst_zed), so a run of more than
-        # ~1.5x that many frames without a keyframe means a *keyframe was lost
-        # upstream* — and every frame muxed until the next IDR references that
-        # missing reference, so those dataset rows won't decode. We can't undo it
-        # here (the orphaned frames are already delivered), but logging it loudly
-        # turns a silent, train-time-only corruption into a diagnosable signal
-        # (which camera, which frame). ``_delivered`` is the running AU index for
-        # the log; ``_gap_warnings`` counts detections for the disconnect summary.
-        self._expected_gop = max(1, round(fps * _DATASET_IDR_INTERVAL_S))
+        # The relay promises an all-intra dataset stream. Verify that contract in
+        # the reader too: accepting one predictive picture would make startup
+        # realignment unsafe and reintroduce the hidden encoder-GOP phase race.
+        self._expected_gop = max(1, int(_DATASET_GOP_FRAMES))
         self._gop_warn_at = self._expected_gop + max(2, self._expected_gop // 2)
         self._since_keyframe = 0
         self._delivered = 0
@@ -590,8 +577,8 @@ class EncodedAuReader:
         # gdpdepay restores the sender's serialized caps and buffer metadata.
         # Keep a fixed H.264 filter as an integrity check; h264parse re-derives
         # dimensions from the SPS and preserves the exposure PTS.
-        # drop=false: never discard an AU (it would break H.264 decode); the pull
-        # thread keeps the appsink drained so it rarely back-pressures shmsrc.
+        # drop=false: never discard an exposure silently; the pull thread keeps
+        # the appsink drained so it rarely back-pressures shmsrc.
         caps = (
             f"video/x-h264,stream-format=byte-stream,alignment=au,"
             f"width={width},height={height},framerate={fps}/1"
@@ -601,6 +588,11 @@ class EncodedAuReader:
             f"! gdpdepay ! {caps} ! h264parse "
             "! appsink name=au emit-signals=false max-buffers=60 drop=false sync=false"
         )
+
+    @property
+    def frames_are_independent(self) -> bool:
+        """Whether callers may discard an AU without breaking later frames."""
+        return self._expected_gop == 1
 
     @property
     def is_connected(self) -> bool:
@@ -664,8 +656,8 @@ class EncodedAuReader:
         ``_minimum_capture_perf`` is the newest sensor PTS this reader had
         already observed, not the host time at which ``flush`` runs. Exposure
         necessarily predates delivery, so a wall-time cutoff would reject the
-        freshly reopened IDR and delay row zero by a whole GOP. Queue clearing,
-        strictly newer PTS, and the actual-IDR requirement together reject the
+        freshly reopened IDR and delay row zero by another frame. Queue clearing,
+        strictly newer PTS, and the all-intra requirement together reject the
         previous episode's tail without confusing transport latency for age.
         """
         self.begin_flush()
@@ -736,8 +728,8 @@ class EncodedAuReader:
             ok, mapinfo = buf.map(Gst.MapFlags.READ)
             if not ok:
                 self._fail(
-                    f"encoded AU on {self._name} could not be mapped; a "
-                    "dependency-bearing frame was lost"
+                    f"encoded AU on {self._name} could not be mapped; an "
+                    "encoded exposure was lost"
                 )
                 continue
             try:
@@ -750,6 +742,13 @@ class EncodedAuReader:
             if not _au_has_coded_slice(au):
                 continue
             is_idr = _au_is_idr(au)
+            if self.frames_are_independent and not is_idr:
+                self._fail(
+                    f"encoded AU on {self._name} is predictive but the dataset "
+                    "encoder is configured all-intra",
+                    permanent=True,
+                )
+                continue
             if buf.pts == Gst.CLOCK_TIME_NONE:
                 self._fail(
                     f"encoded AU on {self._name} has no PTS; exact "
@@ -761,7 +760,7 @@ class EncodedAuReader:
             # legitimate value only for the pipeline's very first frame; once
             # flush() establishes an episode boundary, seeing it means the
             # sender lost a timestamp. Silently filtering it as an old frame
-            # would also leave subsequent P-frames without a reference.
+            # would also destroy exact exposure/row accounting.
             if buf.pts == 0 and self._episode_cutoff_active:
                 self._fail(
                     f"encoded AU on {self._name} reset to PTS 0; exact "
@@ -813,8 +812,9 @@ class EncodedAuReader:
                         self._fail_keyframe_gap()
                         continue
                 # A shmsrc DISCONT after the first AU means an upstream buffer was
-                # dropped between the relay and here — the following frames can lose
-                # their reference. Surface it (the first AU legitimately carries it).
+                # dropped between the relay and here. Even though later all-intra
+                # frames decode, row/exposure accounting is no longer exact. Surface
+                # it (the first AU legitimately carries the startup discontinuity).
                 if discont and self._seen_first_au:
                     self._fail(
                         f"encoded-AU discontinuity on {self._name} near frame "
@@ -825,7 +825,7 @@ class EncodedAuReader:
                     self._error = (
                         f"encoded-AU backlog on {self._name} exceeded "
                         f"{self._queue_limit} frames; capture stopped draining "
-                        "the predictive stream"
+                        "the encoded stream"
                     )
                     self._queue.clear()
                     self._cond.notify_all()

--- a/almond_axol/video/video_proc.py
+++ b/almond_axol/video/video_proc.py
@@ -149,10 +149,8 @@ def _set_dataset_branches_enabled(owned: list[object], enabled: bool) -> None:
             raise RuntimeError("; ".join([*errors, *close_errors]))
         return
 
-    # Two phases are intentional: install the IDR probes on every physical
-    # camera before waiting on any one of them. Sequential arm+wait would stop
-    # cameras at different GOP phases and their episode-opening IDRs could be
-    # hundreds of milliseconds apart.
+    # Keep the two-phase camera API even though all-intra closes are immediate:
+    # legacy/raw cameras can still need an arm followed by a bounded finish.
     armed = []
     errors = []
     for cam in owned:
@@ -167,9 +165,7 @@ def _set_dataset_branches_enabled(owned: list[object], enabled: bool) -> None:
                 cam.set_raw_enabled(False)
             except Exception as exc:  # noqa: BLE001 - finish other cameras
                 errors.append(f"{cam}: {exc}")
-    # Matches gst_zed's gate bound. At the supported 1 fps minimum a valid next
-    # encoder output can arrive almost exactly one second later, so a 1.0 s
-    # deadline spuriously fails under any scheduling load.
+    # Matches gst_zed's gate bound for any legacy/raw finish transaction.
     deadline = time.perf_counter() + 2.0
     for cam in armed:
         try:
@@ -705,7 +701,7 @@ def _relay_main(
                 last = now
 
     def _set_raw_enabled(enabled: bool) -> None:
-        """Gate every dataset branch, coordinating encoded GOP phase."""
+        """Gate every dataset branch at a coordinated exposure boundary."""
         _set_dataset_branches_enabled(owned, bool(enabled))
 
     async def serve() -> None:
@@ -749,9 +745,9 @@ def _relay_main(
                 elif kind == "raw_enable":
                     _, enabled = msg
                     try:
-                        # Waiting for the cameras' next natural IDRs can take a
-                        # GOP. Keep that wait off aiortc's event loop so RTP,
-                        # RTCP, and signaling continue uninterrupted.
+                        # Dataset gates can wait for a shared exposure boundary.
+                        # Keep that wait off aiortc's event loop so RTP, RTCP,
+                        # and signaling continue uninterrupted.
                         await loop.run_in_executor(
                             None, _set_raw_enabled, bool(enabled)
                         )

--- a/tests/test_dagger_control_cleanup.py
+++ b/tests/test_dagger_control_cleanup.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 import threading
 import unittest
+from unittest.mock import patch
 
-from almond_axol.cli.collect_dagger import _stop_dagger_control_thread
+from almond_axol.cli.collect_dagger import (
+    _DaggerControlLoop,
+    _stop_dagger_control_thread,
+)
 
 
 class _BlockingControlThread(threading.Thread):
@@ -17,7 +21,28 @@ class _BlockingControlThread(threading.Thread):
         self.stopped.set()
 
 
+class _RejectedRecorder:
+    def poll_capture_error(self) -> str:
+        return "camera alignment failed"
+
+
 class DaggerControlCleanupTest(unittest.TestCase):
+    def test_capture_rejection_is_episode_local_not_fatal(self) -> None:
+        control_loop = _DaggerControlLoop(
+            robot=object(),
+            policy=object(),
+            teleop=object(),
+            recorder=_RejectedRecorder(),
+            fps=30,
+            teleop_hz=120,
+        )
+
+        with patch("lerobot.utils.utils.log_say"):
+            control_loop.run()
+
+        self.assertEqual(control_loop.capture_error, "camera alignment failed")
+        self.assertIsNone(control_loop.fatal_error)
+
     def test_outer_cleanup_signals_and_joins_started_control_thread(self) -> None:
         control_thread = _BlockingControlThread()
         control_thread.start()

--- a/tests/test_encoded_au_reader.py
+++ b/tests/test_encoded_au_reader.py
@@ -7,7 +7,6 @@ from unittest.mock import patch
 
 from almond_axol.video.shm_frames import EncodedAuReader
 
-
 _IDR = b"\x00\x00\x00\x01\x65\x88"
 _P_FRAME = b"\x00\x00\x00\x01\x41\x9a"
 
@@ -91,8 +90,8 @@ class EncodedAuReaderDiscontinuityTest(unittest.TestCase):
             reader,
             [
                 _FakeBuffer(_IDR, 1_000_000_000),
-                _FakeBuffer(_P_FRAME, 1_016_000_000, discont=True),
-                _FakeBuffer(_P_FRAME, 1_032_000_000, discont=True),
+                _FakeBuffer(_IDR, 1_016_000_000, discont=True),
+                _FakeBuffer(_IDR, 1_032_000_000, discont=True),
             ],
         )
 
@@ -111,9 +110,8 @@ class EncodedAuReaderDiscontinuityTest(unittest.TestCase):
         _pull(
             reader,
             [
-                _FakeBuffer(_P_FRAME, 1_000_000_000, discont=True),
                 _FakeBuffer(_IDR, 1_016_000_000, discont=True),
-                _FakeBuffer(_P_FRAME, 1_032_000_000),
+                _FakeBuffer(_IDR, 1_032_000_000),
             ],
         )
 
@@ -123,7 +121,7 @@ class EncodedAuReaderDiscontinuityTest(unittest.TestCase):
 
         _pull(
             reader,
-            [_FakeBuffer(_P_FRAME, 1_048_000_000, discont=True)],
+            [_FakeBuffer(_IDR, 1_048_000_000, discont=True)],
         )
 
         self.assertEqual(reader.pending, 0)
@@ -131,6 +129,15 @@ class EncodedAuReaderDiscontinuityTest(unittest.TestCase):
             RuntimeError, "encoded-AU discontinuity.*near frame 2"
         ):
             reader.read_next_au(timeout_ms=0)
+
+    def test_predictive_frame_violates_all_intra_contract(self) -> None:
+        reader = _reader()
+
+        _pull(reader, [_FakeBuffer(_P_FRAME, 1_000_000_000)])
+
+        self.assertFalse(reader._first_sample.is_set())
+        self.assertEqual(reader.pending, 0)
+        self.assertIn("configured all-intra", reader._permanent_error or "")
 
     def test_invalid_startup_timestamp_remains_fatal(self) -> None:
         reader = _reader()

--- a/tests/test_gst_dataset_transport.py
+++ b/tests/test_gst_dataset_transport.py
@@ -139,6 +139,7 @@ class GstDatasetTransportTest(unittest.TestCase):
         branch = pipeline[start:end]
 
         self.assertIn(f"name={encoder_name}", branch)
+        self.assertIn("iframeinterval=1 idrinterval=1", branch)
         self.assertIn(
             "video/x-h264,stream-format=byte-stream,alignment=au ! "
             f"queue name={encoder_name}_outq leaky=downstream "
@@ -189,6 +190,19 @@ class GstDatasetTransportTest(unittest.TestCase):
 
 
 class GstDatasetEnableBarrierTest(unittest.TestCase):
+    def test_all_intra_dataset_close_is_immediate(self) -> None:
+        base, valves = _fake_gate_base()
+        valve = valves["rawvalve"]
+        valve.set_property("drop", False)
+        base._dataset_enabled = True
+
+        base._begin_dataset_disable((("rawvalve", "dsenc"),))
+        base._finish_dataset_disable(time.perf_counter() + 1.0)
+
+        self.assertTrue(valve.drop)
+        self.assertFalse(base._dataset_enabled)
+        self.assertEqual(base._dataset_disable, [])
+
     def test_valve_opens_on_first_exposure_at_or_after_shared_target(self) -> None:
         base, valves = _fake_gate_base(offset_s=90.0)
         valve = valves["rawvalve"]
@@ -201,7 +215,7 @@ class GstDatasetEnableBarrierTest(unittest.TestCase):
         self.assertFalse(valve.drop)
         base._finish_dataset_enable(0.0)
 
-    def test_active_episode_expands_bounded_predictive_queue(self) -> None:
+    def test_active_episode_expands_bounded_encoded_queue(self) -> None:
         base, _valves = _fake_gate_base()
         output_queue = base._pipeline.get_by_name("dsenc_outq")
 

--- a/tests/test_h264_mux_stats.py
+++ b/tests/test_h264_mux_stats.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+
+from almond_axol.lerobot.h264_mux_encoder import _CameraH264Muxer
+
+_IDR = b"\x00\x00\x00\x01\x65\x88"
+
+
+class _FakeBuffer:
+    @classmethod
+    def new_wrapped(cls, payload: bytes) -> "_FakeBuffer":
+        instance = cls()
+        instance.payload = payload
+        instance.pts = None
+        instance.dts = None
+        instance.duration = None
+        return instance
+
+
+class _FakeSource:
+    def __init__(self) -> None:
+        self.pushed = 0
+
+    def emit(self, signal: str, _buffer: _FakeBuffer) -> str:
+        assert signal == "push-buffer"
+        self.pushed += 1
+        return "ok"
+
+
+class _FakeStatsWorker:
+    def __init__(self) -> None:
+        self.samples: list[bytes] = []
+
+    def feed(self, au: bytes) -> None:
+        self.samples.append(au)
+
+
+class _FakeFrame:
+    def to_ndarray(self, *, format: str) -> np.ndarray:
+        assert format == "rgb24"
+        return np.zeros((2, 2, 3), dtype=np.uint8)
+
+
+class _FakePacket:
+    def __init__(self, index: int) -> None:
+        self.dts = index
+        self.is_keyframe = True
+        self.decode_calls = 0
+
+    def decode(self) -> list[_FakeFrame]:
+        self.decode_calls += 1
+        return [_FakeFrame()]
+
+
+class _FakeContainer:
+    def __init__(self, packets: list[_FakePacket]) -> None:
+        self.packets = packets
+        self.streams = types.SimpleNamespace(video=[types.SimpleNamespace()])
+
+    def __enter__(self) -> "_FakeContainer":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        pass
+
+    def demux(self, _stream: object) -> list[_FakePacket]:
+        return self.packets
+
+
+class H264MuxStatsSamplingTest(unittest.TestCase):
+    def test_all_idr_stream_keeps_stats_decode_at_four_hz(self) -> None:
+        muxer = _CameraH264Muxer.__new__(_CameraH264Muxer)
+        muxer._gst = types.SimpleNamespace(
+            SECOND=1_000_000_000,
+            Buffer=_FakeBuffer,
+            FlowReturn=types.SimpleNamespace(OK="ok"),
+        )
+        muxer.video_path = Path("camera.mp4")
+        muxer._dur = muxer._gst.SECOND // 60
+        muxer._count = 0
+        muxer._stats_stride = 15
+        muxer._src = _FakeSource()
+        muxer._stats_worker = _FakeStatsWorker()
+
+        for _ in range(60):
+            muxer.feed(_IDR)
+
+        self.assertEqual(muxer._src.pushed, 60)
+        self.assertEqual(muxer._count, 60)
+        self.assertEqual(len(muxer._stats_worker.samples), 4)
+
+    def test_fallback_decodes_only_the_stats_stride(self) -> None:
+        packets = [_FakePacket(index) for index in range(60)]
+        muxer = _CameraH264Muxer.__new__(_CameraH264Muxer)
+        muxer._want_stats = True
+        muxer.video_path = Path(__file__)
+        muxer._stats_stride = 15
+
+        with patch("av.open", return_value=_FakeContainer(packets)):
+            result = muxer._compute_stats_from_file()
+
+        self.assertIsNotNone(result)
+        self.assertEqual(sum(packet.decode_calls for packet in packets), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_recorder_capture_error.py
+++ b/tests/test_recorder_capture_error.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
 import multiprocessing
+import threading
+import time
 import unittest
 from unittest.mock import patch
 
 from almond_axol.recording.record_proc import (
     DatasetRecorderProcess,
     InProcessRecorder,
+    RecorderCaptureError,
+    RecorderDatasetSaveError,
+    _align_independent_encoded_start,
+    run_encoded_capture_loop,
 )
 
 
@@ -26,7 +32,185 @@ class _FakeVerifier:
         self.events.append("verifier-close")
 
 
+class _ReplyConnection:
+    def __init__(self, reply: object) -> None:
+        self.reply = reply
+        self.sent: list[object] = []
+
+    def send(self, value: object) -> None:
+        self.sent.append(value)
+
+    def poll(self, _timeout: float) -> bool:
+        return True
+
+    def recv(self) -> object:
+        return self.reply
+
+
+class _EncodedCamera:
+    frames_are_independent = True
+    capture_fps = 60
+    pending = 0
+
+    def __init__(self, packets: list[tuple[bytes, float, float]]) -> None:
+        self.packets = packets
+
+    def begin_flush(self) -> None:
+        pass
+
+    def finish_flush(self) -> None:
+        pass
+
+    def read_next_au(self, timeout_ms: float) -> tuple[bytes, float, float]:
+        del timeout_ms
+        if not self.packets:
+            raise TimeoutError
+        return self.packets.pop(0)
+
+
+class _CaptureDataset:
+    features: dict = {}
+
+    def __init__(self, stop: threading.Event) -> None:
+        self.stop = stop
+        self.rows: list[dict] = []
+
+    def add_frame(self, row: dict) -> None:
+        self.rows.append(row)
+        self.stop.set()
+
+
 class DatasetRecorderCaptureErrorTest(unittest.TestCase):
+    def test_row_zero_alignment_advances_only_lagging_all_intra_streams(
+        self,
+    ) -> None:
+        packets = {
+            "overhead_left": (b"o0", 10.0000, 1.0),
+            "overhead_right": (b"o1", 10.0000, 1.0),
+            "left_arm": (b"l", 10.0333, 1.0),
+            "right_arm": (b"r0", 10.0000, 1.0),
+        }
+        queued = {
+            "overhead_left": [
+                (b"o2", 10.0167, 1.1),
+                (b"o4", 10.0334, 1.2),
+            ],
+            "overhead_right": [
+                (b"o3", 10.0167, 1.1),
+                (b"o5", 10.0334, 1.2),
+            ],
+            "right_arm": [
+                (b"r1", 10.0167, 1.1),
+                (b"r2", 10.0334, 1.2),
+            ],
+        }
+
+        def read_next(name: str) -> tuple[bytes, float, float] | None:
+            values = queued.get(name, [])
+            return values.pop(0) if values else None
+
+        aligned, dropped = _align_independent_encoded_start(
+            packets,
+            read_next,
+            fps=60,
+            capture_fps=dict.fromkeys(packets, 60),
+        )
+
+        times = [packet[1] for packet in aligned.values()]
+        self.assertLessEqual(max(times) - min(times), 0.025)
+        self.assertEqual(
+            dropped,
+            {"overhead_left": 2, "overhead_right": 2, "right_arm": 2},
+        )
+        self.assertEqual(aligned["left_arm"][0], b"l")
+
+    def test_row_zero_alignment_fails_if_lagging_stream_stalls(self) -> None:
+        packets = {"overhead": (b"o", 1.0, 1.0), "wrist": (b"w", 1.1, 1.0)}
+
+        with self.assertRaisesRegex(TimeoutError, "overhead.*did not catch up"):
+            _align_independent_encoded_start(
+                packets,
+                lambda _name: None,
+                fps=30,
+                capture_fps=dict.fromkeys(packets, 30),
+            )
+
+    def test_row_zero_alignment_rejects_a_dropped_prefix_frame(self) -> None:
+        packets = {"overhead": (b"o", 1.0, 1.0), "wrist": (b"w", 1.1, 1.0)}
+
+        with self.assertRaisesRegex(RuntimeError, "dropped an encoded frame"):
+            _align_independent_encoded_start(
+                packets,
+                lambda _name: (b"jump", 1.075, 1.1),
+                fps=30,
+                capture_fps=dict.fromkeys(packets, 60),
+            )
+
+    def test_encoded_capture_saves_the_aligned_access_units_verbatim(self) -> None:
+        stop = threading.Event()
+        dataset = _CaptureDataset(stop)
+        base = time.perf_counter() + 0.1
+        step = 1.0 / 60.0
+        cameras = {
+            "overhead_left": _EncodedCamera(
+                [
+                    (b"ol0", base, base),
+                    (b"ol1", base + step, base),
+                    (b"ol2", base + 2 * step, base),
+                ]
+            ),
+            "overhead_right": _EncodedCamera(
+                [
+                    (b"or0", base, base),
+                    (b"or1", base + step, base),
+                    (b"or2", base + 2 * step, base),
+                ]
+            ),
+            "left_arm": _EncodedCamera([(b"la2", base + 2 * step, base)]),
+            "right_arm": _EncodedCamera(
+                [
+                    (b"ra0", base, base),
+                    (b"ra1", base + step, base),
+                    (b"ra2", base + 2 * step, base),
+                ]
+            ),
+        }
+        errors: list[str] = []
+
+        def snapshot(ts: float) -> tuple[dict, dict, float, bool]:
+            return {"state": 1}, {"target": 2}, ts, False
+
+        def build_frame(_features: dict, values: dict, prefix: str) -> dict:
+            return {f"{prefix}.{name}": value for name, value in values.items()}
+
+        with (
+            patch(
+                "lerobot.utils.feature_utils.build_dataset_frame",
+                side_effect=build_frame,
+            ),
+            patch("lerobot.utils.visualization_utils.log_rerun_data"),
+        ):
+            run_encoded_capture_loop(
+                cameras=cameras,
+                read_snapshot=lambda: snapshot(time.perf_counter()),
+                read_snapshot_nearest=lambda ts: snapshot(ts),
+                dataset=dataset,
+                robot_obs_proc=lambda obs: obs,
+                fps=60,
+                task="test",
+                rerun_ip=None,
+                stop_event=stop,
+                on_error=errors.append,
+            )
+
+        self.assertEqual(errors, [])
+        self.assertEqual(len(dataset.rows), 1)
+        row = dataset.rows[0]
+        self.assertEqual(row["observation.overhead_left"], b"ol2")
+        self.assertEqual(row["observation.overhead_right"], b"or2")
+        self.assertEqual(row["observation.left_arm"], b"la2")
+        self.assertEqual(row["observation.right_arm"], b"ra2")
+
     def test_in_process_close_discards_normal_unsaved_episode_before_finalize(
         self,
     ) -> None:
@@ -50,6 +234,95 @@ class DatasetRecorderCaptureErrorTest(unittest.TestCase):
             recorder.close()
 
         self.assertEqual(events, ["clear", "finalize", "verifier-close"])
+
+    def test_in_process_finish_capture_error_clears_then_raises_typed(self) -> None:
+        events: list[str] = []
+        recorder = InProcessRecorder.__new__(InProcessRecorder)
+        recorder._thread = None
+        recorder._stop = None
+        recorder._capture_error = "camera alignment failed"
+        recorder._dataset = _FakeDataset(events)
+        recorder._frames = {"n": 4}
+
+        with self.assertRaisesRegex(RecorderCaptureError, "alignment failed"):
+            recorder.finish_episode()
+
+        self.assertEqual(events, ["clear"])
+
+    def test_in_process_finish_stop_failure_stays_fatal(self) -> None:
+        recorder = InProcessRecorder.__new__(InProcessRecorder)
+        with patch.object(
+            recorder,
+            "_stop_capture",
+            side_effect=RuntimeError("capture thread did not stop"),
+        ):
+            with self.assertRaises(RuntimeError) as raised:
+                recorder.finish_episode()
+
+        self.assertNotIsInstance(raised.exception, RecorderCaptureError)
+
+    def test_in_process_save_dropped_frame_is_typed_precommit_rejection(self) -> None:
+        events: list[str] = []
+        recorder = InProcessRecorder.__new__(InProcessRecorder)
+        recorder._thread = None
+        recorder._stop = None
+        recorder._capture_error = None
+        recorder._dataset = _FakeDataset(events)
+
+        with (
+            patch(
+                "almond_axol.lerobot.nvenc_encoder.dropped_frames",
+                return_value=2,
+            ),
+            self.assertRaisesRegex(RecorderCaptureError, "2 video frame"),
+        ):
+            recorder.save_episode()
+
+        self.assertEqual(events, ["clear"])
+
+    def test_process_finish_uses_post_join_capture_error_reply(self) -> None:
+        conn = _ReplyConnection(("finished", 7, "camera alignment failed"))
+        recorder = DatasetRecorderProcess.__new__(DatasetRecorderProcess)
+        recorder._lock = threading.Lock()
+        recorder._conn = conn
+        recorder._capture_error = None
+
+        with self.assertRaisesRegex(RecorderCaptureError, "alignment failed"):
+            recorder.finish_episode()
+
+        self.assertEqual(conn.sent, [("finish_episode",)])
+        self.assertEqual(recorder._capture_error, "camera alignment failed")
+
+    def test_process_finish_non_capture_error_stays_fatal(self) -> None:
+        conn = _ReplyConnection(("error", "capture thread did not stop"))
+        recorder = DatasetRecorderProcess.__new__(DatasetRecorderProcess)
+        recorder._lock = threading.Lock()
+        recorder._conn = conn
+
+        with self.assertRaises(RuntimeError) as raised:
+            recorder.finish_episode()
+
+        self.assertNotIsInstance(raised.exception, RecorderCaptureError)
+
+    def test_process_save_distinguishes_capture_rejection_from_commit_failure(
+        self,
+    ) -> None:
+        recorder = DatasetRecorderProcess.__new__(DatasetRecorderProcess)
+        recorder._lock = threading.Lock()
+        recorder._capture_error = None
+
+        recorder._conn = _ReplyConnection(("capture_error", "2 dropped frames"))
+        with self.assertRaises(RecorderCaptureError):
+            recorder.save_episode()
+
+        recorder._conn = _ReplyConnection(("error", "mux prepare failed"))
+        with self.assertRaises(RuntimeError) as prepare_failure:
+            recorder.save_episode()
+        self.assertNotIsInstance(prepare_failure.exception, RecorderCaptureError)
+
+        recorder._conn = _ReplyConnection(("fatal", "parquet commit failed"))
+        with self.assertRaises(RecorderDatasetSaveError):
+            recorder.save_episode()
 
     def test_capture_error_uses_separate_nonblocking_channel(self) -> None:
         ctx = multiprocessing.get_context("spawn")


### PR DESCRIPTION
## What changed

- make only the dataset H.264 branches all-intra while leaving WebRTC encoders unchanged
- align recorder row zero from the actual sensor-exposure PTS of independently decodable AUs
- validate prefix and saved-AU cadence, discontinuities, and all-intra integrity
- classify only pre-commit capture rejection as episode-local; recorder, IPC, relay, control, and dataset-save failures stay fatal
- discard, home, and retry the same episode in collect-data and collect-dagger
- throttle both live and fallback image-stat decoding to about 4 Hz

## Why

The shared raw-valve barrier acknowledged the same source timestamp, but leaky pre-valve queues and variable Jetson NVENC tail depth could leave the first recorder-visible predictive IDRs two frames apart. That produced a 33.3 ms camera spread against the 25 ms integrity limit and killed the session at record start.

All-intra removes hidden GOP phase from the dataset-only path, and the recorder now forms row zero from the AUs that actually arrived rather than assuming valve acknowledgement implies identical encoder output phase.

## Validation

- 107 Axol unit tests pass
- 34 focused camera-path tests pass
- Ruff check and format pass
- synthetic Jetson nvv4l2h264enc smoke produced 12 of 12 IDR access units with iframeinterval=1 and idrinterval=1
- final camera/recovery audits found no code blockers

A full on-robot four-feed smoke is still recommended to validate aggregate NVENC throughput and visual quality before merging.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core Jetson dataset encoding, multi-camera row-zero sync, and when collection sessions abort vs retry; mistakes could corrupt datasets or leave sessions wedged, but pre-commit typing and tests narrow blast radius.
> 
> **Overview**
> Fixes multi-camera **record-start failures** where the first encoded frames could land tens of milliseconds apart despite a shared valve open, tripping camera-alignment limits and killing the whole session.
> 
> **Dataset-only H.264 is now all-intra** (`iframeinterval=1` / `idrinterval=1` on the relay dataset branches). That removes hidden NVENC GOP phase between episodes, lets the recorder **realign row zero** by advancing lagging streams on actual exposure PTS (with cadence validation), and **closes dataset valves immediately** instead of waiting for the next natural IDR.
> 
> **Capture integrity failures are episode-scoped**: a new `RecorderCaptureError` marks pre-commit rejections (capture thread errors, encoder drops, alignment/cadence checks) after the buffer is cleared. `collect-data` and `collect-dagger` **end the take, discard, home, and retry the same episode index** instead of treating these as fatal; recorder IPC/lifecycle and `RecorderDatasetSaveError` still stop the session. Finish/save paths carry capture errors on the **command reply** so they don’t race the error pipe.
> 
> **Image-stats decoding** for muxed H.264 is throttled to ~4 Hz (live and file fallback) so all-ID streams don’t decode every frame at full fps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ae0fedd650369ea32eecd3c34f953e42c8a8326. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->