### PR TITLE
Buffer dataset encoder startup safely

### DIFF
--- a/almond_axol/cli/collect_data.py
+++ b/almond_axol/cli/collect_data.py
@@ -538,6 +538,18 @@ def main(argv: list[str]) -> None:
     _run(cfg)
 
 
+def _resolve_control_trace_prefix(record: str | None) -> str | None:
+    """Resolve an explicitly requested flight-recorder prefix.
+
+    ``VRTeleopConfig.record`` is an opt-in diagnostic. In particular, keep its
+    documented ``None`` default disabled during data collection instead of
+    silently turning every production session into a flight recording.
+    """
+    if not record:
+        return None
+    return resolve_prefix(record)
+
+
 def _run(
     cfg: CollectDataConfig,
     stop_event: "threading.Event | None" = None,
@@ -609,21 +621,17 @@ def _run(
     ):
         cfg.teleop_config.has_gripper = cfg.robot_config.axol_config.has_gripper
 
-        # Always retain a synchronized control trace for hardware collection.
-        # Camera/recorder load is exactly where timing-only faults can appear,
-        # and without the Rust rows a dangerous oscillation leaves only a
-        # five-second aggregate lateness counter. Honour an explicit recorder
-        # name; otherwise create a unique per-session prefix. The IK/cmd taps
-        # still gate themselves to actual tracking, while the Rust/measured
-        # trace is enabled below only after PyRoKi startup and remains active
-        # through guarded returns so recovery-path faults are captured too.
+        # Keep the optional teleop flight recorder coherent across Python and
+        # Rust. An explicit name enables every stage; the documented ``None``
+        # default stays off so production collection does not incur diagnostic
+        # snapshot/compression work unless the operator asks for it. When
+        # enabled, the IK/cmd taps gate themselves to actual tracking, while the
+        # Rust/measured trace is enabled below only after PyRoKi startup and
+        # remains active through guarded returns.
         vrt_cfg = cfg.teleop_config.vr_teleop_config
-        trace_name = vrt_cfg.record or (
-            time.strftime("collect_data_%Y%m%d_%H%M%S")
-            + f"_{time.time_ns() % 1_000_000_000:09d}"
-        )
-        trace_prefix = resolve_prefix(trace_name)
-        vrt_cfg.record = trace_prefix
+        trace_prefix = _resolve_control_trace_prefix(vrt_cfg.record)
+        if trace_prefix is not None:
+            vrt_cfg.record = trace_prefix
     else:
         trace_prefix = None
 

--- a/almond_axol/recording/record_proc.py
+++ b/almond_axol/recording/record_proc.py
@@ -1404,8 +1404,8 @@ def run_encoded_capture_loop(
                 return
 
             # Trust but verify the raw-valve barrier using the timestamps that
-            # actually reached the recorder. A two-buffer leaky input queue or
-            # a stale NVENC tail can make one first AU later/earlier even though
+            # actually reached the recorder. A bounded leaky input queue or a
+            # stale NVENC tail can make one first AU later/earlier even though
             # every valve crossed the same target. All-intra makes it safe to
             # advance only the lagging streams until their first retained
             # exposures form one valid camera cluster.

--- a/almond_axol/video/gst_zed.py
+++ b/almond_axol/video/gst_zed.py
@@ -428,13 +428,23 @@ def _raw_shmsink(socket_path: str) -> str:
 # Both ``iframeinterval`` and ``idrinterval`` must be one: nvv4l2h264enc exposes
 # them as separate READY-only controls.
 _DATASET_GOP_FRAMES = 1
-# Before the recorder connects, a tiny leaky output queue is intentional: it
-# keeps NVENC returning its NVMM surfaces while shmsink parks GDP's one-shot
-# header. Once an episode opens, two seconds of bounded compressed-AU headroom
-# absorbs scheduler jitter without silently losing encoded exposures.
+# Before the recorder connects, tiny leaky queues around the dataset encoder are
+# intentional: the upstream branch queue keeps the camera tee fresh while the
+# valve is closed, and the output queue keeps NVENC returning its NVMM surfaces
+# while shmsink parks GDP's one-shot header. During an episode a short input
+# queue *after* a forced VIC copy absorbs NVENC startup jitter without retaining
+# a large pool of camera-owned/crop surfaces; the compressed output keeps a
+# longer cushion for recorder scheduling jitter. Both remain bounded and leaky
+# so a dead recorder cannot back-pressure Argus or the independent headset path.
 _DATASET_STARTUP_QUEUE_BUFFERS = 2
-_DATASET_ACTIVE_QUEUE_MIN_BUFFERS = 60
-_DATASET_ACTIVE_QUEUE_SECONDS = 2
+_DATASET_ACTIVE_INPUT_QUEUE_MIN_BUFFERS = 15
+_DATASET_ACTIVE_INPUT_QUEUE_SECONDS = 0.5
+_DATASET_ACTIVE_OUTPUT_QUEUE_MIN_BUFFERS = 60
+_DATASET_ACTIVE_OUTPUT_QUEUE_SECONDS = 2
+# The VIC pool must exceed the downstream queue capacity so NVENC can retain a
+# few input surfaces while a new buffer still reaches the queue and triggers its
+# downstream-leaky policy instead of blocking back into the camera tee.
+_DATASET_VIC_INFLIGHT_SURFACES = 8
 # Opening every camera with a sequence of host-side property writes can straddle
 # multiple source frames. Arm a timestamp probe on every branch first, then let
 # each one open itself on its first exposure at/after one shared future instant.
@@ -461,6 +471,23 @@ def _dataset_rate_limit(capture_fps: int, dataset_fps: int) -> str:
         f"videorate drop-only=true max-rate={dataset_fps} ! "
         "video/x-raw(memory:NVMM),format=NV12,"
         f"framerate={dataset_fps}/1 ! "
+    )
+
+
+def _dataset_input_queue(name: str) -> str:
+    """Named bounded queue between the dataset VIC copy and NVENC."""
+    return (
+        f"queue name={name}_inq leaky=downstream "
+        f"max-size-buffers={_DATASET_STARTUP_QUEUE_BUFFERS} "
+        "max-size-bytes=0 max-size-time=0"
+    )
+
+
+def _dataset_active_input_buffers(dataset_fps: int) -> int:
+    """Short converted-surface cushion for an active dataset encoder."""
+    return max(
+        _DATASET_ACTIVE_INPUT_QUEUE_MIN_BUFFERS,
+        math.ceil(_DATASET_ACTIVE_INPUT_QUEUE_SECONDS * max(1, dataset_fps)),
     )
 
 
@@ -491,8 +518,10 @@ def _dataset_enc_shmsink(
     A leaky queue after the encoder keeps NVENC draining (and releases its NVMM
     input surfaces) while that packet is parked; the queue must stay before
     ``gdppay`` so it can never discard GDP's one-shot stream/caps header. The
-    branch's earlier queue still decouples it from camera capture and the
-    independent headset branch.
+    short named queue between a forced VIC copy and NVENC decouples encoder
+    startup stalls from camera capture and the independent headset branch
+    without retaining the source camera's buffers. Both named queues grow only
+    while an episode is active.
     The rate limiter deliberately stays upstream of the valve: it must continue
     tracking the source timeline between episodes, otherwise reopening a stale
     ``videorate`` can briefly pass capture-rate frames into a lower-rate dataset.
@@ -504,9 +533,12 @@ def _dataset_enc_shmsink(
     ``dataset_vbr_bitrate``).
     """
     target, peak = dataset_vbr_bitrate(w, h, dataset_fps)
+    input_buffers = _dataset_active_input_buffers(dataset_fps)
+    converter_buffers = input_buffers + _DATASET_VIC_INFLIGHT_SURFACES
     return (
-        "nvvidconv ! "
-        f"video/x-raw(memory:NVMM),format=NV12,width={w},height={h} "
+        f"nvvidconv output-buffers={converter_buffers} ! "
+        f"video/x-raw(memory:NVMM),format=I420,width={w},height={h} "
+        f"! {_dataset_input_queue(name)} "
         f"! nvv4l2h264enc name={name} control-rate=0 "
         f"bitrate={target} peak-bitrate={peak} preset-level=1 "
         f"insert-sps-pps=true insert-aud=true "
@@ -627,45 +659,66 @@ class _GstPipelineBase:
             valve = self._pipeline.get_by_name(valve_name)
             if valve is not None:
                 valve.set_property("drop", True)
-        self._set_dataset_output_queue_depth(gates, active=False)
+        # Shrink only after every input valve is closed. Reducing a live input
+        # queue first could itself discard an exposure from the episode we are
+        # trying to fail closed.
+        self._set_dataset_queue_depths(gates, active=False)
 
-    def _set_dataset_output_queue_depth(
+    def _set_dataset_queue_depths(
         self,
         gates: tuple[tuple[str, str | None], ...],
         *,
         active: bool,
     ) -> None:
-        """Select bounded startup or active-episode H.264 queue headroom.
+        """Select bounded startup or active-episode encoder queue headroom.
 
-        Startup must remain aggressively leaky because GDP's header is parked
-        at ``shmsink wait-for-connection=true`` before the recorder exists.
-        During an episode the reader is connected and flushed, so retain two
-        seconds of compressed AUs before failing with DISCONT. Keeping the
-        queue bounded and leaky still isolates camera capture/NVENC if the
-        recorder process dies outright.
+        Startup must remain aggressively leaky: the ordinary pre-valve branch
+        queue keeps the camera tee current while capture is disabled, and GDP's
+        header is parked behind the post-encoder output queue at
+        ``shmsink wait-for-connection=true`` before the recorder exists. During
+        an episode the reader is connected and flushed, so retain a short queue
+        of copied NVMM frames before NVENC and two seconds of compressed AUs
+        after it. Both queues stay bounded and downstream-leaky; exhausting
+        either still surfaces as a PTS/DISCONT capture failure.
         """
         if self._pipeline is None:
             return
         dataset_fps = max(1, int(getattr(self, "dataset_fps", 1)))
-        active_buffers = max(
-            _DATASET_ACTIVE_QUEUE_MIN_BUFFERS,
-            _DATASET_ACTIVE_QUEUE_SECONDS * dataset_fps,
+        active_input_buffers = _dataset_active_input_buffers(dataset_fps)
+        active_output_buffers = max(
+            _DATASET_ACTIVE_OUTPUT_QUEUE_MIN_BUFFERS,
+            _DATASET_ACTIVE_OUTPUT_QUEUE_SECONDS * dataset_fps,
         )
-        depth = active_buffers if active else _DATASET_STARTUP_QUEUE_BUFFERS
         for _valve_name, encoder_name in gates:
             if encoder_name is None:
                 continue
-            output_queue = self._pipeline.get_by_name(f"{encoder_name}_outq")
-            if output_queue is None:
-                raise RuntimeError(
-                    f"missing dataset encoder output queue {encoder_name}_outq"
+            queue_depths = (
+                (
+                    f"{encoder_name}_inq",
+                    active_input_buffers,
+                    "input",
+                ),
+                (
+                    f"{encoder_name}_outq",
+                    active_output_buffers,
+                    "output",
+                ),
+            )
+            for queue_name, active_depth, side in queue_depths:
+                queue = self._pipeline.get_by_name(queue_name)
+                if queue is None:
+                    raise RuntimeError(
+                        f"missing dataset encoder {side} queue {queue_name}"
+                    )
+                queue.set_property("leaky", 2)  # downstream
+                queue.set_property(
+                    "max-size-buffers",
+                    active_depth if active else _DATASET_STARTUP_QUEUE_BUFFERS,
                 )
-            output_queue.set_property("leaky", 2)  # downstream
-            output_queue.set_property("max-size-buffers", depth)
-            # Explicitly disable the queue defaults (10 MB / 1 s); otherwise
-            # either can undercut the intended frame-count bound.
-            output_queue.set_property("max-size-bytes", 0)
-            output_queue.set_property("max-size-time", 0)
+                # Explicitly disable the queue defaults (10 MB / 1 s);
+                # otherwise either can undercut the frame-count bound.
+                queue.set_property("max-size-bytes", 0)
+                queue.set_property("max-size-time", 0)
 
     def _begin_dataset_enable(
         self,
@@ -713,7 +766,10 @@ class _GstPipelineBase:
             ]
         ] = []
         try:
-            self._set_dataset_output_queue_depth(gates, active=True)
+            # Expand both sides before any valve can admit the shared-boundary
+            # exposure. A partial property-update failure is caught below;
+            # abort closes all valves before restoring startup depths.
+            self._set_dataset_queue_depths(gates, active=True)
             for valve_name, encoder_name in gates:
                 valve = self._pipeline.get_by_name(valve_name)
                 if valve is None:
@@ -851,7 +907,7 @@ class _GstPipelineBase:
                 valve = self._pipeline.get_by_name(valve_name)
                 if valve is not None:
                     valve.set_property("drop", True)
-            self._set_dataset_output_queue_depth(gates, active=False)
+            self._set_dataset_queue_depths(gates, active=False)
             raise
         self._dataset_disable = []
 
@@ -1199,7 +1255,7 @@ class ZedGstCamera(_GstPipelineBase, _GstStreamConsumer):
         try:
             self._finish_dataset_disable(deadline)
         finally:
-            self._set_dataset_output_queue_depth(self._raw_gates(), active=False)
+            self._set_dataset_queue_depths(self._raw_gates(), active=False)
 
     def begin_raw_enable(self, target_perf_s: float) -> None:
         """Arm this camera to open on a shared future exposure boundary."""
@@ -1207,7 +1263,13 @@ class ZedGstCamera(_GstPipelineBase, _GstStreamConsumer):
 
     def finish_raw_enable(self, deadline: float) -> None:
         """Wait for a common-boundary open armed by :meth:`begin_raw_enable`."""
-        self._finish_dataset_enable(deadline)
+        try:
+            self._finish_dataset_enable(deadline)
+        except Exception:
+            # Local callers do not have the relay's outer multi-camera abort.
+            # Preserve the same fail-closed queue/valve state either way.
+            self._abort_dataset_enable(self._raw_gates())
+            raise
 
     def abort_raw_enable(self) -> None:
         """Cancel an opening transaction and immediately close every branch."""
@@ -1584,7 +1646,7 @@ class ZedGstStereoCamera(_GstPipelineBase):
         try:
             self._finish_dataset_disable(deadline)
         finally:
-            self._set_dataset_output_queue_depth(self._raw_gates(), active=False)
+            self._set_dataset_queue_depths(self._raw_gates(), active=False)
 
     def begin_raw_enable(self, target_perf_s: float) -> None:
         """Arm both eyes to open on a shared future exposure boundary."""
@@ -1592,7 +1654,11 @@ class ZedGstStereoCamera(_GstPipelineBase):
 
     def finish_raw_enable(self, deadline: float) -> None:
         """Wait for a common-boundary open armed by :meth:`begin_raw_enable`."""
-        self._finish_dataset_enable(deadline)
+        try:
+            self._finish_dataset_enable(deadline)
+        except Exception:
+            self._abort_dataset_enable(self._raw_gates())
+            raise
 
     def abort_raw_enable(self) -> None:
         """Cancel an opening transaction and immediately close every eye."""

--- a/tests/test_collect_data_trace.py
+++ b/tests/test_collect_data_trace.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from almond_axol.cli.collect_data import _resolve_control_trace_prefix
+
+
+class CollectDataControlTraceTest(unittest.TestCase):
+    def test_default_none_keeps_flight_recorder_disabled(self) -> None:
+        with patch("almond_axol.cli.collect_data.resolve_prefix") as resolve:
+            self.assertIsNone(_resolve_control_trace_prefix(None))
+
+        resolve.assert_not_called()
+
+    def test_explicit_prefix_is_resolved(self) -> None:
+        with patch(
+            "almond_axol.cli.collect_data.resolve_prefix",
+            return_value="/tmp/resolved-trace",
+        ) as resolve:
+            self.assertEqual(
+                _resolve_control_trace_prefix("operator-trace"),
+                "/tmp/resolved-trace",
+            )
+
+        resolve.assert_called_once_with("operator-trace")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gst_dataset_transport.py
+++ b/tests/test_gst_dataset_transport.py
@@ -90,17 +90,30 @@ def _fake_gate_base(
 ) -> tuple[_GstPipelineBase, dict[str, _FakeValve]]:
     gst = _FakeGst()
     valves = {name: _FakeValve(gst) for name in valve_names}
-    queues = {
-        ("dsenc" if name == "rawvalve" else f"dsenc_{name.rsplit('_', 1)[1]}")
-        + "_outq": _FakeQueue()
-        for name in valve_names
-    }
+    queues: dict[str, _FakeQueue] = {}
+    for name in valve_names:
+        encoder = "dsenc" if name == "rawvalve" else f"dsenc_{name.rsplit('_', 1)[1]}"
+        queues[f"{encoder}_inq"] = _FakeQueue()
+        queues[f"{encoder}_outq"] = _FakeQueue()
     base = _GstPipelineBase()
     base._gst = gst
     base._pipeline = _FakePipeline({**valves, **queues})
     base._pts_perf_offset_s = offset_s
     base.dataset_fps = 30
     return base, valves
+
+
+def _fake_mono_camera() -> tuple[ZedGstCamera, dict[str, _FakeValve]]:
+    base, valves = _fake_gate_base()
+    camera = ZedGstCamera(
+        serial=1,
+        resolution="SVGA",
+        raw_socket_path="/tmp/mono-dataset.sock",
+    )
+    camera._gst = base._gst
+    camera._pipeline = base._pipeline
+    camera._pts_perf_offset_s = base._pts_perf_offset_s
+    return camera, valves
 
 
 class _FakeCoordinatedCamera:
@@ -130,7 +143,19 @@ class GstDatasetTransportTest(unittest.TestCase):
     def assert_dataset_branch_is_backpressure_safe(
         self, pipeline: str, valve_name: str, encoder_name: str, socket_path: str
     ) -> None:
+        input_queue = (
+            f"queue name={encoder_name}_inq leaky=downstream "
+            "max-size-buffers=2 max-size-bytes=0 max-size-time=0"
+        )
         start = pipeline.index(f"valve name={valve_name} drop=false")
+        self.assertNotEqual(
+            pipeline.rfind(
+                "queue leaky=downstream max-size-buffers=2",
+                0,
+                start,
+            ),
+            -1,
+        )
         sink = (
             f"shmsink name={encoder_name}_shmsink socket-path={socket_path} "
             "wait-for-connection=true"
@@ -138,6 +163,20 @@ class GstDatasetTransportTest(unittest.TestCase):
         end = pipeline.index(sink, start) + len(sink)
         branch = pipeline[start:end]
 
+        self.assertIn(input_queue, branch)
+        self.assertIn(
+            "nvvidconv output-buffers=38 ! "
+            "video/x-raw(memory:NVMM),format=I420,width=960,height=600",
+            branch,
+        )
+        self.assertLess(
+            branch.index("nvvidconv output-buffers=38"),
+            branch.index(input_queue),
+        )
+        self.assertLess(
+            branch.index(input_queue),
+            branch.index(f"nvv4l2h264enc name={encoder_name}"),
+        )
         self.assertIn(f"name={encoder_name}", branch)
         self.assertIn("iframeinterval=1 idrinterval=1", branch)
         self.assertIn(
@@ -215,28 +254,68 @@ class GstDatasetEnableBarrierTest(unittest.TestCase):
         self.assertFalse(valve.drop)
         base._finish_dataset_enable(0.0)
 
-    def test_active_episode_expands_bounded_encoded_queue(self) -> None:
+    def test_active_episode_expands_both_bounded_encoder_queues(self) -> None:
         base, _valves = _fake_gate_base()
+        input_queue = base._pipeline.get_by_name("dsenc_inq")
         output_queue = base._pipeline.get_by_name("dsenc_outq")
 
         base._begin_dataset_enable((("rawvalve", "dsenc"),), 100.0)
 
+        self.assertEqual(input_queue.get_property("leaky"), 2)
+        self.assertEqual(input_queue.get_property("max-size-buffers"), 15)
         self.assertEqual(output_queue.get_property("leaky"), 2)
         self.assertEqual(output_queue.get_property("max-size-buffers"), 60)
-        self.assertEqual(output_queue.get_property("max-size-bytes"), 0)
-        self.assertEqual(output_queue.get_property("max-size-time"), 0)
+        for queue in (input_queue, output_queue):
+            self.assertEqual(queue.get_property("max-size-bytes"), 0)
+            self.assertEqual(queue.get_property("max-size-time"), 0)
 
         base._abort_dataset_enable((("rawvalve", "dsenc"),))
+        self.assertEqual(input_queue.get_property("max-size-buffers"), 2)
         self.assertEqual(output_queue.get_property("max-size-buffers"), 2)
 
-    def test_active_queue_depth_scales_with_capture_rate(self) -> None:
+    def test_active_queue_depths_scale_with_dataset_rate(self) -> None:
         base, _valves = _fake_gate_base()
+        base.fps = 60
         base.dataset_fps = 60
+        input_queue = base._pipeline.get_by_name("dsenc_inq")
         output_queue = base._pipeline.get_by_name("dsenc_outq")
 
         base._begin_dataset_enable((("rawvalve", "dsenc"),), 100.0)
 
+        self.assertEqual(input_queue.get_property("max-size-buffers"), 30)
         self.assertEqual(output_queue.get_property("max-size-buffers"), 120)
+
+    def test_normal_close_shrinks_both_queues_only_after_valve_closes(self) -> None:
+        camera, valves = _fake_mono_camera()
+        valve = valves["rawvalve"]
+        input_queue = camera._pipeline.get_by_name("dsenc_inq")
+        output_queue = camera._pipeline.get_by_name("dsenc_outq")
+        camera._set_dataset_queue_depths(camera._raw_gates(), active=True)
+        valve.set_property("drop", False)
+        camera._dataset_enabled = True
+
+        camera.begin_raw_disable()
+
+        self.assertTrue(valve.drop)
+        self.assertEqual(input_queue.get_property("max-size-buffers"), 30)
+        self.assertEqual(output_queue.get_property("max-size-buffers"), 120)
+
+        camera.finish_raw_disable(time.perf_counter() + 1.0)
+        self.assertEqual(input_queue.get_property("max-size-buffers"), 2)
+        self.assertEqual(output_queue.get_property("max-size-buffers"), 2)
+
+    def test_failed_open_closes_valve_and_shrinks_both_queues(self) -> None:
+        camera, valves = _fake_mono_camera()
+        input_queue = camera._pipeline.get_by_name("dsenc_inq")
+        output_queue = camera._pipeline.get_by_name("dsenc_outq")
+
+        camera.begin_raw_enable(100.0)
+        with self.assertRaisesRegex(RuntimeError, "dsenc.*timed out"):
+            camera.finish_raw_enable(0.0)
+
+        self.assertTrue(valves["rawvalve"].drop)
+        self.assertEqual(input_queue.get_property("max-size-buffers"), 2)
+        self.assertEqual(output_queue.get_property("max-size-buffers"), 2)
 
     def test_repeated_enable_does_not_reclose_live_episode(self) -> None:
         base, valves = _fake_gate_base(offset_s=90.0)


### PR DESCRIPTION
## Summary

- add bounded dataset-encoder input headroom after a forced VIC copy, so NVENC startup jitter cannot drop the first one or two camera exposures
- keep the source-facing queue shallow and isolate the buffered surfaces from ZED/Argus ownership
- retain the existing strict PTS/discontinuity checks so a true overflow still discards the take
- restore collect-data flight recording to its documented opt-in behavior instead of enabling cmd/meas/Rust traces in every production session

## Incident

The post-#224 station log showed two immediate `left_arm` AU gaps after recording began: 33.33 ms and 49.99 ms at 60 fps. Both takes were correctly discarded, but the shallow pre-encoder path had no room for NVENC startup jitter.

The new layout is:

`shallow source queue -> rate limit -> valve -> VIC copy (NVMM I420) -> bounded input queue -> NVENC -> bounded compressed queue -> GDP shm`

The copied input queue is 0.5 s (minimum 15 frames), the compressed queue is 2 s (minimum 60 AUs), and both expand only for an active episode. VIC gets queue capacity plus eight output surfaces so NVENC-held buffers cannot backpressure the camera tee.

## Validation

- `uv run python -m unittest discover -s tests` (111 tests)
- `uvx --from ruff==0.9.7 ruff check .`
- `uvx --from ruff==0.9.7 ruff format --check .`
- Jetson plugin inspection confirms NVMM I420 is accepted by `nvv4l2h264enc` and `nvvidconv output-buffers` is mutable in PLAYING

A station hardware smoke test is still required after deployment; no parallel camera pipeline was started while the production serve session was active.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the live Jetson GStreamer dataset encode path and queue lifecycle, where timing faults already discard takes; trace default-off is lower operational risk but alters production diagnostics unless operators opt in.
> 
> **Overview**
> **Dataset encoder path** adds a shallow bounded queue after a forced **VIC** copy (**I420**, sized `output-buffers`) before **NVENC**, plus separate startup/active depths for input (~0.5 s) and compressed output (~2 s). Queue resizing is coordinated on enable/disable so valves close before depths shrink and failed opens abort fail-closed like the multi-camera relay.
> 
> **Collect-data** stops auto-creating a per-session control/flight-recorder prefix when `VRTeleopConfig.record` is `None`; tracing only arms when the operator sets an explicit name (`_resolve_control_trace_prefix`).
> 
> Recorder commentary and tests reflect the new input queue and trace behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dc2202bce953b1df3663036bbc0fc18584877bb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->