### PR TITLE
Decouple real-time camera capture from CAN feedback on Jetson

### DIFF
--- a/almond_axol/cli/jetson/setup.py
+++ b/almond_axol/cli/jetson/setup.py
@@ -1,16 +1,24 @@
 """
 axol jetson.setup
 
-Pin the Jetson clocks the real-time loops need: the NVENC/VIC engine devfreq
-nodes (so the camera relay's hardware H.264 encode stays low-latency) and the
-CPU governor (so the bursty IK loop isn't underclocked). See
-:mod:`almond_axol.utils.jetson` for why the Tegra defaults hurt.
+Apply the per-boot Jetson tuning the real-time loops need: select the MAXN
+power mode, pin the NVENC/VIC/GPU engine clocks (so the camera relay's
+hardware H.264 encode and ZED SDK processing stay low-latency), set the CPU
+``performance`` governor (so the bursty IK loop isn't underclocked), steer the
+CAN adapters' USB-controller interrupt onto a CAN core (so real-time camera
+work can never delay motor feedback), and schedule the Argus camera daemon
+``SCHED_FIFO`` on the camera cores (so all-camera frame drops under load stop).
+See :mod:`almond_axol.utils.jetson` for why each Tegra default hurts.
 
-These reset on every reboot, so this runs at boot from the systemd unit the
-host installer registers (``ExecStartPre`` on ``axol.service``), and once
+All of it resets on every reboot, so this runs at boot from the systemd unit
+the host installer registers (``ExecStartPre`` on ``axol.service``), and once
 during install. It is intentionally *not* called from ``teleop`` /
 ``collect-data`` / ``serve`` — those just run. Best-effort and a no-op on
 non-Jetson machines.
+
+The install-time counterpart is ``axol provision``, which grants the
+operator's login the rtprio allowance a manual ``axol serve`` needs to run the
+camera relay's capture chain real-time in the first place.
 """
 
 from __future__ import annotations
@@ -24,12 +32,15 @@ def add_parser(subparsers) -> None:  # type: ignore[type-arg]
     """Register the ``jetson.setup`` subcommand."""
     subparsers.add_parser(
         "jetson.setup",
-        help="Pin the Jetson NVENC/VIC and CPU clocks for the real-time loops.",
+        help=(
+            "Per-boot Jetson tuning: MAXN, engine + CPU clocks, CAN interrupt "
+            "placement, and real-time camera daemon scheduling."
+        ),
     ).set_defaults(func=run)
 
 
 def run(_args: object = None) -> None:
-    """Pin the Jetson engine + CPU clocks (interactive sudo when on a tty)."""
+    """Apply the Jetson real-time tuning (interactive sudo when on a tty)."""
     # Surface the pin functions' INFO/WARNING logs (which command did what);
     # force=True in case an imported dependency already installed a handler.
     logging.basicConfig(level=logging.INFO, format="%(message)s", force=True)

--- a/almond_axol/cli/provision.py
+++ b/almond_axol/cli/provision.py
@@ -98,6 +98,10 @@ def _step(label: str, fn: Callable[[], object]) -> bool:
 
 def run(_args: object = None) -> None:
     """Run every provisioning step in order; each self-gates and is idempotent."""
+    # Surface each step's INFO outcome (what was granted/installed, or already
+    # in place) so a run at a customer site is verifiable from its output alone;
+    # force=True in case an imported dependency already installed a handler.
+    logging.basicConfig(level=logging.INFO, format="%(message)s", force=True)
     # adb + the Oculus udev rule (which hands the headset to the `dialout`
     # group operators already have, so adb needs no extra group or re-login)
     # and adds the operator to that group — for streaming Quest controller

--- a/almond_axol/cli/provision.py
+++ b/almond_axol/cli/provision.py
@@ -23,6 +23,12 @@ The single idempotent provisioning path for the pieces ``uv tool install`` /
                       via rustup if needed; sources fetched at the installed
                       package's ref for tool installs), required by hardware
                       control (see :mod:`almond_axol.rt`).
+* rtprio grant      — a ``limits.d`` drop-in letting the operator's login run
+                      the camera relay's capture chain ``SCHED_FIFO`` from a
+                      manual ``axol serve`` (the systemd unit already has
+                      ``LimitRTPRIO``); without it the relay silently runs
+                      CFS and drops exposures under recording load (see
+                      :mod:`almond_axol.utils.rtprio`).
 
 Both the hosted installer (``web/app/public/install``) and the ``axol serve``
 self-updater (:mod:`almond_axol.serve.update`) run *this* command, so the set
@@ -32,8 +38,9 @@ on the ZED SDK / apt / NVENC), so it is safe to run on any host. The hosted
 installer and post-upgrade path add ``--require-rt``: optional hardware remains
 best-effort, but a failed required control-core install makes the command fail.
 
-It does NOT pin Jetson clocks — that's ``axol jetson.setup``, a per-boot runtime
-tweak owned by the systemd ``ExecStartPre``, not an install step.
+It does NOT pin Jetson clocks or steer the CAN adapters' interrupt — that's
+``axol jetson.setup``, a per-boot runtime tweak owned by the systemd
+``ExecStartPre``, not an install step.
 """
 
 from __future__ import annotations
@@ -44,7 +51,7 @@ from pathlib import Path
 
 from ..robot import gyro
 from ..rt import install as rt_install
-from ..utils import adb
+from ..utils import adb, rtprio
 from .gst import build_zed as gst_build_zed
 from .gst import install as gst_install
 from .zed import driver as zed_driver
@@ -63,7 +70,8 @@ def add_parser(subparsers) -> None:  # type: ignore[type-arg]
         "provision",
         help=(
             "Install/refresh the non-PyPI + system pieces "
-            "(cameras, adb, board access, and the axol-rt control core)."
+            "(cameras, adb, board access, the operator's real-time scheduling "
+            "grant, and the axol-rt control core)."
         ),
     )
     parser.add_argument(
@@ -105,6 +113,10 @@ def run(_args: object = None) -> None:
     # Group access to the board IMU's sampling timer, so teleop can start the
     # Jelly's yaw reference without root. Self-gates on the driver's presence.
     _step("board IMU (gyro.install)", gyro.install)
+    # Persistent rtprio allowance for the operator's login, so a manual
+    # `axol serve` can run the camera relay's capture chain SCHED_FIFO like
+    # the systemd unit does (LimitRTPRIO). Applies at the next login.
+    _step("rtprio grant (utils.rtprio)", rtprio.install)
     have_sdk = _ZED_SDK.exists()
     if have_sdk:
         _step("pyzed (zed.install)", zed_install.run)

--- a/almond_axol/rt/link.py
+++ b/almond_axol/rt/link.py
@@ -193,15 +193,18 @@ class RtLink:
             slots[i] = (pos, vel, tau, now - age_us / 1e6)
         return side, slots
 
-    def _send(self, payload: bytes) -> None:
-        if self._fault is not None:
+    def _send(self, payload: bytes, *, allow_faulted: bool = False) -> None:
+        if self._fault is not None and not allow_faulted:
             raise RtLinkError(f"axol-rt: {self._fault}")
         if self._writer is None or self._writer.is_closing():
             raise RtLinkError("axol-rt link is not connected")
         self._writer.write(struct.pack("<I", len(payload)) + payload)
 
-    async def _await_state(self, expected: str, timeout: float) -> None:
-        """Wait for a state message; a ``fault:`` state raises."""
+    async def _await_state(
+        self, expected: str, timeout: float, *, tolerate_fault: bool = False
+    ) -> None:
+        """Wait for a state message; a ``fault:`` state raises unless
+        ``tolerate_fault`` (teardown after a fault still wants the ack)."""
         deadline = asyncio.get_running_loop().time() + timeout
         while True:
             remaining = deadline - asyncio.get_running_loop().time()
@@ -215,7 +218,7 @@ class RtLink:
                 ) from None
             if state == expected:
                 return
-            if state.startswith("fault:"):
+            if state.startswith("fault:") and not tolerate_fault:
                 raise RtLinkError(f"axol-rt: {state}")
             # Unrelated state (e.g. a stats line routed as state) — keep waiting.
 
@@ -232,8 +235,11 @@ class RtLink:
         await self._await_state("armed", _ARM_TIMEOUT_S)
 
     async def disarm(self) -> None:
-        self._send(b"D")
-        await self._await_state("disarmed", 5.0)
+        # Always deliverable, fault or not: after a fault the core has already
+        # disabled the motors, and `D` lets it join its bus threads and ack
+        # instead of treating our socket close as an orphaned-client crash.
+        self._send(b"D", allow_faulted=True)
+        await self._await_state("disarmed", 5.0, tolerate_fault=True)
 
     def send_target(
         self,

--- a/almond_axol/utils/adb.py
+++ b/almond_axol/utils/adb.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import grp
 import logging
-import os
 import pwd
 import shutil
 import subprocess
@@ -24,6 +23,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from .ports import VR_PORT
+from .rtprio import operator_user
 from .sudo import prime_sudo, run_root
 
 _logger = logging.getLogger(__name__)
@@ -74,25 +74,8 @@ def _read_rule() -> str:
 
 
 def _operator_user() -> str | None:
-    """Best-effort operator login to grant headset (``dialout``) access.
-
-    ``axol serve`` runs as root under systemd with no ``SUDO_USER``, so fall
-    back to the owner of the first ``/home/*`` entry — the same heuristic the
-    hosted installer uses to locate the operator's account.
-    """
-    user = os.environ.get("SUDO_USER")
-    if user and user != "root":
-        return user
-    try:
-        homes = sorted(Path("/home").iterdir())
-    except OSError:
-        return None
-    for home in homes:
-        try:
-            return home.owner()
-        except (KeyError, OSError):
-            continue
-    return None
+    """Best-effort operator login to grant headset (``dialout``) access."""
+    return operator_user()
 
 
 def _in_group(user: str, group: str) -> bool:

--- a/almond_axol/utils/affinity.py
+++ b/almond_axol/utils/affinity.py
@@ -46,7 +46,7 @@ _MIN_CORES = 4
 
 
 def core_groups() -> dict[str, set[int]] | None:
-    """``{"can", "realtime", "ik", "relay", "background"}`` → core sets.
+    """``{"can", "realtime", "ik", "relay", "background", "irq"}`` → core sets.
 
     Based on the machine's *physical* core count, NOT the process's current
     affinity: the control process pins itself before spawning the relay/recorder,
@@ -62,6 +62,21 @@ def core_groups() -> dict[str, set[int]] | None:
     interrupts. This also avoids the old shared ``realtime`` layout where
     camera/WebRTC bookkeeping made 5-15% of nominal 240 Hz motor ticks late.
     ``ik`` remains a dedicated core so it cannot deschedule CAN or Python.
+
+    ``irq`` names the CPU the kernel delivers that interrupt to by default
+    (CPU0 on every Jetson seen so far). Only *CFS* work may run there: a CAN
+    reply reaches the socket through the interrupt's bottom half (URB
+    giveback + NET_RX softirq) on that CPU, and any ``SCHED_FIFO`` userspace
+    thread runnable there delays it for as long as it runs — measured
+    2026-09-02 on a customer robot: the FIFO camera capture set on CPU0
+    pushed *both arms'* replies past the 240 Hz reply window and faulted the
+    core within 10 s of arming, and raising ``ksoftirqd/0`` above the camera
+    priorities did not help. What did was moving the interrupt itself onto a
+    CAN core (:func:`can_irq_cpu`), which ``jetson.setup`` does at every boot:
+    the whole receive path then runs where its consumer already is and no
+    camera thread is allowed. :func:`realtime_camera_cores` additionally
+    keeps real-time camera work off the ``irq`` CPU, so the two subsystems
+    stay decoupled even when that steering has not (yet) been applied.
 
     The relay gets *two* private cores so :func:`isolate_relay_cpu` can keep its
     Python work (the aiortc WebRTC send + encoded-AU pull loops, all
@@ -80,11 +95,15 @@ def core_groups() -> dict[str, set[int]] | None:
     n = os.cpu_count()
     if not n or n < _MIN_CORES:
         return None
+    # The Jetson's xHCI interrupt lands on CPU0 until jetson.setup steers it
+    # (its nominal mask says all CPUs; the GIC picks CPU0); every layout keeps
+    # SCHED_FIFO camera work off it.
+    irq = {0}
     if n >= 8:
-        # CPU0 services the Jetson's xHCI interrupt (both USB CAN adapters and
-        # cameras) and is therefore a poor place for a motor deadline. Put the
-        # Rust bus loops on the last two cores and leave the housekeeping CPUs
-        # to throughput-tolerant dataset work.
+        # CPU0 takes the Jetson's xHCI interrupt by default (both USB CAN
+        # adapters and cameras) and is therefore a poor place for a motor
+        # deadline. Put the Rust bus loops on the last two cores and leave the
+        # housekeeping CPUs to throughput-tolerant dataset work.
         can = {n - 2, n - 1}
         rt = {2}
         ik = {3}
@@ -104,7 +123,52 @@ def core_groups() -> dict[str, set[int]] | None:
         "ik": ik,
         "relay": relay,
         "background": bg,
+        "irq": irq,
     }
+
+
+def realtime_camera_cores() -> set[int] | None:
+    """Cores where ``SCHED_FIFO`` camera work is allowed to run.
+
+    The relay's throughput cores (everything but its Python core) plus the
+    background cores — the same pool :func:`isolate_relay_cpu` gives the CFS
+    GStreamer workers — **minus** the ``irq`` CPU. The capture chain the relay
+    elevates (:func:`prioritize_capture_threads`) and the Argus daemon
+    ``jetson.setup`` elevates both live here, so neither can ever sit on the
+    CPU the CAN adapters' interrupt is delivered to before ``jetson.setup``
+    steers it away (see :func:`core_groups`), nor land on a control, IK, or
+    CAN core. ``None`` when partitioning isn't applicable or the pool would be
+    empty.
+    """
+    groups = core_groups()
+    if groups is None:
+        return None
+    relay = sorted(groups["relay"])
+    py_core = {relay[0]} if relay else set()
+    cores = (set(relay[1:]) | groups["background"]) - py_core - groups["irq"]
+    return cores or None
+
+
+def can_irq_cpu() -> int | None:
+    """CPU the CAN adapters' USB-controller interrupt should be delivered to.
+
+    The highest CAN core: the bus loop pinned there is the interrupt's
+    consumer, so the hardirq, URB giveback, NET_RX softirq and socket wake-up
+    all run on a core that carries nothing but an ``axol-rt`` ``SCHED_FIFO``
+    thread and its own idle time. That thread spends most of each 4.17 ms
+    period blocked on exactly this interrupt, so it and the bottom half never
+    compete, and no camera or dataset thread is ever scheduled there (see
+    :func:`core_groups`). ``None`` when the host has no CAN partition.
+
+    This is the placement that ended the camera-versus-CAN coupling in the
+    field (2026-09-02: 160 s of full-load recording with zero missed replies
+    beyond load transitions, versus a fault 10 s after arming with the
+    interrupt on CPU0). ``jetson.setup`` applies it per boot.
+    """
+    groups = core_groups()
+    if groups is None or not groups["can"]:
+        return None
+    return max(groups["can"])
 
 
 def pin_realtime() -> bool:
@@ -226,10 +290,16 @@ def isolate_relay_cpu() -> bool:
     return True
 
 
-# SCHED_FIFO priority for the camera capture threads. Well below the CAN loops
-# (`AXOL_RT_FIFO_PRIORITY`, 20) and on disjoint cores anyway; above every CFS
-# thread so a capture wake-up never queues behind the encode/mux workers.
+# The SCHED_FIFO ladder across the stack, lowest to highest:
+#   CAPTURE_FIFO_PRIORITY  (5)  relay camera capture chain
+#   capture daemon         (6)  nvargus-daemon, see utils.jetson
+#   axol-rt CAN loops     (20)  AXOL_RT_FIFO_PRIORITY, rt.link
+# Camera work sits above every CFS thread so a capture wake-up never queues
+# behind the encode/mux workers; the CAN loops outrank everything and run on
+# disjoint cores anyway. The top rung is also what the persistent rtprio grant
+# (utils.rtprio, LimitRTPRIO in the service unit) allows a non-root launcher.
 CAPTURE_FIFO_PRIORITY = 5
+MAX_FIFO_PRIORITY = 20
 
 
 def prioritize_capture_threads(thread_comms: Iterable[str]) -> int:
@@ -261,11 +331,19 @@ def prioritize_capture_threads(thread_comms: Iterable[str]) -> int:
     ``gst_zed.exposure_critical_thread_comms``) plus every non-Python thread
     that still carries the process's own ``comm`` — GStreamer, GLib, NVENC and
     CUDA all rename theirs, so an unrenamed thread in the relay is the SDK's.
-    Call once after the pipelines are PLAYING (the threads exist by then).
-    Returns the number of threads moved; ``0`` when the platform has no
-    ``sched_setscheduler`` or the process lacks ``CAP_SYS_NICE`` (a manual
-    unprivileged run — the failure is logged once and the threads stay CFS,
-    exactly the previous behaviour).
+
+    Every thread it elevates is also confined to :func:`realtime_camera_cores`.
+    :func:`isolate_relay_cpu` leaves the gst pool free to use the CPU the CAN
+    adapters' interrupt lands on by default, which is fine for CFS work but
+    not for a FIFO thread: one runnable there delays the interrupt's bottom
+    half and with it both arms' CAN feedback (see :func:`core_groups`). Call
+    once after the pipelines are PLAYING (the threads exist by then). Returns
+    the number of threads moved; ``0`` when the platform has no
+    ``sched_setscheduler`` or the process lacks ``CAP_SYS_NICE`` / an rtprio
+    allowance — a manual run from a shell without the ``axol provision``
+    rtprio grant. That case is logged as a warning (it is the whole story
+    behind an otherwise puzzling run of skipped exposures) and the threads
+    stay CFS, exactly the previous behaviour.
     """
     if not hasattr(os, "sched_setscheduler") or not hasattr(os, "SCHED_FIFO"):
         return 0
@@ -280,6 +358,7 @@ def prioritize_capture_threads(thread_comms: Iterable[str]) -> int:
         return 0
     wanted = set(thread_comms) | {process_comm}
     param = os.sched_param(CAPTURE_FIFO_PRIORITY)  # type: ignore[attr-defined]
+    cores = realtime_camera_cores() if hasattr(os, "sched_setaffinity") else None
     moved = 0
     denied: OSError | None = None
     for entry in tasks:
@@ -303,17 +382,28 @@ def prioritize_capture_threads(thread_comms: Iterable[str]) -> int:
             denied = exc
             break
         except OSError:
-            pass
+            continue
+        if cores is not None:
+            try:
+                os.sched_setaffinity(tid, cores)  # type: ignore[attr-defined]
+            except OSError:
+                pass  # exited; the FIFO call above already succeeded
     if denied is not None:
-        _logger.info(
+        _logger.warning(
             "camera capture threads stay SCHED_OTHER (no CAP_SYS_NICE: %s); "
-            "expect skipped exposures under recording load",
+            "expect skipped exposures under recording load. Run `axol provision` "
+            "and log in again (or `sudo prlimit --pid $$ --rtprio=%d:%d` in this "
+            "shell) so a manual `axol serve` may use SCHED_FIFO",
             denied,
+            MAX_FIFO_PRIORITY,
+            MAX_FIFO_PRIORITY,
         )
     elif moved:
         _logger.info(
-            "camera capture threads -> SCHED_FIFO %d (%d threads: %s + SDK workers)",
+            "camera capture threads -> SCHED_FIFO %d on cores %s (%d threads: %s "
+            "+ SDK workers)",
             CAPTURE_FIFO_PRIORITY,
+            sorted(cores) if cores is not None else "(unpinned)",
             moved,
             ", ".join(sorted(wanted - {process_comm})),
         )

--- a/almond_axol/utils/jetson.py
+++ b/almond_axol/utils/jetson.py
@@ -522,7 +522,9 @@ def _steer_can_irq(escalator: _RootEscalator) -> None:
         return
     for irq, action in sorted(irqs.items()):
         if _irq_affinity(irq, proc_root=_PROC_ROOT) == {target}:
-            _logger.debug("irq %d (%s) already on CPU %d", irq, action, target)
+            _logger.info(
+                "irq %d (%s) already on CPU %d (a CAN core)", irq, action, target
+            )
             continue
         path = _PROC_ROOT / "irq" / str(irq) / "smp_affinity_list"
         ok, detail = escalator.write(path, f"{target}\n")

--- a/almond_axol/utils/jetson.py
+++ b/almond_axol/utils/jetson.py
@@ -25,7 +25,24 @@ Tegra defaults trade latency for power/throughput and hurt us:
   cameras feed, and all cameras miss the same frames at once (the relay's
   own capture threads then report ~0 ms CPU wait: they are waiting on the
   daemon, not on the scheduler). :func:`pin_realtime_clocks` runs it
-  ``SCHED_FIFO`` one notch above those relay capture threads.
+  ``SCHED_FIFO`` one notch above those relay capture threads, confined to
+  the same camera cores (``affinity.realtime_camera_cores``) so a
+  real-time daemon never lands on a control, IK, CAN, or interrupt core.
+
+* **CAN interrupt placement** — both USB CAN adapters hang off one xHCI
+  controller whose interrupt the GIC delivers to CPU0, a core the camera
+  relay's worker pool also uses. Every motor reply crosses that CPU's
+  interrupt bottom half (URB giveback, NET_RX softirq), and any
+  ``SCHED_FIFO`` thread runnable there delays it: with the relay's capture
+  chain real-time the core faulted 10 s after arming on a customer robot
+  (2026-09-02), and raising ``ksoftirqd/0`` above the camera priorities did
+  not help. Steering the interrupt onto the highest CAN core did — the whole
+  receive path then runs beside its consumer, where no camera or dataset
+  thread is ever scheduled, and a 160 s full-load recording finished with
+  zero missed replies outside load transitions. :func:`pin_realtime_clocks`
+  applies that steering (``affinity.can_irq_cpu``) at every boot; the
+  interrupt number is resolved from the CAN interfaces' USB bus, never
+  hard-coded.
 
 The clock ceilings are themselves capped by the ``nvpmodel`` power mode, so
 :func:`pin_realtime_clocks` first selects MAXN (mode 0) to uncap them, then
@@ -42,7 +59,8 @@ import shutil
 import subprocess
 from pathlib import Path
 
-from .affinity import CAPTURE_FIFO_PRIORITY
+from ..constants import CAN_LEFT, CAN_RIGHT
+from .affinity import CAPTURE_FIFO_PRIORITY, can_irq_cpu, realtime_camera_cores
 from .sudo import prime_sudo
 
 _logger = logging.getLogger(__name__)
@@ -67,6 +85,14 @@ _CAPTURE_DAEMON_DROPIN = "50-axol-realtime.conf"
 # far below the axol-rt CAN loops (SCHED_FIFO 20).
 _CAPTURE_DAEMON_FIFO_PRIORITY = CAPTURE_FIFO_PRIORITY + 1
 _SYSTEMD_UNIT_DIR = Path("/etc/systemd/system")
+
+# The arm-hub CAN interfaces. Their ``/sys/class/net/<if>/device`` link names
+# the USB bus they hang off, and that bus's host controller owns the
+# ``/proc/interrupts`` row (``xhci-hcd:usbN``) every motor reply arrives on.
+_CAN_ARM_INTERFACES = (CAN_LEFT, CAN_RIGHT)
+_USB_HOST_CONTROLLER = "xhci-hcd"
+_PROC_ROOT = Path("/proc")
+_SYS_ROOT = Path("/sys")
 
 # ``/proc/<tid>/stat`` policy value for SCHED_FIFO (sched.h SCHED_FIFO == 1).
 _SCHED_FIFO = 1
@@ -344,25 +370,221 @@ def _threads_at_fifo(
     return True
 
 
+def _parse_cpu_list(text: str) -> set[int]:
+    """``"0-2,5"`` (the kernel's / ``taskset -c`` list syntax) → ``{0,1,2,5}``."""
+    cpus: set[int] = set()
+    for part in text.strip().split(","):
+        part = part.strip()
+        if not part:
+            continue
+        lo, _, hi = part.partition("-")
+        cpus.update(range(int(lo), int(hi or lo) + 1))
+    return cpus
+
+
+def _cpu_list(cores: set[int]) -> str:
+    """``{1, 5}`` → ``"1,5"`` for ``taskset -c``."""
+    return ",".join(str(c) for c in sorted(cores))
+
+
+def _threads_on_cpus(
+    pid: int, cores: set[int], *, proc_root: Path = _PROC_ROOT
+) -> bool | None:
+    """True when every thread of ``pid`` is confined to exactly ``cores``.
+
+    ``None`` when the process cannot be inspected (gone, or unreadable).
+    """
+    tasks = sorted((proc_root / str(pid) / "task").glob("*"))
+    if not tasks:
+        return None
+    for task in tasks:
+        try:
+            status = (task / "status").read_text()
+        except OSError:
+            return None
+        allowed = None
+        for line in status.splitlines():
+            if line.startswith("Cpus_allowed_list:"):
+                allowed = _parse_cpu_list(line.split(":", 1)[1])
+                break
+        if allowed is None:
+            return None
+        if allowed != cores:
+            return False
+    return True
+
+
+def _can_usb_buses(*, sys_root: Path = _SYS_ROOT) -> set[str]:
+    """USB bus numbers the arm-hub CAN interfaces are enumerated on.
+
+    ``/sys/class/net/<if>/device`` resolves to the interface's USB function
+    directory, ``<bus>-<port[.port...]>:<config>.<iface>`` (e.g.
+    ``1-2.2:1.0``); the leading number is the bus, i.e. the host controller.
+    Interfaces that are absent (adapter unplugged, other host) are skipped.
+    """
+    buses: set[str] = set()
+    for iface in _CAN_ARM_INTERFACES:
+        try:
+            name = (sys_root / "class/net" / iface / "device").resolve().name
+        except OSError:
+            continue
+        bus = name.split(":", 1)[0].split("-", 1)[0]
+        if bus.isdigit():
+            buses.add(bus)
+    return buses
+
+
+def _can_usb_irqs(
+    *, proc_root: Path = _PROC_ROOT, sys_root: Path = _SYS_ROOT
+) -> dict[int, str]:
+    """``{irq: action}`` for the host controller(s) the CAN adapters hang off.
+
+    Rows of ``/proc/interrupts`` whose action names ``xhci-hcd:usb<bus>`` for
+    one of :func:`_can_usb_buses`. When no CAN interface can be resolved to a
+    bus (adapters unplugged at setup time, or a host that enumerates them
+    differently) every ``xhci-hcd`` row is returned instead, so a Jetson still
+    gets its USB interrupts off the camera cores. Empty when the table is
+    unreadable or names no such controller.
+    """
+    try:
+        lines = (proc_root / "interrupts").read_text().splitlines()
+    except OSError:
+        return {}
+    buses = _can_usb_buses(sys_root=sys_root)
+    wanted = {f"{_USB_HOST_CONTROLLER}:usb{bus}" for bus in buses}
+    found: dict[int, str] = {}
+    for line in lines[1:]:
+        irq, sep, _rest = line.partition(":")
+        irq = irq.strip()
+        if not sep or not irq.isdigit():
+            continue
+        action = line.split()[-1]
+        if not action.startswith(_USB_HOST_CONTROLLER):
+            continue
+        if wanted and action not in wanted:
+            continue
+        found[int(irq)] = action
+    return found
+
+
+def _irq_affinity(irq: int, *, proc_root: Path = _PROC_ROOT) -> set[int] | None:
+    """CPUs ``irq`` may currently be delivered to; ``None`` if unreadable."""
+    try:
+        return _parse_cpu_list(
+            (proc_root / "irq" / str(irq) / "smp_affinity_list").read_text()
+        )
+    except (OSError, ValueError):
+        return None
+
+
+def _irqbalance_active() -> bool:
+    """True when the ``irqbalance`` service is running (it would undo our steering)."""
+    systemctl = shutil.which("systemctl")
+    if systemctl is None:
+        return False
+    try:
+        proc = subprocess.run(
+            [systemctl, "is-active", "--quiet", "irqbalance.service"],
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return False
+    return proc.returncode == 0
+
+
+def _steer_can_irq(escalator: _RootEscalator) -> None:
+    """Deliver the CAN adapters' USB-controller interrupt to a CAN core.
+
+    Jetson-only and best-effort. ``/proc/irq/<n>/smp_affinity_list`` is
+    per-boot state, so ``jetson.setup`` re-applies it from the service's
+    ``ExecStartPre`` after every reboot; the interrupt number is looked up
+    each time (see :func:`_can_usb_irqs`). The target core is
+    :func:`affinity.can_irq_cpu`; see :mod:`almond_axol.utils.affinity` for
+    why this, and not a ``ksoftirqd`` priority, is what keeps real-time camera
+    work from stalling both arms' motor feedback.
+    """
+    if not _is_jetson():
+        _logger.debug("not a Jetson; leaving interrupt affinity alone")
+        return
+    target = can_irq_cpu()
+    if target is None:
+        _logger.debug("no CAN core partition on this host; not steering interrupts")
+        return
+    irqs = _can_usb_irqs(proc_root=_PROC_ROOT, sys_root=_SYS_ROOT)
+    if not irqs:
+        _logger.warning(
+            "no %s interrupt found in /proc/interrupts; the CAN adapters' replies "
+            "stay on the kernel's default CPU, where real-time camera work can "
+            "delay them",
+            _USB_HOST_CONTROLLER,
+        )
+        return
+    for irq, action in sorted(irqs.items()):
+        if _irq_affinity(irq, proc_root=_PROC_ROOT) == {target}:
+            _logger.debug("irq %d (%s) already on CPU %d", irq, action, target)
+            continue
+        path = _PROC_ROOT / "irq" / str(irq) / "smp_affinity_list"
+        ok, detail = escalator.write(path, f"{target}\n")
+        if ok and _irq_affinity(irq, proc_root=_PROC_ROOT) == {target}:
+            _logger.info(
+                "irq %d (%s) -> CPU %d: CAN replies now arrive on a CAN core, "
+                "off the camera cores",
+                irq,
+                action,
+                target,
+            )
+        else:
+            _logger.warning(
+                "cannot steer irq %d (%s) to CPU %d (%s) — real-time camera work "
+                "on its CPU can stall both arms' CAN feedback. Fix manually with: "
+                "echo %d | sudo tee %s",
+                irq,
+                action,
+                target,
+                detail or "affinity unchanged after write",
+                target,
+                path,
+            )
+    if _irqbalance_active():
+        _logger.warning(
+            "irqbalance is running and may move the CAN adapters' interrupt back "
+            "onto a camera core; disable it with: sudo systemctl disable --now "
+            "irqbalance"
+        )
+
+
 def _prioritize_capture_daemons(escalator: _RootEscalator) -> None:
     """Run the camera capture daemon(s) SCHED_FIFO, now and after restarts.
 
     Jetson-only and best-effort. Two halves per unit: a systemd drop-in so
-    the policy applies whenever the daemon (re)starts, and ``chrt -a`` on the
-    live process so it applies right now without restarting the daemon under
-    running cameras (threads it creates later inherit the policy).
+    the policy applies whenever the daemon (re)starts, and ``chrt -a`` /
+    ``taskset -a`` on the live process so it applies right now without
+    restarting the daemon under running cameras (threads it creates later
+    inherit both).
+
+    A real-time daemon must not roam: confined to the camera cores
+    (:func:`affinity.realtime_camera_cores`) it cannot preempt the Python
+    control loop or IK, nor sit on the CPU the CAN adapters' interrupt lands
+    on before :func:`_steer_can_irq` moves it, where a FIFO thread delays the
+    interrupt's bottom half and with it both arms' feedback.
     """
     if not _is_jetson():
         _logger.debug("not a Jetson; leaving the camera daemons' scheduling alone")
         return
+    cores = realtime_camera_cores()
     dropin_text = (
         "# Installed by `axol jetson.setup`: every ZED X camera frame passes\n"
         "# through this daemon, so it must not be descheduled behind the\n"
-        "# control/IK/recorder load the cameras feed.\n"
+        "# control/IK/recorder load the cameras feed. It is confined to the\n"
+        "# camera cores: a real-time thread on the CAN adapters' interrupt CPU\n"
+        "# would stall both arms' motor feedback.\n"
         "[Service]\n"
         "CPUSchedulingPolicy=fifo\n"
         f"CPUSchedulingPriority={_CAPTURE_DAEMON_FIFO_PRIORITY}\n"
     )
+    if cores is not None:
+        dropin_text += f"CPUAffinity={' '.join(str(c) for c in sorted(cores))}\n"
     for unit in _CAPTURE_DAEMON_UNITS:
         pid = _service_main_pid(unit)
         dropin = _SYSTEMD_UNIT_DIR / f"{unit}.d" / _CAPTURE_DAEMON_DROPIN
@@ -401,24 +623,46 @@ def _prioritize_capture_daemons(escalator: _RootEscalator) -> None:
                 )
         if pid == 0:
             continue
-        if _threads_at_fifo(pid, _CAPTURE_DAEMON_FIFO_PRIORITY):
+        if not _threads_at_fifo(pid, _CAPTURE_DAEMON_FIFO_PRIORITY):
+            ok, detail = escalator.run(
+                ["chrt", "-f", "-a", "-p", str(_CAPTURE_DAEMON_FIFO_PRIORITY), str(pid)]
+            )
+            if ok:
+                _logger.info(
+                    "%s (pid %d) -> SCHED_FIFO %d",
+                    unit,
+                    pid,
+                    _CAPTURE_DAEMON_FIFO_PRIORITY,
+                )
+            else:
+                _logger.warning(
+                    "cannot re-schedule the running %s (pid %d) SCHED_FIFO (%s) — it "
+                    "stays CFS until its next restart picks up the drop-in. Fix "
+                    "manually with: sudo chrt -f -a -p %d %d",
+                    unit,
+                    pid,
+                    detail or "chrt failed",
+                    _CAPTURE_DAEMON_FIFO_PRIORITY,
+                    pid,
+                )
+        if cores is None or _threads_on_cpus(pid, cores):
             continue
         ok, detail = escalator.run(
-            ["chrt", "-f", "-a", "-p", str(_CAPTURE_DAEMON_FIFO_PRIORITY), str(pid)]
+            ["taskset", "-a", "-c", "-p", _cpu_list(cores), str(pid)]
         )
         if ok:
-            _logger.info(
-                "%s (pid %d) -> SCHED_FIFO %d", unit, pid, _CAPTURE_DAEMON_FIFO_PRIORITY
-            )
+            _logger.info("%s (pid %d) -> cores %s", unit, pid, sorted(cores))
         else:
             _logger.warning(
-                "cannot re-schedule the running %s (pid %d) SCHED_FIFO (%s) — it "
-                "stays CFS until its next restart picks up the drop-in. Fix "
-                "manually with: sudo chrt -f -a -p %d %d",
+                "cannot confine the running %s (pid %d) to cores %s (%s) — a "
+                "real-time daemon on the CAN interrupt CPU can stall motor "
+                "feedback until its next restart picks up the drop-in. Fix "
+                "manually with: sudo taskset -a -c -p %s %d",
                 unit,
                 pid,
-                detail or "chrt failed",
-                _CAPTURE_DAEMON_FIFO_PRIORITY,
+                sorted(cores),
+                detail or "taskset failed",
+                _cpu_list(cores),
                 pid,
             )
 
@@ -487,23 +731,28 @@ def pin_engine_clocks(*, interactive: bool = False) -> None:
 
 
 def pin_realtime_clocks(*, interactive: bool = False) -> None:
-    """Select MAXN, pin engine **and** CPU clocks, and make the capture daemon RT.
+    """Select MAXN, pin clocks, and set the real-time scheduling the loops need.
 
     Selects the MAXN ``nvpmodel`` power mode (uncaps the clock ceiling), pins
     NVENC/VIC/GPU (encode latency, ZED SDK processing), switches the CPUs to
-    the ``performance`` governor (IK rate), and schedules the Argus camera
-    daemon ``SCHED_FIFO`` (all-camera frame drops under load). All are
-    Jetson-only: MAXN selection, CPU-governor pinning and the daemon step are
-    gated on :func:`_is_jetson` so they never alter a non-Tegra host, and
-    engine pinning is a no-op without the Tegra devfreq nodes. MAXN is
-    selected first because it sets the ceiling the governor and engine pins
-    reach. Same best-effort / ``interactive`` escalation semantics as
-    :func:`pin_engine_clocks`; sudo is primed at most once across all of
-    them. Invoked via ``axol jetson.setup`` (host installer + boot service),
-    not from the teleop / collect-data / serve entry points.
+    the ``performance`` governor (IK rate), steers the CAN adapters'
+    USB-controller interrupt onto a CAN core (so real-time camera work can
+    never stall motor feedback), and schedules the Argus camera daemon
+    ``SCHED_FIFO`` on the camera cores (all-camera frame drops under load).
+    All are Jetson-only: MAXN selection, CPU-governor pinning, interrupt
+    steering and daemon scheduling are gated on :func:`_is_jetson` so they
+    never alter a non-Tegra host, and engine pinning is a no-op without the
+    Tegra devfreq nodes. MAXN is selected first because it sets the ceiling
+    the governor and engine pins reach; the interrupt step precedes the daemon
+    step so the CAN receive path is off the camera cores before any camera
+    thread becomes real-time. Same best-effort / ``interactive`` escalation
+    semantics as :func:`pin_engine_clocks`; sudo is primed at most once across
+    all of them. Invoked via ``axol jetson.setup`` (host installer + boot
+    service), not from the teleop / collect-data / serve entry points.
     """
     escalator = _RootEscalator(interactive=interactive)
     _set_max_power_mode(escalator)
     _pin_engines(escalator)
     _pin_cpu(escalator)
+    _steer_can_irq(escalator)
     _prioritize_capture_daemons(escalator)

--- a/almond_axol/utils/rtprio.py
+++ b/almond_axol/utils/rtprio.py
@@ -1,0 +1,124 @@
+"""Persistent ``SCHED_FIFO`` allowance for the operator's login.
+
+The camera relay elevates its capture chain to ``SCHED_FIFO``
+(:func:`almond_axol.utils.affinity.prioritize_capture_threads`) so a 60 Hz
+exposure is never lost to a descheduled source thread. A non-root process may
+only do that when its ``RLIMIT_RTPRIO`` hard limit is at least the priority
+requested. The systemd unit the hosted installer writes grants that
+(``LimitRTPRIO``), but a manual ``axol serve`` from a login shell inherits the
+PAM default of **zero**, the relay silently falls back to CFS, and the first
+recording under load discards its episode on skipped exposures — the failure
+seen on a customer robot on 2026-09-02, where the same checkout worked from a
+shell that happened to have the allowance.
+
+:func:`install` writes a ``/etc/security/limits.d`` drop-in granting the
+operator's account the top rung of the stack's FIFO ladder
+(:data:`almond_axol.utils.affinity.MAX_FIFO_PRIORITY`). PAM applies it at the
+next login, so it survives reboots and needs no per-shell ``prlimit``. It is
+an ``axol provision`` step: an install-time, host-level grant like the udev
+rules and group memberships provisioned alongside it.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import resource
+from pathlib import Path
+
+from .affinity import MAX_FIFO_PRIORITY
+from .sudo import prime_sudo, run_root
+
+_logger = logging.getLogger(__name__)
+
+LIMITS_PATH = Path("/etc/security/limits.d/50-axol-rtprio.conf")
+
+
+def operator_user() -> str | None:
+    """Best-effort login of the operator that runs ``axol`` interactively.
+
+    ``SUDO_USER`` when provisioning runs under ``sudo``; otherwise (a root
+    ``axol serve`` under systemd, or the installer run directly as root) the
+    owner of the first ``/home/*`` entry — the same heuristic the hosted
+    installer uses to locate the dataset owner. ``None`` when neither
+    resolves.
+    """
+    user = os.environ.get("SUDO_USER")
+    if user and user != "root":
+        return user
+    try:
+        homes = sorted(Path("/home").iterdir())
+    except OSError:
+        return None
+    for home in homes:
+        try:
+            owner = home.owner()
+        except (KeyError, OSError):
+            continue
+        if owner != "root":
+            return owner
+    return None
+
+
+def limits_text(user: str) -> str:
+    """The ``limits.d`` drop-in granting ``user`` the stack's FIFO ceiling."""
+    return (
+        "# Written by `axol provision` (almond_axol.utils.rtprio).\n"
+        "# Lets a manual `axol serve` from this account run the camera relay's\n"
+        f"# capture chain SCHED_FIFO (relay uses {MAX_FIFO_PRIORITY} at most);\n"
+        "# without it the relay falls back to CFS and drops exposures under\n"
+        "# recording load. The systemd unit grants the same via LimitRTPRIO.\n"
+        f"{user}\t-\trtprio\t{MAX_FIFO_PRIORITY}\n"
+    )
+
+
+def current_limit() -> int:
+    """This process's ``RLIMIT_RTPRIO`` hard limit (what a child may request)."""
+    _soft, hard = resource.getrlimit(resource.RLIMIT_RTPRIO)
+    # 99 is the highest SCHED_FIFO priority Linux offers, so an unlimited hard
+    # limit is equivalent to it.
+    return 99 if hard == resource.RLIM_INFINITY else int(hard)
+
+
+def install() -> None:
+    """Grant the operator a persistent rtprio allowance via ``limits.d``.
+
+    Idempotent and best-effort: a no-op when the drop-in already matches, and
+    only a warning (with the manual command) when root cannot be obtained.
+    The grant applies to the operator's *next* login; the current shell keeps
+    the limit it started with, which is why the message says so.
+    """
+    user = operator_user()
+    if user is None:
+        _logger.info("no operator account found; skipping the rtprio grant")
+        return
+    wanted = limits_text(user)
+    try:
+        if LIMITS_PATH.read_text() == wanted:
+            _logger.info("rtprio grant already in place for %s (%s)", user, LIMITS_PATH)
+            return
+    except OSError:
+        pass
+    if not prime_sudo():
+        _logger.warning(
+            "rtprio grant needs root; a manual `axol serve` from %s's shell will "
+            "run the camera relay without SCHED_FIFO and drop exposures under "
+            "recording load. Run manually: printf '%%s\\t-\\trtprio\\t%d\\n' %s | "
+            "sudo tee %s",
+            user,
+            MAX_FIFO_PRIORITY,
+            user,
+            LIMITS_PATH,
+        )
+        return
+    run_root(["mkdir", "-p", str(LIMITS_PATH.parent)], check=True)
+    run_root(["tee", str(LIMITS_PATH)], input_text=wanted, check=True)
+    _logger.info(
+        "rtprio %d granted to %s via %s — takes effect at %s's next login "
+        "(current shells keep ulimit -r %d)",
+        MAX_FIFO_PRIORITY,
+        user,
+        LIMITS_PATH,
+        user,
+        current_limit(),
+    )

--- a/almond_axol/video/video_proc.py
+++ b/almond_axol/video/video_proc.py
@@ -771,7 +771,9 @@ def _relay_main(
     # consumers of the two-buffer queues that still hold camera surfaces) must
     # run every 60 Hz period or the exposure is lost; a CFS slot behind the
     # encode pool is not guaranteed once recording starts, so it gets a
-    # real-time class of its own (see prioritize_capture_threads).
+    # real-time class of its own — confined to the camera cores, never the
+    # CPU that delivers the CAN adapters' replies (see
+    # prioritize_capture_threads / realtime_camera_cores).
     from .gst_zed import exposure_critical_thread_comms
 
     affinity.prioritize_capture_threads(exposure_critical_thread_comms())

--- a/docs/cli/jetson-setup.mdx
+++ b/docs/cli/jetson-setup.mdx
@@ -1,20 +1,29 @@
 ---
 title: "jetson.setup"
-description: "Pin the Jetson NVENC/VIC and CPU clocks for the real-time loops."
+description: "Pin the Jetson clocks and real-time scheduling for the control and camera loops."
 ---
 
 Pins the Jetson clocks the real-time loops depend on:
 
 - the **MAXN power mode** (`nvpmodel -m 0`), which uncaps the clock ceiling the other two pins reach (`nvpmodel` otherwise caps how high the governor and engine clocks can go),
-- the **NVENC / VIC engine** devfreq nodes, so the camera relay's hardware H.264 encode stays low-latency (the default devfreq governor scales them for throughput, which roughly triples per-frame encode time), and
+- the **NVENC / VIC / GPU engine** devfreq nodes, so the camera relay's hardware H.264 encode and the ZED SDK's CUDA processing stay low-latency (the default devfreq governor scales them for throughput, which roughly triples per-frame encode time), and
 - the **CPU governor**, so the bursty IK loop isn't underclocked.
+
+And the real-time scheduling that keeps the camera and motor paths from contending:
+
+- **The CAN adapters' USB-controller interrupt** is steered onto a CAN core. Both USB CAN adapters hang off one xHCI controller whose interrupt the Jetson otherwise delivers to CPU0 — a core the camera relay's worker pool shares. Every motor reply crosses that CPU's interrupt bottom half, and a real-time camera thread runnable there delays it: with the relay's capture chain `SCHED_FIFO`, both arms faulted on missing feedback within seconds of arming. Moving the interrupt beside its consumer (the `axol-rt` bus loop pinned to that core, where no camera or dataset thread is ever scheduled) ends the coupling. The interrupt is resolved from the CAN interfaces' USB bus each boot, never hard-coded; a warning names the manual `echo N | sudo tee /proc/irq/<irq>/smp_affinity_list` if it can't be applied, and another if `irqbalance` is running and could undo it.
+- **The Argus capture daemon** (`nvargus-daemon`, every ZED X frame passes through it) runs `SCHED_FIFO` one notch above the relay's capture threads, confined to the camera cores so it never lands on a control, IK, CAN, or interrupt core.
 
 ```bash
 axol jetson.setup
 ```
 
-These pins reset on every reboot, so the [one-command install](/installation) wires this into the `axol.service` systemd unit as an `ExecStartPre`, re-pinning the clocks at every boot, and runs it once during install. It is **not** called from `teleop` / `collect-data` / `serve` — those entry points just run.
+These settings reset on every reboot, so the [one-command install](/installation) wires this into the `axol.service` systemd unit as an `ExecStartPre`, re-applying them at every boot, and runs it once during install. It is **not** called from `teleop` / `collect-data` / `serve` — those entry points just run.
 
 <Note>
-  Best-effort and a no-op on non-Jetson machines. Pinning needs root: run as root, or you'll be prompted for `sudo` once on a terminal; if escalation isn't possible it logs the manual command and continues.
+  Best-effort and a no-op on non-Jetson machines. Everything here needs root: run as root, or you'll be prompted for `sudo` once on a terminal; if escalation isn't possible it logs the manual command and continues.
+</Note>
+
+<Note>
+  `jetson.setup` is the per-boot half. The install-time half is [`axol provision`](/cli/provision), which grants your login the `rtprio` allowance a manual `axol serve` needs before the camera relay can run its capture chain `SCHED_FIFO` at all. Without both, the relay logs `camera capture threads stay SCHED_OTHER` at startup and recordings drop exposures under load.
 </Note>

--- a/docs/cli/provision.mdx
+++ b/docs/cli/provision.mdx
@@ -8,6 +8,7 @@ Installs and refreshes the pieces `uv tool install` can't manage on its own:
 - **adb** + the Quest udev rule — for the [Quest-over-USB](/guides/quest-over-usb) controller transport (the `adb reverse` tunnel that streams poses over the cable). Self-gates on `apt`.
 - [`zed.driver`](/cli/zed-driver) — replaces the ZED Box Duo's known-bad factory **GMSL camera driver** (`stereolabs-zedbox-duo`) with the pinned release. Takes effect on the next reboot (prints a notice; never reboots itself). A no-op off a factory-flashed ZED Box Duo.
 - **board IMU** (`gyro.install`) — grants the `imu` group access to the carrier board's BMI088 sampling timer, [Jelly](/guides/vr-interface#jelly)'s heading-hold yaw reference, so teleop can start it without root. Self-gates on the board driver's presence.
+- **real-time scheduling grant** — writes `/etc/security/limits.d/50-axol-rtprio.conf` so your login can run the camera relay's capture chain `SCHED_FIFO` from a manual `axol serve` (the systemd unit already has `LimitRTPRIO`). Login shells otherwise start with an `rtprio` limit of zero, the relay silently falls back to CFS (`camera capture threads stay SCHED_OTHER` at startup), and recordings under load discard episodes on skipped exposures. Takes effect at your **next login**; check with `ulimit -r` (should print `20`).
 - [`zed.install`](/cli/zed-install) — the **pyzed** bindings (not on PyPI; needs the ZED SDK).
 - [`gst.install`](/cli/gst-install) — the **GStreamer + PyGObject** `appsink` stack (PyGObject builds against the system gobject-introspection and is dropped whenever the tool environment is rebuilt, e.g. by a release upgrade).
 - [`gst.build-zed`](/cli/gst-build-zed) — the patched **`zedxonesrc` / `zedsrc`** plugins (sensor-accurate PTS so collected images line up with joint samples).
@@ -36,11 +37,11 @@ code. Both still share this single provisioning path, keeping their steps in
 lockstep.
 
 <Note>
-  `provision` does **not** pin the Jetson clocks — that's [`jetson.setup`](/cli/jetson-setup), a per-boot runtime tweak owned by the systemd `ExecStartPre`, not an install step.
+  `provision` does **not** pin the Jetson clocks or steer the CAN adapters' interrupt — that's [`jetson.setup`](/cli/jetson-setup), a per-boot runtime tweak owned by the systemd `ExecStartPre`, not an install step. After pulling a fix that touches either, run both: `axol provision` then `axol jetson.setup`, and log in again for the scheduling grant.
 </Note>
 
 When there's no ZED SDK at `/usr/local/zed`, only the pyzed and zed-gstreamer
-build steps are skipped; adb, board access, GStreamer/PyGObject, and `axol-rt`
-are still provisioned.
+build steps are skipped; adb, board access, the scheduling grant,
+GStreamer/PyGObject, and `axol-rt` are still provisioned.
 
 See [Development install → Headset-video stack](/advanced/development-install#headset-video-stack) for when you'd run this by hand.

--- a/rust/axol-rt/README.md
+++ b/rust/axol-rt/README.md
@@ -195,7 +195,13 @@ write them, and the regular five-second status line reports any trace drops.
 `scan` and `bench` are strictly read-only — safe against a powered robot
 at rest. `hold` requires `--yes` to actuate. `serve` only actuates after
 the explicit config/prep/arm handshake, and every exit path (disarm,
-fault, signal, client loss) runs the disable sequence. `proxy` is the sole
+fault, signal, client loss) runs the disable sequence. Missed CAN replies
+degrade rather than fault: host damping is never computed from a stale
+sample, a joint missing 4 of the last 32 replies runs on firmware kd (logged,
+counted in the five-second stats line) until a clean window, and only a motor
+silent for a full second stops the session — bursty loss is expected while
+cameras and IK compilation contend for the same host and USB fabric during
+startup. `proxy` is the sole
 frame transport for maintenance, tuning, firmware, and arm diagnostics;
 `jelly` owns Jelly's wheel bus, while the proxy carries its lift bus. Both use
 the realtime core's persistent-TX-stall detection and queue purge, aborting

--- a/rust/axol-rt/src/serve.rs
+++ b/rust/axol-rt/src/serve.rs
@@ -101,8 +101,11 @@
 //!   runaway). The gripper is exempt — stalling against an object is its
 //!   normal operation.
 //! - Every command batch accepts exactly one fresh reply per motor. A missed
-//!   sample suppresses host damping; repeated/bursty feedback loss disables
-//!   both buses. Late ticks follow the same fail-closed rule, and a full-cycle
+//!   sample suppresses host damping for that tick; bursty loss (4 of the last
+//!   32 ticks) marks the joint *degraded* — host damping stays off until a
+//!   clean 32-tick window, the transition is logged, and the loop keeps
+//!   running on firmware kd. Only a motor silent for a full second faults
+//!   both buses. Clustered late ticks still fail closed, and a full-cycle
 //!   overrun is an immediate fault.
 //! - The gripper is not commanded at all until the first target arrives
 //!   (matching classic mode, where it sits idle until motion_control).
@@ -141,15 +144,25 @@ const VEL_CUTOFF: f64 = 80.0;
 /// Target-tuple slots per arm: 7 arm joints + the gripper.
 const N_SLOTS: usize = 8;
 const GRIPPER_SLOT: usize = 7;
-/// Three absent samples is 12.5 ms at 240 Hz. Continuing impedance control
-/// beyond this point would let the host-damping term act on stale velocity,
-/// so fail closed and require a fresh arm instead.
-const MAX_CONSECUTIVE_MISSED_FEEDBACK: u8 = 3;
-/// Also reject bursty loss that never happens on consecutive ticks. Four
-/// misses in 32 ticks is 12.5% loss over 133 ms at 240 Hz; the failing
-/// collection capture reached nine, while healthy operation should remain
-/// comfortably below this after stale-frame isolation.
-const MAX_RECENT_MISSED_FEEDBACK: u32 = 4;
+/// Rolling feedback loss at or above this many misses in the last 32 ticks
+/// (12.5% over 133 ms at 240 Hz) marks a joint *degraded*: its host damping
+/// stays off until a full clean window has passed, and the transition is
+/// logged. It is not a fault. Host damping is already suppressed on every
+/// tick without a fresh sample, so a missed frame can never feed stale
+/// velocity into the damping term; the arm simply runs on firmware kd for
+/// the lossy stretch. Bursty loss is routine while cameras, IK compilation,
+/// and the dataset writer boot on the same host and USB fabric as the CAN
+/// adapters — disabling both arms for it ended otherwise healthy sessions.
+const DEGRADED_RECENT_MISSED_FEEDBACK: u32 = 4;
+/// A motor that has not replied for this long is treated as gone rather than
+/// lossy. Commanding it blind leaves the deviation abort inactive for that
+/// joint, so past this point the core fails closed. Matches the TX-stall
+/// e-stop detection window rather than the old 12.5 ms.
+const SILENT_FEEDBACK_FAULT: Duration = Duration::from_secs(1);
+/// Degraded/recovered transitions are logged at most this often per bus so a
+/// joint flapping across the threshold during boot cannot flood the log; the
+/// five-second stats line carries the cumulative count regardless.
+const DEGRADED_LOG_INTERVAL: Duration = Duration::from_secs(5);
 /// Leave a small slice of each cycle for telemetry handoff and the next
 /// absolute sleep. The rest is valid reply time; the old 80% window discarded
 /// delayed USB-CAN replies despite there still being cycle headroom.
@@ -280,25 +293,66 @@ fn mark_unique_expected_reply(expected: &[bool], seen: &mut [bool], idx: usize) 
     true
 }
 
+/// Outcome of one feedback opportunity for one arm joint.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum FeedbackVerdict {
+    /// Nothing to report: healthy, an isolated miss, or an ongoing degraded
+    /// stretch that has neither cleared nor gone silent.
+    Steady,
+    /// Rolling loss just crossed the degraded threshold.
+    Degraded,
+    /// A full clean window just closed out a degraded stretch.
+    Recovered,
+    /// The motor has not replied for the silent-fault interval: treat it as
+    /// gone and fail closed.
+    Silent,
+}
+
 #[derive(Clone, Copy, Default)]
 struct FeedbackHealth {
-    consecutive_misses: u8,
+    consecutive_misses: u32,
     recent_misses: u32,
+    degraded: bool,
 }
 
 impl FeedbackHealth {
-    /// Record one 240 Hz feedback opportunity. Returns true once either the
-    /// consecutive-loss or rolling-loss safety limit has been reached.
-    fn record(&mut self, received: bool) -> bool {
+    /// Record one 240 Hz feedback opportunity. `silent_limit` is the
+    /// consecutive-miss count that turns loss into a fault.
+    ///
+    /// Degradation has hysteresis: it starts at
+    /// `DEGRADED_RECENT_MISSED_FEEDBACK` misses in the 32-tick window and only
+    /// clears once that window is entirely clean, so a joint flapping around
+    /// the threshold does not toggle host damping every few ticks.
+    fn record(&mut self, received: bool, silent_limit: u32) -> FeedbackVerdict {
         self.recent_misses = (self.recent_misses << 1) | u32::from(!received);
         if received {
             self.consecutive_misses = 0;
         } else {
             self.consecutive_misses = self.consecutive_misses.saturating_add(1);
         }
-        self.consecutive_misses >= MAX_CONSECUTIVE_MISSED_FEEDBACK
-            || self.recent_misses.count_ones() >= MAX_RECENT_MISSED_FEEDBACK
+        if self.consecutive_misses >= silent_limit {
+            return FeedbackVerdict::Silent;
+        }
+        let lossy = self.recent_misses.count_ones() >= DEGRADED_RECENT_MISSED_FEEDBACK;
+        match (self.degraded, lossy) {
+            (false, true) => {
+                self.degraded = true;
+                FeedbackVerdict::Degraded
+            }
+            (true, false) if self.recent_misses == 0 => {
+                self.degraded = false;
+                FeedbackVerdict::Recovered
+            }
+            _ => FeedbackVerdict::Steady,
+        }
     }
+}
+
+/// Consecutive missed replies that constitute a silent motor at `loop_hz`.
+fn silent_feedback_limit(loop_hz: f64) -> u32 {
+    (loop_hz * SILENT_FEEDBACK_FAULT.as_secs_f64())
+        .ceil()
+        .max(1.0) as u32
 }
 
 #[derive(Clone, Copy, Default)]
@@ -838,22 +892,50 @@ mod tests {
     }
 
     #[test]
-    fn feedback_health_catches_consecutive_and_bursty_loss() {
-        let mut consecutive = FeedbackHealth::default();
-        assert!(!consecutive.record(false));
-        assert!(!consecutive.record(false));
-        assert!(consecutive.record(false));
+    fn feedback_health_degrades_on_bursty_loss_and_recovers_after_clean_window() {
+        let limit = silent_feedback_limit(240.0);
+        assert_eq!(limit, 240);
 
+        // The startup pattern from the field: isolated single-tick misses.
+        // Three of them stay quiet; the fourth degrades the joint, and it
+        // remains degraded (Steady, not re-announced) while lossy.
         let mut bursty = FeedbackHealth::default();
         for _ in 0..3 {
-            assert!(!bursty.record(false));
-            assert!(!bursty.record(true));
+            assert_eq!(bursty.record(false, limit), FeedbackVerdict::Steady);
+            assert_eq!(bursty.record(true, limit), FeedbackVerdict::Steady);
         }
-        assert!(bursty.record(false));
+        assert_eq!(bursty.record(false, limit), FeedbackVerdict::Degraded);
+        assert!(bursty.degraded);
+        assert_eq!(bursty.record(false, limit), FeedbackVerdict::Steady);
+        assert!(bursty.degraded);
+
+        // Hysteresis: dropping below four misses is not enough; the window
+        // must be entirely clean before damping is allowed back on.
+        for _ in 0..31 {
+            assert_eq!(bursty.record(true, limit), FeedbackVerdict::Steady);
+            assert!(bursty.degraded);
+        }
+        assert_eq!(bursty.record(true, limit), FeedbackVerdict::Recovered);
+        assert!(!bursty.degraded);
+
+        // The old 3-consecutive trip is now just a degraded stretch...
+        let mut consecutive = FeedbackHealth::default();
+        for _ in 0..3 {
+            assert_ne!(consecutive.record(false, limit), FeedbackVerdict::Silent);
+        }
+        // ...and only a motor silent for the whole interval faults.
+        for _ in 3..limit - 1 {
+            assert_ne!(consecutive.record(false, limit), FeedbackVerdict::Silent);
+        }
+        assert_eq!(consecutive.record(false, limit), FeedbackVerdict::Silent);
 
         let mut healthy = FeedbackHealth::default();
         for tick in 0..128 {
-            assert!(!healthy.record(tick % 32 != 0));
+            assert_eq!(
+                healthy.record(tick % 32 != 0, limit),
+                FeedbackVerdict::Steady
+            );
+            assert!(!healthy.degraded);
         }
     }
 
@@ -1453,6 +1535,11 @@ fn bus_loop(
     let mut enobufs_since: Option<Instant> = None;
     let mut bus_dead = false;
     let mut feedback_health = [FeedbackHealth::default(); N_SLOTS];
+    let silent_limit = silent_feedback_limit(cfg.loop_hz);
+    let mut degraded_ticks: u64 = 0;
+    let mut degraded_episodes: u64 = 0;
+    let mut degraded_announced = [false; N_SLOTS];
+    let mut next_degraded_log = Instant::now();
     let mut timing_health = TimingHealth::default();
     // Belt-and-braces: sends on a dead bus normally fail fast with ENOBUFS,
     // but if the socket sndbuf fills first a blocking write would hang the
@@ -1634,12 +1721,18 @@ fn bus_loop(
                         let v_cmd_fast = d.v_cmd_fast.update(p_cmd, tick_dt);
                         let friction_ff = filter::friction(v_cmd, m.fc, m.k, m.fv, m.fo);
                         let inertia_ff = c.j_eff * a_cmd;
-                        let v_damp = if feedback_fresh[m.slot] && timing_on_time {
+                        let damp_ok = feedback_fresh[m.slot]
+                            && timing_on_time
+                            && !feedback_health[m.slot].degraded;
+                        let v_damp = if damp_ok {
                             d.bp.update(v_cmd_fast - d.vel_meas, c.damp_w0, c.damp_q, tick_dt)
                         } else {
                             // A missing frame makes measured velocity stale.
                             // Reset rather than carrying band-pass energy into
-                            // the first tick after feedback recovers.
+                            // the first tick after feedback recovers. While the
+                            // joint is degraded, damping stays off for the whole
+                            // stretch: re-engaging a freshly reset band-pass
+                            // every few ticks is a torque transient, not damping.
                             d.bp.reset();
                             0.0
                         };
@@ -1836,26 +1929,66 @@ fn bus_loop(
             // stays far below the fail-closed thresholds.
             missed += pending as u64;
 
-            // Never continue phase-sensitive host damping when an arm motor
-            // has stopped producing fresh feedback. A single miss suppresses
-            // host damping on the next tick; sustained or bursty degradation
-            // faults both buses and forces a clean re-arm. The gripper is
-            // intentionally excluded.
+            // Never run phase-sensitive host damping on stale feedback. A
+            // single miss suppresses host damping on the next tick; bursty
+            // loss marks the joint degraded (damping off until a clean
+            // window, logged) and the loop keeps running on firmware kd. Only
+            // a motor that falls silent for `SILENT_FEEDBACK_FAULT` faults
+            // both buses — the deviation abort has been blind on it for too
+            // long to keep commanding it. The gripper is intentionally
+            // excluded.
+            let mut any_degraded = false;
             for (idx, motor) in motors.iter().enumerate() {
                 if motor.gripper {
                     continue;
                 }
                 feedback_fresh[motor.slot] = seen[idx];
-                if feedback_health[motor.slot].record(seen[idx]) {
-                    fault.store(1, Ordering::SeqCst);
-                    stop.store(true, Ordering::SeqCst);
-                    return Err(io::Error::other(format!(
-                        "{iface}: {} feedback unhealthy ({} consecutive, {} of the last 32 ticks missing); stopping before damping can use stale velocity",
-                        motor.joint,
-                        feedback_health[motor.slot].consecutive_misses,
-                        feedback_health[motor.slot].recent_misses.count_ones(),
-                    )));
+                let health = &mut feedback_health[motor.slot];
+                match health.record(seen[idx], silent_limit) {
+                    FeedbackVerdict::Steady => {}
+                    FeedbackVerdict::Degraded => {
+                        degraded_episodes += 1;
+                        degraded_announced[motor.slot] = began >= next_degraded_log;
+                        if degraded_announced[motor.slot] {
+                            next_degraded_log = began + DEGRADED_LOG_INTERVAL;
+                            send_text(
+                                out_tx,
+                                b'L',
+                                &format!(
+                                    "{iface}: {} feedback degraded ({} of the last 32 ticks missing) — host damping off on this joint until a clean window; firmware kd holds",
+                                    motor.joint,
+                                    health.recent_misses.count_ones(),
+                                ),
+                            );
+                        }
+                    }
+                    FeedbackVerdict::Recovered => {
+                        if std::mem::take(&mut degraded_announced[motor.slot]) {
+                            send_text(
+                                out_tx,
+                                b'L',
+                                &format!(
+                                    "{iface}: {} feedback recovered — host damping resumed",
+                                    motor.joint,
+                                ),
+                            );
+                        }
+                    }
+                    FeedbackVerdict::Silent => {
+                        fault.store(1, Ordering::SeqCst);
+                        stop.store(true, Ordering::SeqCst);
+                        return Err(io::Error::other(format!(
+                            "{iface}: {} silent for {} consecutive ticks ({:.1} s) — motor unreachable; stopping rather than commanding it blind",
+                            motor.joint,
+                            health.consecutive_misses,
+                            health.consecutive_misses as f64 / cfg.loop_hz,
+                        )));
+                    }
                 }
+                any_degraded |= health.degraded;
+            }
+            if any_degraded {
+                degraded_ticks += 1;
             }
 
             // Ship this tick's telemetry to Python (non-blocking mpsc; the
@@ -1871,7 +2004,7 @@ fn bus_loop(
                     out_tx,
                     b'L',
                     &format!(
-                        "{iface}: {ticks} ticks, {late} late ({:.2}%), {missed} missed replies, {rejected} rejected targets, {trace_dropped} trace drops, seq {:?}",
+                        "{iface}: {ticks} ticks, {late} late ({:.2}%), {missed} missed replies, {degraded_ticks} degraded ticks in {degraded_episodes} episodes, {rejected} rejected targets, {trace_dropped} trace drops, seq {:?}",
                         late as f64 / ticks as f64 * 100.0,
                         last_seq,
                     ),

--- a/tests/test_affinity.py
+++ b/tests/test_affinity.py
@@ -41,10 +41,12 @@ class PrioritizeCaptureThreadsTest(TestCase):
     def test_elevates_capture_chain_and_sdk_threads_only(self) -> None:
         # "999" is listed but exited before its comm is read; "x" isn't a tid.
         with (
+            patch.object(affinity.os, "cpu_count", return_value=8),
             patch.object(
                 affinity.os, "listdir", return_value=[*self.comms, "999", "x"]
             ),
             patch.object(affinity.os, "sched_setscheduler", create=True) as setsched,
+            patch.object(affinity.os, "sched_setaffinity") as set_affinity,
             patch.object(
                 affinity.os,
                 "sched_param",
@@ -58,14 +60,22 @@ class PrioritizeCaptureThreadsTest(TestCase):
             moved = affinity.prioritize_capture_threads(self.wanted)
 
         self.assertEqual(moved, 5)
+        elevated = (201, 202, 203, 204, 207)
         param = ("param", affinity.CAPTURE_FIFO_PRIORITY)
         self.assertCountEqual(
             setsched.call_args_list,
-            [call(tid, 1, param) for tid in (201, 202, 203, 204, 207)],
+            [call(tid, 1, param) for tid in elevated],
+        )
+        # Every FIFO thread is kept off CPU0, where the CAN adapters' softirq
+        # bottom half runs as CFS work, and off the relay's Python core.
+        self.assertCountEqual(
+            set_affinity.call_args_list,
+            [call(tid, {1, 5}) for tid in elevated],
         )
 
     def test_permission_denied_leaves_threads_cfs(self) -> None:
         with (
+            patch.object(affinity.os, "cpu_count", return_value=8),
             patch.object(affinity.os, "listdir", return_value=list(self.comms)),
             patch.object(
                 affinity.os,
@@ -73,6 +83,7 @@ class PrioritizeCaptureThreadsTest(TestCase):
                 create=True,
                 side_effect=PermissionError("EPERM"),
             ) as setsched,
+            patch.object(affinity.os, "sched_setaffinity") as set_affinity,
             patch.object(
                 affinity.os, "sched_param", create=True, side_effect=lambda p: p
             ),
@@ -85,11 +96,52 @@ class PrioritizeCaptureThreadsTest(TestCase):
 
         self.assertEqual(moved, 0)
         self.assertEqual(setsched.call_count, 1)  # stops at the first EPERM
+        self.assertEqual(set_affinity.call_count, 0)  # CFS threads keep the pool
         self.assertTrue(any("CAP_SYS_NICE" in line for line in logs.output))
 
     def test_noop_without_scheduler_api(self) -> None:
         with patch.object(affinity, "os", SimpleNamespace(listdir=lambda _p: [])):
             self.assertEqual(affinity.prioritize_capture_threads(self.wanted), 0)
+
+
+class RealtimeCameraCoresTest(TestCase):
+    def test_eight_cores_excludes_irq_cpu_and_relay_python_core(self) -> None:
+        with patch.object(affinity.os, "cpu_count", return_value=8):
+            groups = affinity.core_groups()
+            cores = affinity.realtime_camera_cores()
+        assert groups is not None
+        self.assertEqual(groups["irq"], {0})
+        self.assertEqual(cores, {1, 5})
+        # Disjoint from everything a FIFO camera thread must never preempt.
+        for group in ("can", "realtime", "ik", "irq"):
+            self.assertTrue(cores.isdisjoint(groups[group]), group)
+        self.assertNotIn(min(groups["relay"]), cores)
+
+    def test_smaller_layouts_still_avoid_cpu0(self) -> None:
+        for n, expected in ((6, {4, 5}), (5, {3, 4}), (4, {3})):
+            with patch.object(affinity.os, "cpu_count", return_value=n):
+                self.assertEqual(affinity.realtime_camera_cores(), expected, n)
+
+    def test_none_when_partitioning_is_not_applicable(self) -> None:
+        with patch.object(affinity.os, "cpu_count", return_value=2):
+            self.assertIsNone(affinity.realtime_camera_cores())
+
+
+class CanIrqCpuTest(TestCase):
+    def test_is_the_highest_can_core_and_never_a_camera_core(self) -> None:
+        for n in (8, 6, 5, 4):
+            with patch.object(affinity.os, "cpu_count", return_value=n):
+                groups = affinity.core_groups()
+                target = affinity.can_irq_cpu()
+                cameras = affinity.realtime_camera_cores()
+            assert groups is not None and target is not None and cameras is not None
+            self.assertEqual(target, max(groups["can"]), n)
+            self.assertNotIn(target, cameras, n)
+            self.assertNotIn(target, groups["irq"], n)
+
+    def test_none_without_a_can_partition(self) -> None:
+        with patch.object(affinity.os, "cpu_count", return_value=2):
+            self.assertIsNone(affinity.can_irq_cpu())
 
 
 class IsolateRelayCpuTest(TestCase):

--- a/tests/test_jetson.py
+++ b/tests/test_jetson.py
@@ -61,6 +61,180 @@ class _Escalator:
         return True, ""
 
 
+class ThreadsOnCpusTest(TestCase):
+    def _proc(self, tasks: dict[int, str]) -> Path:
+        root = Path(tempfile.mkdtemp())
+        for tid, allowed in tasks.items():
+            task = root / "4242" / "task" / str(tid)
+            task.mkdir(parents=True)
+            (task / "status").write_text(
+                f"Name:\tnvargus-daemon\nCpus_allowed_list:\t{allowed}\nMems_allowed_list:\t0\n"
+            )
+        return root
+
+    def test_parse_cpu_list_handles_ranges(self) -> None:
+        self.assertEqual(jetson._parse_cpu_list("0-2,5"), {0, 1, 2, 5})
+        self.assertEqual(jetson._parse_cpu_list(" 7 "), {7})
+        self.assertEqual(jetson._cpu_list({5, 1}), "1,5")
+
+    def test_all_threads_confined(self) -> None:
+        root = self._proc({4242: "1,5", 4300: "1,5"})
+        self.assertTrue(jetson._threads_on_cpus(4242, {1, 5}, proc_root=root))
+
+    def test_roaming_thread_is_false(self) -> None:
+        root = self._proc({4242: "1,5", 4300: "0-7"})
+        self.assertFalse(jetson._threads_on_cpus(4242, {1, 5}, proc_root=root))
+
+    def test_missing_process_is_none(self) -> None:
+        root = Path(tempfile.mkdtemp())
+        self.assertIsNone(jetson._threads_on_cpus(4242, {1, 5}, proc_root=root))
+
+
+_INTERRUPTS = """\
+           CPU0       CPU1       CPU2       CPU3
+ 11:    5000000    4999000    5001000    5000500     GICv3  27 Level     arch_timer
+123:    7900000          0          0          0     GICv3 251 Level     xhci-hcd:usb1
+124:          0          0          0          0     GICv3 252 Level     xhci-hcd:usb2
+200:          0        120          0          0     GICv3 300 Level     tegra-can-ish
+ERR:          0
+"""
+
+
+def _fake_proc(interrupts: str | None, affinity: dict[int, str] = {}) -> Path:
+    """A ``/proc`` stand-in: an interrupts table plus per-irq affinity files."""
+    root = Path(tempfile.mkdtemp())
+    if interrupts is not None:
+        (root / "interrupts").write_text(interrupts)
+    for irq, cpus in affinity.items():
+        (root / "irq" / str(irq)).mkdir(parents=True)
+        (root / "irq" / str(irq) / "smp_affinity_list").write_text(cpus + "\n")
+    return root
+
+
+def _fake_sys(devices: dict[str, str]) -> Path:
+    """A ``/sys`` stand-in where each CAN interface's ``device`` link resolves
+    to a USB function directory named like the kernel does (``1-2.2:1.0``)."""
+    root = Path(tempfile.mkdtemp())
+    for iface, function in devices.items():
+        target = root / "bus/usb/devices" / function
+        target.mkdir(parents=True)
+        net = root / "class/net" / iface
+        net.mkdir(parents=True)
+        (net / "device").symlink_to(target)
+    return root
+
+
+class CanUsbIrqsTest(TestCase):
+    def test_resolves_the_bus_from_the_interfaces_usb_function(self) -> None:
+        sys_root = _fake_sys(
+            {jetson.CAN_LEFT: "1-2.2:1.0", jetson.CAN_RIGHT: "1-2.2:1.1"}
+        )
+        self.assertEqual(jetson._can_usb_buses(sys_root=sys_root), {"1"})
+
+    def test_only_the_controller_the_adapters_hang_off(self) -> None:
+        # usb2 is a different controller: it must not be steered.
+        sys_root = _fake_sys({jetson.CAN_LEFT: "1-2.2:1.0"})
+        root = _fake_proc(_INTERRUPTS)
+        self.assertEqual(
+            jetson._can_usb_irqs(proc_root=root, sys_root=sys_root),
+            {123: "xhci-hcd:usb1"},
+        )
+
+    def test_every_xhci_row_when_no_interface_resolves(self) -> None:
+        root = _fake_proc(_INTERRUPTS)
+        self.assertEqual(
+            jetson._can_usb_irqs(proc_root=root, sys_root=Path(tempfile.mkdtemp())),
+            {123: "xhci-hcd:usb1", 124: "xhci-hcd:usb2"},
+        )
+
+    def test_unreadable_table_is_empty(self) -> None:
+        root = _fake_proc(None)
+        self.assertEqual(
+            jetson._can_usb_irqs(proc_root=root, sys_root=Path(tempfile.mkdtemp())),
+            {},
+        )
+
+    def test_irq_affinity_parses_and_tolerates_absence(self) -> None:
+        root = _fake_proc(None, {123: "0-7"})
+        self.assertEqual(jetson._irq_affinity(123, proc_root=root), set(range(8)))
+        self.assertIsNone(jetson._irq_affinity(9, proc_root=root))
+
+
+class SteerCanIrqTest(TestCase):
+    def setUp(self) -> None:
+        self.sys_root = _fake_sys({jetson.CAN_LEFT: "1-2.2:1.0"})
+        patches = [
+            patch.object(jetson, "_is_jetson", return_value=True),
+            patch.object(jetson, "can_irq_cpu", return_value=7),
+            patch.object(jetson, "_irqbalance_active", return_value=False),
+            patch.object(jetson, "_SYS_ROOT", self.sys_root),
+        ]
+        for p in patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+    def test_steers_the_can_controller_irq_onto_the_can_core(self) -> None:
+        root = _fake_proc(_INTERRUPTS, {123: "0-7", 124: "0-7"})
+        esc = _Escalator()
+        with patch.object(jetson, "_PROC_ROOT", root):
+            jetson._steer_can_irq(esc)
+        self.assertEqual(esc.writes, [root / "irq/123/smp_affinity_list"])
+        self.assertEqual(jetson._irq_affinity(123, proc_root=root), {7})
+        # The other controller was left alone.
+        self.assertEqual(jetson._irq_affinity(124, proc_root=root), set(range(8)))
+
+    def test_rerun_is_a_no_op_once_applied(self) -> None:
+        root = _fake_proc(_INTERRUPTS, {123: "7"})
+        esc = _Escalator()
+        with patch.object(jetson, "_PROC_ROOT", root):
+            jetson._steer_can_irq(esc)
+        self.assertEqual(esc.writes, [])
+
+    def test_missing_controller_only_warns(self) -> None:
+        root = _fake_proc("           CPU0\n 11:   1   GICv3  arch_timer\n")
+        esc = _Escalator()
+        with (
+            patch.object(jetson, "_PROC_ROOT", root),
+            self.assertLogs(jetson._logger, level="WARNING"),
+        ):
+            jetson._steer_can_irq(esc)
+        self.assertEqual(esc.writes, [])
+
+    def test_failed_write_warns_with_the_manual_command(self) -> None:
+        root = _fake_proc(_INTERRUPTS, {123: "0-7"})
+
+        class _Denied(_Escalator):
+            def write(self, path, value):
+                return False, "sudo unavailable"
+
+        with (
+            patch.object(jetson, "_PROC_ROOT", root),
+            self.assertLogs(jetson._logger, level="WARNING") as logs,
+        ):
+            jetson._steer_can_irq(_Denied())
+        self.assertIn("echo 7 | sudo tee", "\n".join(logs.output))
+
+    def test_irqbalance_is_called_out(self) -> None:
+        root = _fake_proc(_INTERRUPTS, {123: "7"})
+        with (
+            patch.object(jetson, "_PROC_ROOT", root),
+            patch.object(jetson, "_irqbalance_active", return_value=True),
+            self.assertLogs(jetson._logger, level="WARNING") as logs,
+        ):
+            jetson._steer_can_irq(_Escalator())
+        self.assertIn("irqbalance", "\n".join(logs.output))
+
+    def test_no_can_partition_is_a_no_op(self) -> None:
+        root = _fake_proc(_INTERRUPTS, {123: "0-7"})
+        esc = _Escalator()
+        with (
+            patch.object(jetson, "_PROC_ROOT", root),
+            patch.object(jetson, "can_irq_cpu", return_value=None),
+        ):
+            jetson._steer_can_irq(esc)
+        self.assertEqual(esc.writes, [])
+
+
 class PrioritizeCaptureDaemonsTest(TestCase):
     def setUp(self) -> None:
         self.unit_dir = Path(tempfile.mkdtemp())
@@ -68,6 +242,7 @@ class PrioritizeCaptureDaemonsTest(TestCase):
             patch.object(jetson, "_is_jetson", return_value=True),
             patch.object(jetson, "_SYSTEMD_UNIT_DIR", self.unit_dir),
             patch.object(jetson, "_CAPTURE_DAEMON_UNITS", ("nvargus-daemon.service",)),
+            patch.object(jetson, "realtime_camera_cores", return_value={1, 5}),
         ]
         for p in patches:
             p.start()
@@ -81,6 +256,7 @@ class PrioritizeCaptureDaemonsTest(TestCase):
         with (
             patch.object(jetson, "_service_main_pid", return_value=777),
             patch.object(jetson, "_threads_at_fifo", return_value=False),
+            patch.object(jetson, "_threads_on_cpus", return_value=False),
         ):
             jetson._prioritize_capture_daemons(esc)
 
@@ -89,6 +265,7 @@ class PrioritizeCaptureDaemonsTest(TestCase):
         self.assertIn(
             f"CPUSchedulingPriority={jetson._CAPTURE_DAEMON_FIFO_PRIORITY}", text
         )
+        self.assertIn("CPUAffinity=1 5", text)
         self.assertIn(["systemctl", "daemon-reload"], esc.runs)
         self.assertIn(
             [
@@ -101,22 +278,47 @@ class PrioritizeCaptureDaemonsTest(TestCase):
             ],
             esc.runs,
         )
+        self.assertIn(["taskset", "-a", "-c", "-p", "1,5", "777"], esc.runs)
 
     def test_rerun_is_a_no_op_once_applied(self) -> None:
         esc = _Escalator()
         with (
             patch.object(jetson, "_service_main_pid", return_value=777),
             patch.object(jetson, "_threads_at_fifo", return_value=False),
+            patch.object(jetson, "_threads_on_cpus", return_value=False),
         ):
             jetson._prioritize_capture_daemons(esc)
         again = _Escalator()
         with (
             patch.object(jetson, "_service_main_pid", return_value=777),
             patch.object(jetson, "_threads_at_fifo", return_value=True),
+            patch.object(jetson, "_threads_on_cpus", return_value=True),
         ):
             jetson._prioritize_capture_daemons(again)
         self.assertEqual(again.runs, [])
         self.assertEqual(again.writes, [])
+
+    def test_affinity_alone_is_reapplied_when_daemon_roams(self) -> None:
+        esc = _Escalator()
+        with (
+            patch.object(jetson, "_service_main_pid", return_value=777),
+            patch.object(jetson, "_threads_at_fifo", return_value=True),
+            patch.object(jetson, "_threads_on_cpus", return_value=False),
+        ):
+            jetson._prioritize_capture_daemons(esc)
+        self.assertNotIn("chrt", [argv[0] for argv in esc.runs])
+        self.assertIn(["taskset", "-a", "-c", "-p", "1,5", "777"], esc.runs)
+
+    def test_dropin_omits_affinity_without_a_partition(self) -> None:
+        esc = _Escalator()
+        with (
+            patch.object(jetson, "realtime_camera_cores", return_value=None),
+            patch.object(jetson, "_service_main_pid", return_value=0),
+        ):
+            self.dropin.parent.mkdir(parents=True)
+            self.dropin.write_text("stale\n")
+            jetson._prioritize_capture_daemons(esc)
+        self.assertNotIn("CPUAffinity", self.dropin.read_text())
 
     def test_absent_daemon_is_skipped_entirely(self) -> None:
         esc = _Escalator()

--- a/tests/test_rtprio.py
+++ b/tests/test_rtprio.py
@@ -1,0 +1,100 @@
+import tempfile
+from pathlib import Path
+from unittest import TestCase
+from unittest.mock import patch
+
+from almond_axol.utils import rtprio
+from almond_axol.utils.affinity import MAX_FIFO_PRIORITY
+
+
+class OperatorUserTest(TestCase):
+    def test_prefers_sudo_user(self) -> None:
+        with patch.dict(rtprio.os.environ, {"SUDO_USER": "shawn"}):
+            self.assertEqual(rtprio.operator_user(), "shawn")
+
+    def test_root_sudo_user_falls_through_to_home(self) -> None:
+        home = Path(tempfile.mkdtemp())
+        (home / "alice").mkdir()
+        with (
+            patch.dict(rtprio.os.environ, {"SUDO_USER": "root"}),
+            patch.object(Path, "iterdir", lambda self: iter([home / "alice"])),
+            patch.object(Path, "owner", lambda self: "alice"),
+        ):
+            self.assertEqual(rtprio.operator_user(), "alice")
+
+    def test_none_without_homes(self) -> None:
+        with (
+            patch.dict(rtprio.os.environ, {}, clear=True),
+            patch.object(Path, "iterdir", side_effect=OSError),
+        ):
+            self.assertIsNone(rtprio.operator_user())
+
+
+class InstallTest(TestCase):
+    def setUp(self) -> None:
+        self.limits = Path(tempfile.mkdtemp()) / "limits.d" / "50-axol-rtprio.conf"
+        patches = [
+            patch.object(rtprio, "LIMITS_PATH", self.limits),
+            patch.object(rtprio, "operator_user", return_value="shawn"),
+        ]
+        for p in patches:
+            p.start()
+            self.addCleanup(p.stop)
+
+    def _run_root(self, argv, *, input_text=None, check=False):
+        self.runs.append(argv)
+        if argv[0] == "mkdir":
+            Path(argv[-1]).mkdir(parents=True, exist_ok=True)
+        elif argv[0] == "tee":
+            Path(argv[-1]).write_text(input_text)
+        return True
+
+    def test_writes_the_grant_at_the_stacks_fifo_ceiling(self) -> None:
+        self.runs: list[list[str]] = []
+        with (
+            patch.object(rtprio, "prime_sudo", return_value=True),
+            patch.object(rtprio, "run_root", self._run_root),
+        ):
+            rtprio.install()
+        text = self.limits.read_text()
+        self.assertIn(f"shawn\t-\trtprio\t{MAX_FIFO_PRIORITY}\n", text)
+        # Matches what the relay's capture chain and the CAN loops request.
+        self.assertGreaterEqual(MAX_FIFO_PRIORITY, 20)
+
+    def test_rerun_is_a_no_op(self) -> None:
+        self.limits.parent.mkdir(parents=True)
+        self.limits.write_text(rtprio.limits_text("shawn"))
+        with (
+            patch.object(rtprio, "prime_sudo", side_effect=AssertionError),
+            patch.object(rtprio, "run_root", side_effect=AssertionError),
+        ):
+            rtprio.install()
+
+    def test_drifted_file_is_rewritten(self) -> None:
+        self.runs = []
+        self.limits.parent.mkdir(parents=True)
+        self.limits.write_text("shawn - rtprio 5\n")
+        with (
+            patch.object(rtprio, "prime_sudo", return_value=True),
+            patch.object(rtprio, "run_root", self._run_root),
+        ):
+            rtprio.install()
+        self.assertEqual(self.limits.read_text(), rtprio.limits_text("shawn"))
+
+    def test_no_root_only_warns_with_the_manual_command(self) -> None:
+        with (
+            patch.object(rtprio, "prime_sudo", return_value=False),
+            patch.object(rtprio, "run_root", side_effect=AssertionError),
+            self.assertLogs(rtprio._logger, level="WARNING") as logs,
+        ):
+            rtprio.install()
+        self.assertIn("sudo tee", "\n".join(logs.output))
+        self.assertFalse(self.limits.exists())
+
+    def test_no_operator_is_skipped(self) -> None:
+        with (
+            patch.object(rtprio, "operator_user", return_value=None),
+            patch.object(rtprio, "prime_sudo", side_effect=AssertionError),
+        ):
+            rtprio.install()
+        self.assertFalse(self.limits.exists())


### PR DESCRIPTION
## Summary

A customer robot (2026-09-02) could not record datasets. Two failures turned out to be one root cause seen from both sides:

- With the camera relay's capture chain on CFS (the launching shell had `ulimit -r 0`), the overhead ZED X skipped a 60 Hz exposure every ~10 rows with 10–50 ms of CPU wait, and the recorder's concealment budget discarded every episode.
- Granting `SCHED_FIFO` to those threads fixed the camera but made `axol-rt` fault within 10 s of arming on `shoulder_1 feedback unhealthy (4 of the last 32 ticks missing)`.

Both USB CAN adapters hang off one xHCI controller whose interrupt the Jetson delivers to CPU0, which the relay's real-time camera threads also ran on. A FIFO camera thread runnable there delays every motor reply's bottom half. Boosting `ksoftirqd/0` did not help; moving the interrupt onto a CAN core did: 160 s of full-load recording, two episodes saved, zero skipped exposures, `0 late` on both arms.

This PR makes that field fix the default via the two host commands:

**`axol jetson.setup`** (per boot, `ExecStartPre`)
- Resolves the CAN adapters' USB bus from `/sys/class/net/<can_if>/device`, finds the matching `xhci-hcd:usbN` row in `/proc/interrupts`, and steers it to `affinity.can_irq_cpu()` (the highest CAN core). Never hard-codes the IRQ number. Warns with the manual `echo N | sudo tee ...` if it can't, and if `irqbalance` is running.
- Drops the `ksoftirqd` FIFO boost.
- Confines `nvargus-daemon` to the camera cores, which now exclude the IRQ CPU.

**`axol provision`** (install time)
- New `rtprio` step: writes `/etc/security/limits.d/50-axol-rtprio.conf` granting the operator's login `rtprio 20`, so a manual `axol serve` can run the capture chain `SCHED_FIFO` like the systemd unit (`LimitRTPRIO`) does. Shares `operator_user()` with `adb`.

**Relay (`utils/affinity.py`)**
- FIFO camera threads are never placed on the IRQ CPU (defense in depth).
- The `SCHED_OTHER` fallback is now a WARNING naming the fix; it was the whole story in the first log and easy to miss at INFO.

**`axol-rt` (`serve.rs`, `rt/link.py`)**
- Bursty feedback loss (4 of 32 ticks) marks a joint *degraded* (host damping off for that joint, logged, throttled) instead of disabling both arms; the core fails closed only after 1 s of silence from a motor. Startup contention (cameras opening, IK compile, recorder attach) was ending otherwise healthy sessions.
- `disarm` is deliverable after a fault so teardown acks cleanly instead of the "orphaned client" 10 s hold.

## On-site procedure

```bash
git pull
uv sync --extra sim --extra lerobot
uv run axol provision
uv run axol jetson.setup
# log out / in, then:
uv run axol serve
```

Expect `camera capture threads -> SCHED_FIFO 5 (...)` at relay start and `irq N (xhci-hcd:usb1) -> CPU 7` from `jetson.setup`.

## Test plan

- [x] `python -m unittest discover -s tests`: 169 pass (new `test_rtprio.py`; `test_jetson.py` covers IRQ resolution, steering, no-op rerun, failed write, irqbalance; `test_affinity.py` covers `can_irq_cpu()` disjoint from camera/IRQ cores on every layout)
- [x] `cargo test` in `rust/axol-rt`: 28 pass, including the new degrade/recover hysteresis test
- [x] ruff check + format clean
- [ ] On the customer Jetson: `axol provision` then `axol jetson.setup`, re-login, `ulimit -r` prints 20, `cat /proc/irq/<xhci irq>/smp_affinity_list` prints 7, record two episodes with no `omitted`/`skipped exposure` lines and no CAN fault
- [ ] On the internal robot: confirm nothing regresses when the IRQ was already off CPU0 / rtprio already granted

Made with [Cursor](https://cursor.com)