### PR TITLE
Fix all-intra dataset bitrate, capture-thread scheduling, and the one-frame-short mp4 finalize

### DIFF
--- a/almond_axol/lerobot/h264_mux_encoder.py
+++ b/almond_axol/lerobot/h264_mux_encoder.py
@@ -306,9 +306,22 @@ class _CameraH264Muxer:
             f"! h264parse ! {mux}"
         )
         src = pipeline.get_by_name("src")
+        # The framerate is load-bearing: h264parse re-stamps each frame's
+        # duration from the caps framerate (the encoder's SPS carries no
+        # timing, so without it the duration we set on the appsrc buffer is
+        # dropped). mp4mux derives a sample's duration from the *next*
+        # buffer's PTS and, for the final sample at EOS, from the buffer's
+        # duration — so without a framerate the last sample is written with
+        # duration 0, the track/edit list ends one frame early, and ffmpeg
+        # (honouring the edit list) never yields that frame: a file with
+        # ``n`` advertised samples that demuxes to ``n - 1``, which
+        # ``_validate_finalized_file`` rightly rejects.
         src.set_property(
             "caps",
-            Gst.Caps.from_string("video/x-h264,stream-format=byte-stream,alignment=au"),
+            Gst.Caps.from_string(
+                "video/x-h264,stream-format=byte-stream,alignment=au,"
+                f"framerate={self._fps}/1"
+            ),
         )
         # Bound appsrc so a wedged pipeline surfaces as back-pressure, not
         # unbounded memory; block so we never silently drop a (dependency-bearing)

--- a/almond_axol/recording/record_proc.py
+++ b/almond_axol/recording/record_proc.py
@@ -83,14 +83,19 @@ _ENCODED_POLL_MS = 100
 # for those missing cadence slots is bounded corruption (at most 33 ms at
 # 60 Hz) and, unlike accepting the future AU early, does not shift that camera
 # against every subsequent robot-state/dataset row.  A single hole longer than
-# two frames is fatal, and so is a camera that keeps hiccuping: the ZED
-# sources drop isolated frames in clusters around a record start (both stereo
-# eyes together, or one wrist), so one event per episode aborted nearly every
-# take and homed the arms mid-teleop, but a stream past the per-episode budget
-# below is genuinely unhealthy and still fails closed.
+# two frames is fatal, and so is a camera that is losing frames faster than a
+# rare hiccup: the ZED sources have been observed dropping one exposure every
+# one to four seconds during a teleoperated take (both stereo eyes together,
+# so the loss is in the source, not the relay's queues or transport), and a
+# fixed handful of events per episode aborted every take within seconds and
+# homed the arms mid-teleop.  The budget is therefore a rate: a burst of
+# events inside a short window, or concealed frames above a small fraction of
+# the episode, means the stream is unhealthy and still fails closed.
 _ENCODED_MAX_CONCEALED_FRAMES_PER_EVENT = 2
-_ENCODED_MAX_CONCEALED_FRAMES_PER_CAMERA = 6
-_ENCODED_MAX_CONCEALMENT_EVENTS_PER_CAMERA = 4
+_ENCODED_MAX_CONCEALMENT_EVENTS_PER_WINDOW = 3
+_ENCODED_CONCEALMENT_WINDOW_S = 2.0
+_ENCODED_MIN_CONCEALED_FRAMES_PER_CAMERA = 6
+_ENCODED_MAX_CONCEALED_FRACTION = 0.02
 _ENCODED_GAP_GRID_TOLERANCE_FRAMES = 0.25
 # A just-arrived exposure can precede the newest control snapshot by one control
 # tick. Briefly poll the state ring for the upper bracket; never clamp outside
@@ -976,6 +981,34 @@ def _concealable_encoded_gap_frames(
     return missing
 
 
+def _concealment_within_budget(
+    *,
+    event_rows: list[int],
+    row: int,
+    concealed_frames: int,
+    missing: int,
+    total_rows: int,
+    fps: int,
+) -> bool:
+    """Decide whether one more repair keeps this camera inside its rate budget.
+
+    ``event_rows`` holds the dataset rows of this camera's earlier repairs in
+    this episode. A burst (too many events inside a short window) or a stream
+    whose concealed frames exceed a small fraction of the episode so far is
+    unhealthy and must fail closed; an isolated hiccup every few seconds is
+    repaired and audited.
+    """
+    window_rows = max(1, int(round(_ENCODED_CONCEALMENT_WINDOW_S * fps)))
+    recent = sum(1 for prior in event_rows if row - prior < window_rows)
+    if recent >= _ENCODED_MAX_CONCEALMENT_EVENTS_PER_WINDOW:
+        return False
+    allowance = max(
+        _ENCODED_MIN_CONCEALED_FRAMES_PER_CAMERA,
+        int(_ENCODED_MAX_CONCEALED_FRACTION * total_rows),
+    )
+    return concealed_frames + missing <= allowance
+
+
 def _align_independent_encoded_start(
     packets: dict[str, tuple[bytes, float, float]],
     read_next: Callable[[str], tuple[bytes, float, float] | None],
@@ -1345,10 +1378,11 @@ def run_encoded_capture_loop(
     read naturally paces the loop to the dataset cadence. A timeout, missing PTS,
     cross-camera phase error, or excessive state skew aborts the episode.  The
     sole exception is a bounded one/two-frame hole on an equal-rate all-intra
-    camera, within a small per-episode budget of events and frames per camera:
-    the prior IDR is repeated on the missing cadence slots while the future AU
-    is held, preserving all subsequent image/camera/state alignment. The repair
-    is warned and returned through ``repair_events`` for a save-time audit log;
+    camera, within a per-camera rate budget (no burst of events inside a short
+    window, concealed frames a small fraction of the episode): the prior IDR is
+    repeated on the missing cadence slots while the future AU is held,
+    preserving all subsequent image/camera/state alignment. The repair is
+    warned and returned through ``repair_events`` for a save-time audit log;
     larger holes, a camera past its budget, predictive, rate-converted,
     transport, or non-grid losses remain fatal.
 
@@ -1431,7 +1465,7 @@ def run_encoded_capture_loop(
             str, tuple[tuple[bytes, float, float], int, dict[str, Any]]
         ] = {}
         concealed_frames: dict[str, int] = {}
-        concealment_events: dict[str, int] = {}
+        concealment_rows: dict[str, list[int]] = {}
         primed = False
         rows_added = 0
         total_rows = 0
@@ -1559,12 +1593,14 @@ def run_encoded_capture_loop(
                         ),
                     )
                     already_concealed = concealed_frames.get(cam_key, 0)
-                    prior_events = concealment_events.get(cam_key, 0)
-                    if (
-                        missing == 0
-                        or prior_events >= _ENCODED_MAX_CONCEALMENT_EVENTS_PER_CAMERA
-                        or already_concealed + missing
-                        > _ENCODED_MAX_CONCEALED_FRAMES_PER_CAMERA
+                    prior_rows = concealment_rows.setdefault(cam_key, [])
+                    if missing == 0 or not _concealment_within_budget(
+                        event_rows=prior_rows,
+                        row=total_rows,
+                        concealed_frames=already_concealed,
+                        missing=missing,
+                        total_rows=total_rows,
+                        fps=fps,
                     ):
                         continue
                     event: dict[str, Any] = {
@@ -1586,7 +1622,7 @@ def run_encoded_capture_loop(
                     )
                     synthetic_repairs[cam_key] = event
                     concealed_frames[cam_key] = already_concealed + missing
-                    concealment_events[cam_key] = prior_events + 1
+                    prior_rows.append(total_rows)
                     _logger.warning(
                         "camera %r omitted %d all-intra frame(s) at dataset "
                         "row %d (PTS gap %.2fms); repeating the prior IDR for "

--- a/almond_axol/recording/record_proc.py
+++ b/almond_axol/recording/record_proc.py
@@ -82,10 +82,15 @@ _ENCODED_POLL_MS = 100
 # the rest of the camera/control stack remains healthy.  Holding the last IDR
 # for those missing cadence slots is bounded corruption (at most 33 ms at
 # 60 Hz) and, unlike accepting the future AU early, does not shift that camera
-# against every subsequent robot-state/dataset row.  More than one event or two
-# frames on a camera is evidence of an unhealthy stream and remains fatal.
-_ENCODED_MAX_CONCEALED_FRAMES_PER_CAMERA = 2
-_ENCODED_MAX_CONCEALMENT_EVENTS_PER_CAMERA = 1
+# against every subsequent robot-state/dataset row.  A single hole longer than
+# two frames is fatal, and so is a camera that keeps hiccuping: the ZED
+# sources drop isolated frames in clusters around a record start (both stereo
+# eyes together, or one wrist), so one event per episode aborted nearly every
+# take and homed the arms mid-teleop, but a stream past the per-episode budget
+# below is genuinely unhealthy and still fails closed.
+_ENCODED_MAX_CONCEALED_FRAMES_PER_EVENT = 2
+_ENCODED_MAX_CONCEALED_FRAMES_PER_CAMERA = 6
+_ENCODED_MAX_CONCEALMENT_EVENTS_PER_CAMERA = 4
 _ENCODED_GAP_GRID_TOLERANCE_FRAMES = 0.25
 # A just-arrived exposure can precede the newest control snapshot by one control
 # tick. Briefly poll the state ring for the upper bracket; never clamp outside
@@ -963,7 +968,7 @@ def _concealable_encoded_gap_frames(
         return 0
     periods = round(delta * fps)
     missing = periods - 1
-    if not 1 <= missing <= _ENCODED_MAX_CONCEALED_FRAMES_PER_CAMERA:
+    if not 1 <= missing <= _ENCODED_MAX_CONCEALED_FRAMES_PER_EVENT:
         return 0
     residual = abs(delta - periods / fps)
     if residual > _ENCODED_GAP_GRID_TOLERANCE_FRAMES / capture_fps:
@@ -1339,12 +1344,13 @@ def run_encoded_capture_loop(
     independent of encoder, shm, and scheduler latency. The blocking per-camera
     read naturally paces the loop to the dataset cadence. A timeout, missing PTS,
     cross-camera phase error, or excessive state skew aborts the episode.  The
-    sole exception is one bounded one/two-frame hole per equal-rate all-intra
-    camera: the prior IDR is repeated on the missing cadence slots while the
-    future AU is held, preserving all subsequent image/camera/state alignment.
-    The repair is warned and returned through ``repair_events`` for a save-time
-    audit log; larger, repeated, predictive, rate-converted, transport, or
-    non-grid losses remain fatal.
+    sole exception is a bounded one/two-frame hole on an equal-rate all-intra
+    camera, within a small per-episode budget of events and frames per camera:
+    the prior IDR is repeated on the missing cadence slots while the future AU
+    is held, preserving all subsequent image/camera/state alignment. The repair
+    is warned and returned through ``repair_events`` for a save-time audit log;
+    larger holes, a camera past its budget, predictive, rate-converted,
+    transport, or non-grid losses remain fatal.
 
     The muxer assigns each AU a constant-fps PTS (``k / fps``), so the mp4
     timeline is exact regardless of arrival jitter; its physical exposure PTS is

--- a/almond_axol/utils/affinity.py
+++ b/almond_axol/utils/affinity.py
@@ -225,6 +225,95 @@ def isolate_relay_cpu() -> bool:
     return True
 
 
+# SCHED_FIFO priority for the camera capture threads. Well below the CAN loops
+# (`AXOL_RT_FIFO_PRIORITY`, 20) and on disjoint cores anyway; above every CFS
+# thread so a capture wake-up never queues behind the encode/mux workers.
+CAPTURE_FIFO_PRIORITY = 5
+
+
+def prioritize_capture_threads(source_thread_name: str) -> int:
+    """Move the camera *capture* threads to ``SCHED_FIFO`` so they never miss an exposure.
+
+    The relay's gst pool is ~80 CFS threads (VIC copies, NVENC dispatch, shm
+    writers) sharing a few cores with the dataset recorder. CFS hands them out
+    round-robin, so whenever a burst of them is runnable together a thread can
+    sit runnable-but-unscheduled for most of a scheduling period (~20 ms). For
+    the encode/mux threads that is harmless — queues absorb it. For the capture
+    chain it is not: the source streaming thread (``<source>:src``, the
+    SDK ``grab`` + rectify + push) and the ZED SDK's own worker threads (the
+    V4L2 dequeue / frame assembly it spawns unnamed) must run within one
+    60 Hz period or the SDK discards the exposure — seen on the robot as
+    ``skipped exposure(s)`` with ``CPU wait since previous frame`` of 14-26 ms
+    while every other attribution (SDK/link time, GPU clock, arm motion) was
+    clean. A real-time class fixes that at the root: a FIFO wake-up preempts
+    the CFS pool immediately and its CPU wait is ~0 regardless of how many
+    encoders are dispatching. Their combined load is small and bounded (a few
+    percent of a core per camera), so they cannot starve the recorder, and the
+    kernel's RT throttle caps a runaway at 95 % of a core anyway.
+
+    Elevates every thread whose ``comm`` is ``"<source_thread_name>:src"``
+    (GStreamer names task threads after their pad) plus every non-Python
+    thread that still carries the process's own ``comm`` — GStreamer, GLib,
+    NVENC and CUDA all rename theirs, so an unrenamed thread in the relay is
+    the SDK's. Call once after the pipelines are PLAYING (the threads exist
+    by then). Returns the number of threads moved; ``0`` when the platform
+    has no ``sched_setscheduler`` or the process lacks ``CAP_SYS_NICE`` (a
+    manual unprivileged run — the failure is logged once and the threads
+    stay CFS, exactly the previous behaviour).
+    """
+    if not hasattr(os, "sched_setscheduler") or not hasattr(os, "SCHED_FIFO"):
+        return 0
+    import threading
+
+    py_tids = {t.native_id for t in threading.enumerate() if t.native_id is not None}
+    try:
+        with open("/proc/self/comm") as fh:
+            process_comm = fh.read().strip()
+        tasks = os.listdir("/proc/self/task")
+    except OSError:
+        return 0
+    wanted = {f"{source_thread_name}:src", process_comm}
+    param = os.sched_param(CAPTURE_FIFO_PRIORITY)  # type: ignore[attr-defined]
+    moved = 0
+    denied: OSError | None = None
+    for entry in tasks:
+        try:
+            tid = int(entry)
+        except ValueError:
+            continue
+        if tid in py_tids:
+            continue
+        try:
+            with open(f"/proc/self/task/{tid}/comm") as fh:
+                comm = fh.read().strip()
+        except OSError:
+            continue  # exited between listdir and here
+        if comm not in wanted:
+            continue
+        try:
+            os.sched_setscheduler(tid, os.SCHED_FIFO, param)  # type: ignore[attr-defined]
+            moved += 1
+        except PermissionError as exc:
+            denied = exc
+            break
+        except OSError:
+            pass
+    if denied is not None:
+        _logger.info(
+            "camera capture threads stay SCHED_OTHER (no CAP_SYS_NICE: %s); "
+            "expect skipped exposures under recording load",
+            denied,
+        )
+    elif moved:
+        _logger.info(
+            "camera capture threads -> SCHED_FIFO %d (%d threads: %s:src + SDK workers)",
+            CAPTURE_FIFO_PRIORITY,
+            moved,
+            source_thread_name,
+        )
+    return moved
+
+
 def _pin(group: str) -> bool:
     groups = core_groups()
     if groups is None:

--- a/almond_axol/utils/affinity.py
+++ b/almond_axol/utils/affinity.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Iterable
 
 _logger = logging.getLogger(__name__)
 
@@ -231,35 +232,40 @@ def isolate_relay_cpu() -> bool:
 CAPTURE_FIFO_PRIORITY = 5
 
 
-def prioritize_capture_threads(source_thread_name: str) -> int:
-    """Move the camera *capture* threads to ``SCHED_FIFO`` so they never miss an exposure.
+def prioritize_capture_threads(thread_comms: Iterable[str]) -> int:
+    """Move the camera *capture* chain to ``SCHED_FIFO`` so it never misses an exposure.
 
     The relay's gst pool is ~80 CFS threads (VIC copies, NVENC dispatch, shm
     writers) sharing a few cores with the dataset recorder. CFS hands them out
     round-robin, so whenever a burst of them is runnable together a thread can
     sit runnable-but-unscheduled for most of a scheduling period (~20 ms). For
     the encode/mux threads that is harmless — queues absorb it. For the capture
-    chain it is not: the source streaming thread (``<source>:src``, the
-    SDK ``grab`` + rectify + push) and the ZED SDK's own worker threads (the
-    V4L2 dequeue / frame assembly it spawns unnamed) must run within one
-    60 Hz period or the SDK discards the exposure — seen on the robot as
-    ``skipped exposure(s)`` with ``CPU wait since previous frame`` of 14-26 ms
-    while every other attribution (SDK/link time, GPU clock, arm motion) was
-    clean. A real-time class fixes that at the root: a FIFO wake-up preempts
-    the CFS pool immediately and its CPU wait is ~0 regardless of how many
-    encoders are dispatching. Their combined load is small and bounded (a few
-    percent of a core per camera), so they cannot starve the recorder, and the
-    kernel's RT throttle caps a runaway at 95 % of a core anyway.
+    chain it is not: the source streaming thread (the SDK ``grab`` + rectify +
+    push), the ZED SDK's own worker threads (the V4L2 dequeue / frame assembly
+    it spawns unnamed), and the consumers of the two-buffer queues that still
+    hold un-copied camera surfaces (the stereo eye crops and the dataset VIC
+    copies) must each run within one 60 Hz period or the exposure is gone —
+    seen on the robot as ``skipped exposure(s)`` with ``CPU wait since
+    previous frame`` of 14-26 ms while every other attribution (SDK/link
+    time, GPU clock, arm motion) was clean. A real-time class fixes that at
+    the root: a FIFO wake-up preempts the CFS pool immediately and its CPU
+    wait is ~0 regardless of how many encoders are dispatching. Their combined
+    load is small and bounded (a few percent of a core per camera; the VIC
+    consumers mostly sleep on the hardware fence), so they cannot starve the
+    recorder, and the kernel's RT throttle caps a runaway at 95 % of a core
+    anyway.
 
-    Elevates every thread whose ``comm`` is ``"<source_thread_name>:src"``
-    (GStreamer names task threads after their pad) plus every non-Python
-    thread that still carries the process's own ``comm`` — GStreamer, GLib,
-    NVENC and CUDA all rename theirs, so an unrenamed thread in the relay is
-    the SDK's. Call once after the pipelines are PLAYING (the threads exist
-    by then). Returns the number of threads moved; ``0`` when the platform
-    has no ``sched_setscheduler`` or the process lacks ``CAP_SYS_NICE`` (a
-    manual unprivileged run — the failure is logged once and the threads
-    stay CFS, exactly the previous behaviour).
+    Elevates every thread whose ``comm`` is in ``thread_comms`` (GStreamer
+    names task threads ``<element>:<pad>``, truncated to the kernel's 15-char
+    limit — the caller passes them already truncated; see
+    ``gst_zed.exposure_critical_thread_comms``) plus every non-Python thread
+    that still carries the process's own ``comm`` — GStreamer, GLib, NVENC and
+    CUDA all rename theirs, so an unrenamed thread in the relay is the SDK's.
+    Call once after the pipelines are PLAYING (the threads exist by then).
+    Returns the number of threads moved; ``0`` when the platform has no
+    ``sched_setscheduler`` or the process lacks ``CAP_SYS_NICE`` (a manual
+    unprivileged run — the failure is logged once and the threads stay CFS,
+    exactly the previous behaviour).
     """
     if not hasattr(os, "sched_setscheduler") or not hasattr(os, "SCHED_FIFO"):
         return 0
@@ -272,7 +278,7 @@ def prioritize_capture_threads(source_thread_name: str) -> int:
         tasks = os.listdir("/proc/self/task")
     except OSError:
         return 0
-    wanted = {f"{source_thread_name}:src", process_comm}
+    wanted = set(thread_comms) | {process_comm}
     param = os.sched_param(CAPTURE_FIFO_PRIORITY)  # type: ignore[attr-defined]
     moved = 0
     denied: OSError | None = None
@@ -306,10 +312,10 @@ def prioritize_capture_threads(source_thread_name: str) -> int:
         )
     elif moved:
         _logger.info(
-            "camera capture threads -> SCHED_FIFO %d (%d threads: %s:src + SDK workers)",
+            "camera capture threads -> SCHED_FIFO %d (%d threads: %s + SDK workers)",
             CAPTURE_FIFO_PRIORITY,
             moved,
-            source_thread_name,
+            ", ".join(sorted(wanted - {process_comm})),
         )
     return moved
 

--- a/almond_axol/utils/jetson.py
+++ b/almond_axol/utils/jetson.py
@@ -1,20 +1,33 @@
 """Jetson system tweaks for the real-time teleop / data-collection loops.
 
-Two Tegra defaults trade latency for power/throughput and hurt us:
+Tegra defaults trade latency for power/throughput and hurt us:
 
 * **Engine devfreq** — the camera relay's hardware encode path
   (``almond_axol.video.hw_video``) depends on NVENC (the H.264 encoder) and
   the VIC (``nvvidconv``'s colorspace conversion). The default
   ``tegra_wmark`` governor grants just enough clock to keep up with the
   frame rate, so each frame takes nearly a full frame-time to encode
-  (~3x worse per-frame latency at the ~25% clock it settles on).
+  (~3x worse per-frame latency at the ~25% clock it settles on). The GPU is
+  in the same boat: the ZED SDK does its per-frame image processing in CUDA,
+  and the default ``nvhost_podgov`` governor parks the GPU at its floor
+  (306 of 918 MHz on Orin) and only ramps after the load is already late —
+  every camera frame drop we attributed on a station happened at that floor.
 
 * **CPU cpufreq** — the IK solver (JAX/XLA) is a bursty, sleep-heavy
   workload. The default ``schedutil`` governor reads that idle and
   underclocks the cores to ~40-70% of max, which drops the IK rate by a
   matching ~30% (measured 79 Hz vs 113 Hz pinned).
 
-Both ceilings are themselves capped by the ``nvpmodel`` power mode, so
+* **Capture daemon scheduling** — on ZED X (GMSL2) every camera's frames
+  flow through NVIDIA's Argus daemon, whose capture-request loop runs per
+  frame for all sensors in one process. It ships as a plain CFS service, so
+  under load it is descheduled behind the control / IK / recorder work the
+  cameras feed, and all cameras miss the same frames at once (the relay's
+  own capture threads then report ~0 ms CPU wait: they are waiting on the
+  daemon, not on the scheduler). :func:`pin_realtime_clocks` runs it
+  ``SCHED_FIFO`` one notch above those relay capture threads.
+
+The clock ceilings are themselves capped by the ``nvpmodel`` power mode, so
 :func:`pin_realtime_clocks` first selects MAXN (mode 0) to uncap them, then
 pins the engine and CPU clocks to that max — fixing the latency / rate.
 Best-effort and cleared on reboot, so ``axol jetson.setup`` (which calls
@@ -29,12 +42,34 @@ import shutil
 import subprocess
 from pathlib import Path
 
+from .affinity import CAPTURE_FIFO_PRIORITY
 from .sudo import prime_sudo
 
 _logger = logging.getLogger(__name__)
 
-# Hardware engines whose devfreq clocks the encode path depends on.
-_ENGINE_CLOCK_GLOBS = ("*.nvenc", "*.vic")
+# Tegra-only encode engines; their presence identifies a Jetson when the L4T
+# release file is missing (see :func:`_is_jetson`).
+_JETSON_ENGINE_GLOBS = ("*.nvenc", "*.vic")
+
+# Hardware engines whose devfreq clocks the camera path depends on: the
+# encode engines plus the GPU the ZED SDK's CUDA processing runs on. The GPU
+# is deliberately not a Jetson marker — other ARM SoCs expose a ``*.gpu``
+# devfreq node too.
+_ENGINE_CLOCK_GLOBS = (*_JETSON_ENGINE_GLOBS, "*.gpu")
+
+# The camera capture daemon(s) in every ZED X frame's path, and the systemd
+# drop-in that makes their realtime scheduling survive a daemon restart. The
+# live instance is re-scheduled in place with ``chrt`` (threads it spawns
+# later inherit), so the daemon is never restarted under running cameras.
+_CAPTURE_DAEMON_UNITS = ("nvargus-daemon.service",)
+_CAPTURE_DAEMON_DROPIN = "50-axol-realtime.conf"
+# One notch above the relay's capture threads (they block on the daemon),
+# far below the axol-rt CAN loops (SCHED_FIFO 20).
+_CAPTURE_DAEMON_FIFO_PRIORITY = CAPTURE_FIFO_PRIORITY + 1
+_SYSTEMD_UNIT_DIR = Path("/etc/systemd/system")
+
+# ``/proc/<tid>/stat`` policy value for SCHED_FIFO (sched.h SCHED_FIFO == 1).
+_SCHED_FIFO = 1
 
 # cpufreq governor that holds the cores at their max clock. The ceiling it
 # holds them at is whatever the active ``nvpmodel`` power mode allows, so we
@@ -76,7 +111,8 @@ def _is_jetson() -> bool:
     # (``glob`` returns a generator that is always truthy, so it must be
     # consumed — ``any(glob(...))`` — to test whether it actually matched.)
     return any(
-        any(Path("/sys/class/devfreq").glob(pattern)) for pattern in _ENGINE_CLOCK_GLOBS
+        any(Path("/sys/class/devfreq").glob(pattern))
+        for pattern in _JETSON_ENGINE_GLOBS
     )
 
 
@@ -238,7 +274,7 @@ def _set_max_power_mode(escalator: _RootEscalator) -> None:
 
 
 def _pin_engines(writer: _RootEscalator) -> None:
-    """Set ``min_freq = max_freq`` on the NVENC/VIC devfreq nodes."""
+    """Set ``min_freq = max_freq`` on the NVENC/VIC/GPU devfreq nodes."""
     for pattern in _ENGINE_CLOCK_GLOBS:
         for node in Path("/sys/class/devfreq").glob(pattern):
             try:
@@ -253,14 +289,138 @@ def _pin_engines(writer: _RootEscalator) -> None:
                 _logger.info("pinned %s clock to %s Hz", node.name, max_freq)
             else:
                 _logger.warning(
-                    "cannot pin %s to its max clock (%s) — hardware encode "
-                    "latency will be ~3x worse. Fix manually with: "
-                    "echo %s | sudo tee %s",
+                    "cannot pin %s to its max clock (%s) — the camera path "
+                    "(hardware encode, ZED SDK CUDA processing) runs at the "
+                    "governor's floor and drops frames under load. Fix manually "
+                    "with: echo %s | sudo tee %s",
                     node.name,
                     detail or "write failed",
                     max_freq,
                     node / "min_freq",
                 )
+
+
+def _service_main_pid(unit: str) -> int:
+    """The unit's MainPID per systemd, 0 when inactive/unknown."""
+    try:
+        proc = subprocess.run(
+            ["systemctl", "show", "-p", "MainPID", "--value", unit],
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return 0
+    try:
+        return int(proc.stdout.strip() or 0)
+    except ValueError:
+        return 0
+
+
+def _threads_at_fifo(
+    pid: int, priority: int, *, proc_root: Path = Path("/proc")
+) -> bool | None:
+    """True when every thread of ``pid`` already runs SCHED_FIFO at ``priority``.
+
+    ``None`` when the process cannot be inspected (gone, or unreadable).
+    """
+    tasks = sorted((proc_root / str(pid) / "task").glob("*"))
+    if not tasks:
+        return None
+    for task in tasks:
+        try:
+            stat = (task / "stat").read_text()
+        except OSError:
+            return None
+        # Fields after the parenthesised comm (which may contain spaces):
+        # index 37 is rt_priority, 38 the scheduling policy (0-based from
+        # the field following ")", i.e. proc(5) fields 40 and 41).
+        fields = stat.rsplit(")", 1)[1].split()
+        try:
+            rt_priority, policy = int(fields[37]), int(fields[38])
+        except (IndexError, ValueError):
+            return None
+        if policy != _SCHED_FIFO or rt_priority != priority:
+            return False
+    return True
+
+
+def _prioritize_capture_daemons(escalator: _RootEscalator) -> None:
+    """Run the camera capture daemon(s) SCHED_FIFO, now and after restarts.
+
+    Jetson-only and best-effort. Two halves per unit: a systemd drop-in so
+    the policy applies whenever the daemon (re)starts, and ``chrt -a`` on the
+    live process so it applies right now without restarting the daemon under
+    running cameras (threads it creates later inherit the policy).
+    """
+    if not _is_jetson():
+        _logger.debug("not a Jetson; leaving the camera daemons' scheduling alone")
+        return
+    dropin_text = (
+        "# Installed by `axol jetson.setup`: every ZED X camera frame passes\n"
+        "# through this daemon, so it must not be descheduled behind the\n"
+        "# control/IK/recorder load the cameras feed.\n"
+        "[Service]\n"
+        "CPUSchedulingPolicy=fifo\n"
+        f"CPUSchedulingPriority={_CAPTURE_DAEMON_FIFO_PRIORITY}\n"
+    )
+    for unit in _CAPTURE_DAEMON_UNITS:
+        pid = _service_main_pid(unit)
+        dropin = _SYSTEMD_UNIT_DIR / f"{unit}.d" / _CAPTURE_DAEMON_DROPIN
+        if pid == 0 and not dropin.exists():
+            # Not installed on this station (no Argus daemon => not ZED X).
+            _logger.debug("%s not running; skipping its realtime drop-in", unit)
+            continue
+        try:
+            dropin_current = dropin.read_text() == dropin_text
+        except OSError:
+            dropin_current = False
+        if not dropin_current:
+            ok, detail = escalator.run(["mkdir", "-p", str(dropin.parent)])
+            if ok:
+                ok, detail = escalator.write(dropin, dropin_text)
+            if ok:
+                ok, detail = escalator.run(["systemctl", "daemon-reload"])
+            if ok:
+                _logger.info(
+                    "%s: SCHED_FIFO %d on future starts (%s)",
+                    unit,
+                    _CAPTURE_DAEMON_FIFO_PRIORITY,
+                    dropin,
+                )
+            else:
+                _logger.warning(
+                    "cannot install the realtime drop-in for %s (%s) — the "
+                    "capture daemon stays CFS after its next restart and all "
+                    "cameras drop the same frames under load. Fix manually "
+                    "with: sudo systemctl edit %s (CPUSchedulingPolicy=fifo, "
+                    "CPUSchedulingPriority=%d)",
+                    unit,
+                    detail or "failed",
+                    unit,
+                    _CAPTURE_DAEMON_FIFO_PRIORITY,
+                )
+        if pid == 0:
+            continue
+        if _threads_at_fifo(pid, _CAPTURE_DAEMON_FIFO_PRIORITY):
+            continue
+        ok, detail = escalator.run(
+            ["chrt", "-f", "-a", "-p", str(_CAPTURE_DAEMON_FIFO_PRIORITY), str(pid)]
+        )
+        if ok:
+            _logger.info(
+                "%s (pid %d) -> SCHED_FIFO %d", unit, pid, _CAPTURE_DAEMON_FIFO_PRIORITY
+            )
+        else:
+            _logger.warning(
+                "cannot re-schedule the running %s (pid %d) SCHED_FIFO (%s) — it "
+                "stays CFS until its next restart picks up the drop-in. Fix "
+                "manually with: sudo chrt -f -a -p %d %d",
+                unit,
+                pid,
+                detail or "chrt failed",
+                _CAPTURE_DAEMON_FIFO_PRIORITY,
+                pid,
+            )
 
 
 def _pin_cpu(writer: _RootEscalator) -> None:
@@ -327,16 +487,18 @@ def pin_engine_clocks(*, interactive: bool = False) -> None:
 
 
 def pin_realtime_clocks(*, interactive: bool = False) -> None:
-    """Select MAXN and pin engine **and** CPU clocks for the control loops.
+    """Select MAXN, pin engine **and** CPU clocks, and make the capture daemon RT.
 
     Selects the MAXN ``nvpmodel`` power mode (uncaps the clock ceiling), pins
-    NVENC/VIC (encode latency), and switches the CPUs to the ``performance``
-    governor (IK rate). All three are Jetson-only: MAXN selection and
-    CPU-governor pinning are gated on :func:`_is_jetson` so they never alter a
-    non-Tegra host, and engine pinning is a no-op without the Tegra devfreq
-    nodes. MAXN is selected first because it sets the ceiling the governor and
-    engine pins reach. Same best-effort / ``interactive`` escalation semantics
-    as :func:`pin_engine_clocks`; sudo is primed at most once across all of
+    NVENC/VIC/GPU (encode latency, ZED SDK processing), switches the CPUs to
+    the ``performance`` governor (IK rate), and schedules the Argus camera
+    daemon ``SCHED_FIFO`` (all-camera frame drops under load). All are
+    Jetson-only: MAXN selection, CPU-governor pinning and the daemon step are
+    gated on :func:`_is_jetson` so they never alter a non-Tegra host, and
+    engine pinning is a no-op without the Tegra devfreq nodes. MAXN is
+    selected first because it sets the ceiling the governor and engine pins
+    reach. Same best-effort / ``interactive`` escalation semantics as
+    :func:`pin_engine_clocks`; sudo is primed at most once across all of
     them. Invoked via ``axol jetson.setup`` (host installer + boot service),
     not from the teleop / collect-data / serve entry points.
     """
@@ -344,3 +506,4 @@ def pin_realtime_clocks(*, interactive: bool = False) -> None:
     _set_max_power_mode(escalator)
     _pin_engines(escalator)
     _pin_cpu(escalator)
+    _prioritize_capture_daemons(escalator)

--- a/almond_axol/video/gst_zed.py
+++ b/almond_axol/video/gst_zed.py
@@ -464,6 +464,39 @@ _DATASET_GATE_TIMEOUT_S = 2.0
 _SOURCE_ELEMENT_NAME = "camsrc"
 _SOURCE_GAP_WARN_MS = 25.0
 _GPU_DEVFREQ_GLOB = "/sys/class/devfreq/*.gpu"
+# The Linux thread name (``comm``) is truncated to this many characters, so
+# gst task threads named ``<element>:<pad>`` may only be matched on a prefix.
+_COMM_MAX = 15
+# The named queues whose consumer thread still holds an *un-copied* camera
+# surface: the stereo eye crops and the dataset source queues in front of the
+# VIC copy. Argus owns only a handful of those surfaces, so these queues are
+# two buffers deep and an overrun there is a lost exposure; everything after
+# the VIC copy has its own (deeper) buffering.
+_EXPOSURE_CRITICAL_QUEUES = (
+    "eye_l_cropq",
+    "eye_r_cropq",
+    "dsenc_srcq",
+    "dsenc_l_srcq",
+    "dsenc_r_srcq",
+)
+
+
+def _task_thread_comm(element_name: str) -> str:
+    """The ``comm`` GStreamer gives the streaming thread of ``element_name``."""
+    return f"{element_name}:src"[:_COMM_MAX]
+
+
+def exposure_critical_thread_comms() -> frozenset[str]:
+    """``comm`` names of the relay threads that must run every capture period.
+
+    The camera source streaming thread plus the consumers of
+    :data:`_EXPOSURE_CRITICAL_QUEUES`. Used by the relay to give exactly this
+    chain real-time scheduling (see ``affinity.prioritize_capture_threads``).
+    """
+    return frozenset(
+        _task_thread_comm(name)
+        for name in (_SOURCE_ELEMENT_NAME, *_EXPOSURE_CRITICAL_QUEUES)
+    )
 
 
 def _thread_sched_wait_ns() -> int | None:
@@ -473,6 +506,75 @@ def _thread_sched_wait_ns() -> int | None:
             return int(f.read().split()[1])
     except (OSError, ValueError, IndexError):
         return None
+
+
+def _find_thread_by_comm(comm: str) -> int | None:
+    """TID of this process's thread named ``comm``, or ``None``."""
+    try:
+        entries = os.listdir("/proc/self/task")
+    except OSError:
+        return None
+    for entry in entries:
+        try:
+            with open(f"/proc/self/task/{entry}/comm") as f:
+                if f.read().strip() == comm:
+                    return int(entry)
+        except (OSError, ValueError):
+            continue
+    return None
+
+
+def _thread_sched_snapshot(tid: int) -> tuple[int, str, str] | None:
+    """``(runnable-wait ns, state letter, wchan)`` of a thread of this process.
+
+    ``state`` is ``R`` when the thread is runnable (running or waiting for a
+    CPU), ``S``/``D`` when it is blocked — for a VIC/NVENC dispatch thread that
+    means waiting on the hardware, and ``wchan`` names the kernel wait.
+    """
+    try:
+        with open(f"/proc/self/task/{tid}/schedstat") as f:
+            wait_ns = int(f.read().split()[1])
+        with open(f"/proc/self/task/{tid}/stat") as f:
+            state = f.read().rsplit(")", 1)[1].split()[0]
+    except (OSError, ValueError, IndexError):
+        return None
+    try:
+        with open(f"/proc/self/task/{tid}/wchan") as f:
+            wchan = f.read().strip() or "-"
+    except OSError:
+        wchan = "-"
+    return wait_ns, state, wchan
+
+
+def _consumer_attribution(state: dict[str, Any], comm: str) -> str:
+    """Describe what a queue's consumer thread was doing at an overrun.
+
+    Sampled per overrun event (cheap: three procfs reads) and phrased so the
+    two causes read apart in the log: a consumer that is ``state=R`` with a CPU
+    wait close to the elapsed time was starved of a core; one that is
+    ``state=S``/``D`` in an ``nvhost``/fence wait with ~0 CPU wait was blocked
+    on the VIC/NVENC hardware or its memory path.
+    """
+    now = time.perf_counter()
+    tid = state.get("tid")
+    if tid is None:
+        tid = state["tid"] = _find_thread_by_comm(comm)
+        if tid is None:
+            return f"consumer {comm} not found"
+    snap = _thread_sched_snapshot(tid)
+    if snap is None:
+        state["tid"] = None
+        return f"consumer {comm} exited"
+    wait_ns, sched_state, wchan = snap
+    prev_t, prev_wait = state.get("t"), state.get("wait")
+    state["t"], state["wait"] = now, wait_ns
+    head = f"consumer {comm} state={sched_state} wchan={wchan}"
+    if prev_t is None or prev_wait is None or now - prev_t > 1.0:
+        return head
+    return (
+        f"{head}, CPU wait {(wait_ns - prev_wait) / 1e6:.1f}ms of the "
+        f"{(now - prev_t) * 1e3:.1f}ms since its previous overrun"
+    )
 
 
 def _gpu_clock_summary() -> str:
@@ -805,6 +907,7 @@ class _GstPipelineBase:
                 _logger.debug("dataset queue diagnostic missing %s", queue_name)
                 continue
             self._dataset_queue_overruns.setdefault(queue_name, 0)
+            consumer_state: dict[str, Any] = {}
 
             def on_overrun(
                 element: Any,
@@ -812,6 +915,7 @@ class _GstPipelineBase:
                 label: str = queue_name,
                 branch_valve: Any = valve,
                 source: str = owner,
+                consumer: dict[str, Any] = consumer_state,
             ) -> None:
                 # Source/crop queues are live before an episode. An overrun
                 # counts only after this branch's valve admits its first
@@ -823,6 +927,10 @@ class _GstPipelineBase:
                     return
                 count = self._dataset_queue_overruns.get(label, 0) + 1
                 self._dataset_queue_overruns[label] = count
+                # Sample the consumer on every overrun so the wait delta spans
+                # exactly the interval between two overruns, but log only the
+                # first and powers of two.
+                attribution = _consumer_attribution(consumer, _task_thread_comm(label))
                 if count != 1 and count & (count - 1):
                     return
                 try:
@@ -832,12 +940,13 @@ class _GstPipelineBase:
                     level = limit = -1
                 _logger.warning(
                     "dataset relay %s queue %s overrun #%d "
-                    "(level=%d, limit=%d); an encoded exposure may be lost",
+                    "(level=%d, limit=%d); %s; an encoded exposure may be lost",
                     source,
                     label,
                     count,
                     level,
                     limit,
+                    attribution,
                 )
 
             try:

--- a/almond_axol/video/gst_zed.py
+++ b/almond_axol/video/gst_zed.py
@@ -458,6 +458,37 @@ _DATASET_ENABLE_LEAD_S = 0.100
 # The shared gate still has a bounded acknowledgement wait. A timeout means a
 # source stopped producing exposure timestamps, not ordinary scheduler jitter.
 _DATASET_GATE_TIMEOUT_S = 2.0
+# Every camera source element carries this name so the source-gap diagnostic
+# can find its pad. A sensor-timestamp step of 1.5 periods at the fastest
+# supported capture rate (60 Hz) is already a whole missing exposure.
+_SOURCE_ELEMENT_NAME = "camsrc"
+_SOURCE_GAP_WARN_MS = 25.0
+_GPU_DEVFREQ_GLOB = "/sys/class/devfreq/*.gpu"
+
+
+def _thread_sched_wait_ns() -> int | None:
+    """Cumulative time this thread spent runnable-but-waiting (Linux only)."""
+    try:
+        with open("/proc/thread-self/schedstat") as f:
+            return int(f.read().split()[1])
+    except (OSError, ValueError, IndexError):
+        return None
+
+
+def _gpu_clock_summary() -> str:
+    """``cur/max MHz`` of the Tegra GPU devfreq, or ``n/a`` off-Jetson."""
+    import glob
+
+    for node in glob.glob(_GPU_DEVFREQ_GLOB):
+        try:
+            with open(f"{node}/cur_freq") as f:
+                cur = int(f.read()) // 1_000_000
+            with open(f"{node}/max_freq") as f:
+                top = int(f.read()) // 1_000_000
+        except (OSError, ValueError):
+            continue
+        return f"{cur}/{top}MHz"
+    return "n/a"
 
 
 def _dataset_rate_limit(capture_fps: int, dataset_fps: int) -> str:
@@ -1185,6 +1216,66 @@ class _GstPipelineBase:
         self._gst = Gst
         _logger.info("gst zed pipeline: %s", pipeline_str)
         self._pipeline = Gst.parse_launch(pipeline_str)
+        self._attach_source_gap_diagnostic()
+
+    def _attach_source_gap_diagnostic(self) -> None:
+        """Log every exposure the camera source itself fails to deliver.
+
+        The dataset queues report their own overruns, and the recorder detects
+        a missing AU downstream, but neither can say *where* a frame vanished
+        when no queue overran: that leaves the source element (the ZED SDK's
+        grab loop) or the camera link. This probe sits on the source pad, so a
+        sensor-timestamp gap here is a frame the source never produced. It
+        also attributes the miss: the source's streaming thread cannot call
+        ``grab()`` while descheduled, so if its ``schedstat`` wait time grew by
+        most of the gap it was starved of CPU; otherwise the time went inside
+        the SDK (GPU work, or a link/sensor frame that never arrived), which is
+        why the GPU clock — the one camera-path engine ``jetson.setup`` does
+        not pin — is logged alongside.
+        """
+        Gst = self._gst
+        source = self._pipeline.get_by_name(_SOURCE_ELEMENT_NAME)
+        if source is None:
+            return
+        pad = source.get_static_pad("src")
+        if pad is None:
+            return
+        state: dict[str, Any] = {"pts": None, "wait_ns": None}
+        label = repr(self)
+
+        def on_buffer(_pad: Any, info: Any) -> Any:
+            buf = info.get_buffer()
+            if buf is None or buf.pts == Gst.CLOCK_TIME_NONE:
+                return Gst.PadProbeReturn.OK
+            previous = state["pts"]
+            previous_wait = state["wait_ns"]
+            wait_ns = _thread_sched_wait_ns()
+            state["pts"] = buf.pts
+            state["wait_ns"] = wait_ns
+            if previous is None or buf.pts <= previous:
+                return Gst.PadProbeReturn.OK
+            gap_ms = (buf.pts - previous) / 1e6
+            if gap_ms < _SOURCE_GAP_WARN_MS:
+                return Gst.PadProbeReturn.OK
+            starved_ms = (
+                (wait_ns - previous_wait) / 1e6
+                if wait_ns is not None and previous_wait is not None
+                else None
+            )
+            _logger.warning(
+                "camera source %s skipped exposure(s): sensor PTS gap %.2fms; "
+                "source thread CPU wait since previous frame %s; gpu %s",
+                label,
+                gap_ms,
+                "unknown" if starved_ms is None else f"{starved_ms:.2f}ms",
+                _gpu_clock_summary(),
+            )
+            return Gst.PadProbeReturn.OK
+
+        try:
+            pad.add_probe(Gst.PadProbeType.BUFFER, on_buffer)
+        except Exception as exc:  # diagnostics never gate capture
+            _logger.debug("could not attach source gap diagnostic: %s", exc)
 
     def _play_and_wait(self, channels: tuple[_AUChannel, ...]) -> bool:
         Gst = self._gst
@@ -1296,7 +1387,7 @@ class ZedGstCamera(_GstPipelineBase, _GstStreamConsumer):
     def _pipeline_str(self) -> str:
         bitrate = _bitrate_for(self.width, self.height, self.stream_fps)
         src = (
-            f"zedxonesrc camera-sn={self.serial} "
+            f"zedxonesrc name={_SOURCE_ELEMENT_NAME} camera-sn={self.serial} "
             f"camera-resolution={_RESOLUTION_ENUM[self.resolution]} "
             f"camera-fps={self.fps} stream-type=1 do-timestamp=false "
             f"ctrl-auto-exposure-range-max={_MAX_AUTO_EXPOSURE_US} "
@@ -1789,7 +1880,7 @@ class ZedGstStereoCamera(_GstPipelineBase):
 
     def _pipeline_str(self) -> str:
         src = (
-            f"zedsrc camera-sn={self.serial} "
+            f"zedsrc name={_SOURCE_ELEMENT_NAME} camera-sn={self.serial} "
             f"camera-resolution={_STEREO_RESOLUTION_ENUM[self.resolution]} "
             f"camera-fps={self.fps} stream-type=7 depth-mode=0 "
             "do-timestamp=false "

--- a/almond_axol/video/gst_zed.py
+++ b/almond_axol/video/gst_zed.py
@@ -52,7 +52,7 @@ import time
 from typing import TYPE_CHECKING, Any
 
 from .constants import HEADSET_STREAM_FPS
-from .hw_video import _bitrate_for, dataset_vbr_bitrate, hw_h264_available
+from .hw_video import _bitrate_for, dataset_intra_vbr_bitrate, hw_h264_available
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -542,10 +542,12 @@ def _dataset_enc_shmsink(
     before the parent later closes the branch between episodes.
 
     Encoding runs in VBR with a peak cap so the recorded dataset stays bounded
-    and uniformly sized across cameras even when one sensor is very noisy (see
-    ``dataset_vbr_bitrate``).
+    and uniformly sized across cameras even when one sensor is very noisy. The
+    budget is the all-intra one (``dataset_intra_vbr_bitrate``): every frame is
+    an IDR here, so the predictive-GOP budget would leave each frame visibly
+    blocky.
     """
-    target, peak = dataset_vbr_bitrate(w, h, dataset_fps)
+    target, peak = dataset_intra_vbr_bitrate(w, h, dataset_fps)
     input_buffers = _dataset_active_input_buffers(dataset_fps)
     converter_buffers = input_buffers + _DATASET_VIC_INFLIGHT_SURFACES
     return (

--- a/almond_axol/video/hw_video.py
+++ b/almond_axol/video/hw_video.py
@@ -98,6 +98,25 @@ def dataset_vbr_bitrate(width: int, height: int, fps: int) -> tuple[int, int]:
     return target, int(target * _DATASET_PEAK_MULT)
 
 
+# All-intra budget for the relay's encoded dataset branch (``gst_zed``), where
+# every frame is an IDR. Intra frames cannot borrow from their neighbours, so at
+# the predictive budget above each 960x600 frame gets ~12 KB and lands around
+# 31 dB PSNR-Y — visibly blocky on the edge detail the policies rely on — versus
+# ~45 dB for the same bits spread over a 15-frame GOP (measured on the Jetson
+# encoder against a recorded arm camera). ~0.6 bpp (≈21 Mbps at SVGA @ 60)
+# recovers ~41 dB; the cost is about 3.5x the on-disk/upload size per camera.
+_DATASET_INTRA_BPP = 0.6
+_DATASET_INTRA_PEAK_MULT = 1.5
+
+
+def dataset_intra_vbr_bitrate(width: int, height: int, fps: int) -> tuple[int, int]:
+    """(target, peak) VBR bitrate (bits/s) for an all-intra dataset encode."""
+    target = max(
+        8_000_000, min(50_000_000, int(width * height * fps * _DATASET_INTRA_BPP))
+    )
+    return target, int(target * _DATASET_INTRA_PEAK_MULT)
+
+
 def _gst_argv(width: int, height: int, fps: int, bitrate: int) -> list[str]:
     """``gst-launch-1.0`` argv: BGRA on stdin -> H.264 byte stream on stdout.
 

--- a/almond_axol/video/video_proc.py
+++ b/almond_axol/video/video_proc.py
@@ -767,13 +767,14 @@ def _relay_main(
     # camera pipelines are PLAYING (their workers exist) and before this event
     # loop starts.
     affinity.isolate_relay_cpu()
-    # The capture chain (source streaming thread + SDK workers) must run every
-    # 60 Hz period or the SDK drops the exposure; a CFS slot behind the encode
-    # pool is not guaranteed once recording starts, so it gets a real-time
-    # class of its own (see prioritize_capture_threads).
-    from .gst_zed import _SOURCE_ELEMENT_NAME
+    # The capture chain (source streaming thread, SDK workers, and the
+    # consumers of the two-buffer queues that still hold camera surfaces) must
+    # run every 60 Hz period or the exposure is lost; a CFS slot behind the
+    # encode pool is not guaranteed once recording starts, so it gets a
+    # real-time class of its own (see prioritize_capture_threads).
+    from .gst_zed import exposure_critical_thread_comms
 
-    affinity.prioritize_capture_threads(_SOURCE_ELEMENT_NAME)
+    affinity.prioritize_capture_threads(exposure_critical_thread_comms())
 
     try:
         asyncio.run(serve())

--- a/almond_axol/video/video_proc.py
+++ b/almond_axol/video/video_proc.py
@@ -767,6 +767,13 @@ def _relay_main(
     # camera pipelines are PLAYING (their workers exist) and before this event
     # loop starts.
     affinity.isolate_relay_cpu()
+    # The capture chain (source streaming thread + SDK workers) must run every
+    # 60 Hz period or the SDK drops the exposure; a CFS slot behind the encode
+    # pool is not guaranteed once recording starts, so it gets a real-time
+    # class of its own (see prioritize_capture_threads).
+    from .gst_zed import _SOURCE_ELEMENT_NAME
+
+    affinity.prioritize_capture_threads(_SOURCE_ELEMENT_NAME)
 
     try:
         asyncio.run(serve())

--- a/tests/test_affinity.py
+++ b/tests/test_affinity.py
@@ -1,8 +1,92 @@
+import io
 from types import SimpleNamespace
 from unittest import TestCase
 from unittest.mock import call, patch
 
 from almond_axol.utils import affinity
+
+
+def _proc_files(comms: dict[str, str], process_comm: str = "python"):
+    """``open`` stand-in serving ``/proc/self/comm`` and per-task ``comm`` files."""
+
+    def _open(path, *args, **kwargs):
+        if path == "/proc/self/comm":
+            return io.StringIO(process_comm + "\n")
+        prefix = "/proc/self/task/"
+        if path.startswith(prefix) and path.endswith("/comm"):
+            tid = path[len(prefix) : -len("/comm")]
+            if tid in comms:
+                return io.StringIO(comms[tid] + "\n")
+            raise FileNotFoundError(path)
+        raise AssertionError(f"unexpected open({path!r})")
+
+    return _open
+
+
+class PrioritizeCaptureThreadsTest(TestCase):
+    comms = {
+        "101": "python",  # Python main thread (excluded via threading)
+        "201": "camsrc:src",  # zedsrc streaming thread
+        "202": "camsrc:src",  # a second camera's
+        "203": "python",  # ZED SDK worker: never renamed its comm
+        "204": "eye_l_cropq:src",  # gst VIC dispatch: stays CFS
+        "205": "V4L2_EncThread",  # NVENC: stays CFS
+        "206": "cuda-EvtHandlr",
+    }
+    python_threads = [SimpleNamespace(native_id=101)]
+
+    def test_elevates_source_and_sdk_threads_only(self) -> None:
+        # "999" is listed but exited before its comm is read; "x" isn't a tid.
+        with (
+            patch.object(
+                affinity.os, "listdir", return_value=[*self.comms, "999", "x"]
+            ),
+            patch.object(affinity.os, "sched_setscheduler", create=True) as setsched,
+            patch.object(
+                affinity.os,
+                "sched_param",
+                create=True,
+                side_effect=lambda p: ("param", p),
+            ),
+            patch.object(affinity.os, "SCHED_FIFO", 1, create=True),
+            patch("builtins.open", _proc_files(self.comms)),
+            patch("threading.enumerate", return_value=self.python_threads),
+        ):
+            moved = affinity.prioritize_capture_threads("camsrc")
+
+        self.assertEqual(moved, 3)
+        param = ("param", affinity.CAPTURE_FIFO_PRIORITY)
+        self.assertCountEqual(
+            setsched.call_args_list,
+            [call(201, 1, param), call(202, 1, param), call(203, 1, param)],
+        )
+
+    def test_permission_denied_leaves_threads_cfs(self) -> None:
+        with (
+            patch.object(affinity.os, "listdir", return_value=list(self.comms)),
+            patch.object(
+                affinity.os,
+                "sched_setscheduler",
+                create=True,
+                side_effect=PermissionError("EPERM"),
+            ) as setsched,
+            patch.object(
+                affinity.os, "sched_param", create=True, side_effect=lambda p: p
+            ),
+            patch.object(affinity.os, "SCHED_FIFO", 1, create=True),
+            patch("builtins.open", _proc_files(self.comms)),
+            patch("threading.enumerate", return_value=self.python_threads),
+            self.assertLogs(affinity._logger, level="INFO") as logs,
+        ):
+            moved = affinity.prioritize_capture_threads("camsrc")
+
+        self.assertEqual(moved, 0)
+        self.assertEqual(setsched.call_count, 1)  # stops at the first EPERM
+        self.assertTrue(any("CAP_SYS_NICE" in line for line in logs.output))
+
+    def test_noop_without_scheduler_api(self) -> None:
+        with patch.object(affinity, "os", SimpleNamespace(listdir=lambda _p: [])):
+            self.assertEqual(affinity.prioritize_capture_threads("camsrc"), 0)
 
 
 class IsolateRelayCpuTest(TestCase):

--- a/tests/test_affinity.py
+++ b/tests/test_affinity.py
@@ -29,13 +29,16 @@ class PrioritizeCaptureThreadsTest(TestCase):
         "201": "camsrc:src",  # zedsrc streaming thread
         "202": "camsrc:src",  # a second camera's
         "203": "python",  # ZED SDK worker: never renamed its comm
-        "204": "eye_l_cropq:src",  # gst VIC dispatch: stays CFS
+        "204": "eye_l_cropq:src",  # crop VIC dispatch: holds a camera surface
         "205": "V4L2_EncThread",  # NVENC: stays CFS
         "206": "cuda-EvtHandlr",
+        "207": "dsenc_l_srcq:sr",  # 15-char comm truncation of dsenc_l_srcq:src
+        "208": "dsenc_l_outq:sr",  # post-encode: stays CFS
     }
     python_threads = [SimpleNamespace(native_id=101)]
+    wanted = ("camsrc:src", "eye_l_cropq:src", "dsenc_l_srcq:sr")
 
-    def test_elevates_source_and_sdk_threads_only(self) -> None:
+    def test_elevates_capture_chain_and_sdk_threads_only(self) -> None:
         # "999" is listed but exited before its comm is read; "x" isn't a tid.
         with (
             patch.object(
@@ -52,13 +55,13 @@ class PrioritizeCaptureThreadsTest(TestCase):
             patch("builtins.open", _proc_files(self.comms)),
             patch("threading.enumerate", return_value=self.python_threads),
         ):
-            moved = affinity.prioritize_capture_threads("camsrc")
+            moved = affinity.prioritize_capture_threads(self.wanted)
 
-        self.assertEqual(moved, 3)
+        self.assertEqual(moved, 5)
         param = ("param", affinity.CAPTURE_FIFO_PRIORITY)
         self.assertCountEqual(
             setsched.call_args_list,
-            [call(201, 1, param), call(202, 1, param), call(203, 1, param)],
+            [call(tid, 1, param) for tid in (201, 202, 203, 204, 207)],
         )
 
     def test_permission_denied_leaves_threads_cfs(self) -> None:
@@ -78,7 +81,7 @@ class PrioritizeCaptureThreadsTest(TestCase):
             patch("threading.enumerate", return_value=self.python_threads),
             self.assertLogs(affinity._logger, level="INFO") as logs,
         ):
-            moved = affinity.prioritize_capture_threads("camsrc")
+            moved = affinity.prioritize_capture_threads(self.wanted)
 
         self.assertEqual(moved, 0)
         self.assertEqual(setsched.call_count, 1)  # stops at the first EPERM
@@ -86,7 +89,7 @@ class PrioritizeCaptureThreadsTest(TestCase):
 
     def test_noop_without_scheduler_api(self) -> None:
         with patch.object(affinity, "os", SimpleNamespace(listdir=lambda _p: [])):
-            self.assertEqual(affinity.prioritize_capture_threads("camsrc"), 0)
+            self.assertEqual(affinity.prioritize_capture_threads(self.wanted), 0)
 
 
 class IsolateRelayCpuTest(TestCase):

--- a/tests/test_gst_dataset_transport.py
+++ b/tests/test_gst_dataset_transport.py
@@ -9,7 +9,10 @@ from unittest.mock import patch
 from almond_axol.video.gst_zed import (
     ZedGstCamera,
     ZedGstStereoCamera,
+    _consumer_attribution,
     _GstPipelineBase,
+    _task_thread_comm,
+    exposure_critical_thread_comms,
 )
 from almond_axol.video.hw_video import dataset_intra_vbr_bitrate, dataset_vbr_bitrate
 from almond_axol.video.video_proc import _set_dataset_branches_enabled
@@ -508,6 +511,63 @@ class GstDatasetEnableBarrierTest(unittest.TestCase):
         self.assertNotIn("finish", [call[0] for call in calls])
         self.assertIn(("abort", "overhead"), calls)
         self.assertIn(("abort", "left_arm"), calls)
+
+
+class ExposureCriticalThreadsTest(unittest.TestCase):
+    def test_comms_cover_source_crop_and_dataset_source_queues(self) -> None:
+        comms = exposure_critical_thread_comms()
+
+        # Every name is a valid Linux comm (<= 15 chars) and the ones that
+        # would overflow are truncated the way the kernel does it.
+        self.assertTrue(all(len(c) <= 15 for c in comms))
+        self.assertEqual(
+            comms,
+            {
+                "camsrc:src",
+                "eye_l_cropq:src",
+                "eye_r_cropq:src",
+                "dsenc_srcq:src",
+                "dsenc_l_srcq:sr",
+                "dsenc_r_srcq:sr",
+            },
+        )
+        # Post-copy stages keep CFS: they have their own deeper buffering.
+        self.assertNotIn(_task_thread_comm("dsenc_l_inq"), comms)
+        self.assertNotIn(_task_thread_comm("dsenc_outq"), comms)
+
+    def test_consumer_attribution_reports_wait_between_overruns(self) -> None:
+        snapshots = iter([(1_000_000, "R", "0"), (21_000_000, "R", "0")])
+        state: dict = {}
+        with (
+            patch("almond_axol.video.gst_zed._find_thread_by_comm", return_value=4242),
+            patch(
+                "almond_axol.video.gst_zed._thread_sched_snapshot",
+                side_effect=lambda tid: next(snapshots),
+            ),
+            patch(
+                "almond_axol.video.gst_zed.time.perf_counter",
+                side_effect=(100.0, 100.0334),
+            ),
+        ):
+            first = _consumer_attribution(state, "eye_l_cropq:src")
+            second = _consumer_attribution(state, "eye_l_cropq:src")
+
+        self.assertEqual(first, "consumer eye_l_cropq:src state=R wchan=0")
+        self.assertEqual(
+            second,
+            "consumer eye_l_cropq:src state=R wchan=0, CPU wait 20.0ms of the "
+            "33.4ms since its previous overrun",
+        )
+        self.assertEqual(state["tid"], 4242)
+
+    def test_consumer_attribution_forgets_an_exited_thread(self) -> None:
+        state: dict = {"tid": 7}
+        with patch(
+            "almond_axol.video.gst_zed._thread_sched_snapshot", return_value=None
+        ):
+            text = _consumer_attribution(state, "dsenc_srcq:src")
+        self.assertEqual(text, "consumer dsenc_srcq:src exited")
+        self.assertIsNone(state["tid"])
 
 
 if __name__ == "__main__":

--- a/tests/test_gst_dataset_transport.py
+++ b/tests/test_gst_dataset_transport.py
@@ -11,6 +11,7 @@ from almond_axol.video.gst_zed import (
     ZedGstStereoCamera,
     _GstPipelineBase,
 )
+from almond_axol.video.hw_video import dataset_intra_vbr_bitrate, dataset_vbr_bitrate
 from almond_axol.video.video_proc import _set_dataset_branches_enabled
 
 
@@ -191,6 +192,10 @@ class GstDatasetTransportTest(unittest.TestCase):
         )
         self.assertIn(f"name={encoder_name}", branch)
         self.assertIn("iframeinterval=1 idrinterval=1", branch)
+        # All-IDR frames need the intra budget, not the predictive-GOP one.
+        target, peak = dataset_intra_vbr_bitrate(960, 600, 60)
+        self.assertGreater(target, dataset_vbr_bitrate(960, 600, 60)[0] * 3)
+        self.assertIn(f"bitrate={target} peak-bitrate={peak} ", branch)
         self.assertIn(
             "video/x-h264,stream-format=byte-stream,alignment=au ! "
             f"queue name={encoder_name}_outq leaky=downstream "

--- a/tests/test_h264_mux_finalize.py
+++ b/tests/test_h264_mux_finalize.py
@@ -1,0 +1,103 @@
+"""End-to-end finalize check for the mux-only recorder against real GStreamer.
+
+Regression for the "finalized with n-1 packets (n advertised)" save failure:
+without a framerate on the appsrc caps, h264parse drops the per-buffer
+duration and mp4mux writes the final sample with duration 0, so the track /
+edit list ends one frame early and ffmpeg never yields the last frame.
+
+Runs only where PyGObject + h264parse/mp4mux + openh264enc + PyAV are
+installed; skipped elsewhere. openh264enc is the fixture encoder on purpose:
+like nvv4l2h264enc it writes an SPS without VUI timing, so h264parse has no
+in-band source for the frame duration and the bug reproduces; x264enc's SPS
+carries timing info and masks it.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from almond_axol.lerobot.h264_mux_encoder import _CameraH264Muxer
+from almond_axol.video.gst_zed import _element_available
+
+_FPS = 60
+
+
+def _software_encoded_aus(count: int) -> list[bytes]:
+    """``count`` all-IDR Annex-B access units from openh264enc (no VUI timing)."""
+    from almond_axol.video.gst_zed import _require_gst
+
+    Gst, _ = _require_gst()
+    pipeline = Gst.parse_launch(
+        f"videotestsrc num-buffers={count} pattern=ball "
+        f"! video/x-raw,width=64,height=64,framerate={_FPS}/1 "
+        "! openh264enc gop-size=1 bitrate=64000 "
+        "! video/x-h264,stream-format=byte-stream,alignment=au "
+        "! appsink name=out sync=false"
+    )
+    sink = pipeline.get_by_name("out")
+    pipeline.set_state(Gst.State.PLAYING)
+    aus: list[bytes] = []
+    try:
+        while True:
+            sample = sink.emit("pull-sample")
+            if sample is None:
+                break
+            buf = sample.get_buffer()
+            ok, info = buf.map(Gst.MapFlags.READ)
+            assert ok
+            try:
+                aus.append(bytes(info.data))
+            finally:
+                buf.unmap(info)
+    finally:
+        pipeline.set_state(Gst.State.NULL)
+    return aus
+
+
+def _demuxed(path: Path) -> tuple[int, int, int]:
+    """(advertised sample count, real demuxed packets, last packet pts ticks)."""
+    import av
+
+    with av.open(str(path)) as container:
+        stream = container.streams.video[0]
+        packets = [
+            packet
+            for packet in container.demux(stream)
+            if packet.pts is not None and packet.dts is not None
+        ]
+        return int(stream.frames or 0), len(packets), int(packets[-1].pts)
+
+
+@unittest.skipUnless(
+    all(
+        _element_available(e) for e in ("appsrc", "h264parse", "mp4mux", "openh264enc")
+    ),
+    "needs GStreamer with h264parse/mp4mux/openh264enc",
+)
+class H264MuxFinalizeTest(unittest.TestCase):
+    def setUp(self) -> None:
+        try:
+            import av  # noqa: F401
+        except ImportError:
+            self.skipTest("needs PyAV")
+
+    def test_every_fed_access_unit_is_a_demuxable_sample(self) -> None:
+        for count in (1, 3, 100):
+            with self.subTest(count=count), tempfile.TemporaryDirectory() as tmp:
+                path = Path(tmp) / "observation.images.cam_streaming.mp4"
+                muxer = _CameraH264Muxer(path, _FPS, want_stats=False)
+                for au in _software_encoded_aus(count):
+                    muxer.feed(au)
+                out_path, stats = muxer.finish()
+
+                self.assertEqual(out_path, path)
+                self.assertIsNone(stats)
+                advertised, demuxed, last_pts = _demuxed(path)
+                self.assertEqual(advertised, count)
+                self.assertEqual(demuxed, count)
+                # mp4 timescale is fps*1000, so one frame == 1000 ticks and
+                # the last frame sits exactly at (count-1)/fps: the final
+                # sample carries a full frame duration, not zero.
+                self.assertEqual(last_pts, (count - 1) * 1000)

--- a/tests/test_jetson.py
+++ b/tests/test_jetson.py
@@ -1,0 +1,139 @@
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import patch
+
+from almond_axol.utils import jetson
+
+
+def _stat_line(tid: int, comm: str, rt_priority: int, policy: int) -> str:
+    """A proc(5) ``stat`` line with the given rt_priority (40) / policy (41)."""
+    fields = ["S", "1"] + ["0"] * 35  # state .. field 39
+    fields += [str(rt_priority), str(policy), "0", "0"]
+    return f"{tid} ({comm}) " + " ".join(fields) + "\n"
+
+
+class ThreadsAtFifoTest(TestCase):
+    def _proc(self, tasks: dict[int, tuple[int, int]]) -> Path:
+        root = Path(tempfile.mkdtemp())
+        for tid, (rt_priority, policy) in tasks.items():
+            task = root / "4242" / "task" / str(tid)
+            task.mkdir(parents=True)
+            # A comm with a space and a ")" is legal and must not shift fields.
+            (task / "stat").write_text(
+                _stat_line(tid, "nvargus (x) d", rt_priority, policy)
+            )
+        return root
+
+    def test_all_threads_fifo_at_priority(self) -> None:
+        root = self._proc({4242: (6, 1), 4300: (6, 1)})
+        self.assertTrue(jetson._threads_at_fifo(4242, 6, proc_root=root))
+
+    def test_any_cfs_thread_is_false(self) -> None:
+        root = self._proc({4242: (6, 1), 4300: (0, 0)})
+        self.assertFalse(jetson._threads_at_fifo(4242, 6, proc_root=root))
+
+    def test_wrong_priority_is_false(self) -> None:
+        root = self._proc({4242: (5, 1)})
+        self.assertFalse(jetson._threads_at_fifo(4242, 6, proc_root=root))
+
+    def test_missing_process_is_none(self) -> None:
+        root = Path(tempfile.mkdtemp())
+        self.assertIsNone(jetson._threads_at_fifo(4242, 6, proc_root=root))
+
+
+class _Escalator:
+    """Records root operations; ``write`` really writes so re-runs can compare."""
+
+    def __init__(self) -> None:
+        self.runs: list[list[str]] = []
+        self.writes: list[Path] = []
+
+    def run(self, argv, *, input_text=None):
+        self.runs.append(argv)
+        if argv[0] == "mkdir":
+            Path(argv[-1]).mkdir(parents=True, exist_ok=True)
+        return True, ""
+
+    def write(self, path, value):
+        self.writes.append(path)
+        path.write_text(value)
+        return True, ""
+
+
+class PrioritizeCaptureDaemonsTest(TestCase):
+    def setUp(self) -> None:
+        self.unit_dir = Path(tempfile.mkdtemp())
+        patches = [
+            patch.object(jetson, "_is_jetson", return_value=True),
+            patch.object(jetson, "_SYSTEMD_UNIT_DIR", self.unit_dir),
+            patch.object(jetson, "_CAPTURE_DAEMON_UNITS", ("nvargus-daemon.service",)),
+        ]
+        for p in patches:
+            p.start()
+            self.addCleanup(p.stop)
+        self.dropin = (
+            self.unit_dir / "nvargus-daemon.service.d" / jetson._CAPTURE_DAEMON_DROPIN
+        )
+
+    def test_installs_dropin_and_reschedules_live_daemon(self) -> None:
+        esc = _Escalator()
+        with (
+            patch.object(jetson, "_service_main_pid", return_value=777),
+            patch.object(jetson, "_threads_at_fifo", return_value=False),
+        ):
+            jetson._prioritize_capture_daemons(esc)
+
+        text = self.dropin.read_text()
+        self.assertIn("CPUSchedulingPolicy=fifo", text)
+        self.assertIn(
+            f"CPUSchedulingPriority={jetson._CAPTURE_DAEMON_FIFO_PRIORITY}", text
+        )
+        self.assertIn(["systemctl", "daemon-reload"], esc.runs)
+        self.assertIn(
+            [
+                "chrt",
+                "-f",
+                "-a",
+                "-p",
+                str(jetson._CAPTURE_DAEMON_FIFO_PRIORITY),
+                "777",
+            ],
+            esc.runs,
+        )
+
+    def test_rerun_is_a_no_op_once_applied(self) -> None:
+        esc = _Escalator()
+        with (
+            patch.object(jetson, "_service_main_pid", return_value=777),
+            patch.object(jetson, "_threads_at_fifo", return_value=False),
+        ):
+            jetson._prioritize_capture_daemons(esc)
+        again = _Escalator()
+        with (
+            patch.object(jetson, "_service_main_pid", return_value=777),
+            patch.object(jetson, "_threads_at_fifo", return_value=True),
+        ):
+            jetson._prioritize_capture_daemons(again)
+        self.assertEqual(again.runs, [])
+        self.assertEqual(again.writes, [])
+
+    def test_absent_daemon_is_skipped_entirely(self) -> None:
+        esc = _Escalator()
+        with patch.object(jetson, "_service_main_pid", return_value=0):
+            jetson._prioritize_capture_daemons(esc)
+        self.assertFalse(self.dropin.exists())
+        self.assertEqual(esc.runs, [])
+
+    def test_stopped_daemon_with_dropin_only_refreshes_dropin(self) -> None:
+        self.dropin.parent.mkdir(parents=True)
+        self.dropin.write_text("stale\n")
+        esc = _Escalator()
+        with patch.object(jetson, "_service_main_pid", return_value=0):
+            jetson._prioritize_capture_daemons(esc)
+        self.assertIn("CPUSchedulingPolicy=fifo", self.dropin.read_text())
+        self.assertNotIn("chrt", [argv[0] for argv in esc.runs])
+
+    def test_gpu_is_pinned_but_not_a_jetson_marker(self) -> None:
+        self.assertIn("*.gpu", jetson._ENGINE_CLOCK_GLOBS)
+        self.assertNotIn("*.gpu", jetson._JETSON_ENGINE_GLOBS)

--- a/tests/test_recorder_capture_error.py
+++ b/tests/test_recorder_capture_error.py
@@ -11,6 +11,8 @@ from almond_axol.recording.record_proc import (
     InProcessRecorder,
     RecorderCaptureError,
     RecorderDatasetSaveError,
+    _ENCODED_MAX_CONCEALED_FRAMES_PER_CAMERA,
+    _ENCODED_MAX_CONCEALMENT_EVENTS_PER_CAMERA,
     _align_independent_encoded_start,
     _concealable_encoded_gap_frames,
     run_encoded_capture_loop,
@@ -252,7 +254,10 @@ class DatasetRecorderCaptureErrorTest(unittest.TestCase):
         self.assertEqual(repairs, [])
         self.assertRegex(errors[0], "dropped an encoded frame")
 
-    def test_second_gap_event_remains_fatal(self) -> None:
+    def test_repeated_isolated_gaps_within_budget_are_concealed(self) -> None:
+        # The ZED sources drop isolated frames in clusters around a record
+        # start (this session: both overhead eyes at row 12, then again half a
+        # second later). Each hole stays bounded, so the take survives.
         base = time.perf_counter() + 0.1
         step = 1.0 / 60.0
         cameras = {
@@ -267,9 +272,52 @@ class DatasetRecorderCaptureErrorTest(unittest.TestCase):
 
         dataset, errors, repairs, _ = self._run_encoded(cameras, fps=60, rows=5)
 
-        self.assertEqual(len(dataset.rows), 3)
-        self.assertEqual(len(repairs), 1)
-        self.assertEqual(repairs[0]["missing_frames"], 1)
+        self.assertEqual(errors, [])
+        self.assertEqual(
+            [row["observation.camera"] for row in dataset.rows],
+            [b"a0", b"a0", b"a2", b"a2", b"a4"],
+        )
+        self.assertEqual([event["missing_frames"] for event in repairs], [1, 1])
+        self.assertEqual([event["frame_index"] for event in repairs], [1, 3])
+
+    def test_gap_past_per_episode_budget_is_fatal(self) -> None:
+        base = time.perf_counter() + 0.1
+        step = 1.0 / 60.0
+        packets = [(b"a0", base, base)]
+        # One event over the per-camera budget, each a single missing frame.
+        for i in range(_ENCODED_MAX_CONCEALMENT_EVENTS_PER_CAMERA + 1):
+            ts = base + 2 * (i + 1) * step
+            packets.append((f"a{2 * (i + 1)}".encode(), ts, base))
+        cameras = {"camera": _EncodedCamera(packets)}
+
+        dataset, errors, repairs, _ = self._run_encoded(
+            cameras, fps=60, rows=len(packets) * 2
+        )
+
+        self.assertEqual(len(repairs), _ENCODED_MAX_CONCEALMENT_EVENTS_PER_CAMERA)
+        self.assertEqual(
+            len(dataset.rows), 2 * _ENCODED_MAX_CONCEALMENT_EVENTS_PER_CAMERA + 1
+        )
+        self.assertRegex(errors[0], "dropped an encoded frame")
+
+    def test_gap_past_per_episode_frame_budget_is_fatal(self) -> None:
+        base = time.perf_counter() + 0.1
+        step = 1.0 / 60.0
+        # Two-frame holes exhaust the frame budget before the event budget.
+        events = _ENCODED_MAX_CONCEALED_FRAMES_PER_CAMERA // 2
+        self.assertLess(events, _ENCODED_MAX_CONCEALMENT_EVENTS_PER_CAMERA)
+        packets = [(b"a0", base, base)]
+        for i in range(events + 1):
+            ts = base + 3 * (i + 1) * step
+            packets.append((f"a{3 * (i + 1)}".encode(), ts, base))
+        cameras = {"camera": _EncodedCamera(packets)}
+
+        dataset, errors, repairs, _ = self._run_encoded(
+            cameras, fps=60, rows=len(packets) * 3
+        )
+
+        self.assertEqual(len(repairs), events)
+        self.assertEqual(len(dataset.rows), 3 * events + 1)
         self.assertRegex(errors[0], "dropped an encoded frame")
 
     def test_row_zero_alignment_advances_only_lagging_all_intra_streams(

--- a/tests/test_recorder_capture_error.py
+++ b/tests/test_recorder_capture_error.py
@@ -11,10 +11,12 @@ from almond_axol.recording.record_proc import (
     InProcessRecorder,
     RecorderCaptureError,
     RecorderDatasetSaveError,
-    _ENCODED_MAX_CONCEALED_FRAMES_PER_CAMERA,
-    _ENCODED_MAX_CONCEALMENT_EVENTS_PER_CAMERA,
+    _ENCODED_CONCEALMENT_WINDOW_S,
+    _ENCODED_MAX_CONCEALMENT_EVENTS_PER_WINDOW,
+    _ENCODED_MIN_CONCEALED_FRAMES_PER_CAMERA,
     _align_independent_encoded_start,
     _concealable_encoded_gap_frames,
+    _concealment_within_budget,
     run_encoded_capture_loop,
 )
 
@@ -280,12 +282,12 @@ class DatasetRecorderCaptureErrorTest(unittest.TestCase):
         self.assertEqual([event["missing_frames"] for event in repairs], [1, 1])
         self.assertEqual([event["frame_index"] for event in repairs], [1, 3])
 
-    def test_gap_past_per_episode_budget_is_fatal(self) -> None:
+    def test_gap_burst_inside_window_is_fatal(self) -> None:
         base = time.perf_counter() + 0.1
         step = 1.0 / 60.0
         packets = [(b"a0", base, base)]
-        # One event over the per-camera budget, each a single missing frame.
-        for i in range(_ENCODED_MAX_CONCEALMENT_EVENTS_PER_CAMERA + 1):
+        # One event over the burst budget, back to back, each a single frame.
+        for i in range(_ENCODED_MAX_CONCEALMENT_EVENTS_PER_WINDOW + 1):
             ts = base + 2 * (i + 1) * step
             packets.append((f"a{2 * (i + 1)}".encode(), ts, base))
         cameras = {"camera": _EncodedCamera(packets)}
@@ -294,31 +296,84 @@ class DatasetRecorderCaptureErrorTest(unittest.TestCase):
             cameras, fps=60, rows=len(packets) * 2
         )
 
-        self.assertEqual(len(repairs), _ENCODED_MAX_CONCEALMENT_EVENTS_PER_CAMERA)
+        self.assertEqual(len(repairs), _ENCODED_MAX_CONCEALMENT_EVENTS_PER_WINDOW)
         self.assertEqual(
-            len(dataset.rows), 2 * _ENCODED_MAX_CONCEALMENT_EVENTS_PER_CAMERA + 1
+            len(dataset.rows), 2 * _ENCODED_MAX_CONCEALMENT_EVENTS_PER_WINDOW + 1
         )
         self.assertRegex(errors[0], "dropped an encoded frame")
 
-    def test_gap_past_per_episode_frame_budget_is_fatal(self) -> None:
+    def test_isolated_gaps_every_few_seconds_survive_a_long_take(self) -> None:
+        # Today's overhead pattern: one exposure lost every 1-4 s for the whole
+        # take. Spaced past the burst window and well under the fraction cap,
+        # every hole is repaired.
         base = time.perf_counter() + 0.1
         step = 1.0 / 60.0
-        # Two-frame holes exhaust the frame budget before the event budget.
-        events = _ENCODED_MAX_CONCEALED_FRAMES_PER_CAMERA // 2
-        self.assertLess(events, _ENCODED_MAX_CONCEALMENT_EVENTS_PER_CAMERA)
-        packets = [(b"a0", base, base)]
-        for i in range(events + 1):
-            ts = base + 3 * (i + 1) * step
-            packets.append((f"a{3 * (i + 1)}".encode(), ts, base))
+        spacing = 90  # frames between the lost exposures (1.5 s at 60 Hz)
+        packets = []
+        frame = 0
+        for _ in range(8):
+            for _ in range(spacing - 1):
+                packets.append((f"a{frame}".encode(), base + frame * step, base))
+                frame += 1
+            frame += 1  # the lost exposure
         cameras = {"camera": _EncodedCamera(packets)}
 
         dataset, errors, repairs, _ = self._run_encoded(
-            cameras, fps=60, rows=len(packets) * 3
+            cameras, fps=60, rows=8 * spacing - 1
         )
 
-        self.assertEqual(len(repairs), events)
-        self.assertEqual(len(dataset.rows), 3 * events + 1)
-        self.assertRegex(errors[0], "dropped an encoded frame")
+        self.assertEqual(errors, [])
+        self.assertEqual(len(repairs), 7)
+        self.assertEqual({event["missing_frames"] for event in repairs}, {1})
+
+    def test_concealment_budget_rules(self) -> None:
+        fps = 60
+        window = int(_ENCODED_CONCEALMENT_WINDOW_S * fps)
+        kwargs = dict(concealed_frames=0, missing=1, total_rows=1000, fps=fps)
+        # Two earlier events inside the window leave room for a third only.
+        self.assertTrue(
+            _concealment_within_budget(event_rows=[10, 50], row=100, **kwargs)
+        )
+        self.assertFalse(
+            _concealment_within_budget(event_rows=[10, 50, 90], row=100, **kwargs)
+        )
+        # Once the oldest event ages out of the window a new one fits again.
+        self.assertTrue(
+            _concealment_within_budget(
+                event_rows=[10, 50, 90], row=10 + window, **kwargs
+            )
+        )
+        # The frame allowance is the larger of the floor and the fraction.
+        self.assertTrue(
+            _concealment_within_budget(
+                event_rows=[],
+                row=10,
+                concealed_frames=_ENCODED_MIN_CONCEALED_FRAMES_PER_CAMERA - 1,
+                missing=1,
+                total_rows=10,
+                fps=fps,
+            )
+        )
+        self.assertFalse(
+            _concealment_within_budget(
+                event_rows=[],
+                row=10,
+                concealed_frames=_ENCODED_MIN_CONCEALED_FRAMES_PER_CAMERA,
+                missing=1,
+                total_rows=10,
+                fps=fps,
+            )
+        )
+        self.assertTrue(
+            _concealment_within_budget(
+                event_rows=[],
+                row=10_000,
+                concealed_frames=_ENCODED_MIN_CONCEALED_FRAMES_PER_CAMERA,
+                missing=2,
+                total_rows=10_000,
+                fps=fps,
+            )
+        )
 
     def test_row_zero_alignment_advances_only_lagging_all_intra_streams(
         self,


### PR DESCRIPTION
## Summary
Three dataset-capture fixes, stacked on #227.

### All-intra bitrate budget
- #224 made every dataset frame an IDR but left `dataset_vbr_bitrate` at the predictive-GOP budget (0.17 bpp, ~5.9 Mbps at 960x600@60). Intra frames cannot borrow bits from neighbours, so each frame got ~12 KB.
- Measured on the Jetson `nvv4l2h264enc` against 600 frames of a recorded `left_arm` video (`debur_082926`): GOP-15 @ 5.9 Mbps ≈ 44.8 dB PSNR-Y; all-intra @ 5.9 Mbps ≈ **31.1 dB** (visibly blocky flange-hole edges); all-intra @ 20.7 Mbps ≈ 41.2 dB (p5 39.7).
- Adds `dataset_intra_vbr_bitrate` (~0.6 bpp, peak 1.5x, clamped 8–50 Mbps) and uses it on the relay's all-intra dataset branch only; the in-process predictive `nvenc_encoder` path keeps the existing budget.
- Cost: ~3.5x per-camera dataset size (~0.6 → ~2.5 GB per recorded hour across four SVGA streams), which lengthens the nightly Pi ingest and S3 mirror. NVENC throughput is unaffected.

### Per-camera rate budget for gap repairs, plus source-loss attribution
- Every recording attempt today died within seconds of "Recording started" from dropped source frames: `left_arm` at 17:00; both overhead eyes at 19:07 and 19:33 (one exposure every 1-4 s for the whole take). Each time the take was discarded and the arms homed while the operator was still teleoperating.
- Recorder: the per-hole bound stays at two frames, but the fixed per-episode budget becomes a rate budget: at most 3 events per 2 s window per camera, and concealed frames within max(6, 2 %) of the episode. Repairs are still warned per row and summarized at save time.
- Relay: a probe on every camera source pad warns on a sensor-PTS gap with the streaming thread's `schedstat` wait since the previous frame (CPU starvation vs. time inside the SDK/link) and the GPU devfreq clock.

### Capture threads run SCHED_FIFO (the root cause)
- The attribution probe answered it on a static-arm session (20:19 log): every in-recording skipped exposure carried a **14–26 ms `CPU wait since previous frame`** — the `camsrc:src` streaming thread and the ZED SDK's workers were runnable but queued behind the ~80 CFS gst threads and the recorder on the shared cores for most of a 60 Hz period, so the SDK dropped the exposure. Warm-up gaps before the recorder attaches had ~0–4 ms wait (SDK startup, harmless). GPU clock, link, and arm motion were all ruled out.
- `affinity.prioritize_capture_threads` moves the capture chain — `<source>:src` plus every non-Python thread still carrying the process comm (GStreamer/GLib/NVENC/CUDA all rename theirs; the SDK's stay unnamed) — to SCHED_FIFO 5 once the pipelines are PLAYING. Below the CAN loops (20, disjoint cores), above every CFS thread; their load is a few percent of a core per camera and the kernel RT throttle caps a runaway at 95 %. Without CAP_SYS_NICE it logs once and leaves them CFS.

- Follow-up (teleop take, 21:34 log): with the source threads real-time, the loss moved one stage downstream — `eye_*_cropq` / `dsenc*_srcq` overran simultaneously on all three cameras while every source thread showed ~0 CPU wait, and `right_arm` lost 6 frames at once. Those queues are two deep because their consumer still holds an Argus-owned surface, so the FIFO class now covers exactly that chain (source + crop + dataset VIC-copy dispatch, from one list in `gst_zed.exposure_critical_thread_comms`; post-copy stages stay CFS). Each logged overrun also snapshots its consumer thread (state / wchan / runnable-wait since the previous overrun) so starvation and a VIC/memory stall read apart in the log; event-only, no per-buffer probes.

### Last mp4 sample no longer written with duration 0 (every save failed)
- The first take that survived to Save (20:57 log, ~93 s, zero skipped exposures with the FIFO capture threads) failed at finalize: `overhead_left ... finalized with 5555 packets (5556 advertised) after accepting 5556 access units`. Reproduced deterministically off-robot for any length (3, 10, 100, 5556 AUs): `stts = [(n-1, 1000), (1, 0)]`, track duration `(n-1)/fps`, edit list one frame short — ffmpeg honours it and never yields the last frame.
- Cause: the recorder's appsrc caps had no framerate and NVENC's SPS has no VUI timing, so `h264parse` dropped the per-buffer duration; `mp4mux` takes a sample's duration from the *next* buffer's PTS and, for the final one at EOS, from the buffer duration — hence 0. The validator added in `25ca408` is correct; before it, every episode silently shipped one visible frame short.
- Fix: `framerate={fps}/1` on the appsrc caps. Regression test against the real gst stack uses `openh264enc` (no VUI timing, like NVENC — `x264enc` masks the bug); skipped where not installed.

## Test plan
- [x] `tests.test_h264_mux_finalize` in the station venv: fails without the caps framerate (`2 packets (3 advertised)`), passes with it; 5556-AU synthetic all-intra stream muxes to 5556 demuxable samples
- [x] `python -m unittest tests.test_gst_dataset_transport tests.test_encoded_au_reader tests.test_h264_mux_stats tests.test_recorder_capture_error tests.test_affinity`
- [x] Source-gap probe exercised on the live overhead camera; thread targeting verified against a live `zedsrc` pipeline (`camsrc:src` + 4 unnamed SDK threads matched, encoder/VIC/CUDA threads left alone)
- [x] ruff check / format
- [x] Static-arm episode on the station: `camera capture threads -> SCHED_FIFO 5 (27 threads ...)`, zero `skipped exposure(s)` across a 93 s recording (20:57 log)
- [x] Overrun attribution exercised live on a mono camera (`dsenc_outq:src state=S wchan=futex_wait_queue_me, CPU wait 0.0ms` while no recorder is attached — blocked, not starved)
- [ ] Teleop take on the station: no `eye_*_cropq` / `dsenc*_srcq` overruns after "Recording started"; if any, the `consumer ... state=` field says whether it was CPU or hardware
- [ ] Save an episode on the station: `H264 mux finalize ... (N frames)` for all four cameras and the episode commits

## jetson.setup: GPU clock pin + nvargus-daemon SCHED_FIFO

With the relay capture threads realtime, the remaining drops were all three cameras skipping the same exposures at once with ~0 ms CPU wait on our side — i.e. waiting on something outside the process. Two station-level gaps: the GPU sat on `nvhost_podgov`'s 306 MHz floor (every attributed drop logged `gpu 306/918MHz`) under the ZED SDK's CUDA work, and `nvargus-daemon` — the per-frame capture-request loop for every ZED X sensor — ran as plain CFS on all cores. `jetson.setup` now pins the GPU devfreq like NVENC/VIC (not used as a Jetson marker: other ARM SoCs have `*.gpu` devfreq nodes) and installs a systemd drop-in + `chrt -a` for the live daemon (SCHED_FIFO 6, above the relay capture threads, below the CAN loops), never restarting it under running cameras. Unit tests in `tests/test_jetson.py`.