### PR TITLE
Harden transient encoded camera gaps

### DIFF
--- a/almond_axol/lerobot/h264_mux_encoder.py
+++ b/almond_axol/lerobot/h264_mux_encoder.py
@@ -306,9 +306,22 @@ class _CameraH264Muxer:
             f"! h264parse ! {mux}"
         )
         src = pipeline.get_by_name("src")
+        # The framerate is load-bearing: h264parse re-stamps each frame's
+        # duration from the caps framerate (the encoder's SPS carries no
+        # timing, so without it the duration we set on the appsrc buffer is
+        # dropped). mp4mux derives a sample's duration from the *next*
+        # buffer's PTS and, for the final sample at EOS, from the buffer's
+        # duration — so without a framerate the last sample is written with
+        # duration 0, the track/edit list ends one frame early, and ffmpeg
+        # (honouring the edit list) never yields that frame: a file with
+        # ``n`` advertised samples that demuxes to ``n - 1``, which
+        # ``_validate_finalized_file`` rightly rejects.
         src.set_property(
             "caps",
-            Gst.Caps.from_string("video/x-h264,stream-format=byte-stream,alignment=au"),
+            Gst.Caps.from_string(
+                "video/x-h264,stream-format=byte-stream,alignment=au,"
+                f"framerate={self._fps}/1"
+            ),
         )
         # Bound appsrc so a wedged pipeline surfaces as back-pressure, not
         # unbounded memory; block so we never silently drop a (dependency-bearing)

--- a/almond_axol/lerobot/h264_mux_encoder.py
+++ b/almond_axol/lerobot/h264_mux_encoder.py
@@ -29,10 +29,11 @@ exactly ``i / fps``, with exactly as many frames as dataset rows. GDP preserves
 the physical capture PTS across ``shmsink``/``shmsrc`` for state association;
 this muxer independently assigns the dataset timeline: the *k*-th access unit is
 muxed at ``pts = k / fps`` (``dts`` and ``duration`` match). The caller
-(:func:`~almond_axol.recording.record_proc.run_encoded_capture_loop`) requires
-one fresh AU per camera per row and aborts on a stall—encoded exposures are
-never replayed—so frame-count == row-count by construction. The concat step reasserts
-that exact grid across episodes (see
+(:func:`~almond_axol.recording.record_proc.run_encoded_capture_loop`) ordinarily
+requires one fresh AU per camera per row. It may explicitly repeat an all-intra
+AU for one bounded one/two-frame source hole, while retaining the future AU, so
+frame-count and subsequent exposure/row alignment remain exact. The concat step
+reasserts that grid across episodes (see
 :func:`~almond_axol.recording.record_proc._concatenate_video_files_rebased`).
 
 Because the frames arrive pre-encoded, the first muxed AU of an episode must be

--- a/almond_axol/recording/record_proc.py
+++ b/almond_axol/recording/record_proc.py
@@ -78,6 +78,15 @@ _ENCODED_START_TIMEOUT_S = 15.0
 _ENCODED_ROW_TIMEOUT_S = 1.0
 # How often the blocking AU read wakes to re-check stop_event.
 _ENCODED_POLL_MS = 100
+# A relay/source hiccup occasionally omits one or two all-intra AUs even while
+# the rest of the camera/control stack remains healthy.  Holding the last IDR
+# for those missing cadence slots is bounded corruption (at most 33 ms at
+# 60 Hz) and, unlike accepting the future AU early, does not shift that camera
+# against every subsequent robot-state/dataset row.  More than one event or two
+# frames on a camera is evidence of an unhealthy stream and remains fatal.
+_ENCODED_MAX_CONCEALED_FRAMES_PER_CAMERA = 2
+_ENCODED_MAX_CONCEALMENT_EVENTS_PER_CAMERA = 1
+_ENCODED_GAP_GRID_TOLERANCE_FRAMES = 0.25
 # A just-arrived exposure can precede the newest control snapshot by one control
 # tick. Briefly poll the state ring for the upper bracket; never clamp outside
 # its retained range.
@@ -924,6 +933,44 @@ def _validate_encoded_cadence_step(
         )
 
 
+def _concealable_encoded_gap_frames(
+    *,
+    previous_ts: float,
+    capture_ts: float,
+    fps: int,
+    capture_fps: int,
+    frames_are_independent: bool,
+) -> int:
+    """Return the number of bounded missing cadence slots, else zero.
+
+    This is intentionally narrower than the cadence validator.  A repair is
+    safe for the encoded transport only when every source frame is a standalone
+    IDR and the dataset consumes every captured exposure.  Rate-converted
+    streams can legitimately alternate source-frame spacings, so they retain
+    the exact/fail-closed path rather than having that selection pattern
+    mistaken for loss.
+    """
+    if (
+        not frames_are_independent
+        or fps <= 0
+        or capture_fps != fps
+        or not math.isfinite(previous_ts)
+        or not math.isfinite(capture_ts)
+    ):
+        return 0
+    delta = capture_ts - previous_ts
+    if delta <= 0:
+        return 0
+    periods = round(delta * fps)
+    missing = periods - 1
+    if not 1 <= missing <= _ENCODED_MAX_CONCEALED_FRAMES_PER_CAMERA:
+        return 0
+    residual = abs(delta - periods / fps)
+    if residual > _ENCODED_GAP_GRID_TOLERANCE_FRAMES / capture_fps:
+        return 0
+    return missing
+
+
 def _align_independent_encoded_start(
     packets: dict[str, tuple[bytes, float, float]],
     read_next: Callable[[str], tuple[bytes, float, float] | None],
@@ -1273,6 +1320,7 @@ def run_encoded_capture_loop(
     rerun_ip: str | None,
     stop_event: threading.Event,
     frame_counter: "dict[str, int] | None" = None,
+    repair_events: "list[dict[str, Any]] | None" = None,
     on_error: Callable[[str], None] | None = None,
     on_armed: Callable[[], None] | None = None,
 ) -> None:
@@ -1290,8 +1338,13 @@ def run_encoded_capture_loop(
     is paired with the joint/action snapshot nearest the median camera exposure,
     independent of encoder, shm, and scheduler latency. The blocking per-camera
     read naturally paces the loop to the dataset cadence. A timeout, missing PTS,
-    dropped frame, cross-camera phase error, or excessive state skew aborts the
-    episode; exposures are never duplicated or silently omitted mid-episode.
+    cross-camera phase error, or excessive state skew aborts the episode.  The
+    sole exception is one bounded one/two-frame hole per equal-rate all-intra
+    camera: the prior IDR is repeated on the missing cadence slots while the
+    future AU is held, preserving all subsequent image/camera/state alignment.
+    The repair is warned and returned through ``repair_events`` for a save-time
+    audit log; larger, repeated, predictive, rate-converted, transport, or
+    non-grid losses remain fatal.
 
     The muxer assigns each AU a constant-fps PTS (``k / fps``), so the mp4
     timeline is exact regardless of arrival jitter; its physical exposure PTS is
@@ -1361,10 +1414,21 @@ def run_encoded_capture_loop(
             return None
 
         previous_capture_ts: dict[str, float] = {}
+        previous_packets: dict[str, tuple[bytes, float, float]] = {}
         first_capture_ts: dict[str, float] = {}
         capture_intervals: dict[str, int] = {}
+        # A detected future AU stays here until every missing logical cadence
+        # slot has emitted the previous independently-decodable IDR.  Reading
+        # peers continues normally, so the existing cross-camera validator
+        # proves every repaired row is still synchronized.
+        held_packets: dict[
+            str, tuple[tuple[bytes, float, float], int, dict[str, Any]]
+        ] = {}
+        concealed_frames: dict[str, int] = {}
+        concealment_events: dict[str, int] = {}
         primed = False
         rows_added = 0
+        total_rows = 0
         max_pending = 0
         snapshot_skew_sum = 0.0
         snapshot_skew_max = 0.0
@@ -1380,8 +1444,25 @@ def run_encoded_capture_loop(
             # non-blocking attempt still accepts an AU already queued.
             row_deadline = time.perf_counter() + budget
             packets: dict[str, tuple[bytes, float, float]] = {}
+            synthetic_repairs: dict[str, dict[str, Any]] = {}
             for cam_key, cam in cameras.items():
-                packet = read_au(cam, row_deadline)
+                held = held_packets.get(cam_key)
+                if held is not None:
+                    future, remaining, event = held
+                    if remaining > 0:
+                        previous = previous_packets[cam_key]
+                        packet = (
+                            previous[0],
+                            previous[1] + 1.0 / fps,
+                            future[2],
+                        )
+                        held_packets[cam_key] = (future, remaining - 1, event)
+                        synthetic_repairs[cam_key] = event
+                    else:
+                        packet = future
+                        del held_packets[cam_key]
+                else:
+                    packet = read_au(cam, row_deadline)
                 if packet is None:
                     if stop_event.is_set():
                         return
@@ -1450,6 +1531,68 @@ def run_encoded_capture_loop(
                     for cam in cameras.values():
                         max_pending = max(max_pending, cam.pending)
 
+            # Do not accept a future AU early: mux re-stamping would shift this
+            # camera against every later row.  For the one explicitly bounded
+            # all-IDR case, hold it and fill the missing logical exposure slots
+            # from the prior IDR.  This decision belongs here (with all cameras
+            # visible), not inside an individual EncodedAuReader.
+            if primed:
+                for cam_key, packet in tuple(packets.items()):
+                    if cam_key in held_packets:
+                        continue  # already emitting a planned synthetic slot
+                    previous = previous_packets[cam_key]
+                    camera = cameras[cam_key]
+                    capture_fps = int(getattr(camera, "capture_fps", fps))
+                    missing = _concealable_encoded_gap_frames(
+                        previous_ts=previous[1],
+                        capture_ts=packet[1],
+                        fps=fps,
+                        capture_fps=capture_fps,
+                        frames_are_independent=bool(
+                            getattr(camera, "frames_are_independent", False)
+                        ),
+                    )
+                    already_concealed = concealed_frames.get(cam_key, 0)
+                    prior_events = concealment_events.get(cam_key, 0)
+                    if (
+                        missing == 0
+                        or prior_events >= _ENCODED_MAX_CONCEALMENT_EVENTS_PER_CAMERA
+                        or already_concealed + missing
+                        > _ENCODED_MAX_CONCEALED_FRAMES_PER_CAMERA
+                    ):
+                        continue
+                    event: dict[str, Any] = {
+                        "camera": cam_key,
+                        "frame_index": total_rows,
+                        # Updated only after each synthetic dataset row commits.
+                        # This keeps a save that lands midway through a two-row
+                        # repair honest, and records nothing if add_frame fails.
+                        "missing_frames": 0,
+                        "gap_ms": 1e3 * (packet[1] - previous[1]),
+                        "concealed_ms": 0.0,
+                        "method": "repeat_previous_idr",
+                    }
+                    held_packets[cam_key] = (packet, missing - 1, event)
+                    packets[cam_key] = (
+                        previous[0],
+                        previous[1] + 1.0 / fps,
+                        packet[2],
+                    )
+                    synthetic_repairs[cam_key] = event
+                    concealed_frames[cam_key] = already_concealed + missing
+                    concealment_events[cam_key] = prior_events + 1
+                    _logger.warning(
+                        "camera %r omitted %d all-intra frame(s) at dataset "
+                        "row %d (PTS gap %.2fms); repeating the prior IDR for "
+                        "%.2fms and holding the future AU to preserve camera/"
+                        "state alignment",
+                        cam_key,
+                        missing,
+                        total_rows,
+                        event["gap_ms"],
+                        1e3 * missing / fps,
+                    )
+
             aus = {name: packet[0] for name, packet in packets.items()}
             capture_ts = {name: packet[1] for name, packet in packets.items()}
             primed = True
@@ -1475,6 +1618,7 @@ def run_encoded_capture_loop(
                     first_capture_ts[cam_key] = cap_ts
                     capture_intervals[cam_key] = 0
                 previous_capture_ts[cam_key] = cap_ts
+                previous_packets[cam_key] = packets[cam_key]
 
             exposure_times = list(capture_ts.values())
             row_capture_ts = float(median(exposure_times))
@@ -1538,9 +1682,15 @@ def run_encoded_capture_loop(
             if tag_intervention:
                 row["intervention"] = np.array([intervention], dtype=bool)
             dataset.add_frame(row)
+            for event in synthetic_repairs.values():
+                if event["missing_frames"] == 0 and repair_events is not None:
+                    repair_events.append(event)
+                event["missing_frames"] += 1
+                event["concealed_ms"] = 1e3 * event["missing_frames"] / fps
             if frame_counter is not None:
                 frame_counter["n"] += 1
             rows_added += 1
+            total_rows += 1
 
             if rerun_ip:
                 # No decoded frames on this path; log joints/action only.
@@ -2167,6 +2317,7 @@ def _recorder_main(
     thread: threading.Thread | None = None
     stop: threading.Event | None = None
     capture_error: dict[str, str | None] = {"v": None}
+    capture_repairs: list[dict[str, Any]] = []
     episodes_recorded = 0
     save_poisoned = False
     # Mid-episode capture gate + row counter (see run_capture_loop). The gate
@@ -2214,6 +2365,7 @@ def _recorder_main(
                     continue
                 dataset.clear_episode_buffer()
                 capture_error["v"] = None
+                capture_repairs.clear()
                 record_event.set()
                 frame_counter["n"] = 0
                 from ..lerobot.nvenc_encoder import reset_dropped_frames
@@ -2238,6 +2390,7 @@ def _recorder_main(
                 armed = threading.Event()
                 if encoded_mode:
                     loop_kwargs["on_armed"] = armed.set
+                    loop_kwargs["repair_events"] = capture_repairs
                 thread = threading.Thread(
                     target=(
                         run_encoded_capture_loop if encoded_mode else run_capture_loop
@@ -2360,6 +2513,19 @@ def _recorder_main(
                         )
                         if episode_row is not None:
                             verifier.submit(episode_row)
+                        if capture_repairs:
+                            _logger.warning(
+                                "saved episode %d with bounded camera-gap "
+                                "repair(s): %s",
+                                dataset.num_episodes - 1,
+                                ", ".join(
+                                    f"{event['camera']}@row "
+                                    f"{event['frame_index']}="
+                                    f"{event['missing_frames']} frame(s)"
+                                    for event in capture_repairs
+                                ),
+                            )
+                        capture_repairs.clear()
                         episodes_recorded += 1
                         conn.send(("saved", dataset.num_episodes))
                     except Exception as exc:  # irreversible writer state possible
@@ -2377,6 +2543,7 @@ def _recorder_main(
                     conn.send(("error", str(exc)))
                     continue
                 dataset.clear_episode_buffer()
+                capture_repairs.clear()
                 conn.send(("cancelled",))
     finally:
         # Never close/finalize the dataset while its capture thread may still

--- a/almond_axol/recording/record_proc.py
+++ b/almond_axol/recording/record_proc.py
@@ -82,10 +82,20 @@ _ENCODED_POLL_MS = 100
 # the rest of the camera/control stack remains healthy.  Holding the last IDR
 # for those missing cadence slots is bounded corruption (at most 33 ms at
 # 60 Hz) and, unlike accepting the future AU early, does not shift that camera
-# against every subsequent robot-state/dataset row.  More than one event or two
-# frames on a camera is evidence of an unhealthy stream and remains fatal.
-_ENCODED_MAX_CONCEALED_FRAMES_PER_CAMERA = 2
-_ENCODED_MAX_CONCEALMENT_EVENTS_PER_CAMERA = 1
+# against every subsequent robot-state/dataset row.  A single hole longer than
+# two frames is fatal, and so is a camera that is losing frames faster than a
+# rare hiccup: the ZED sources have been observed dropping one exposure every
+# one to four seconds during a teleoperated take (both stereo eyes together,
+# so the loss is in the source, not the relay's queues or transport), and a
+# fixed handful of events per episode aborted every take within seconds and
+# homed the arms mid-teleop.  The budget is therefore a rate: a burst of
+# events inside a short window, or concealed frames above a small fraction of
+# the episode, means the stream is unhealthy and still fails closed.
+_ENCODED_MAX_CONCEALED_FRAMES_PER_EVENT = 2
+_ENCODED_MAX_CONCEALMENT_EVENTS_PER_WINDOW = 3
+_ENCODED_CONCEALMENT_WINDOW_S = 2.0
+_ENCODED_MIN_CONCEALED_FRAMES_PER_CAMERA = 6
+_ENCODED_MAX_CONCEALED_FRACTION = 0.02
 _ENCODED_GAP_GRID_TOLERANCE_FRAMES = 0.25
 # A just-arrived exposure can precede the newest control snapshot by one control
 # tick. Briefly poll the state ring for the upper bracket; never clamp outside
@@ -963,12 +973,40 @@ def _concealable_encoded_gap_frames(
         return 0
     periods = round(delta * fps)
     missing = periods - 1
-    if not 1 <= missing <= _ENCODED_MAX_CONCEALED_FRAMES_PER_CAMERA:
+    if not 1 <= missing <= _ENCODED_MAX_CONCEALED_FRAMES_PER_EVENT:
         return 0
     residual = abs(delta - periods / fps)
     if residual > _ENCODED_GAP_GRID_TOLERANCE_FRAMES / capture_fps:
         return 0
     return missing
+
+
+def _concealment_within_budget(
+    *,
+    event_rows: list[int],
+    row: int,
+    concealed_frames: int,
+    missing: int,
+    total_rows: int,
+    fps: int,
+) -> bool:
+    """Decide whether one more repair keeps this camera inside its rate budget.
+
+    ``event_rows`` holds the dataset rows of this camera's earlier repairs in
+    this episode. A burst (too many events inside a short window) or a stream
+    whose concealed frames exceed a small fraction of the episode so far is
+    unhealthy and must fail closed; an isolated hiccup every few seconds is
+    repaired and audited.
+    """
+    window_rows = max(1, int(round(_ENCODED_CONCEALMENT_WINDOW_S * fps)))
+    recent = sum(1 for prior in event_rows if row - prior < window_rows)
+    if recent >= _ENCODED_MAX_CONCEALMENT_EVENTS_PER_WINDOW:
+        return False
+    allowance = max(
+        _ENCODED_MIN_CONCEALED_FRAMES_PER_CAMERA,
+        int(_ENCODED_MAX_CONCEALED_FRACTION * total_rows),
+    )
+    return concealed_frames + missing <= allowance
 
 
 def _align_independent_encoded_start(
@@ -1339,12 +1377,14 @@ def run_encoded_capture_loop(
     independent of encoder, shm, and scheduler latency. The blocking per-camera
     read naturally paces the loop to the dataset cadence. A timeout, missing PTS,
     cross-camera phase error, or excessive state skew aborts the episode.  The
-    sole exception is one bounded one/two-frame hole per equal-rate all-intra
-    camera: the prior IDR is repeated on the missing cadence slots while the
-    future AU is held, preserving all subsequent image/camera/state alignment.
-    The repair is warned and returned through ``repair_events`` for a save-time
-    audit log; larger, repeated, predictive, rate-converted, transport, or
-    non-grid losses remain fatal.
+    sole exception is a bounded one/two-frame hole on an equal-rate all-intra
+    camera, within a per-camera rate budget (no burst of events inside a short
+    window, concealed frames a small fraction of the episode): the prior IDR is
+    repeated on the missing cadence slots while the future AU is held,
+    preserving all subsequent image/camera/state alignment. The repair is
+    warned and returned through ``repair_events`` for a save-time audit log;
+    larger holes, a camera past its budget, predictive, rate-converted,
+    transport, or non-grid losses remain fatal.
 
     The muxer assigns each AU a constant-fps PTS (``k / fps``), so the mp4
     timeline is exact regardless of arrival jitter; its physical exposure PTS is
@@ -1425,7 +1465,7 @@ def run_encoded_capture_loop(
             str, tuple[tuple[bytes, float, float], int, dict[str, Any]]
         ] = {}
         concealed_frames: dict[str, int] = {}
-        concealment_events: dict[str, int] = {}
+        concealment_rows: dict[str, list[int]] = {}
         primed = False
         rows_added = 0
         total_rows = 0
@@ -1553,12 +1593,14 @@ def run_encoded_capture_loop(
                         ),
                     )
                     already_concealed = concealed_frames.get(cam_key, 0)
-                    prior_events = concealment_events.get(cam_key, 0)
-                    if (
-                        missing == 0
-                        or prior_events >= _ENCODED_MAX_CONCEALMENT_EVENTS_PER_CAMERA
-                        or already_concealed + missing
-                        > _ENCODED_MAX_CONCEALED_FRAMES_PER_CAMERA
+                    prior_rows = concealment_rows.setdefault(cam_key, [])
+                    if missing == 0 or not _concealment_within_budget(
+                        event_rows=prior_rows,
+                        row=total_rows,
+                        concealed_frames=already_concealed,
+                        missing=missing,
+                        total_rows=total_rows,
+                        fps=fps,
                     ):
                         continue
                     event: dict[str, Any] = {
@@ -1580,7 +1622,7 @@ def run_encoded_capture_loop(
                     )
                     synthetic_repairs[cam_key] = event
                     concealed_frames[cam_key] = already_concealed + missing
-                    concealment_events[cam_key] = prior_events + 1
+                    prior_rows.append(total_rows)
                     _logger.warning(
                         "camera %r omitted %d all-intra frame(s) at dataset "
                         "row %d (PTS gap %.2fms); repeating the prior IDR for "

--- a/almond_axol/utils/affinity.py
+++ b/almond_axol/utils/affinity.py
@@ -15,8 +15,9 @@ During ``collect-data`` the box runs five kinds of work that contend for cores:
   feed is clean; once recording starts, the dataset raw-branch piles onto the
   same cores and starves the send — packets go out late and bursty (0% loss but
   rising jitter), so the live feed gets laggy + grainy.
-* **background** — the dataset recorder + its per-camera NVENC encoders. Pure
-  throughput; tolerant of an occasional dropped frame.
+* **background** — the dataset recorder plus throughput-oriented relay
+  GStreamer work. It may share CPU with camera/VIC/NVENC dispatch, but never
+  with control, IK, CAN, or the latency-sensitive WebRTC Python loop.
 
 Partitioning the cores by role keeps each group off the others': the control
 loop never gets preempted (no jerk), IK solves at full rate, and the relay's send
@@ -61,16 +62,15 @@ def core_groups() -> dict[str, set[int]] | None:
     camera/WebRTC bookkeeping made 5-15% of nominal 240 Hz motor ticks late.
     ``ik`` remains a dedicated core so it cannot deschedule CAN or Python.
 
-    The relay gets *two* cores so :func:`isolate_relay_cpu` can split its Python
-    work (the aiortc WebRTC send + encoded-AU pull loops, all GIL-serialized) onto
-    one core and GStreamer's C thread pool (camera capture, NVENC dispatch, and the
-    dataset raw-branch VIC resize + shmsink copy) onto the other. That split is the
-    whole point: naively handing the relay a second *roaming* core does nothing —
-    the Python side is GIL-bound and just ping-pongs the GIL across cores — but
-    physically moving the lock-free C threads off the send's core stops the
-    recording raw-branch from preempting the send (which otherwise starves it:
-    event-loop maxlag 100-385ms, send collapsing ~5000->~1400 pkt/s at 0% loss).
-    The dataset recorder keeps the remaining cores.
+    The relay gets *two* private cores so :func:`isolate_relay_cpu` can keep its
+    Python work (the aiortc WebRTC send + encoded-AU pull loops, all
+    GIL-serialized) on one. GStreamer's much wider C thread pool may use the
+    other relay core **and** the background cores. That split is the whole point:
+    naively letting Python roam just ping-pongs the GIL, while restricting the
+    ~70-80 camera/VIC/NVENC/shm tasks to one CPU can deschedule a dataset branch
+    for multiple 60 Hz exposures. Sharing throughput cores with the mux-only
+    recorder preserves the WebRTC/control isolation without creating that
+    single-core bottleneck.
 
     Below 8 cores there's no room to dedicate an IK core, so ``ik`` shares the
     control group; on 4-5 cores the relay also shares the background group (still
@@ -153,7 +153,7 @@ def pin_background() -> bool:
 
 
 def isolate_relay_cpu() -> bool:
-    """Split the relay's Python threads and GStreamer C threads onto separate cores.
+    """Separate relay Python from GStreamer and give gst throughput headroom.
 
     The relay's latency-critical work — the aiortc WebRTC send (SRTP + sendto for
     every stream) and the encoded-AU pull loops — is all Python, so the GIL
@@ -164,16 +164,15 @@ def isolate_relay_cpu() -> bool:
     moment recording starts, and the feed stutters (event-loop maxlag 100-385ms,
     send ~5000->~1400 pkt/s at 0% loss).
 
-    So pin every Python thread — enumerated via :mod:`threading`, and kept together
-    so the GIL never crosses cores — to ``relay[0]``, and every other thread in the
-    process (GStreamer's C workers, which don't surface as Python threads but do
-    appear under ``/proc/self/task``) to ``relay[1]``. The send then owns a core
-    the recording raw-branch can't touch, so it stays as clean under recording as
-    in teleop. Call once from the relay's event-loop (main) thread after the gst
-    pipelines are PLAYING (all their threads exist) and before the send loop runs;
-    Python threads spawned later (aiortc helpers) inherit this thread's ``relay[0]``
-    affinity. Best-effort: a no-op without ``sched_setaffinity`` or ``/proc``, or
-    when the relay group has fewer than two cores.
+    Pin every Python thread — enumerated via :mod:`threading`, and kept together
+    so the GIL never crosses cores — to ``relay[0]``. Pin every other thread in
+    the process (GStreamer's C workers, which do not surface as Python threads)
+    to the remaining relay cores plus ``background``. The send owns a core the
+    recording branch cannot touch, while dozens of gst tasks can make forward
+    progress through a short scheduler stall instead of overflowing a two-frame
+    source queue. Call once after the gst pipelines are PLAYING and before the
+    send loop runs. Best-effort: a no-op without ``sched_setaffinity`` or
+    ``/proc``, or when the relay group has fewer than two cores.
     """
     if not hasattr(os, "sched_setaffinity"):
         return False
@@ -184,7 +183,13 @@ def isolate_relay_cpu() -> bool:
     if len(relay) < 2:
         return False
     py_core = {relay[0]}
-    gst_core = {relay[1]}
+    # The recorder is mux-only on the production H.264 transport, so sharing
+    # its throughput CPUs is far safer than serializing ~80 gst workers onto
+    # relay[1].  Exclude py_core for small-host layouts where relay/background
+    # intentionally overlap.
+    gst_cores = (set(relay[1:]) | groups["background"]) - py_core
+    if not gst_cores:
+        return False
     import threading
 
     py_tids = {t.native_id for t in threading.enumerate() if t.native_id is not None}
@@ -207,15 +212,15 @@ def isolate_relay_cpu() -> bool:
         if tid in py_tids:
             continue
         try:
-            os.sched_setaffinity(tid, gst_core)  # type: ignore[attr-defined]
+            os.sched_setaffinity(tid, gst_cores)  # type: ignore[attr-defined]
             moved += 1
         except OSError:
             pass  # thread may have exited between listdir and the pin
     _logger.info(
-        "isolated relay CPU: python threads -> core %d, %d gst threads -> core %d",
+        "isolated relay CPU: python threads -> core %d, %d gst threads -> cores %s",
         relay[0],
         moved,
-        relay[1],
+        sorted(gst_cores),
     )
     return True
 

--- a/almond_axol/utils/affinity.py
+++ b/almond_axol/utils/affinity.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Iterable
 
 _logger = logging.getLogger(__name__)
 
@@ -223,6 +224,100 @@ def isolate_relay_cpu() -> bool:
         sorted(gst_cores),
     )
     return True
+
+
+# SCHED_FIFO priority for the camera capture threads. Well below the CAN loops
+# (`AXOL_RT_FIFO_PRIORITY`, 20) and on disjoint cores anyway; above every CFS
+# thread so a capture wake-up never queues behind the encode/mux workers.
+CAPTURE_FIFO_PRIORITY = 5
+
+
+def prioritize_capture_threads(thread_comms: Iterable[str]) -> int:
+    """Move the camera *capture* chain to ``SCHED_FIFO`` so it never misses an exposure.
+
+    The relay's gst pool is ~80 CFS threads (VIC copies, NVENC dispatch, shm
+    writers) sharing a few cores with the dataset recorder. CFS hands them out
+    round-robin, so whenever a burst of them is runnable together a thread can
+    sit runnable-but-unscheduled for most of a scheduling period (~20 ms). For
+    the encode/mux threads that is harmless — queues absorb it. For the capture
+    chain it is not: the source streaming thread (the SDK ``grab`` + rectify +
+    push), the ZED SDK's own worker threads (the V4L2 dequeue / frame assembly
+    it spawns unnamed), and the consumers of the two-buffer queues that still
+    hold un-copied camera surfaces (the stereo eye crops and the dataset VIC
+    copies) must each run within one 60 Hz period or the exposure is gone —
+    seen on the robot as ``skipped exposure(s)`` with ``CPU wait since
+    previous frame`` of 14-26 ms while every other attribution (SDK/link
+    time, GPU clock, arm motion) was clean. A real-time class fixes that at
+    the root: a FIFO wake-up preempts the CFS pool immediately and its CPU
+    wait is ~0 regardless of how many encoders are dispatching. Their combined
+    load is small and bounded (a few percent of a core per camera; the VIC
+    consumers mostly sleep on the hardware fence), so they cannot starve the
+    recorder, and the kernel's RT throttle caps a runaway at 95 % of a core
+    anyway.
+
+    Elevates every thread whose ``comm`` is in ``thread_comms`` (GStreamer
+    names task threads ``<element>:<pad>``, truncated to the kernel's 15-char
+    limit — the caller passes them already truncated; see
+    ``gst_zed.exposure_critical_thread_comms``) plus every non-Python thread
+    that still carries the process's own ``comm`` — GStreamer, GLib, NVENC and
+    CUDA all rename theirs, so an unrenamed thread in the relay is the SDK's.
+    Call once after the pipelines are PLAYING (the threads exist by then).
+    Returns the number of threads moved; ``0`` when the platform has no
+    ``sched_setscheduler`` or the process lacks ``CAP_SYS_NICE`` (a manual
+    unprivileged run — the failure is logged once and the threads stay CFS,
+    exactly the previous behaviour).
+    """
+    if not hasattr(os, "sched_setscheduler") or not hasattr(os, "SCHED_FIFO"):
+        return 0
+    import threading
+
+    py_tids = {t.native_id for t in threading.enumerate() if t.native_id is not None}
+    try:
+        with open("/proc/self/comm") as fh:
+            process_comm = fh.read().strip()
+        tasks = os.listdir("/proc/self/task")
+    except OSError:
+        return 0
+    wanted = set(thread_comms) | {process_comm}
+    param = os.sched_param(CAPTURE_FIFO_PRIORITY)  # type: ignore[attr-defined]
+    moved = 0
+    denied: OSError | None = None
+    for entry in tasks:
+        try:
+            tid = int(entry)
+        except ValueError:
+            continue
+        if tid in py_tids:
+            continue
+        try:
+            with open(f"/proc/self/task/{tid}/comm") as fh:
+                comm = fh.read().strip()
+        except OSError:
+            continue  # exited between listdir and here
+        if comm not in wanted:
+            continue
+        try:
+            os.sched_setscheduler(tid, os.SCHED_FIFO, param)  # type: ignore[attr-defined]
+            moved += 1
+        except PermissionError as exc:
+            denied = exc
+            break
+        except OSError:
+            pass
+    if denied is not None:
+        _logger.info(
+            "camera capture threads stay SCHED_OTHER (no CAP_SYS_NICE: %s); "
+            "expect skipped exposures under recording load",
+            denied,
+        )
+    elif moved:
+        _logger.info(
+            "camera capture threads -> SCHED_FIFO %d (%d threads: %s + SDK workers)",
+            CAPTURE_FIFO_PRIORITY,
+            moved,
+            ", ".join(sorted(wanted - {process_comm})),
+        )
+    return moved
 
 
 def _pin(group: str) -> bool:

--- a/almond_axol/utils/jetson.py
+++ b/almond_axol/utils/jetson.py
@@ -1,20 +1,33 @@
 """Jetson system tweaks for the real-time teleop / data-collection loops.
 
-Two Tegra defaults trade latency for power/throughput and hurt us:
+Tegra defaults trade latency for power/throughput and hurt us:
 
 * **Engine devfreq** — the camera relay's hardware encode path
   (``almond_axol.video.hw_video``) depends on NVENC (the H.264 encoder) and
   the VIC (``nvvidconv``'s colorspace conversion). The default
   ``tegra_wmark`` governor grants just enough clock to keep up with the
   frame rate, so each frame takes nearly a full frame-time to encode
-  (~3x worse per-frame latency at the ~25% clock it settles on).
+  (~3x worse per-frame latency at the ~25% clock it settles on). The GPU is
+  in the same boat: the ZED SDK does its per-frame image processing in CUDA,
+  and the default ``nvhost_podgov`` governor parks the GPU at its floor
+  (306 of 918 MHz on Orin) and only ramps after the load is already late —
+  every camera frame drop we attributed on a station happened at that floor.
 
 * **CPU cpufreq** — the IK solver (JAX/XLA) is a bursty, sleep-heavy
   workload. The default ``schedutil`` governor reads that idle and
   underclocks the cores to ~40-70% of max, which drops the IK rate by a
   matching ~30% (measured 79 Hz vs 113 Hz pinned).
 
-Both ceilings are themselves capped by the ``nvpmodel`` power mode, so
+* **Capture daemon scheduling** — on ZED X (GMSL2) every camera's frames
+  flow through NVIDIA's Argus daemon, whose capture-request loop runs per
+  frame for all sensors in one process. It ships as a plain CFS service, so
+  under load it is descheduled behind the control / IK / recorder work the
+  cameras feed, and all cameras miss the same frames at once (the relay's
+  own capture threads then report ~0 ms CPU wait: they are waiting on the
+  daemon, not on the scheduler). :func:`pin_realtime_clocks` runs it
+  ``SCHED_FIFO`` one notch above those relay capture threads.
+
+The clock ceilings are themselves capped by the ``nvpmodel`` power mode, so
 :func:`pin_realtime_clocks` first selects MAXN (mode 0) to uncap them, then
 pins the engine and CPU clocks to that max — fixing the latency / rate.
 Best-effort and cleared on reboot, so ``axol jetson.setup`` (which calls
@@ -29,12 +42,34 @@ import shutil
 import subprocess
 from pathlib import Path
 
+from .affinity import CAPTURE_FIFO_PRIORITY
 from .sudo import prime_sudo
 
 _logger = logging.getLogger(__name__)
 
-# Hardware engines whose devfreq clocks the encode path depends on.
-_ENGINE_CLOCK_GLOBS = ("*.nvenc", "*.vic")
+# Tegra-only encode engines; their presence identifies a Jetson when the L4T
+# release file is missing (see :func:`_is_jetson`).
+_JETSON_ENGINE_GLOBS = ("*.nvenc", "*.vic")
+
+# Hardware engines whose devfreq clocks the camera path depends on: the
+# encode engines plus the GPU the ZED SDK's CUDA processing runs on. The GPU
+# is deliberately not a Jetson marker — other ARM SoCs expose a ``*.gpu``
+# devfreq node too.
+_ENGINE_CLOCK_GLOBS = (*_JETSON_ENGINE_GLOBS, "*.gpu")
+
+# The camera capture daemon(s) in every ZED X frame's path, and the systemd
+# drop-in that makes their realtime scheduling survive a daemon restart. The
+# live instance is re-scheduled in place with ``chrt`` (threads it spawns
+# later inherit), so the daemon is never restarted under running cameras.
+_CAPTURE_DAEMON_UNITS = ("nvargus-daemon.service",)
+_CAPTURE_DAEMON_DROPIN = "50-axol-realtime.conf"
+# One notch above the relay's capture threads (they block on the daemon),
+# far below the axol-rt CAN loops (SCHED_FIFO 20).
+_CAPTURE_DAEMON_FIFO_PRIORITY = CAPTURE_FIFO_PRIORITY + 1
+_SYSTEMD_UNIT_DIR = Path("/etc/systemd/system")
+
+# ``/proc/<tid>/stat`` policy value for SCHED_FIFO (sched.h SCHED_FIFO == 1).
+_SCHED_FIFO = 1
 
 # cpufreq governor that holds the cores at their max clock. The ceiling it
 # holds them at is whatever the active ``nvpmodel`` power mode allows, so we
@@ -76,7 +111,8 @@ def _is_jetson() -> bool:
     # (``glob`` returns a generator that is always truthy, so it must be
     # consumed — ``any(glob(...))`` — to test whether it actually matched.)
     return any(
-        any(Path("/sys/class/devfreq").glob(pattern)) for pattern in _ENGINE_CLOCK_GLOBS
+        any(Path("/sys/class/devfreq").glob(pattern))
+        for pattern in _JETSON_ENGINE_GLOBS
     )
 
 
@@ -238,7 +274,7 @@ def _set_max_power_mode(escalator: _RootEscalator) -> None:
 
 
 def _pin_engines(writer: _RootEscalator) -> None:
-    """Set ``min_freq = max_freq`` on the NVENC/VIC devfreq nodes."""
+    """Set ``min_freq = max_freq`` on the NVENC/VIC/GPU devfreq nodes."""
     for pattern in _ENGINE_CLOCK_GLOBS:
         for node in Path("/sys/class/devfreq").glob(pattern):
             try:
@@ -253,14 +289,138 @@ def _pin_engines(writer: _RootEscalator) -> None:
                 _logger.info("pinned %s clock to %s Hz", node.name, max_freq)
             else:
                 _logger.warning(
-                    "cannot pin %s to its max clock (%s) — hardware encode "
-                    "latency will be ~3x worse. Fix manually with: "
-                    "echo %s | sudo tee %s",
+                    "cannot pin %s to its max clock (%s) — the camera path "
+                    "(hardware encode, ZED SDK CUDA processing) runs at the "
+                    "governor's floor and drops frames under load. Fix manually "
+                    "with: echo %s | sudo tee %s",
                     node.name,
                     detail or "write failed",
                     max_freq,
                     node / "min_freq",
                 )
+
+
+def _service_main_pid(unit: str) -> int:
+    """The unit's MainPID per systemd, 0 when inactive/unknown."""
+    try:
+        proc = subprocess.run(
+            ["systemctl", "show", "-p", "MainPID", "--value", unit],
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return 0
+    try:
+        return int(proc.stdout.strip() or 0)
+    except ValueError:
+        return 0
+
+
+def _threads_at_fifo(
+    pid: int, priority: int, *, proc_root: Path = Path("/proc")
+) -> bool | None:
+    """True when every thread of ``pid`` already runs SCHED_FIFO at ``priority``.
+
+    ``None`` when the process cannot be inspected (gone, or unreadable).
+    """
+    tasks = sorted((proc_root / str(pid) / "task").glob("*"))
+    if not tasks:
+        return None
+    for task in tasks:
+        try:
+            stat = (task / "stat").read_text()
+        except OSError:
+            return None
+        # Fields after the parenthesised comm (which may contain spaces):
+        # index 37 is rt_priority, 38 the scheduling policy (0-based from
+        # the field following ")", i.e. proc(5) fields 40 and 41).
+        fields = stat.rsplit(")", 1)[1].split()
+        try:
+            rt_priority, policy = int(fields[37]), int(fields[38])
+        except (IndexError, ValueError):
+            return None
+        if policy != _SCHED_FIFO or rt_priority != priority:
+            return False
+    return True
+
+
+def _prioritize_capture_daemons(escalator: _RootEscalator) -> None:
+    """Run the camera capture daemon(s) SCHED_FIFO, now and after restarts.
+
+    Jetson-only and best-effort. Two halves per unit: a systemd drop-in so
+    the policy applies whenever the daemon (re)starts, and ``chrt -a`` on the
+    live process so it applies right now without restarting the daemon under
+    running cameras (threads it creates later inherit the policy).
+    """
+    if not _is_jetson():
+        _logger.debug("not a Jetson; leaving the camera daemons' scheduling alone")
+        return
+    dropin_text = (
+        "# Installed by `axol jetson.setup`: every ZED X camera frame passes\n"
+        "# through this daemon, so it must not be descheduled behind the\n"
+        "# control/IK/recorder load the cameras feed.\n"
+        "[Service]\n"
+        "CPUSchedulingPolicy=fifo\n"
+        f"CPUSchedulingPriority={_CAPTURE_DAEMON_FIFO_PRIORITY}\n"
+    )
+    for unit in _CAPTURE_DAEMON_UNITS:
+        pid = _service_main_pid(unit)
+        dropin = _SYSTEMD_UNIT_DIR / f"{unit}.d" / _CAPTURE_DAEMON_DROPIN
+        if pid == 0 and not dropin.exists():
+            # Not installed on this station (no Argus daemon => not ZED X).
+            _logger.debug("%s not running; skipping its realtime drop-in", unit)
+            continue
+        try:
+            dropin_current = dropin.read_text() == dropin_text
+        except OSError:
+            dropin_current = False
+        if not dropin_current:
+            ok, detail = escalator.run(["mkdir", "-p", str(dropin.parent)])
+            if ok:
+                ok, detail = escalator.write(dropin, dropin_text)
+            if ok:
+                ok, detail = escalator.run(["systemctl", "daemon-reload"])
+            if ok:
+                _logger.info(
+                    "%s: SCHED_FIFO %d on future starts (%s)",
+                    unit,
+                    _CAPTURE_DAEMON_FIFO_PRIORITY,
+                    dropin,
+                )
+            else:
+                _logger.warning(
+                    "cannot install the realtime drop-in for %s (%s) — the "
+                    "capture daemon stays CFS after its next restart and all "
+                    "cameras drop the same frames under load. Fix manually "
+                    "with: sudo systemctl edit %s (CPUSchedulingPolicy=fifo, "
+                    "CPUSchedulingPriority=%d)",
+                    unit,
+                    detail or "failed",
+                    unit,
+                    _CAPTURE_DAEMON_FIFO_PRIORITY,
+                )
+        if pid == 0:
+            continue
+        if _threads_at_fifo(pid, _CAPTURE_DAEMON_FIFO_PRIORITY):
+            continue
+        ok, detail = escalator.run(
+            ["chrt", "-f", "-a", "-p", str(_CAPTURE_DAEMON_FIFO_PRIORITY), str(pid)]
+        )
+        if ok:
+            _logger.info(
+                "%s (pid %d) -> SCHED_FIFO %d", unit, pid, _CAPTURE_DAEMON_FIFO_PRIORITY
+            )
+        else:
+            _logger.warning(
+                "cannot re-schedule the running %s (pid %d) SCHED_FIFO (%s) — it "
+                "stays CFS until its next restart picks up the drop-in. Fix "
+                "manually with: sudo chrt -f -a -p %d %d",
+                unit,
+                pid,
+                detail or "chrt failed",
+                _CAPTURE_DAEMON_FIFO_PRIORITY,
+                pid,
+            )
 
 
 def _pin_cpu(writer: _RootEscalator) -> None:
@@ -327,16 +487,18 @@ def pin_engine_clocks(*, interactive: bool = False) -> None:
 
 
 def pin_realtime_clocks(*, interactive: bool = False) -> None:
-    """Select MAXN and pin engine **and** CPU clocks for the control loops.
+    """Select MAXN, pin engine **and** CPU clocks, and make the capture daemon RT.
 
     Selects the MAXN ``nvpmodel`` power mode (uncaps the clock ceiling), pins
-    NVENC/VIC (encode latency), and switches the CPUs to the ``performance``
-    governor (IK rate). All three are Jetson-only: MAXN selection and
-    CPU-governor pinning are gated on :func:`_is_jetson` so they never alter a
-    non-Tegra host, and engine pinning is a no-op without the Tegra devfreq
-    nodes. MAXN is selected first because it sets the ceiling the governor and
-    engine pins reach. Same best-effort / ``interactive`` escalation semantics
-    as :func:`pin_engine_clocks`; sudo is primed at most once across all of
+    NVENC/VIC/GPU (encode latency, ZED SDK processing), switches the CPUs to
+    the ``performance`` governor (IK rate), and schedules the Argus camera
+    daemon ``SCHED_FIFO`` (all-camera frame drops under load). All are
+    Jetson-only: MAXN selection, CPU-governor pinning and the daemon step are
+    gated on :func:`_is_jetson` so they never alter a non-Tegra host, and
+    engine pinning is a no-op without the Tegra devfreq nodes. MAXN is
+    selected first because it sets the ceiling the governor and engine pins
+    reach. Same best-effort / ``interactive`` escalation semantics as
+    :func:`pin_engine_clocks`; sudo is primed at most once across all of
     them. Invoked via ``axol jetson.setup`` (host installer + boot service),
     not from the teleop / collect-data / serve entry points.
     """
@@ -344,3 +506,4 @@ def pin_realtime_clocks(*, interactive: bool = False) -> None:
     _set_max_power_mode(escalator)
     _pin_engines(escalator)
     _pin_cpu(escalator)
+    _prioritize_capture_daemons(escalator)

--- a/almond_axol/video/gst_zed.py
+++ b/almond_axol/video/gst_zed.py
@@ -441,10 +441,14 @@ _DATASET_ACTIVE_INPUT_QUEUE_MIN_BUFFERS = 15
 _DATASET_ACTIVE_INPUT_QUEUE_SECONDS = 0.5
 _DATASET_ACTIVE_OUTPUT_QUEUE_MIN_BUFFERS = 60
 _DATASET_ACTIVE_OUTPUT_QUEUE_SECONDS = 2
-# The VIC pool must exceed the downstream queue capacity so NVENC can retain a
-# few input surfaces while a new buffer still reaches the queue and triggers its
-# downstream-leaky policy instead of blocking back into the camera tee.
-_DATASET_VIC_INFLIGHT_SURFACES = 8
+# The VIC pool must exceed the downstream queue capacity so NVENC can retain its
+# input surfaces while a new buffer still reaches the queue and triggers its
+# downstream-leaky policy instead of blocking back into the camera tee. Eight
+# spare surfaces is a thin, undocumented allowance for NVENC retention across
+# four simultaneous all-intra 60 Hz encoders. Thirty-two provides bounded
+# headroom (about 28 MiB beyond the queue itself per SVGA branch) and keeps
+# backpressure behind the copied-surface boundary.
+_DATASET_VIC_INFLIGHT_SURFACES = 32
 # Opening every camera with a sequence of host-side property writes can straddle
 # multiple source frames. Arm a timestamp probe on every branch first, then let
 # each one open itself on its first exposure at/after one shared future instant.
@@ -478,6 +482,15 @@ def _dataset_input_queue(name: str) -> str:
     """Named bounded queue between the dataset VIC copy and NVENC."""
     return (
         f"queue name={name}_inq leaky=downstream "
+        f"max-size-buffers={_DATASET_STARTUP_QUEUE_BUFFERS} "
+        "max-size-bytes=0 max-size-time=0"
+    )
+
+
+def _dataset_source_queue(name: str) -> str:
+    """Shallow named queue before the dataset valve/VIC ownership boundary."""
+    return (
+        f"queue name={name}_srcq leaky=downstream "
         f"max-size-buffers={_DATASET_STARTUP_QUEUE_BUFFERS} "
         "max-size-bytes=0 max-size-time=0"
     )
@@ -617,6 +630,10 @@ class _GstPipelineBase:
             ]
         ] = []
         self._dataset_enabled = False
+        # Named gst queue overruns are the missing stage-level evidence when a
+        # later reader sees only a PTS hole. Values are reset at each episode;
+        # callbacks log only active/opening dataset branches.
+        self._dataset_queue_overruns: dict[str, int] = {}
 
     def _cancel_dataset_disable(self) -> None:
         """Remove any outstanding legacy dataset-close probes (best effort)."""
@@ -720,6 +737,85 @@ class _GstPipelineBase:
                 queue.set_property("max-size-bytes", 0)
                 queue.set_property("max-size-time", 0)
 
+    def _attach_dataset_queue_diagnostics(
+        self, gates: tuple[tuple[str, str | None], ...]
+    ) -> None:
+        """Log the exact relay queue that sheds an active-episode frame.
+
+        Queue callbacks are event-only (no per-buffer Python probe), so they add
+        no steady-state GIL work to the relay. Counts are rate-limited to the
+        first and powers of two in case a failed recorder leaves a branch
+        overflowing until teardown.
+        """
+        if self._pipeline is None:
+            return
+        queue_valves: dict[str, Any] = {}
+        for valve_name, encoder_name in gates:
+            if encoder_name is None:
+                continue
+            valve = self._pipeline.get_by_name(valve_name)
+            if valve is None:
+                _logger.debug("dataset queue diagnostic missing valve %s", valve_name)
+                continue
+            for queue_name in (
+                f"{encoder_name}_srcq",
+                f"{encoder_name}_inq",
+                f"{encoder_name}_outq",
+            ):
+                queue_valves[queue_name] = valve
+            if encoder_name.startswith("dsenc_"):
+                queue_valves[f"eye_{encoder_name.rsplit('_', 1)[1]}_cropq"] = valve
+        owner = repr(self)
+        for queue_name, valve in sorted(queue_valves.items()):
+            queue = self._pipeline.get_by_name(queue_name)
+            if queue is None:
+                _logger.debug("dataset queue diagnostic missing %s", queue_name)
+                continue
+            self._dataset_queue_overruns.setdefault(queue_name, 0)
+
+            def on_overrun(
+                element: Any,
+                *,
+                label: str = queue_name,
+                branch_valve: Any = valve,
+                source: str = owner,
+            ) -> None:
+                # Source/crop queues are live before an episode. An overrun
+                # counts only after this branch's valve admits its first
+                # dataset exposure; one stereo eye can open before its sibling.
+                try:
+                    if bool(branch_valve.get_property("drop")):
+                        return
+                except Exception:  # noqa: BLE001 - diagnostics only
+                    return
+                count = self._dataset_queue_overruns.get(label, 0) + 1
+                self._dataset_queue_overruns[label] = count
+                if count != 1 and count & (count - 1):
+                    return
+                try:
+                    level = int(element.get_property("current-level-buffers"))
+                    limit = int(element.get_property("max-size-buffers"))
+                except Exception:  # noqa: BLE001 - diagnostics only
+                    level = limit = -1
+                _logger.warning(
+                    "dataset relay %s queue %s overrun #%d "
+                    "(level=%d, limit=%d); an encoded exposure may be lost",
+                    source,
+                    label,
+                    count,
+                    level,
+                    limit,
+                )
+
+            try:
+                queue.connect("overrun", on_overrun)
+            except Exception as exc:  # noqa: BLE001 - diagnostics only
+                _logger.debug(
+                    "could not attach overrun diagnostic to %s: %s",
+                    queue_name,
+                    exc,
+                )
+
     def _begin_dataset_enable(
         self,
         gates: tuple[tuple[str, str | None], ...],
@@ -766,6 +862,8 @@ class _GstPipelineBase:
             ]
         ] = []
         try:
+            for queue_name in self._dataset_queue_overruns:
+                self._dataset_queue_overruns[queue_name] = 0
             # Expand both sides before any valve can admit the shared-boundary
             # exposure. A partial property-update failure is caught below;
             # abort closes all valves before restoring startup depths.
@@ -1220,7 +1318,8 @@ class ZedGstCamera(_GstPipelineBase, _GstStreamConsumer):
         if self._raw_socket_path:
             dataset_rate = _dataset_rate_limit(self.fps, self.dataset_fps)
             raw = (
-                f"{_QUEUE} ! {dataset_rate}valve name=rawvalve drop=false ! "
+                f"{_dataset_source_queue('dsenc')} ! {dataset_rate}"
+                "valve name=rawvalve drop=false ! "
                 + _dataset_enc_shmsink(
                     self._raw_socket_path,
                     self.raw_width,
@@ -1298,6 +1397,7 @@ class ZedGstCamera(_GstPipelineBase, _GstStreamConsumer):
     def connect(self, warmup: bool = True) -> None:
         """Open the camera, start the pipeline, and block until it streams."""
         self._launch(self._pipeline_str())
+        self._attach_dataset_queue_diagnostics(self._raw_gates())
         if self._enc is not None:
             self._start_pull(
                 f"zedgst-{self.serial}-enc",
@@ -1562,7 +1662,11 @@ class ZedGstStereoCamera(_GstPipelineBase):
             f"video/x-raw(memory:NVMM),format=NV12,width={eye_w},height={eye_h},"
             "pixel-aspect-ratio=1/1"
         )
-        crop = f"{_QUEUE} ! nvvidconv left={left} right={right} top=0 bottom={eye_h} ! {caps}"
+        crop = (
+            f"queue name=eye_{sink_suffix}_cropq leaky=downstream "
+            "max-size-buffers=2 ! "
+            f"nvvidconv left={left} right={right} top=0 bottom={eye_h} ! {caps}"
+        )
         sock = (
             self._left_raw_socket_path
             if sink_suffix == "l"
@@ -1575,7 +1679,7 @@ class ZedGstStereoCamera(_GstPipelineBase):
         if sock:
             dataset_rate = _dataset_rate_limit(self.fps, self.dataset_fps)
             raw = (
-                f"{_QUEUE} ! {dataset_rate}"
+                f"{_dataset_source_queue('dsenc_' + sink_suffix)} ! {dataset_rate}"
                 f"valve name=rawvalve_{sink_suffix} drop=false ! "
                 + _dataset_enc_shmsink(
                     sock,
@@ -1697,6 +1801,7 @@ class ZedGstStereoCamera(_GstPipelineBase):
 
     def connect(self, warmup: bool = True) -> None:
         self._launch(self._pipeline_str())
+        self._attach_dataset_queue_diagnostics(self._raw_gates())
         eye_specs = [
             (
                 "left",

--- a/almond_axol/video/gst_zed.py
+++ b/almond_axol/video/gst_zed.py
@@ -52,7 +52,7 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from .constants import HEADSET_STREAM_FPS
-from .hw_video import _bitrate_for, dataset_vbr_bitrate, hw_h264_available
+from .hw_video import _bitrate_for, dataset_intra_vbr_bitrate, hw_h264_available
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -458,6 +458,139 @@ _DATASET_ENABLE_LEAD_S = 0.100
 # The shared gate still has a bounded acknowledgement wait. A timeout means a
 # source stopped producing exposure timestamps, not ordinary scheduler jitter.
 _DATASET_GATE_TIMEOUT_S = 2.0
+# Every camera source element carries this name so the source-gap diagnostic
+# can find its pad. A sensor-timestamp step of 1.5 periods at the fastest
+# supported capture rate (60 Hz) is already a whole missing exposure.
+_SOURCE_ELEMENT_NAME = "camsrc"
+_SOURCE_GAP_WARN_MS = 25.0
+_GPU_DEVFREQ_GLOB = "/sys/class/devfreq/*.gpu"
+# The Linux thread name (``comm``) is truncated to this many characters, so
+# gst task threads named ``<element>:<pad>`` may only be matched on a prefix.
+_COMM_MAX = 15
+# The named queues whose consumer thread still holds an *un-copied* camera
+# surface: the stereo eye crops and the dataset source queues in front of the
+# VIC copy. Argus owns only a handful of those surfaces, so these queues are
+# two buffers deep and an overrun there is a lost exposure; everything after
+# the VIC copy has its own (deeper) buffering.
+_EXPOSURE_CRITICAL_QUEUES = (
+    "eye_l_cropq",
+    "eye_r_cropq",
+    "dsenc_srcq",
+    "dsenc_l_srcq",
+    "dsenc_r_srcq",
+)
+
+
+def _task_thread_comm(element_name: str) -> str:
+    """The ``comm`` GStreamer gives the streaming thread of ``element_name``."""
+    return f"{element_name}:src"[:_COMM_MAX]
+
+
+def exposure_critical_thread_comms() -> frozenset[str]:
+    """``comm`` names of the relay threads that must run every capture period.
+
+    The camera source streaming thread plus the consumers of
+    :data:`_EXPOSURE_CRITICAL_QUEUES`. Used by the relay to give exactly this
+    chain real-time scheduling (see ``affinity.prioritize_capture_threads``).
+    """
+    return frozenset(
+        _task_thread_comm(name)
+        for name in (_SOURCE_ELEMENT_NAME, *_EXPOSURE_CRITICAL_QUEUES)
+    )
+
+
+def _thread_sched_wait_ns() -> int | None:
+    """Cumulative time this thread spent runnable-but-waiting (Linux only)."""
+    try:
+        with open("/proc/thread-self/schedstat") as f:
+            return int(f.read().split()[1])
+    except (OSError, ValueError, IndexError):
+        return None
+
+
+def _find_thread_by_comm(comm: str) -> int | None:
+    """TID of this process's thread named ``comm``, or ``None``."""
+    try:
+        entries = os.listdir("/proc/self/task")
+    except OSError:
+        return None
+    for entry in entries:
+        try:
+            with open(f"/proc/self/task/{entry}/comm") as f:
+                if f.read().strip() == comm:
+                    return int(entry)
+        except (OSError, ValueError):
+            continue
+    return None
+
+
+def _thread_sched_snapshot(tid: int) -> tuple[int, str, str] | None:
+    """``(runnable-wait ns, state letter, wchan)`` of a thread of this process.
+
+    ``state`` is ``R`` when the thread is runnable (running or waiting for a
+    CPU), ``S``/``D`` when it is blocked — for a VIC/NVENC dispatch thread that
+    means waiting on the hardware, and ``wchan`` names the kernel wait.
+    """
+    try:
+        with open(f"/proc/self/task/{tid}/schedstat") as f:
+            wait_ns = int(f.read().split()[1])
+        with open(f"/proc/self/task/{tid}/stat") as f:
+            state = f.read().rsplit(")", 1)[1].split()[0]
+    except (OSError, ValueError, IndexError):
+        return None
+    try:
+        with open(f"/proc/self/task/{tid}/wchan") as f:
+            wchan = f.read().strip() or "-"
+    except OSError:
+        wchan = "-"
+    return wait_ns, state, wchan
+
+
+def _consumer_attribution(state: dict[str, Any], comm: str) -> str:
+    """Describe what a queue's consumer thread was doing at an overrun.
+
+    Sampled per overrun event (cheap: three procfs reads) and phrased so the
+    two causes read apart in the log: a consumer that is ``state=R`` with a CPU
+    wait close to the elapsed time was starved of a core; one that is
+    ``state=S``/``D`` in an ``nvhost``/fence wait with ~0 CPU wait was blocked
+    on the VIC/NVENC hardware or its memory path.
+    """
+    now = time.perf_counter()
+    tid = state.get("tid")
+    if tid is None:
+        tid = state["tid"] = _find_thread_by_comm(comm)
+        if tid is None:
+            return f"consumer {comm} not found"
+    snap = _thread_sched_snapshot(tid)
+    if snap is None:
+        state["tid"] = None
+        return f"consumer {comm} exited"
+    wait_ns, sched_state, wchan = snap
+    prev_t, prev_wait = state.get("t"), state.get("wait")
+    state["t"], state["wait"] = now, wait_ns
+    head = f"consumer {comm} state={sched_state} wchan={wchan}"
+    if prev_t is None or prev_wait is None or now - prev_t > 1.0:
+        return head
+    return (
+        f"{head}, CPU wait {(wait_ns - prev_wait) / 1e6:.1f}ms of the "
+        f"{(now - prev_t) * 1e3:.1f}ms since its previous overrun"
+    )
+
+
+def _gpu_clock_summary() -> str:
+    """``cur/max MHz`` of the Tegra GPU devfreq, or ``n/a`` off-Jetson."""
+    import glob
+
+    for node in glob.glob(_GPU_DEVFREQ_GLOB):
+        try:
+            with open(f"{node}/cur_freq") as f:
+                cur = int(f.read()) // 1_000_000
+            with open(f"{node}/max_freq") as f:
+                top = int(f.read()) // 1_000_000
+        except (OSError, ValueError):
+            continue
+        return f"{cur}/{top}MHz"
+    return "n/a"
 
 
 def _dataset_rate_limit(capture_fps: int, dataset_fps: int) -> str:
@@ -542,10 +675,12 @@ def _dataset_enc_shmsink(
     before the parent later closes the branch between episodes.
 
     Encoding runs in VBR with a peak cap so the recorded dataset stays bounded
-    and uniformly sized across cameras even when one sensor is very noisy (see
-    ``dataset_vbr_bitrate``).
+    and uniformly sized across cameras even when one sensor is very noisy. The
+    budget is the all-intra one (``dataset_intra_vbr_bitrate``): every frame is
+    an IDR here, so the predictive-GOP budget would leave each frame visibly
+    blocky.
     """
-    target, peak = dataset_vbr_bitrate(w, h, dataset_fps)
+    target, peak = dataset_intra_vbr_bitrate(w, h, dataset_fps)
     input_buffers = _dataset_active_input_buffers(dataset_fps)
     converter_buffers = input_buffers + _DATASET_VIC_INFLIGHT_SURFACES
     return (
@@ -772,6 +907,7 @@ class _GstPipelineBase:
                 _logger.debug("dataset queue diagnostic missing %s", queue_name)
                 continue
             self._dataset_queue_overruns.setdefault(queue_name, 0)
+            consumer_state: dict[str, Any] = {}
 
             def on_overrun(
                 element: Any,
@@ -779,6 +915,7 @@ class _GstPipelineBase:
                 label: str = queue_name,
                 branch_valve: Any = valve,
                 source: str = owner,
+                consumer: dict[str, Any] = consumer_state,
             ) -> None:
                 # Source/crop queues are live before an episode. An overrun
                 # counts only after this branch's valve admits its first
@@ -790,6 +927,10 @@ class _GstPipelineBase:
                     return
                 count = self._dataset_queue_overruns.get(label, 0) + 1
                 self._dataset_queue_overruns[label] = count
+                # Sample the consumer on every overrun so the wait delta spans
+                # exactly the interval between two overruns, but log only the
+                # first and powers of two.
+                attribution = _consumer_attribution(consumer, _task_thread_comm(label))
                 if count != 1 and count & (count - 1):
                     return
                 try:
@@ -799,12 +940,13 @@ class _GstPipelineBase:
                     level = limit = -1
                 _logger.warning(
                     "dataset relay %s queue %s overrun #%d "
-                    "(level=%d, limit=%d); an encoded exposure may be lost",
+                    "(level=%d, limit=%d); %s; an encoded exposure may be lost",
                     source,
                     label,
                     count,
                     level,
                     limit,
+                    attribution,
                 )
 
             try:
@@ -1183,6 +1325,66 @@ class _GstPipelineBase:
         self._gst = Gst
         _logger.info("gst zed pipeline: %s", pipeline_str)
         self._pipeline = Gst.parse_launch(pipeline_str)
+        self._attach_source_gap_diagnostic()
+
+    def _attach_source_gap_diagnostic(self) -> None:
+        """Log every exposure the camera source itself fails to deliver.
+
+        The dataset queues report their own overruns, and the recorder detects
+        a missing AU downstream, but neither can say *where* a frame vanished
+        when no queue overran: that leaves the source element (the ZED SDK's
+        grab loop) or the camera link. This probe sits on the source pad, so a
+        sensor-timestamp gap here is a frame the source never produced. It
+        also attributes the miss: the source's streaming thread cannot call
+        ``grab()`` while descheduled, so if its ``schedstat`` wait time grew by
+        most of the gap it was starved of CPU; otherwise the time went inside
+        the SDK (GPU work, or a link/sensor frame that never arrived), which is
+        why the GPU clock — the one camera-path engine ``jetson.setup`` does
+        not pin — is logged alongside.
+        """
+        Gst = self._gst
+        source = self._pipeline.get_by_name(_SOURCE_ELEMENT_NAME)
+        if source is None:
+            return
+        pad = source.get_static_pad("src")
+        if pad is None:
+            return
+        state: dict[str, Any] = {"pts": None, "wait_ns": None}
+        label = repr(self)
+
+        def on_buffer(_pad: Any, info: Any) -> Any:
+            buf = info.get_buffer()
+            if buf is None or buf.pts == Gst.CLOCK_TIME_NONE:
+                return Gst.PadProbeReturn.OK
+            previous = state["pts"]
+            previous_wait = state["wait_ns"]
+            wait_ns = _thread_sched_wait_ns()
+            state["pts"] = buf.pts
+            state["wait_ns"] = wait_ns
+            if previous is None or buf.pts <= previous:
+                return Gst.PadProbeReturn.OK
+            gap_ms = (buf.pts - previous) / 1e6
+            if gap_ms < _SOURCE_GAP_WARN_MS:
+                return Gst.PadProbeReturn.OK
+            starved_ms = (
+                (wait_ns - previous_wait) / 1e6
+                if wait_ns is not None and previous_wait is not None
+                else None
+            )
+            _logger.warning(
+                "camera source %s skipped exposure(s): sensor PTS gap %.2fms; "
+                "source thread CPU wait since previous frame %s; gpu %s",
+                label,
+                gap_ms,
+                "unknown" if starved_ms is None else f"{starved_ms:.2f}ms",
+                _gpu_clock_summary(),
+            )
+            return Gst.PadProbeReturn.OK
+
+        try:
+            pad.add_probe(Gst.PadProbeType.BUFFER, on_buffer)
+        except Exception as exc:  # diagnostics never gate capture
+            _logger.debug("could not attach source gap diagnostic: %s", exc)
 
     def _play_and_wait(self, channels: tuple[_AUChannel, ...]) -> bool:
         Gst = self._gst
@@ -1294,7 +1496,7 @@ class ZedGstCamera(_GstPipelineBase, _GstStreamConsumer):
     def _pipeline_str(self) -> str:
         bitrate = _bitrate_for(self.width, self.height, self.stream_fps)
         src = (
-            f"zedxonesrc camera-sn={self.serial} "
+            f"zedxonesrc name={_SOURCE_ELEMENT_NAME} camera-sn={self.serial} "
             f"camera-resolution={_RESOLUTION_ENUM[self.resolution]} "
             f"camera-fps={self.fps} stream-type=1 do-timestamp=false "
             f"ctrl-auto-exposure-range-max={_MAX_AUTO_EXPOSURE_US} "
@@ -1787,7 +1989,7 @@ class ZedGstStereoCamera(_GstPipelineBase):
 
     def _pipeline_str(self) -> str:
         src = (
-            f"zedsrc camera-sn={self.serial} "
+            f"zedsrc name={_SOURCE_ELEMENT_NAME} camera-sn={self.serial} "
             f"camera-resolution={_STEREO_RESOLUTION_ENUM[self.resolution]} "
             f"camera-fps={self.fps} stream-type=7 depth-mode=0 "
             "do-timestamp=false "

--- a/almond_axol/video/hw_video.py
+++ b/almond_axol/video/hw_video.py
@@ -98,6 +98,25 @@ def dataset_vbr_bitrate(width: int, height: int, fps: int) -> tuple[int, int]:
     return target, int(target * _DATASET_PEAK_MULT)
 
 
+# All-intra budget for the relay's encoded dataset branch (``gst_zed``), where
+# every frame is an IDR. Intra frames cannot borrow from their neighbours, so at
+# the predictive budget above each 960x600 frame gets ~12 KB and lands around
+# 31 dB PSNR-Y — visibly blocky on the edge detail the policies rely on — versus
+# ~45 dB for the same bits spread over a 15-frame GOP (measured on the Jetson
+# encoder against a recorded arm camera). ~0.6 bpp (≈21 Mbps at SVGA @ 60)
+# recovers ~41 dB; the cost is about 3.5x the on-disk/upload size per camera.
+_DATASET_INTRA_BPP = 0.6
+_DATASET_INTRA_PEAK_MULT = 1.5
+
+
+def dataset_intra_vbr_bitrate(width: int, height: int, fps: int) -> tuple[int, int]:
+    """(target, peak) VBR bitrate (bits/s) for an all-intra dataset encode."""
+    target = max(
+        8_000_000, min(50_000_000, int(width * height * fps * _DATASET_INTRA_BPP))
+    )
+    return target, int(target * _DATASET_INTRA_PEAK_MULT)
+
+
 def _gst_argv(width: int, height: int, fps: int, bitrate: int) -> list[str]:
     """``gst-launch-1.0`` argv: BGRA on stdin -> H.264 byte stream on stdout.
 

--- a/almond_axol/video/video_proc.py
+++ b/almond_axol/video/video_proc.py
@@ -767,6 +767,14 @@ def _relay_main(
     # camera pipelines are PLAYING (their workers exist) and before this event
     # loop starts.
     affinity.isolate_relay_cpu()
+    # The capture chain (source streaming thread, SDK workers, and the
+    # consumers of the two-buffer queues that still hold camera surfaces) must
+    # run every 60 Hz period or the exposure is lost; a CFS slot behind the
+    # encode pool is not guaranteed once recording starts, so it gets a
+    # real-time class of its own (see prioritize_capture_threads).
+    from .gst_zed import exposure_critical_thread_comms
+
+    affinity.prioritize_capture_threads(exposure_critical_thread_comms())
 
     try:
         asyncio.run(serve())

--- a/almond_axol/video/video_proc.py
+++ b/almond_axol/video/video_proc.py
@@ -761,12 +761,11 @@ def _relay_main(
         if manager is not None:
             await manager.close_all()
 
-    # Split the relay across its two cores: all Python threads (this WebRTC-send
-    # main thread + the encoded-AU pull loops) onto one, GStreamer's C threads
-    # (camera/NVENC and the recording raw-branch shm copy) onto the other, so the
-    # recording workload can't preempt the send. Done here — after the cameras'
-    # gst pipelines are PLAYING (all their threads exist) and right before the
-    # event loop runs on this thread.
+    # Keep all Python threads (this WebRTC-send main thread + encoded-AU pull
+    # loops) on one relay core, and spread GStreamer's much wider C thread pool
+    # over the other relay/background throughput cores. Done here — after the
+    # camera pipelines are PLAYING (their workers exist) and before this event
+    # loop starts.
     affinity.isolate_relay_cpu()
 
     try:

--- a/rust/axol-rt/src/bench.rs
+++ b/rust/axol-rt/src/bench.rs
@@ -112,8 +112,9 @@ fn tick_pipelined(sock: &CanSock, timeout: Duration) -> io::Result<usize> {
         if now >= deadline {
             break;
         }
-        sock.set_recv_timeout(deadline - now)?;
-        let Some(frame) = sock.recv()? else { break };
+        let Some(frame) = sock.recv_timeout(deadline - now)? else {
+            break;
+        };
         let motor_id = match frame.id {
             id if (0x241..=0x245).contains(&id) && frame.data[0] == proto::MA_MULTI_TURN_ANGLE => {
                 (id - 0x240) as usize

--- a/rust/axol-rt/src/can.rs
+++ b/rust/axol-rt/src/can.rs
@@ -6,7 +6,7 @@
 use std::ffi::CString;
 use std::io;
 use std::os::unix::io::RawFd;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 /// Classic CAN frame as the kernel defines it (`struct can_frame`).
 #[repr(C)]
@@ -76,9 +76,45 @@ impl CanSock {
         Ok(Self { fd })
     }
 
-    /// Set the blocking-receive timeout (`SO_RCVTIMEO`).
+    /// Set the blocking-receive timeout (`SO_RCVTIMEO`) for coarse,
+    /// stop-flag-polling receive loops (the proxy).
+    ///
+    /// Never use this for a deadline the control loop must honour: the kernel
+    /// rounds a socket timeout up to whole scheduler jiffies and the timer
+    /// wheel then expires it one to two jiffies late. Measured on the Jetson's
+    /// HZ=250 kernel, a 3.7 ms `SO_RCVTIMEO` blocked 4-12 ms (6.7 ms on
+    /// average), and a `Duration` under 1 µs disables the timeout entirely
+    /// (blocks forever). Use [`Self::recv_timeout`] for deadlines.
     pub fn set_recv_timeout(&self, timeout: Duration) -> io::Result<()> {
         self.set_timeout(libc::SO_RCVTIMEO, timeout)
+    }
+
+    /// Wait up to `timeout` for one frame; `Ok(None)` when nothing arrived.
+    ///
+    /// Built on `ppoll` + a non-blocking `recv` so the wait ends within
+    /// microseconds of the deadline: `ppoll` timeouts are hrtimer-based
+    /// (with zero slack for a SCHED_FIFO caller), unlike `SO_RCVTIMEO`'s
+    /// jiffy-granular timer-wheel timeout. This is what lets the 240 Hz bus
+    /// loop bound its reply window inside the cycle — with `SO_RCVTIMEO`, one
+    /// missing motor reply stretched a 4.17 ms tick to ~9 ms and the next
+    /// tick tripped the whole-cycle timing fault. A zero `timeout` is a plain
+    /// non-blocking probe.
+    pub fn recv_timeout(&self, timeout: Duration) -> io::Result<Option<Frame>> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if !wait_readable(self.fd, deadline)? {
+                return Ok(None);
+            }
+            // Readiness can be spurious (or signal a socket error, which the
+            // receive surfaces); never block here, and re-check the deadline
+            // rather than spinning if nothing was actually queued.
+            if let Some(frame) = self.recv_nonblocking()? {
+                return Ok(Some(frame));
+            }
+            if Instant::now() >= deadline {
+                return Ok(None);
+            }
+        }
     }
 
     /// Set the blocking-send timeout (`SO_SNDTIMEO`). A dead bus (e-stop —
@@ -197,5 +233,97 @@ impl CanSock {
 impl Drop for CanSock {
     fn drop(&mut self) {
         unsafe { libc::close(self.fd) };
+    }
+}
+
+/// Block until `fd` is readable or `deadline` passes; `Ok(false)` on expiry.
+///
+/// `ppoll` with an absolute-deadline-derived timeout: hrtimer-precise, and a
+/// deadline already in the past is a non-blocking probe (unlike a zero
+/// `SO_RCVTIMEO`, which the kernel reads as "no timeout"). `EINTR` re-arms
+/// against the same deadline.
+fn wait_readable(fd: RawFd, deadline: Instant) -> io::Result<bool> {
+    loop {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        let ts = libc::timespec {
+            tv_sec: remaining.as_secs() as libc::time_t,
+            tv_nsec: remaining.subsec_nanos() as libc::c_long,
+        };
+        let mut pfd = libc::pollfd {
+            fd,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        let rc = unsafe { libc::ppoll(&mut pfd, 1, &ts, std::ptr::null()) };
+        if rc < 0 {
+            let err = io::Error::last_os_error();
+            if err.kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(err);
+        }
+        return Ok(rc > 0);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::UdpSocket;
+    use std::os::unix::io::AsRawFd;
+
+    fn idle_socket() -> UdpSocket {
+        UdpSocket::bind("127.0.0.1:0").expect("bind loopback udp socket")
+    }
+
+    #[test]
+    fn wait_readable_expires_close_to_the_deadline() {
+        // The whole point of ppoll over SO_RCVTIMEO: a sub-jiffy wait must end
+        // near the requested instant, not one or two scheduler ticks later
+        // (4-12 ms measured for a 3.7 ms socket timeout on an HZ=250 kernel).
+        // Use a median so one preempted iteration cannot fail the test.
+        let sock = idle_socket();
+        let timeout = Duration::from_micros(2_000);
+        let mut waits: Vec<Duration> = (0..15)
+            .map(|_| {
+                let started = Instant::now();
+                let ready = wait_readable(sock.as_raw_fd(), started + timeout).unwrap();
+                assert!(!ready);
+                started.elapsed()
+            })
+            .collect();
+        waits.sort();
+        let median = waits[waits.len() / 2];
+        assert!(median >= timeout, "returned early: {median:?}");
+        assert!(
+            median < timeout + Duration::from_millis(1),
+            "wait overran its deadline: {median:?} for {timeout:?}"
+        );
+    }
+
+    #[test]
+    fn wait_readable_treats_a_past_deadline_as_a_probe() {
+        // A sub-microsecond remaining window used to become SO_RCVTIMEO = 0,
+        // which the kernel treats as "block forever".
+        let sock = idle_socket();
+        let started = Instant::now();
+        let ready = wait_readable(sock.as_raw_fd(), started + Duration::from_nanos(500)).unwrap();
+        assert!(!ready);
+        assert!(started.elapsed() < Duration::from_millis(50));
+        let ready = wait_readable(sock.as_raw_fd(), started).unwrap();
+        assert!(!ready);
+    }
+
+    #[test]
+    fn wait_readable_returns_as_soon_as_data_arrives() {
+        let sock = idle_socket();
+        let sender = idle_socket();
+        sender
+            .send_to(b"x", sock.local_addr().unwrap())
+            .expect("loopback send");
+        let started = Instant::now();
+        let ready = wait_readable(sock.as_raw_fd(), started + Duration::from_secs(5)).unwrap();
+        assert!(ready);
+        assert!(started.elapsed() < Duration::from_secs(1));
     }
 }

--- a/rust/axol-rt/src/hold.rs
+++ b/rust/axol-rt/src/hold.rs
@@ -300,8 +300,9 @@ fn stream(
             if now >= reply_deadline {
                 break;
             }
-            sock.set_recv_timeout(reply_deadline - now)?;
-            let Some(frame) = sock.recv()? else { break };
+            let Some(frame) = sock.recv_timeout(reply_deadline - now)? else {
+                break;
+            };
             let (idx, pos) = match frame.id {
                 id if (0x501..=0x505).contains(&id) => {
                     let motor_id = (id - 0x500) as u8;

--- a/rust/axol-rt/src/jelly.rs
+++ b/rust/axol-rt/src/jelly.rs
@@ -253,8 +253,7 @@ fn collect_feedback(
         if now >= deadline {
             break;
         }
-        sock.set_recv_timeout(deadline - now)?;
-        let Some(f) = sock.recv()? else {
+        let Some(f) = sock.recv_timeout(deadline - now)? else {
             break;
         };
         if !(0x11..=0x14).contains(&f.id) {

--- a/rust/axol-rt/src/serve.rs
+++ b/rust/axol-rt/src/serve.rs
@@ -1442,6 +1442,7 @@ fn bus_loop(
     let watchdog = Duration::from_secs_f64(cfg.watchdog_ms / 1e3);
     let mut rejected: u64 = 0;
     let mut late: u64 = 0;
+    let mut missed: u64 = 0;
     let mut trace_dropped: u64 = 0;
     let mut ticks: u64 = 0;
     let mut watchdog_frozen = false;
@@ -1733,6 +1734,9 @@ fn bus_loop(
             // window begins when this tick actually began, not at its nominal
             // schedule point: a late wake must not discard shoulder feedback
             // simply because the old absolute deadline has already elapsed.
+            // The wait is hrtimer-precise (`recv_timeout`): a missing reply
+            // must end the window at `reply_deadline`, never a jiffy or two
+            // later, or the overrun lands on the next tick as lateness.
             let reply_deadline = began + period.saturating_sub(REPLY_GUARD);
             let mut seen = vec![false; motors.len()];
             let mut pending = expected.iter().filter(|&&value| value).count();
@@ -1741,8 +1745,9 @@ fn bus_loop(
                 if now >= reply_deadline {
                     break;
                 }
-                sock.set_recv_timeout(reply_deadline - now)?;
-                let Some(frame) = sock.recv()? else { break };
+                let Some(frame) = sock.recv_timeout(reply_deadline - now)? else {
+                    break;
+                };
                 let (idx, pos, vel, tau) = match frame.id {
                     id if (0x501..=0x505).contains(&id) => {
                         let motor_id = (id - 0x500) as u8;
@@ -1826,6 +1831,11 @@ fn bus_loop(
                 }
             }
 
+            // Replies still outstanding at the window's end. Counted into the
+            // periodic stats so a rare miss is visible in the log even when it
+            // stays far below the fail-closed thresholds.
+            missed += pending as u64;
+
             // Never continue phase-sensitive host damping when an arm motor
             // has stopped producing fresh feedback. A single miss suppresses
             // host damping on the next tick; sustained or bursty degradation
@@ -1861,7 +1871,7 @@ fn bus_loop(
                     out_tx,
                     b'L',
                     &format!(
-                        "{iface}: {ticks} ticks, {late} late ({:.2}%), {rejected} rejected targets, {trace_dropped} trace drops, seq {:?}",
+                        "{iface}: {ticks} ticks, {late} late ({:.2}%), {missed} missed replies, {rejected} rejected targets, {trace_dropped} trace drops, seq {:?}",
                         late as f64 / ticks as f64 * 100.0,
                         last_seq,
                     ),

--- a/rust/axol-rt/src/txn.rs
+++ b/rust/axol-rt/src/txn.rs
@@ -18,8 +18,7 @@ fn wait_for(
         if now >= deadline {
             return Ok(None);
         }
-        sock.set_recv_timeout(deadline - now)?;
-        match sock.recv()? {
+        match sock.recv_timeout(deadline - now)? {
             None => return Ok(None),
             Some(frame) if accept(&frame) => return Ok(Some(frame)),
             Some(_) => continue,

--- a/tests/test_affinity.py
+++ b/tests/test_affinity.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import call, patch
+
+from almond_axol.utils import affinity
+
+
+class IsolateRelayCpuTest(TestCase):
+    def test_gstreamer_threads_share_relay_and_background_cores(self) -> None:
+        python_threads = [
+            SimpleNamespace(native_id=101),
+            SimpleNamespace(native_id=102),
+        ]
+
+        with (
+            patch.object(affinity.os, "cpu_count", return_value=8),
+            patch.object(
+                affinity.os,
+                "listdir",
+                return_value=["101", "102", "201", "202", "not-a-tid"],
+            ),
+            patch.object(affinity.os, "sched_setaffinity") as set_affinity,
+            patch("threading.enumerate", return_value=python_threads),
+        ):
+            self.assertTrue(affinity.isolate_relay_cpu())
+
+        self.assertCountEqual(
+            set_affinity.call_args_list[:2],
+            [call(101, {4}), call(102, {4})],
+        )
+        self.assertEqual(
+            set_affinity.call_args_list[2:],
+            [call(201, {0, 1, 5}), call(202, {0, 1, 5})],
+        )
+
+    def test_gstreamer_set_excludes_python_core_when_groups_overlap(self) -> None:
+        groups = {
+            "relay": {2, 3},
+            "background": {2, 3},
+        }
+        python_threads = [SimpleNamespace(native_id=101)]
+
+        with (
+            patch.object(affinity, "core_groups", return_value=groups),
+            patch.object(affinity.os, "listdir", return_value=["101", "201"]),
+            patch.object(affinity.os, "sched_setaffinity") as set_affinity,
+            patch("threading.enumerate", return_value=python_threads),
+        ):
+            self.assertTrue(affinity.isolate_relay_cpu())
+
+        self.assertEqual(
+            set_affinity.call_args_list,
+            [call(101, {2}), call(201, {3})],
+        )

--- a/tests/test_affinity.py
+++ b/tests/test_affinity.py
@@ -1,8 +1,95 @@
+import io
 from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import call, patch
 
 from almond_axol.utils import affinity
+
+
+def _proc_files(comms: dict[str, str], process_comm: str = "python"):
+    """``open`` stand-in serving ``/proc/self/comm`` and per-task ``comm`` files."""
+
+    def _open(path, *args, **kwargs):
+        if path == "/proc/self/comm":
+            return io.StringIO(process_comm + "\n")
+        prefix = "/proc/self/task/"
+        if path.startswith(prefix) and path.endswith("/comm"):
+            tid = path[len(prefix) : -len("/comm")]
+            if tid in comms:
+                return io.StringIO(comms[tid] + "\n")
+            raise FileNotFoundError(path)
+        raise AssertionError(f"unexpected open({path!r})")
+
+    return _open
+
+
+class PrioritizeCaptureThreadsTest(TestCase):
+    comms = {
+        "101": "python",  # Python main thread (excluded via threading)
+        "201": "camsrc:src",  # zedsrc streaming thread
+        "202": "camsrc:src",  # a second camera's
+        "203": "python",  # ZED SDK worker: never renamed its comm
+        "204": "eye_l_cropq:src",  # crop VIC dispatch: holds a camera surface
+        "205": "V4L2_EncThread",  # NVENC: stays CFS
+        "206": "cuda-EvtHandlr",
+        "207": "dsenc_l_srcq:sr",  # 15-char comm truncation of dsenc_l_srcq:src
+        "208": "dsenc_l_outq:sr",  # post-encode: stays CFS
+    }
+    python_threads = [SimpleNamespace(native_id=101)]
+    wanted = ("camsrc:src", "eye_l_cropq:src", "dsenc_l_srcq:sr")
+
+    def test_elevates_capture_chain_and_sdk_threads_only(self) -> None:
+        # "999" is listed but exited before its comm is read; "x" isn't a tid.
+        with (
+            patch.object(
+                affinity.os, "listdir", return_value=[*self.comms, "999", "x"]
+            ),
+            patch.object(affinity.os, "sched_setscheduler", create=True) as setsched,
+            patch.object(
+                affinity.os,
+                "sched_param",
+                create=True,
+                side_effect=lambda p: ("param", p),
+            ),
+            patch.object(affinity.os, "SCHED_FIFO", 1, create=True),
+            patch("builtins.open", _proc_files(self.comms)),
+            patch("threading.enumerate", return_value=self.python_threads),
+        ):
+            moved = affinity.prioritize_capture_threads(self.wanted)
+
+        self.assertEqual(moved, 5)
+        param = ("param", affinity.CAPTURE_FIFO_PRIORITY)
+        self.assertCountEqual(
+            setsched.call_args_list,
+            [call(tid, 1, param) for tid in (201, 202, 203, 204, 207)],
+        )
+
+    def test_permission_denied_leaves_threads_cfs(self) -> None:
+        with (
+            patch.object(affinity.os, "listdir", return_value=list(self.comms)),
+            patch.object(
+                affinity.os,
+                "sched_setscheduler",
+                create=True,
+                side_effect=PermissionError("EPERM"),
+            ) as setsched,
+            patch.object(
+                affinity.os, "sched_param", create=True, side_effect=lambda p: p
+            ),
+            patch.object(affinity.os, "SCHED_FIFO", 1, create=True),
+            patch("builtins.open", _proc_files(self.comms)),
+            patch("threading.enumerate", return_value=self.python_threads),
+            self.assertLogs(affinity._logger, level="INFO") as logs,
+        ):
+            moved = affinity.prioritize_capture_threads(self.wanted)
+
+        self.assertEqual(moved, 0)
+        self.assertEqual(setsched.call_count, 1)  # stops at the first EPERM
+        self.assertTrue(any("CAP_SYS_NICE" in line for line in logs.output))
+
+    def test_noop_without_scheduler_api(self) -> None:
+        with patch.object(affinity, "os", SimpleNamespace(listdir=lambda _p: [])):
+            self.assertEqual(affinity.prioritize_capture_threads(self.wanted), 0)
 
 
 class IsolateRelayCpuTest(TestCase):

--- a/tests/test_gst_dataset_transport.py
+++ b/tests/test_gst_dataset_transport.py
@@ -68,13 +68,23 @@ class _FakeQueue:
             "max-size-buffers": 2,
             "max-size-bytes": 0,
             "max-size-time": 0,
+            "current-level-buffers": 2,
         }
+        self.overrun_callbacks: list[object] = []
 
     def set_property(self, name: str, value: int) -> None:
         self.properties[name] = int(value)
 
     def get_property(self, name: str) -> int:
         return self.properties[name]
+
+    def connect(self, signal: str, callback: object) -> None:
+        assert signal == "overrun"
+        self.overrun_callbacks.append(callback)
+
+    def emit_overrun(self) -> None:
+        for callback in self.overrun_callbacks:
+            callback(self)
 
 
 class _FakePipeline:
@@ -93,8 +103,11 @@ def _fake_gate_base(
     queues: dict[str, _FakeQueue] = {}
     for name in valve_names:
         encoder = "dsenc" if name == "rawvalve" else f"dsenc_{name.rsplit('_', 1)[1]}"
+        queues[f"{encoder}_srcq"] = _FakeQueue()
         queues[f"{encoder}_inq"] = _FakeQueue()
         queues[f"{encoder}_outq"] = _FakeQueue()
+        if encoder.startswith("dsenc_"):
+            queues[f"eye_{encoder.rsplit('_', 1)[1]}_cropq"] = _FakeQueue()
     base = _GstPipelineBase()
     base._gst = gst
     base._pipeline = _FakePipeline({**valves, **queues})
@@ -143,19 +156,16 @@ class GstDatasetTransportTest(unittest.TestCase):
     def assert_dataset_branch_is_backpressure_safe(
         self, pipeline: str, valve_name: str, encoder_name: str, socket_path: str
     ) -> None:
+        source_queue = (
+            f"queue name={encoder_name}_srcq leaky=downstream "
+            "max-size-buffers=2 max-size-bytes=0 max-size-time=0"
+        )
         input_queue = (
             f"queue name={encoder_name}_inq leaky=downstream "
             "max-size-buffers=2 max-size-bytes=0 max-size-time=0"
         )
-        start = pipeline.index(f"valve name={valve_name} drop=false")
-        self.assertNotEqual(
-            pipeline.rfind(
-                "queue leaky=downstream max-size-buffers=2",
-                0,
-                start,
-            ),
-            -1,
-        )
+        start = pipeline.index(source_queue)
+        valve = f"valve name={valve_name} drop=false"
         sink = (
             f"shmsink name={encoder_name}_shmsink socket-path={socket_path} "
             "wait-for-connection=true"
@@ -163,14 +173,16 @@ class GstDatasetTransportTest(unittest.TestCase):
         end = pipeline.index(sink, start) + len(sink)
         branch = pipeline[start:end]
 
+        self.assertIn(source_queue, branch)
+        self.assertLess(branch.index(source_queue), branch.index(valve))
         self.assertIn(input_queue, branch)
         self.assertIn(
-            "nvvidconv output-buffers=38 ! "
+            "nvvidconv output-buffers=62 ! "
             "video/x-raw(memory:NVMM),format=I420,width=960,height=600",
             branch,
         )
         self.assertLess(
-            branch.index("nvvidconv output-buffers=38"),
+            branch.index("nvvidconv output-buffers=62"),
             branch.index(input_queue),
         )
         self.assertLess(
@@ -216,6 +228,16 @@ class GstDatasetTransportTest(unittest.TestCase):
 
         self.assertIn("valve name=rawvalve_l drop=false", pipeline)
         self.assertIn("valve name=rawvalve_r drop=false", pipeline)
+        self.assertIn(
+            "queue name=eye_l_cropq leaky=downstream max-size-buffers=2 ! "
+            "nvvidconv left=0 right=960 top=0 bottom=600",
+            pipeline,
+        )
+        self.assertIn(
+            "queue name=eye_r_cropq leaky=downstream max-size-buffers=2 ! "
+            "nvvidconv left=960 right=1920 top=0 bottom=600",
+            pipeline,
+        )
         self.assert_dataset_branch_is_backpressure_safe(
             pipeline, "rawvalve_l", "dsenc_l", "/tmp/left-dataset.sock"
         )
@@ -256,6 +278,7 @@ class GstDatasetEnableBarrierTest(unittest.TestCase):
 
     def test_active_episode_expands_both_bounded_encoder_queues(self) -> None:
         base, _valves = _fake_gate_base()
+        source_queue = base._pipeline.get_by_name("dsenc_srcq")
         input_queue = base._pipeline.get_by_name("dsenc_inq")
         output_queue = base._pipeline.get_by_name("dsenc_outq")
 
@@ -263,6 +286,7 @@ class GstDatasetEnableBarrierTest(unittest.TestCase):
 
         self.assertEqual(input_queue.get_property("leaky"), 2)
         self.assertEqual(input_queue.get_property("max-size-buffers"), 15)
+        self.assertEqual(source_queue.get_property("max-size-buffers"), 2)
         self.assertEqual(output_queue.get_property("leaky"), 2)
         self.assertEqual(output_queue.get_property("max-size-buffers"), 60)
         for queue in (input_queue, output_queue):
@@ -272,6 +296,41 @@ class GstDatasetEnableBarrierTest(unittest.TestCase):
         base._abort_dataset_enable((("rawvalve", "dsenc"),))
         self.assertEqual(input_queue.get_property("max-size-buffers"), 2)
         self.assertEqual(output_queue.get_property("max-size-buffers"), 2)
+
+    def test_queue_overrun_diagnostics_are_active_only_and_rate_limited(self) -> None:
+        base, valves = _fake_gate_base()
+        gates = (("rawvalve", "dsenc"),)
+        source_queue = base._pipeline.get_by_name("dsenc_srcq")
+        base._attach_dataset_queue_diagnostics(gates)
+
+        source_queue.emit_overrun()
+        self.assertEqual(base._dataset_queue_overruns["dsenc_srcq"], 0)
+
+        with self.assertLogs("almond_axol.video.gst_zed", level="WARNING") as logs:
+            base._begin_dataset_enable(gates, 100.0)
+            source_queue.emit_overrun()
+            self.assertEqual(base._dataset_queue_overruns["dsenc_srcq"], 0)
+            valves["rawvalve"].sink.push(10_000_000_000)
+            for _ in range(4):
+                source_queue.emit_overrun()
+            base._finish_dataset_enable(0.0)
+
+        self.assertEqual(base._dataset_queue_overruns["dsenc_srcq"], 4)
+        self.assertEqual(len(logs.output), 3)
+        self.assertIn("overrun #1", logs.output[0])
+        self.assertIn("overrun #2", logs.output[1])
+        self.assertIn("overrun #4", logs.output[2])
+        self.assertIn("_GstPipelineBase", logs.output[0])
+        self.assertIn("dsenc_srcq", logs.output[0])
+
+        base._begin_dataset_disable(gates)
+        base._finish_dataset_disable(time.perf_counter() + 1.0)
+        source_queue.emit_overrun()
+        self.assertEqual(base._dataset_queue_overruns["dsenc_srcq"], 4)
+
+        base._begin_dataset_enable(gates, 101.0)
+        self.assertEqual(base._dataset_queue_overruns["dsenc_srcq"], 0)
+        base._abort_dataset_enable(gates)
 
     def test_active_queue_depths_scale_with_dataset_rate(self) -> None:
         base, _valves = _fake_gate_base()

--- a/tests/test_gst_dataset_transport.py
+++ b/tests/test_gst_dataset_transport.py
@@ -9,8 +9,12 @@ from unittest.mock import patch
 from almond_axol.video.gst_zed import (
     ZedGstCamera,
     ZedGstStereoCamera,
+    _consumer_attribution,
     _GstPipelineBase,
+    _task_thread_comm,
+    exposure_critical_thread_comms,
 )
+from almond_axol.video.hw_video import dataset_intra_vbr_bitrate, dataset_vbr_bitrate
 from almond_axol.video.video_proc import _set_dataset_branches_enabled
 
 
@@ -191,6 +195,10 @@ class GstDatasetTransportTest(unittest.TestCase):
         )
         self.assertIn(f"name={encoder_name}", branch)
         self.assertIn("iframeinterval=1 idrinterval=1", branch)
+        # All-IDR frames need the intra budget, not the predictive-GOP one.
+        target, peak = dataset_intra_vbr_bitrate(960, 600, 60)
+        self.assertGreater(target, dataset_vbr_bitrate(960, 600, 60)[0] * 3)
+        self.assertIn(f"bitrate={target} peak-bitrate={peak} ", branch)
         self.assertIn(
             "video/x-h264,stream-format=byte-stream,alignment=au ! "
             f"queue name={encoder_name}_outq leaky=downstream "
@@ -503,6 +511,63 @@ class GstDatasetEnableBarrierTest(unittest.TestCase):
         self.assertNotIn("finish", [call[0] for call in calls])
         self.assertIn(("abort", "overhead"), calls)
         self.assertIn(("abort", "left_arm"), calls)
+
+
+class ExposureCriticalThreadsTest(unittest.TestCase):
+    def test_comms_cover_source_crop_and_dataset_source_queues(self) -> None:
+        comms = exposure_critical_thread_comms()
+
+        # Every name is a valid Linux comm (<= 15 chars) and the ones that
+        # would overflow are truncated the way the kernel does it.
+        self.assertTrue(all(len(c) <= 15 for c in comms))
+        self.assertEqual(
+            comms,
+            {
+                "camsrc:src",
+                "eye_l_cropq:src",
+                "eye_r_cropq:src",
+                "dsenc_srcq:src",
+                "dsenc_l_srcq:sr",
+                "dsenc_r_srcq:sr",
+            },
+        )
+        # Post-copy stages keep CFS: they have their own deeper buffering.
+        self.assertNotIn(_task_thread_comm("dsenc_l_inq"), comms)
+        self.assertNotIn(_task_thread_comm("dsenc_outq"), comms)
+
+    def test_consumer_attribution_reports_wait_between_overruns(self) -> None:
+        snapshots = iter([(1_000_000, "R", "0"), (21_000_000, "R", "0")])
+        state: dict = {}
+        with (
+            patch("almond_axol.video.gst_zed._find_thread_by_comm", return_value=4242),
+            patch(
+                "almond_axol.video.gst_zed._thread_sched_snapshot",
+                side_effect=lambda tid: next(snapshots),
+            ),
+            patch(
+                "almond_axol.video.gst_zed.time.perf_counter",
+                side_effect=(100.0, 100.0334),
+            ),
+        ):
+            first = _consumer_attribution(state, "eye_l_cropq:src")
+            second = _consumer_attribution(state, "eye_l_cropq:src")
+
+        self.assertEqual(first, "consumer eye_l_cropq:src state=R wchan=0")
+        self.assertEqual(
+            second,
+            "consumer eye_l_cropq:src state=R wchan=0, CPU wait 20.0ms of the "
+            "33.4ms since its previous overrun",
+        )
+        self.assertEqual(state["tid"], 4242)
+
+    def test_consumer_attribution_forgets_an_exited_thread(self) -> None:
+        state: dict = {"tid": 7}
+        with patch(
+            "almond_axol.video.gst_zed._thread_sched_snapshot", return_value=None
+        ):
+            text = _consumer_attribution(state, "dsenc_srcq:src")
+        self.assertEqual(text, "consumer dsenc_srcq:src exited")
+        self.assertIsNone(state["tid"])
 
 
 if __name__ == "__main__":

--- a/tests/test_h264_mux_finalize.py
+++ b/tests/test_h264_mux_finalize.py
@@ -1,0 +1,103 @@
+"""End-to-end finalize check for the mux-only recorder against real GStreamer.
+
+Regression for the "finalized with n-1 packets (n advertised)" save failure:
+without a framerate on the appsrc caps, h264parse drops the per-buffer
+duration and mp4mux writes the final sample with duration 0, so the track /
+edit list ends one frame early and ffmpeg never yields the last frame.
+
+Runs only where PyGObject + h264parse/mp4mux + openh264enc + PyAV are
+installed; skipped elsewhere. openh264enc is the fixture encoder on purpose:
+like nvv4l2h264enc it writes an SPS without VUI timing, so h264parse has no
+in-band source for the frame duration and the bug reproduces; x264enc's SPS
+carries timing info and masks it.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from almond_axol.lerobot.h264_mux_encoder import _CameraH264Muxer
+from almond_axol.video.gst_zed import _element_available
+
+_FPS = 60
+
+
+def _software_encoded_aus(count: int) -> list[bytes]:
+    """``count`` all-IDR Annex-B access units from openh264enc (no VUI timing)."""
+    from almond_axol.video.gst_zed import _require_gst
+
+    Gst, _ = _require_gst()
+    pipeline = Gst.parse_launch(
+        f"videotestsrc num-buffers={count} pattern=ball "
+        f"! video/x-raw,width=64,height=64,framerate={_FPS}/1 "
+        "! openh264enc gop-size=1 bitrate=64000 "
+        "! video/x-h264,stream-format=byte-stream,alignment=au "
+        "! appsink name=out sync=false"
+    )
+    sink = pipeline.get_by_name("out")
+    pipeline.set_state(Gst.State.PLAYING)
+    aus: list[bytes] = []
+    try:
+        while True:
+            sample = sink.emit("pull-sample")
+            if sample is None:
+                break
+            buf = sample.get_buffer()
+            ok, info = buf.map(Gst.MapFlags.READ)
+            assert ok
+            try:
+                aus.append(bytes(info.data))
+            finally:
+                buf.unmap(info)
+    finally:
+        pipeline.set_state(Gst.State.NULL)
+    return aus
+
+
+def _demuxed(path: Path) -> tuple[int, int, int]:
+    """(advertised sample count, real demuxed packets, last packet pts ticks)."""
+    import av
+
+    with av.open(str(path)) as container:
+        stream = container.streams.video[0]
+        packets = [
+            packet
+            for packet in container.demux(stream)
+            if packet.pts is not None and packet.dts is not None
+        ]
+        return int(stream.frames or 0), len(packets), int(packets[-1].pts)
+
+
+@unittest.skipUnless(
+    all(
+        _element_available(e) for e in ("appsrc", "h264parse", "mp4mux", "openh264enc")
+    ),
+    "needs GStreamer with h264parse/mp4mux/openh264enc",
+)
+class H264MuxFinalizeTest(unittest.TestCase):
+    def setUp(self) -> None:
+        try:
+            import av  # noqa: F401
+        except ImportError:
+            self.skipTest("needs PyAV")
+
+    def test_every_fed_access_unit_is_a_demuxable_sample(self) -> None:
+        for count in (1, 3, 100):
+            with self.subTest(count=count), tempfile.TemporaryDirectory() as tmp:
+                path = Path(tmp) / "observation.images.cam_streaming.mp4"
+                muxer = _CameraH264Muxer(path, _FPS, want_stats=False)
+                for au in _software_encoded_aus(count):
+                    muxer.feed(au)
+                out_path, stats = muxer.finish()
+
+                self.assertEqual(out_path, path)
+                self.assertIsNone(stats)
+                advertised, demuxed, last_pts = _demuxed(path)
+                self.assertEqual(advertised, count)
+                self.assertEqual(demuxed, count)
+                # mp4 timescale is fps*1000, so one frame == 1000 ticks and
+                # the last frame sits exactly at (count-1)/fps: the final
+                # sample carries a full frame duration, not zero.
+                self.assertEqual(last_pts, (count - 1) * 1000)

--- a/tests/test_h264_mux_stats.py
+++ b/tests/test_h264_mux_stats.py
@@ -26,10 +26,12 @@ class _FakeBuffer:
 class _FakeSource:
     def __init__(self) -> None:
         self.pushed = 0
+        self.buffers: list[_FakeBuffer] = []
 
-    def emit(self, signal: str, _buffer: _FakeBuffer) -> str:
+    def emit(self, signal: str, buffer: _FakeBuffer) -> str:
         assert signal == "push-buffer"
         self.pushed += 1
+        self.buffers.append(buffer)
         return "ok"
 
 
@@ -94,6 +96,32 @@ class H264MuxStatsSamplingTest(unittest.TestCase):
         self.assertEqual(muxer._src.pushed, 60)
         self.assertEqual(muxer._count, 60)
         self.assertEqual(len(muxer._stats_worker.samples), 4)
+
+    def test_repeated_idr_still_advances_mux_timeline(self) -> None:
+        muxer = _CameraH264Muxer.__new__(_CameraH264Muxer)
+        muxer._gst = types.SimpleNamespace(
+            SECOND=1_000_000_000,
+            Buffer=_FakeBuffer,
+            FlowReturn=types.SimpleNamespace(OK="ok"),
+        )
+        muxer.video_path = Path("camera.mp4")
+        muxer._dur = muxer._gst.SECOND // 60
+        muxer._count = 0
+        muxer._stats_stride = 15
+        muxer._src = _FakeSource()
+        muxer._stats_worker = None
+
+        muxer.feed(_IDR)
+        muxer.feed(_IDR)
+
+        self.assertEqual(
+            [buffer.pts for buffer in muxer._src.buffers],
+            [0, muxer._dur],
+        )
+        self.assertEqual(
+            [buffer.duration for buffer in muxer._src.buffers],
+            [muxer._dur, muxer._dur],
+        )
 
     def test_fallback_decodes_only_the_stats_stride(self) -> None:
         packets = [_FakePacket(index) for index in range(60)]

--- a/tests/test_jetson.py
+++ b/tests/test_jetson.py
@@ -1,0 +1,139 @@
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import patch
+
+from almond_axol.utils import jetson
+
+
+def _stat_line(tid: int, comm: str, rt_priority: int, policy: int) -> str:
+    """A proc(5) ``stat`` line with the given rt_priority (40) / policy (41)."""
+    fields = ["S", "1"] + ["0"] * 35  # state .. field 39
+    fields += [str(rt_priority), str(policy), "0", "0"]
+    return f"{tid} ({comm}) " + " ".join(fields) + "\n"
+
+
+class ThreadsAtFifoTest(TestCase):
+    def _proc(self, tasks: dict[int, tuple[int, int]]) -> Path:
+        root = Path(tempfile.mkdtemp())
+        for tid, (rt_priority, policy) in tasks.items():
+            task = root / "4242" / "task" / str(tid)
+            task.mkdir(parents=True)
+            # A comm with a space and a ")" is legal and must not shift fields.
+            (task / "stat").write_text(
+                _stat_line(tid, "nvargus (x) d", rt_priority, policy)
+            )
+        return root
+
+    def test_all_threads_fifo_at_priority(self) -> None:
+        root = self._proc({4242: (6, 1), 4300: (6, 1)})
+        self.assertTrue(jetson._threads_at_fifo(4242, 6, proc_root=root))
+
+    def test_any_cfs_thread_is_false(self) -> None:
+        root = self._proc({4242: (6, 1), 4300: (0, 0)})
+        self.assertFalse(jetson._threads_at_fifo(4242, 6, proc_root=root))
+
+    def test_wrong_priority_is_false(self) -> None:
+        root = self._proc({4242: (5, 1)})
+        self.assertFalse(jetson._threads_at_fifo(4242, 6, proc_root=root))
+
+    def test_missing_process_is_none(self) -> None:
+        root = Path(tempfile.mkdtemp())
+        self.assertIsNone(jetson._threads_at_fifo(4242, 6, proc_root=root))
+
+
+class _Escalator:
+    """Records root operations; ``write`` really writes so re-runs can compare."""
+
+    def __init__(self) -> None:
+        self.runs: list[list[str]] = []
+        self.writes: list[Path] = []
+
+    def run(self, argv, *, input_text=None):
+        self.runs.append(argv)
+        if argv[0] == "mkdir":
+            Path(argv[-1]).mkdir(parents=True, exist_ok=True)
+        return True, ""
+
+    def write(self, path, value):
+        self.writes.append(path)
+        path.write_text(value)
+        return True, ""
+
+
+class PrioritizeCaptureDaemonsTest(TestCase):
+    def setUp(self) -> None:
+        self.unit_dir = Path(tempfile.mkdtemp())
+        patches = [
+            patch.object(jetson, "_is_jetson", return_value=True),
+            patch.object(jetson, "_SYSTEMD_UNIT_DIR", self.unit_dir),
+            patch.object(jetson, "_CAPTURE_DAEMON_UNITS", ("nvargus-daemon.service",)),
+        ]
+        for p in patches:
+            p.start()
+            self.addCleanup(p.stop)
+        self.dropin = (
+            self.unit_dir / "nvargus-daemon.service.d" / jetson._CAPTURE_DAEMON_DROPIN
+        )
+
+    def test_installs_dropin_and_reschedules_live_daemon(self) -> None:
+        esc = _Escalator()
+        with (
+            patch.object(jetson, "_service_main_pid", return_value=777),
+            patch.object(jetson, "_threads_at_fifo", return_value=False),
+        ):
+            jetson._prioritize_capture_daemons(esc)
+
+        text = self.dropin.read_text()
+        self.assertIn("CPUSchedulingPolicy=fifo", text)
+        self.assertIn(
+            f"CPUSchedulingPriority={jetson._CAPTURE_DAEMON_FIFO_PRIORITY}", text
+        )
+        self.assertIn(["systemctl", "daemon-reload"], esc.runs)
+        self.assertIn(
+            [
+                "chrt",
+                "-f",
+                "-a",
+                "-p",
+                str(jetson._CAPTURE_DAEMON_FIFO_PRIORITY),
+                "777",
+            ],
+            esc.runs,
+        )
+
+    def test_rerun_is_a_no_op_once_applied(self) -> None:
+        esc = _Escalator()
+        with (
+            patch.object(jetson, "_service_main_pid", return_value=777),
+            patch.object(jetson, "_threads_at_fifo", return_value=False),
+        ):
+            jetson._prioritize_capture_daemons(esc)
+        again = _Escalator()
+        with (
+            patch.object(jetson, "_service_main_pid", return_value=777),
+            patch.object(jetson, "_threads_at_fifo", return_value=True),
+        ):
+            jetson._prioritize_capture_daemons(again)
+        self.assertEqual(again.runs, [])
+        self.assertEqual(again.writes, [])
+
+    def test_absent_daemon_is_skipped_entirely(self) -> None:
+        esc = _Escalator()
+        with patch.object(jetson, "_service_main_pid", return_value=0):
+            jetson._prioritize_capture_daemons(esc)
+        self.assertFalse(self.dropin.exists())
+        self.assertEqual(esc.runs, [])
+
+    def test_stopped_daemon_with_dropin_only_refreshes_dropin(self) -> None:
+        self.dropin.parent.mkdir(parents=True)
+        self.dropin.write_text("stale\n")
+        esc = _Escalator()
+        with patch.object(jetson, "_service_main_pid", return_value=0):
+            jetson._prioritize_capture_daemons(esc)
+        self.assertIn("CPUSchedulingPolicy=fifo", self.dropin.read_text())
+        self.assertNotIn("chrt", [argv[0] for argv in esc.runs])
+
+    def test_gpu_is_pinned_but_not_a_jetson_marker(self) -> None:
+        self.assertIn("*.gpu", jetson._ENGINE_CLOCK_GLOBS)
+        self.assertNotIn("*.gpu", jetson._JETSON_ENGINE_GLOBS)

--- a/tests/test_recorder_capture_error.py
+++ b/tests/test_recorder_capture_error.py
@@ -12,6 +12,7 @@ from almond_axol.recording.record_proc import (
     RecorderCaptureError,
     RecorderDatasetSaveError,
     _align_independent_encoded_start,
+    _concealable_encoded_gap_frames,
     run_encoded_capture_loop,
 )
 
@@ -52,8 +53,17 @@ class _EncodedCamera:
     capture_fps = 60
     pending = 0
 
-    def __init__(self, packets: list[tuple[bytes, float, float]]) -> None:
+    def __init__(
+        self,
+        packets: list[tuple[bytes, float, float]],
+        *,
+        independent: bool = True,
+        capture_fps: int = 60,
+    ) -> None:
         self.packets = packets
+        self.frames_are_independent = independent
+        self.capture_fps = capture_fps
+        self.reads = 0
 
     def begin_flush(self) -> None:
         pass
@@ -65,22 +75,203 @@ class _EncodedCamera:
         del timeout_ms
         if not self.packets:
             raise TimeoutError
+        self.reads += 1
         return self.packets.pop(0)
 
 
 class _CaptureDataset:
     features: dict = {}
 
-    def __init__(self, stop: threading.Event) -> None:
+    def __init__(self, stop: threading.Event, stop_after: int = 1) -> None:
         self.stop = stop
+        self.stop_after = stop_after
         self.rows: list[dict] = []
 
     def add_frame(self, row: dict) -> None:
         self.rows.append(row)
-        self.stop.set()
+        if len(self.rows) >= self.stop_after:
+            self.stop.set()
 
 
 class DatasetRecorderCaptureErrorTest(unittest.TestCase):
+    def _run_encoded(
+        self,
+        cameras: dict[str, _EncodedCamera],
+        *,
+        fps: int,
+        rows: int,
+    ) -> tuple[_CaptureDataset, list[str], list[dict], list[float]]:
+        stop = threading.Event()
+        dataset = _CaptureDataset(stop, stop_after=rows)
+        errors: list[str] = []
+        repairs: list[dict] = []
+        snapshot_times: list[float] = []
+
+        def snapshot(ts: float) -> tuple[dict, dict, float, bool]:
+            snapshot_times.append(ts)
+            return {"state": 1}, {"target": 2}, ts, False
+
+        def build_frame(_features: dict, values: dict, prefix: str) -> dict:
+            return {f"{prefix}.{name}": value for name, value in values.items()}
+
+        with (
+            patch(
+                "lerobot.utils.feature_utils.build_dataset_frame",
+                side_effect=build_frame,
+            ),
+            patch("lerobot.utils.visualization_utils.log_rerun_data"),
+        ):
+            run_encoded_capture_loop(
+                cameras=cameras,
+                read_snapshot=lambda: (
+                    {"state": 1},
+                    {"target": 2},
+                    time.perf_counter(),
+                    False,
+                ),
+                read_snapshot_nearest=snapshot,
+                dataset=dataset,
+                robot_obs_proc=lambda obs: obs,
+                fps=fps,
+                task="test",
+                rerun_ip=None,
+                stop_event=stop,
+                repair_events=repairs,
+                on_error=errors.append,
+            )
+        return dataset, errors, repairs, snapshot_times
+
+    def test_bounded_gap_concealment_holds_future_au_and_state_grid(self) -> None:
+        base = time.perf_counter() + 0.1
+        step = 1.0 / 60.0
+        cameras = {
+            "camera_a": _EncodedCamera(
+                [(b"a0", base, base), (b"a3", base + 3 * step, base)]
+            ),
+            "camera_b": _EncodedCamera(
+                [
+                    (b"b0", base, base),
+                    (b"b1", base + step, base),
+                    (b"b2", base + 2 * step, base),
+                    (b"b3", base + 3 * step, base),
+                ]
+            ),
+        }
+
+        dataset, errors, repairs, snapshot_times = self._run_encoded(
+            cameras, fps=60, rows=4
+        )
+
+        self.assertEqual(errors, [])
+        self.assertEqual(
+            [row["observation.camera_a"] for row in dataset.rows],
+            [b"a0", b"a0", b"a0", b"a3"],
+        )
+        self.assertEqual(
+            [row["observation.camera_b"] for row in dataset.rows],
+            [b"b0", b"b1", b"b2", b"b3"],
+        )
+        self.assertEqual(cameras["camera_a"].reads, 2)
+        self.assertEqual(cameras["camera_b"].reads, 4)
+        self.assertEqual(len(snapshot_times), 4)
+        for actual, expected in zip(
+            snapshot_times, [base + i * step for i in range(4)]
+        ):
+            self.assertAlmostEqual(actual, expected, places=6)
+        self.assertEqual(len(repairs), 1)
+        self.assertEqual(repairs[0]["camera"], "camera_a")
+        self.assertEqual(repairs[0]["frame_index"], 1)
+        self.assertEqual(repairs[0]["missing_frames"], 2)
+
+    def test_stop_mid_repair_reports_only_committed_synthetic_rows(self) -> None:
+        base = time.perf_counter() + 0.1
+        step = 1.0 / 60.0
+        cameras = {
+            "camera_a": _EncodedCamera(
+                [(b"a0", base, base), (b"a3", base + 3 * step, base)]
+            ),
+            "camera_b": _EncodedCamera(
+                [(b"b0", base, base), (b"b1", base + step, base)]
+            ),
+        }
+
+        dataset, errors, repairs, _ = self._run_encoded(cameras, fps=60, rows=2)
+
+        self.assertEqual(errors, [])
+        self.assertEqual(len(dataset.rows), 2)
+        self.assertEqual(repairs[0]["frame_index"], 1)
+        self.assertEqual(repairs[0]["missing_frames"], 1)
+        self.assertAlmostEqual(repairs[0]["concealed_ms"], 1000 / 60)
+
+    def test_only_small_equal_rate_independent_grid_gaps_are_concealable(self) -> None:
+        step = 1.0 / 60.0
+
+        self.assertEqual(
+            _concealable_encoded_gap_frames(
+                previous_ts=1.0,
+                capture_ts=1.0 + 3 * step - 0.0002,
+                fps=60,
+                capture_fps=60,
+                frames_are_independent=True,
+            ),
+            2,
+        )
+        for kwargs in (
+            {"capture_ts": 1.0 + 4 * step},
+            {"capture_ts": 1.0 + 2.5 * step},
+            {"capture_ts": 1.0 + 2 * step, "capture_fps": 120},
+            {"capture_ts": 1.0 + 2 * step, "capture_fps": 30},
+            {
+                "capture_ts": 1.0 + 2 * step,
+                "frames_are_independent": False,
+            },
+        ):
+            args = dict(
+                previous_ts=1.0,
+                capture_ts=1.0 + 2 * step,
+                fps=60,
+                capture_fps=60,
+                frames_are_independent=True,
+            )
+            args.update(kwargs)
+            self.assertEqual(_concealable_encoded_gap_frames(**args), 0)
+
+    def test_invalid_lower_capture_rate_cannot_enable_concealment(self) -> None:
+        base = time.perf_counter() + 0.1
+        step = 1.0 / 60.0
+        cameras = {
+            "camera": _EncodedCamera(
+                [(b"a0", base, base), (b"a2", base + 2 * step, base)],
+                capture_fps=30,
+            )
+        }
+
+        dataset, errors, repairs, _ = self._run_encoded(cameras, fps=60, rows=3)
+
+        self.assertEqual(len(dataset.rows), 1)
+        self.assertEqual(repairs, [])
+        self.assertRegex(errors[0], "dropped an encoded frame")
+
+    def test_second_gap_event_remains_fatal(self) -> None:
+        base = time.perf_counter() + 0.1
+        step = 1.0 / 60.0
+        cameras = {
+            "camera": _EncodedCamera(
+                [
+                    (b"a0", base, base),
+                    (b"a2", base + 2 * step, base),
+                    (b"a4", base + 4 * step, base),
+                ]
+            )
+        }
+
+        dataset, errors, repairs, _ = self._run_encoded(cameras, fps=60, rows=5)
+
+        self.assertEqual(len(dataset.rows), 3)
+        self.assertEqual(len(repairs), 1)
+        self.assertEqual(repairs[0]["missing_frames"], 1)
+        self.assertRegex(errors[0], "dropped an encoded frame")
+
     def test_row_zero_alignment_advances_only_lagging_all_intra_streams(
         self,
     ) -> None:

--- a/tests/test_recorder_capture_error.py
+++ b/tests/test_recorder_capture_error.py
@@ -11,8 +11,12 @@ from almond_axol.recording.record_proc import (
     InProcessRecorder,
     RecorderCaptureError,
     RecorderDatasetSaveError,
+    _ENCODED_CONCEALMENT_WINDOW_S,
+    _ENCODED_MAX_CONCEALMENT_EVENTS_PER_WINDOW,
+    _ENCODED_MIN_CONCEALED_FRAMES_PER_CAMERA,
     _align_independent_encoded_start,
     _concealable_encoded_gap_frames,
+    _concealment_within_budget,
     run_encoded_capture_loop,
 )
 
@@ -252,7 +256,10 @@ class DatasetRecorderCaptureErrorTest(unittest.TestCase):
         self.assertEqual(repairs, [])
         self.assertRegex(errors[0], "dropped an encoded frame")
 
-    def test_second_gap_event_remains_fatal(self) -> None:
+    def test_repeated_isolated_gaps_within_budget_are_concealed(self) -> None:
+        # The ZED sources drop isolated frames in clusters around a record
+        # start (this session: both overhead eyes at row 12, then again half a
+        # second later). Each hole stays bounded, so the take survives.
         base = time.perf_counter() + 0.1
         step = 1.0 / 60.0
         cameras = {
@@ -267,10 +274,106 @@ class DatasetRecorderCaptureErrorTest(unittest.TestCase):
 
         dataset, errors, repairs, _ = self._run_encoded(cameras, fps=60, rows=5)
 
-        self.assertEqual(len(dataset.rows), 3)
-        self.assertEqual(len(repairs), 1)
-        self.assertEqual(repairs[0]["missing_frames"], 1)
+        self.assertEqual(errors, [])
+        self.assertEqual(
+            [row["observation.camera"] for row in dataset.rows],
+            [b"a0", b"a0", b"a2", b"a2", b"a4"],
+        )
+        self.assertEqual([event["missing_frames"] for event in repairs], [1, 1])
+        self.assertEqual([event["frame_index"] for event in repairs], [1, 3])
+
+    def test_gap_burst_inside_window_is_fatal(self) -> None:
+        base = time.perf_counter() + 0.1
+        step = 1.0 / 60.0
+        packets = [(b"a0", base, base)]
+        # One event over the burst budget, back to back, each a single frame.
+        for i in range(_ENCODED_MAX_CONCEALMENT_EVENTS_PER_WINDOW + 1):
+            ts = base + 2 * (i + 1) * step
+            packets.append((f"a{2 * (i + 1)}".encode(), ts, base))
+        cameras = {"camera": _EncodedCamera(packets)}
+
+        dataset, errors, repairs, _ = self._run_encoded(
+            cameras, fps=60, rows=len(packets) * 2
+        )
+
+        self.assertEqual(len(repairs), _ENCODED_MAX_CONCEALMENT_EVENTS_PER_WINDOW)
+        self.assertEqual(
+            len(dataset.rows), 2 * _ENCODED_MAX_CONCEALMENT_EVENTS_PER_WINDOW + 1
+        )
         self.assertRegex(errors[0], "dropped an encoded frame")
+
+    def test_isolated_gaps_every_few_seconds_survive_a_long_take(self) -> None:
+        # Today's overhead pattern: one exposure lost every 1-4 s for the whole
+        # take. Spaced past the burst window and well under the fraction cap,
+        # every hole is repaired.
+        base = time.perf_counter() + 0.1
+        step = 1.0 / 60.0
+        spacing = 90  # frames between the lost exposures (1.5 s at 60 Hz)
+        packets = []
+        frame = 0
+        for _ in range(8):
+            for _ in range(spacing - 1):
+                packets.append((f"a{frame}".encode(), base + frame * step, base))
+                frame += 1
+            frame += 1  # the lost exposure
+        cameras = {"camera": _EncodedCamera(packets)}
+
+        dataset, errors, repairs, _ = self._run_encoded(
+            cameras, fps=60, rows=8 * spacing - 1
+        )
+
+        self.assertEqual(errors, [])
+        self.assertEqual(len(repairs), 7)
+        self.assertEqual({event["missing_frames"] for event in repairs}, {1})
+
+    def test_concealment_budget_rules(self) -> None:
+        fps = 60
+        window = int(_ENCODED_CONCEALMENT_WINDOW_S * fps)
+        kwargs = dict(concealed_frames=0, missing=1, total_rows=1000, fps=fps)
+        # Two earlier events inside the window leave room for a third only.
+        self.assertTrue(
+            _concealment_within_budget(event_rows=[10, 50], row=100, **kwargs)
+        )
+        self.assertFalse(
+            _concealment_within_budget(event_rows=[10, 50, 90], row=100, **kwargs)
+        )
+        # Once the oldest event ages out of the window a new one fits again.
+        self.assertTrue(
+            _concealment_within_budget(
+                event_rows=[10, 50, 90], row=10 + window, **kwargs
+            )
+        )
+        # The frame allowance is the larger of the floor and the fraction.
+        self.assertTrue(
+            _concealment_within_budget(
+                event_rows=[],
+                row=10,
+                concealed_frames=_ENCODED_MIN_CONCEALED_FRAMES_PER_CAMERA - 1,
+                missing=1,
+                total_rows=10,
+                fps=fps,
+            )
+        )
+        self.assertFalse(
+            _concealment_within_budget(
+                event_rows=[],
+                row=10,
+                concealed_frames=_ENCODED_MIN_CONCEALED_FRAMES_PER_CAMERA,
+                missing=1,
+                total_rows=10,
+                fps=fps,
+            )
+        )
+        self.assertTrue(
+            _concealment_within_budget(
+                event_rows=[],
+                row=10_000,
+                concealed_frames=_ENCODED_MIN_CONCEALED_FRAMES_PER_CAMERA,
+                missing=2,
+                total_rows=10_000,
+                fps=fps,
+            )
+        )
 
     def test_row_zero_alignment_advances_only_lagging_all_intra_streams(
         self,


### PR DESCRIPTION
## Summary
- spread relay-native GStreamer workers across the non-realtime throughput cores while keeping WebRTC Python, control, IK, and CAN isolated
- increase copied-surface headroom and identify the exact active dataset queue if it overruns
- recover one bounded 1-2-frame hole only for equal-rate all-IDR streams by holding the future AU and repeating the prior IDR on the missing cadence slots
- keep repeated, larger, predictive, rate-converted, DISCONT, and non-grid losses fail-closed

This targets the on-robot mid-episode failure where overhead_left jumped 49.81 ms at 60 fps while the Rust loop stayed healthy at 0 late/rejected/trace-drop ticks.

## Validation
- uv run python -m unittest discover -s tests (120 passed)
- Ruff check with import sorting and Ruff format check on all changed Python files
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live encoded capture semantics and CPU isolation during recording; bounded repeat-ID repair could mask rare upstream loss while still preserving row count and alignment.
> 
> **Overview**
> **Hardens mid-episode encoded-camera hiccups** without breaking LeRobot’s strict per-row video timeline or cross-camera/state alignment.
> 
> The encoded capture loop (`run_encoded_capture_loop`) can now **hold the next AU** and **repeat the previous all-intra IDR** for at most **1–2 missing cadence slots** on equal-rate independent streams—one concealment event per camera, with warnings and **`repair_events`** logged at save. Larger gaps, rate-mismatches, non–all-intra streams, and second events on the same camera still **fail closed** (episode discarded). Docs in `h264_mux_encoder` reflect that mux PTS still advances one sample per dataset row when an IDR is repeated.
> 
> **Relay throughput / diagnostics:** `isolate_relay_cpu` pins Python to one relay core but lets **GStreamer workers use relay + background cores** (avoids ~80 tasks on a single CPU). Dataset branches gain **shallow source/crop queues**, **larger VIC surface pool (32)**, and **rate-limited queue overrun logging** tied to active episodes.
> 
> Tests cover concealment behavior, affinity pinning, pipeline queue layout, and mux timeline on repeated IDRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf2f94b69f11b6aa17fb03ae9349a0db7646e2a1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->