### PR TITLE
axol-rt: late ticks degrade, never limp; attribute the stall; mlockall

### DIFF
--- a/almond_axol/diagnostics/rom/enable.py
+++ b/almond_axol/diagnostics/rom/enable.py
@@ -143,7 +143,7 @@ async def _stream(
 ) -> None:
     """Ship one target pair to the core, refusing to keep "sweeping" limp arms.
 
-    Once the core has gone limp (loss-of-trust fault: timing, a silent motor)
+    Once the core has gone limp (loss-of-trust fault: a silent motor)
     ``RtAxol.motion_control`` streams gravity comp instead of tracking, so the
     arms would hang weightless while this script kept announcing sweeps. Stop
     the run instead; the operator hand-guides the arms to rest.

--- a/almond_axol/lerobot/robot/robot_axol.py
+++ b/almond_axol/lerobot/robot/robot_axol.py
@@ -436,6 +436,19 @@ class AxolRobot(Robot):
         assert self._loop is not None, "connect() first"
         return self._loop
 
+    @property
+    def limp(self) -> str | None:
+        """Why the realtime core went limp, or ``None`` while it is healthy.
+
+        Mirrors :attr:`almond_axol.rt.RtAxol.limp`: once set, every arm joint
+        is at kp = 0 with the streamed gravity feedforward for the rest of
+        the session and :meth:`send_action` streams gravity comp instead of
+        tracking. Recording flows check this before promising motion (a
+        take started on a limp core records arms that will not move) and
+        surface it to the operator; ``None`` before :meth:`connect`.
+        """
+        return None if self._axol is None else self._axol.limp
+
     # ------------------------------------------------------------------
     # Observation / action
     # ------------------------------------------------------------------

--- a/almond_axol/rt/install.py
+++ b/almond_axol/rt/install.py
@@ -334,7 +334,12 @@ def _grant_realtime(binary: Path) -> None:
     A dedicated CPU is not sufficient under Linux's normal scheduler: a
     SCHED_OTHER thread can still be suspended beyond the entire 4.17 ms motor
     period. File-scoped ``CAP_SYS_NICE`` lets ``axol-rt`` raise its own two CAN
-    threads without running the Python/UI/camera process as root.
+    threads without running the Python/UI/camera process as root, and
+    ``CAP_IPC_LOCK`` lets it ``mlockall`` its memory past the unprivileged
+    ``RLIMIT_MEMLOCK`` (8 MiB on most distros — less than its thread stacks)
+    so a page reclaimed under the recorder's I/O pressure can never fault a
+    CAN thread mid-tick. Without the second capability the core still runs,
+    unlocked, and says so.
     """
     if sys.platform != "linux":
         return
@@ -344,7 +349,7 @@ def _grant_realtime(binary: Path) -> None:
     if setcap is None:
         raise RuntimeError("setcap is required to grant axol-rt real-time scheduling")
 
-    cmd = [setcap, "cap_sys_nice=ep", str(binary)]
+    cmd = [setcap, "cap_sys_nice,cap_ipc_lock=ep", str(binary)]
     if os.geteuid() == 0:
         subprocess.run(cmd, check=True)
     elif sys.stdin is not None and sys.stdin.isatty():

--- a/almond_axol/rt/link.py
+++ b/almond_axol/rt/link.py
@@ -190,6 +190,12 @@ class RtLink:
                     self._states.put_nowait(body)
                 elif tag == b"L":
                     _logger.info("axol-rt: %s", body)
+                elif tag == b"W":
+                    # A degraded transition the core wants noticed (timing
+                    # degraded with its stall attribution, memory not
+                    # locked): not a state change, but worth the journal's
+                    # WARNING level so a field log can be read for it.
+                    _logger.warning("axol-rt: %s", body)
                 else:
                     _logger.warning("axol-rt: unknown message tag %r", tag)
         except (asyncio.IncompleteReadError, ConnectionResetError):

--- a/almond_axol/rt/robot.py
+++ b/almond_axol/rt/robot.py
@@ -41,10 +41,10 @@ state, and ``gravity_compensate`` streams its tuples through the same
 command sink, so the contact watchdog, the limp contact hold, and the
 replanned reset all run against the core.
 
-Faults never drop the arms. When the core loses trust in its own loop
-(unhealthy timing, a motor silent for a second) it goes *limp* — every arm
-joint at kp = 0 with the streamed gravity feedforward, still serving — and
-reports ``limp: ...``. ``motion_control`` then streams gravity comp instead
+Faults never drop the arms. When the core loses trust in a motor (silent
+for a second) it goes *limp* — every arm joint at kp = 0 with the streamed
+gravity feedforward, still serving — and reports ``limp: ...``. Bad control
+timing never does: it only degrades (host damping off, logged). ``motion_control`` then streams gravity comp instead
 of tracking, so the arms stay weightless and hand-guidable while the
 operator moves them to rest and stops the session; ``disable`` leaves them
 limp rather than torquing off. A hard fault (dead bus, protocol error) or a

--- a/docs/cli/rt-install.mdx
+++ b/docs/cli/rt-install.mdx
@@ -9,12 +9,16 @@ Builds and installs the `axol-rt` Rust realtime core, the sole production hardwa
 axol rt.install
 ```
 
-On Linux this also grants the built `axol-rt` binary the narrowly scoped
-`CAP_SYS_NICE` capability used by its two CAN threads. An interactive
+On Linux this also grants the built `axol-rt` binary two narrowly scoped
+capabilities: `CAP_SYS_NICE`, used by its two CAN threads to enter their
+real-time scheduling class, and `CAP_IPC_LOCK`, which lets it lock its memory
+(`mlockall`) past the unprivileged `RLIMIT_MEMLOCK` so a page reclaimed under
+recording I/O pressure can never fault a CAN thread mid-tick. An interactive
 development install prompts for `sudo`; the production system service performs
 the step as root. The control core refuses to arm if its requested real-time
 scheduler cannot be established, so a normal scheduler pause can never occur
-after the motors enable.
+after the motors enable; a failed memory lock is only reported (the core runs
+unlocked, as every session did before it locked at all).
 
 Three concerns, each idempotent and self-gating:
 

--- a/rust/axol-rt/README.md
+++ b/rust/axol-rt/README.md
@@ -133,6 +133,35 @@ own trajectory and feedback states:
   operator moves them to rest and restarts. This is the classic
   contact-hold gravity comp, entered from the core side; limp is never
   cleared within a session and a disarm while limp leaves the motors limp.
+- **Late ticks degrade first, limp on repeat.** Timing gets the same
+  two-tier treatment as missed replies. A whole-cycle overrun (a tick that
+  wakes a full period or more late), three late ticks (> 0.5 ms) in a
+  row, or 8 of the last 32 late marks that *bus* timing-degraded: host
+  damping off on every joint of the bus until a clean 32-tick window, and
+  the overrun tick's tracker advances one nominal period with its
+  derivative chains re-seeded at rest — the motors held the previous
+  command across the gap, so there is no trajectory to differentiate and
+  no inertia or damping torque to compute from it. Firmware kp/kd and the
+  streamed gravity `t_ff` are untouched: the arm keeps holding. The
+  transition is a `W` warning line carrying the thread's own counters
+  across that wake (`src/stall.rs`: `/proc/thread-self/schedstat`
+  runnable-wait, `getrusage(RUSAGE_THREAD)` page faults and involuntary
+  switches, sampled every tick for ~2 µs) and what they read as —
+  *preempted*, *page fault*, or *kernel stall* — so a field log names the
+  subsystem to look at. A **second** overrun inside the window, or the
+  loop late on 16 of 32 ticks, is timing that stays unhealthy and takes
+  the session limp. (Before this, one overrun went straight to limp; the
+  2026-09-04 field record was a single 20–60 ms stall in an otherwise
+  perfect ~770k-tick session, each time while the dataset writer flushed
+  a save, and it cost a full stop/restart while the arms were holding
+  still.)
+- **Memory is locked.** `serve` calls `mlockall(MCL_CURRENT | MCL_FUTURE)`
+  before accepting its client, so a page reclaimed under the recorder's
+  I/O pressure can never fault a `SCHED_FIFO` bus thread mid-tick; the
+  per-tick reply bookkeeping is preallocated so the loop never grows the
+  heap. A failed lock (no `CAP_IPC_LOCK`, low `RLIMIT_MEMLOCK` on a dev
+  build) is reported on stdout and as a `W` line and the core runs
+  unlocked as it always did.
 - **Hard faults leave the last command in place.** A dead bus (e-stop),
   bring-up failure, protocol error, signal, or lost client stops the
   stream and exits with each motor holding its last MIT command on
@@ -219,17 +248,21 @@ write them, and the regular five-second status line reports any trace drops.
 `scan` and `bench` are strictly read-only — safe against a powered robot
 at rest. `hold` requires `--yes` to actuate. `serve` only actuates after
 the explicit config/prep/arm handshake. Only a deliberate disarm of a
-healthy session disables the motors (a disabled arm falls). A timing or
-silent-motor fault takes the session limp — gravity comp on every joint,
-still serving, so the operator can hand-guide the arms to rest; a dead
-bus, signal, or client loss stops the stream and leaves the arms holding
-their last command. Missed CAN replies degrade rather than fault: host
-damping is never computed from a stale sample, a joint missing 4 of the
-last 32 replies runs on firmware kd (logged, counted in the five-second
-stats line) until a clean window, and only a motor silent for a full second
-takes the session limp — bursty loss is expected while
-cameras and IK compilation contend for the same host and USB fabric during
-startup. `proxy` is the sole
+healthy session disables the motors (a disabled arm falls). Persistently
+unhealthy timing or a silent motor takes the session limp — gravity comp
+on every joint, still serving, so the operator can hand-guide the arms to
+rest; a dead bus, signal, or client loss stops the stream and leaves the
+arms holding their last command. Missed CAN replies and late ticks
+degrade rather than fault: host damping is never computed from a stale
+sample or across a lost tick, a joint missing 4 of the last 32 replies (or
+a bus with a whole-cycle overrun / 8 of 32 late ticks) runs on firmware kd
+(logged with the stall's attribution, counted in the five-second stats
+line) until a clean window, and only a motor silent for a full second, a
+second overrun within 32 ticks, or a loop late on half its ticks takes
+the session limp — bursty loss is expected while cameras and IK
+compilation contend for the same host and USB fabric during startup, and
+an isolated stall while the dataset writer flushes is not a reason to end
+a session whose arms were holding still. `proxy` is the sole
 frame transport for maintenance, tuning, firmware, and arm diagnostics;
 `jelly` owns Jelly's wheel bus, while the proxy carries its lift bus. Both use
 the realtime core's persistent-TX-stall detection and queue purge, aborting

--- a/rust/axol-rt/README.md
+++ b/rust/axol-rt/README.md
@@ -123,9 +123,9 @@ own trajectory and feedback states:
   anything the checks detect. Torque comes off only on an explicit `D`
   disarm of a healthy session (the operator's deliberate stop) or an
   e-stop.
-- **Loss-of-trust faults go limp.** Unhealthy control timing or a motor
-  silent for a second means the core should stop applying stiffness and
-  phase-sensitive damping — so it does exactly that: every arm joint on
+- **A loss-of-trust fault goes limp.** A motor silent for a second means
+  the core should stop applying stiffness and phase-sensitive damping to a
+  joint it cannot see — so it does exactly that: every arm joint on
   both buses drops to kp = 0, firmware kd only, with the streamed gravity
   `t_ff` still applied, and the loop keeps running. It reports `limp: ...`;
   Python's `motion_control` switches to streaming gravity comp (gravity at
@@ -133,8 +133,8 @@ own trajectory and feedback states:
   operator moves them to rest and restarts. This is the classic
   contact-hold gravity comp, entered from the core side; limp is never
   cleared within a session and a disarm while limp leaves the motors limp.
-- **Late ticks degrade first, limp on repeat.** Timing gets the same
-  two-tier treatment as missed replies. A whole-cycle overrun (a tick that
+- **Late ticks degrade, never limp.** Timing gets missed replies'
+  degraded tier and nothing above it. A whole-cycle overrun (a tick that
   wakes a full period or more late), three late ticks (> 0.5 ms) in a
   row, or 8 of the last 32 late marks that *bus* timing-degraded: host
   damping off on every joint of the bus until a clean 32-tick window, and
@@ -148,13 +148,16 @@ own trajectory and feedback states:
   runnable-wait, `getrusage(RUSAGE_THREAD)` page faults and involuntary
   switches, sampled every tick for ~2 µs) and what they read as —
   *preempted*, *page fault*, or *kernel stall* — so a field log names the
-  subsystem to look at. A **second** overrun inside the window, or the
-  loop late on 16 of 32 ticks, is timing that stays unhealthy and takes
-  the session limp. (Before this, one overrun went straight to limp; the
-  2026-09-04 field record was a single 20–60 ms stall in an otherwise
-  perfect ~770k-tick session, each time while the dataset writer flushed
-  a save, and it cost a full stop/restart while the arms were holding
-  still.)
+  subsystem to look at; further overruns inside a degraded stretch are
+  logged the same way (rate-limited), and the five-second stats line
+  counts overruns and degraded ticks/episodes. No amount of lateness is a
+  loss of trust: a late tick invalidates exactly the terms degraded turns
+  off, and the motors ride out a late host on their own firmware gains —
+  the same thing they do if the host dies. (Before this, one overrun went
+  straight to limp; the 2026-09-04 field record was a single 20–60 ms
+  stall in an otherwise perfect ~770k-tick session, each time while the
+  dataset writer flushed a save, and it cost a full stop/restart while the
+  arms were holding still.)
 - **Memory is locked.** `serve` calls `mlockall(MCL_CURRENT | MCL_FUTURE)`
   before accepting its client, so a page reclaimed under the recorder's
   I/O pressure can never fault a `SCHED_FIFO` bus thread mid-tick; the
@@ -248,8 +251,8 @@ write them, and the regular five-second status line reports any trace drops.
 `scan` and `bench` are strictly read-only — safe against a powered robot
 at rest. `hold` requires `--yes` to actuate. `serve` only actuates after
 the explicit config/prep/arm handshake. Only a deliberate disarm of a
-healthy session disables the motors (a disabled arm falls). Persistently
-unhealthy timing or a silent motor takes the session limp — gravity comp
+healthy session disables the motors (a disabled arm falls). A silent
+motor takes the session limp — gravity comp
 on every joint, still serving, so the operator can hand-guide the arms to
 rest; a dead bus, signal, or client loss stops the stream and leaves the
 arms holding their last command. Missed CAN replies and late ticks
@@ -257,9 +260,8 @@ degrade rather than fault: host damping is never computed from a stale
 sample or across a lost tick, a joint missing 4 of the last 32 replies (or
 a bus with a whole-cycle overrun / 8 of 32 late ticks) runs on firmware kd
 (logged with the stall's attribution, counted in the five-second stats
-line) until a clean window, and only a motor silent for a full second, a
-second overrun within 32 ticks, or a loop late on half its ticks takes
-the session limp — bursty loss is expected while cameras and IK
+line) until a clean window, and only a motor silent for a full second
+takes the session limp — bursty loss is expected while cameras and IK
 compilation contend for the same host and USB fabric during startup, and
 an isolated stall while the dataset writer flushes is not a reason to end
 a session whose arms were holding still. `proxy` is the sole

--- a/rust/axol-rt/src/main.rs
+++ b/rust/axol-rt/src/main.rs
@@ -28,6 +28,7 @@ mod proxy;
 mod safety;
 mod scan;
 mod serve;
+mod stall;
 mod timing;
 mod txn;
 

--- a/rust/axol-rt/src/serve.rs
+++ b/rust/axol-rt/src/serve.rs
@@ -88,6 +88,8 @@
 //!                     gravity t_ff on every arm joint (see Safety); the
 //!                     client should keep streaming gravity-comp targets.
 //! - `L` + text        log line
+//! - `W` + text        warning line: a degraded transition worth the
+//!                     operator's attention (the client logs it at WARNING)
 //! - `F` + binary      telemetry, one per bus per tick while armed: side
 //!                     u8, valid-mask u8, then 8 x (pos f64, vel f64, tau
 //!                     f64, age_us u32) — the latest decoded feedback per
@@ -137,9 +139,27 @@
 //!   32 ticks) marks the joint *degraded* — host damping stays off until a
 //!   clean 32-tick window, the transition is logged, and the loop keeps
 //!   running on firmware kd. Only a motor silent for a full second takes
-//!   the session limp. Clustered late ticks and a full-cycle overrun go
-//!   limp the same way — phase-sensitive damping must not run on stale
-//!   timing, and limp mode has none.
+//!   the session limp.
+//! - **Late ticks degrade first, limp on repeat.** Timing gets the same
+//!   two-tier treatment as feedback. A whole-cycle overrun (a wake a full
+//!   period or more late), three late ticks in a row, or 8 of the last 32
+//!   late marks the *bus* timing-degraded: host damping off on every joint
+//!   of that bus until a clean 32-tick window, and the overrun tick's
+//!   tracker advances one nominal period with its derivative chains
+//!   re-seeded at rest — the motors held the previous command across the
+//!   gap, so there is no trajectory to differentiate. Firmware kp/kd and
+//!   the streamed gravity `t_ff` are untouched, so the arm keeps holding.
+//!   The transition is logged as a warning with the thread's own
+//!   scheduler/memory counters across that wake (`stall.rs`: runnable-wait,
+//!   page faults, involuntary switches) so the line says whether the loop
+//!   was preempted, faulting, or blocked in the kernel. A *second* overrun
+//!   inside the window, or the loop late on 16 of 32 ticks, is timing that
+//!   stays unhealthy and takes the session limp as above.
+//! - The process locks its memory (`mlockall`, `stall::lock_memory`) before
+//!   accepting a client, so a page reclaimed under the dataset writer's I/O
+//!   pressure can never fault a bus thread mid-tick. A failed lock (no
+//!   `CAP_IPC_LOCK`, low `RLIMIT_MEMLOCK` on a dev build) is logged and
+//!   the core runs unlocked as it always did.
 //! - The gripper is not commanded at all until the first target arrives
 //!   (matching classic mode, where it sits idle until motion_control).
 //! - Watchdog: no target for `watchdog_ms` holds the last target (the
@@ -164,6 +184,7 @@ use crate::filter::{self, BandPass, LpDiff, Trapezoid};
 use crate::hold::sleep_until;
 use crate::proto;
 use crate::safety::{guarded_send, purge_tx_queue, SendOutcome, STALL_DETECT};
+use crate::stall;
 
 /// Pole (rad/s) of the motor-facing command derivatives — `CUTOFF_FREQ` in
 /// `almond_axol.robot.control`.  The slow pole keeps target-rate steps out of
@@ -210,7 +231,25 @@ const REPLY_GUARD: Duration = Duration::from_micros(150);
 /// A tick starting more than this far past its deadline is phase-degraded. Its
 /// host damping is suppressed even when feedback itself is fresh.
 const LATE_TICK: Duration = Duration::from_micros(500);
-const MAX_RECENT_LATE_TICKS: u32 = 8;
+/// Clustered lateness that marks a bus's *timing* degraded (host damping off
+/// on every joint of that bus until a clean 32-tick window): three late
+/// ticks in a row, or this many in the window. Not a fault — the same
+/// treatment bursty feedback loss gets. A whole-cycle overrun (a tick that
+/// wakes a full period or more late) degrades on its own: the sample/command
+/// ordering that tick was lost, so its damping and inertia terms are
+/// re-seeded rather than computed over the gap.
+const DEGRADED_RECENT_LATE_TICKS: u32 = 8;
+/// Timing that stays unhealthy is a loss of trust: a *second* whole-cycle
+/// overrun inside the window (two stalls within 133 ms), or the loop late on
+/// half its ticks, takes the session limp. One overrun does not: the field
+/// record (2026-09-04) is a single 20–60 ms stall in an otherwise perfect
+/// ~770k-tick session, each time while the dataset writer flushed a save,
+/// and answering it with a session-ending limp cost a full stop/restart per
+/// hiccup while the arms were holding still. Degraded covers what the
+/// overrun actually breaks (phase-sensitive terms); limp is for a loop that
+/// is demonstrably not being scheduled.
+const LIMP_RECENT_OVERRUNS: u32 = 2;
+const LIMP_RECENT_LATE_TICKS: u32 = 16;
 
 static SHUTDOWN: AtomicBool = AtomicBool::new(false);
 
@@ -395,30 +434,67 @@ fn silent_feedback_limit(loop_hz: f64) -> u32 {
         .max(1.0) as u32
 }
 
+/// Outcome of one tick's wake-up timing for the bus.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TimingVerdict {
+    /// Nothing to report: on time, an isolated late tick, or an ongoing
+    /// degraded stretch that has neither cleared nor worsened.
+    Steady,
+    /// Timing just became untrustworthy: host damping off on this bus until
+    /// a clean window (see `DEGRADED_RECENT_LATE_TICKS`).
+    Degraded,
+    /// A full clean window just closed out a degraded stretch.
+    Recovered,
+    /// Timing is persistently unhealthy: take the session limp.
+    Limp,
+}
+
 #[derive(Clone, Copy, Default)]
 struct TimingHealth {
+    /// Ticks that woke more than `LATE_TICK` past their deadline.
     recent_late: u32,
+    /// Ticks that woke a whole period or more late.
+    recent_overruns: u32,
     consecutive_late: u8,
+    degraded: bool,
 }
 
 impl TimingHealth {
-    fn record(&mut self, on_time: bool) -> bool {
-        self.recent_late = (self.recent_late << 1) | u32::from(!on_time);
-        if on_time {
-            self.consecutive_late = 0;
-        } else {
+    /// Record one tick's wake-up lateness. The verdict includes the tick
+    /// itself: a fault diagnostic must describe the tick that triggered it.
+    ///
+    /// Mirrors `FeedbackHealth`: degradation has hysteresis (it starts at
+    /// an overrun or a late cluster and only clears once the 32-tick window
+    /// has no late tick at all), and the fault sits well above it.
+    fn record(&mut self, lateness: Duration, period: Duration) -> TimingVerdict {
+        let late = lateness > LATE_TICK;
+        let overrun = lateness >= period;
+        self.recent_late = (self.recent_late << 1) | u32::from(late);
+        self.recent_overruns = (self.recent_overruns << 1) | u32::from(overrun);
+        if late {
             self.consecutive_late = self.consecutive_late.saturating_add(1);
+        } else {
+            self.consecutive_late = 0;
         }
-        self.consecutive_late >= 3 || self.recent_late.count_ones() >= MAX_RECENT_LATE_TICKS
-    }
-
-    /// Record this tick before applying the immediate full-cycle limit.  The
-    /// ordering matters: the fault diagnostic must include the tick that
-    /// triggered it, even when `lateness >= period` is already sufficient to
-    /// stop the loop.
-    fn record_lateness(&mut self, lateness: Duration, period: Duration) -> bool {
-        let clustered_lateness = self.record(lateness <= LATE_TICK);
-        lateness >= period || clustered_lateness
+        if self.recent_overruns.count_ones() >= LIMP_RECENT_OVERRUNS
+            || self.recent_late.count_ones() >= LIMP_RECENT_LATE_TICKS
+        {
+            return TimingVerdict::Limp;
+        }
+        let unhealthy = overrun
+            || self.consecutive_late >= 3
+            || self.recent_late.count_ones() >= DEGRADED_RECENT_LATE_TICKS;
+        match (self.degraded, unhealthy) {
+            (false, true) => {
+                self.degraded = true;
+                TimingVerdict::Degraded
+            }
+            (true, false) if self.recent_late == 0 => {
+                self.degraded = false;
+                TimingVerdict::Recovered
+            }
+            _ => TimingVerdict::Steady,
+        }
     }
 }
 
@@ -990,23 +1066,93 @@ mod tests {
         }
     }
 
+    const PERIOD: Duration = Duration::from_micros(4_167);
+    const ON_TIME: Duration = Duration::from_micros(50);
+    const LATE: Duration = Duration::from_micros(800);
+
     #[test]
-    fn timing_health_catches_clustered_late_ticks() {
+    fn timing_health_degrades_on_clustered_late_ticks_and_recovers() {
+        // Alternating late/on-time: the eighth late tick in the window
+        // degrades the bus (the old limp trip), and it stays degraded
+        // (Steady, not re-announced) while the pattern continues.
         let mut health = TimingHealth::default();
         for _ in 0..7 {
-            assert!(!health.record(false));
-            assert!(!health.record(true));
+            assert_eq!(health.record(LATE, PERIOD), TimingVerdict::Steady);
+            assert_eq!(health.record(ON_TIME, PERIOD), TimingVerdict::Steady);
         }
-        assert!(health.record(false));
+        assert_eq!(health.record(LATE, PERIOD), TimingVerdict::Degraded);
+        assert!(health.degraded);
+
+        // Hysteresis: only a fully clean window (32 on-time ticks after the
+        // last late one) recovers.
+        for _ in 0..31 {
+            assert_eq!(health.record(ON_TIME, PERIOD), TimingVerdict::Steady);
+            assert!(health.degraded);
+        }
+        assert_eq!(health.record(ON_TIME, PERIOD), TimingVerdict::Recovered);
+        assert!(!health.degraded);
+
+        // Three in a row degrades too.
+        let mut consecutive = TimingHealth::default();
+        assert_eq!(consecutive.record(LATE, PERIOD), TimingVerdict::Steady);
+        assert_eq!(consecutive.record(LATE, PERIOD), TimingVerdict::Steady);
+        assert_eq!(consecutive.record(LATE, PERIOD), TimingVerdict::Degraded);
     }
 
     #[test]
-    fn timing_health_counts_immediate_full_cycle_fault() {
+    fn timing_health_isolated_overrun_degrades_not_limps() {
+        // The field record: one 60 ms stall in an otherwise perfect stream.
         let mut health = TimingHealth::default();
-        let period = Duration::from_micros(4_167);
-        assert!(health.record_lateness(period, period));
+        for _ in 0..1000 {
+            assert_eq!(health.record(ON_TIME, PERIOD), TimingVerdict::Steady);
+        }
+        assert_eq!(
+            health.record(Duration::from_millis(60), PERIOD),
+            TimingVerdict::Degraded
+        );
+        assert!(health.degraded);
+        assert_eq!(health.recent_overruns.count_ones(), 1);
         assert_eq!(health.recent_late.count_ones(), 1);
-        assert_eq!(health.consecutive_late, 1);
+        // The next tick is on time again; damping stays off for the window...
+        for _ in 0..31 {
+            assert_eq!(health.record(ON_TIME, PERIOD), TimingVerdict::Steady);
+        }
+        // ...then comes back.
+        assert_eq!(health.record(ON_TIME, PERIOD), TimingVerdict::Recovered);
+        assert_eq!(health.recent_overruns, 0);
+    }
+
+    #[test]
+    fn timing_health_limps_on_repeated_overruns_or_persistent_lateness() {
+        // Two whole-cycle overruns inside the window: the loop is not being
+        // scheduled; the verdict names the tick that made it two.
+        let mut health = TimingHealth::default();
+        assert_eq!(health.record(PERIOD, PERIOD), TimingVerdict::Degraded);
+        for _ in 0..20 {
+            assert_eq!(health.record(ON_TIME, PERIOD), TimingVerdict::Steady);
+        }
+        assert_eq!(health.record(PERIOD * 3, PERIOD), TimingVerdict::Limp);
+        assert_eq!(health.recent_overruns.count_ones(), 2);
+
+        // Two overruns further apart than the window are two degraded
+        // episodes, not a fault.
+        let mut spaced = TimingHealth::default();
+        assert_eq!(spaced.record(PERIOD, PERIOD), TimingVerdict::Degraded);
+        for _ in 0..31 {
+            assert_eq!(spaced.record(ON_TIME, PERIOD), TimingVerdict::Steady);
+        }
+        assert_eq!(spaced.record(ON_TIME, PERIOD), TimingVerdict::Recovered);
+        assert_eq!(spaced.record(PERIOD, PERIOD), TimingVerdict::Degraded);
+
+        // Late on half the window.
+        let mut persistent = TimingHealth::default();
+        let mut verdicts = Vec::new();
+        for _ in 0..16 {
+            verdicts.push(persistent.record(LATE, PERIOD));
+            verdicts.push(persistent.record(ON_TIME, PERIOD));
+        }
+        assert!(verdicts.contains(&TimingVerdict::Degraded));
+        assert_eq!(verdicts[30], TimingVerdict::Limp);
     }
 
     #[test]
@@ -1204,12 +1350,36 @@ pub fn run(socket_path: &str) -> io::Result<()> {
         libc::signal(libc::SIGTERM, on_signal as *const () as libc::sighandler_t);
     }
     let _ = std::fs::remove_file(socket_path);
+    // Lock memory before anything the bus threads will touch is mapped:
+    // MCL_FUTURE then covers the socket buffers, the channel, and the
+    // threads' stacks as they are created (see the Safety notes).
+    let memory_locked = match stall::lock_memory() {
+        Ok(()) => {
+            println!("axol-rt serve: memory locked (mlockall)");
+            true
+        }
+        Err(err) => {
+            println!(
+                "axol-rt serve: could not lock memory ({err}); running unlocked — a page fault can stall a bus thread (grant CAP_IPC_LOCK / raise RLIMIT_MEMLOCK)"
+            );
+            false
+        }
+    };
     let listener = UnixListener::bind(socket_path)?;
     println!("axol-rt serve: listening on {socket_path}");
     let (mut stream, _) = listener.accept()?;
     println!("axol-rt serve: client connected");
 
     let (out_tx, out_rx) = mpsc::channel::<Vec<u8>>();
+    if !memory_locked {
+        // Repeat over the link so the warning lands in the session log, not
+        // only on the core's stdout.
+        send_text(
+            &out_tx,
+            b'W',
+            "memory not locked (mlockall failed) — a page fault can stall a bus thread; grant CAP_IPC_LOCK or raise RLIMIT_MEMLOCK",
+        );
+    }
     let writer = std::thread::spawn({
         let stream = stream.try_clone()?;
         move || writer_thread(stream, out_rx)
@@ -1621,6 +1791,18 @@ fn bus_loop(
     let mut degraded_announced = [false; N_SLOTS];
     let mut next_degraded_log = Instant::now();
     let mut timing_health = TimingHealth::default();
+    let mut timing_degraded_ticks: u64 = 0;
+    let mut timing_degraded_episodes: u64 = 0;
+    let mut timing_announced = false;
+    let mut next_timing_log = Instant::now();
+    let mut overruns: u64 = 0;
+    // Per-thread scheduler/memory counters, sampled at every wake so a late
+    // tick can be attributed to what actually kept the thread off the CPU.
+    let mut stall_probe = stall::StallProbe::open();
+    // Per-tick reply bookkeeping, allocated once: the loop must not grow
+    // the heap (a fresh page is a fault, see `stall::lock_memory`).
+    let mut expected = vec![false; motors.len()];
+    let mut seen = vec![false; motors.len()];
     // Belt-and-braces: sends on a dead bus normally fail fast with ENOBUFS,
     // but if the socket sndbuf fills first a blocking write would hang the
     // loop; the timeout turns that into EAGAIN (treated as TX-full).
@@ -1659,24 +1841,77 @@ fn bus_loop(
             if !timing_on_time {
                 late += 1;
             }
+            let overrun = lateness >= period;
+            if overrun {
+                overruns += 1;
+            }
+            // Bracket this wake with the thread's own scheduler/memory
+            // counters (µs, before any bus work) so a late tick is attributed
+            // — preempted, page fault, kernel stall — not just measured.
+            let stall = stall_probe.sample();
             // A whole-cycle overrun means the causal sample/command ordering
-            // has been lost; clustered lateness says the same more slowly.
-            // Phase-sensitive host damping must not run on that, so the
-            // session goes *limp*: kp = 0, firmware kd only, gravity from
-            // the streamed t_ff — no host damping to be out of phase. The
-            // operator hand-guides the arms to rest and restarts. Already
-            // limp: nothing left to protect, keep serving gravity comp.
+            // was lost for this tick; clustered lateness says timing cannot be
+            // trusted more slowly. Phase-sensitive host damping must not run
+            // on either, so the bus goes *timing-degraded*: damping off on
+            // every joint until a clean window, and the overrun tick's command
+            // derivatives re-seeded rather than integrated across the gap
+            // (firmware kp/kd and the streamed gravity t_ff are unaffected,
+            // so the arm keeps holding). Only timing that stays unhealthy —
+            // a second overrun within the window, or late on half the ticks
+            // — takes the session *limp*: kp = 0, firmware kd, gravity from
+            // the streamed t_ff; the operator hand-guides the arms to rest
+            // and restarts. Already limp: nothing left to protect.
             let is_limp = limp.load(Ordering::SeqCst);
-            if timing_health.record_lateness(lateness, period) && !is_limp {
-                go_limp(
-                    limp,
-                    out_tx,
-                    &format!(
-                        "{iface}: control timing unhealthy ({:.3} ms late, {} of the last 32 ticks late) — going limp before phase-sensitive damping",
-                        lateness.as_secs_f64() * 1e3,
-                        timing_health.recent_late.count_ones(),
-                    ),
-                );
+            match timing_health.record(lateness, period) {
+                TimingVerdict::Steady => {}
+                TimingVerdict::Degraded => {
+                    timing_degraded_episodes += 1;
+                    // Rate-limited like the feedback transitions; the stats
+                    // line carries the cumulative counts regardless.
+                    timing_announced = began >= next_timing_log;
+                    if timing_announced {
+                        next_timing_log = began + DEGRADED_LOG_INTERVAL;
+                        send_text(
+                            out_tx,
+                            b'W',
+                            &format!(
+                                "{iface}: control timing degraded ({:.3} ms late, {} of the last 32 ticks late, {} whole-cycle overrun{}; {}) — host damping off on this bus until a clean window; firmware gains hold",
+                                lateness.as_secs_f64() * 1e3,
+                                timing_health.recent_late.count_ones(),
+                                timing_health.recent_overruns.count_ones(),
+                                if timing_health.recent_overruns.count_ones() == 1 { "" } else { "s" },
+                                stall.describe(lateness),
+                            ),
+                        );
+                    }
+                }
+                TimingVerdict::Recovered => {
+                    if std::mem::take(&mut timing_announced) {
+                        send_text(
+                            out_tx,
+                            b'L',
+                            &format!("{iface}: control timing recovered — host damping resumed"),
+                        );
+                    }
+                }
+                TimingVerdict::Limp => {
+                    if !is_limp {
+                        go_limp(
+                            limp,
+                            out_tx,
+                            &format!(
+                                "{iface}: control timing unhealthy ({:.3} ms late, {} of the last 32 ticks late, {} whole-cycle overruns; {}) — going limp before phase-sensitive damping",
+                                lateness.as_secs_f64() * 1e3,
+                                timing_health.recent_late.count_ones(),
+                                timing_health.recent_overruns.count_ones(),
+                                stall.describe(lateness),
+                            ),
+                        );
+                    }
+                }
+            }
+            if timing_health.degraded {
+                timing_degraded_ticks += 1;
             }
             let is_limp = is_limp || limp.load(Ordering::SeqCst);
             ticks += 1;
@@ -1728,8 +1963,18 @@ fn bus_loop(
 
             // Tick spacing for the damping chain (measured, not nominal —
             // a late tick then damps over the interval it actually covers).
+            // An overrun is the exception: the motors held the previous
+            // command for the whole gap, so the tracker advances one nominal
+            // period rather than rendering a max-velocity catch-up step over
+            // the wall-clock it lost, and the command derivatives are
+            // re-seeded (below) instead of differentiated across it.
             let tick_dt = prev_tick.map_or(0.0, |p| began.duration_since(p).as_secs_f64());
             prev_tick = Some(began);
+            let cmd_dt = if overrun {
+                period.as_secs_f64()
+            } else {
+                tick_dt
+            };
 
             // The user-facing flight recorder gates the verbose core trace to
             // the same engage segment as IK/cmd/meas. On each new segment the
@@ -1762,7 +2007,7 @@ fn bus_loop(
 
             // Send all commands back-to-back and remember exactly which
             // motors were successfully queued in this tick.
-            let mut expected = vec![false; motors.len()];
+            expected.fill(false);
             let mut trace_pending: [Option<TraceRow>; N_SLOTS] = [None; N_SLOTS];
             for (motor_index, m) in motors.iter().enumerate() {
                 let c = if is_limp && !m.gripper {
@@ -1811,48 +2056,62 @@ fn bus_loop(
                     // so a later mode switch starts transient-free.
                     let tracked = c.mode >= 0.5;
                     let p_cmd = if tracked {
-                        let (p, _, _) = trk[m.slot].update(c.p_des, tick_dt);
+                        let (p, _, _) = trk[m.slot].update(c.p_des, cmd_dt);
                         p
                     } else {
                         trk[m.slot].seed(c.p_des);
                         c.p_des
                     };
                     let d = &mut damp[m.slot];
-                    let (v_wire, a_cmd, v_cmd_fast, friction_ff, inertia_ff, v_damp) = if tracked {
-                        // Match classic AxolArm.motion_control: friction uses
-                        // the 20 rad/s low-pass position derivative, inertia
-                        // uses a second identical derivative, and damping
-                        // uses its independent 80 rad/s desired-velocity
-                        // derivative.  Only the source position/rate differ:
-                        // the core can use the trajectory it really sends.
-                        let v_cmd = d.v_cmd.update(p_cmd, tick_dt);
-                        let a_cmd = d.a_cmd.update(v_cmd, tick_dt);
-                        let v_cmd_fast = d.v_cmd_fast.update(p_cmd, tick_dt);
-                        let friction_ff = filter::friction(v_cmd, m.fc, m.k, m.fv, m.fo);
-                        let inertia_ff = c.j_eff * a_cmd;
-                        let damp_ok = feedback_fresh[m.slot]
-                            && timing_on_time
-                            && !feedback_health[m.slot].degraded;
-                        let v_damp = if damp_ok {
-                            d.bp.update(v_cmd_fast - d.vel_meas, c.damp_w0, c.damp_q, tick_dt)
-                        } else {
-                            // A missing frame makes measured velocity stale.
-                            // Reset rather than carrying band-pass energy into
-                            // the first tick after feedback recovers. While the
-                            // joint is degraded, damping stays off for the whole
-                            // stretch: re-engaging a freshly reset band-pass
-                            // every few ticks is a torque transient, not damping.
+                    let (v_wire, a_cmd, v_cmd_fast, friction_ff, inertia_ff, v_damp) =
+                        if tracked && overrun {
+                            // The gap since the last command is not a trajectory
+                            // segment the motor followed — it held. Re-prime the
+                            // derivative chains at rest here so the first tick
+                            // back carries no fictitious velocity, acceleration
+                            // (inertia torque), or band-pass energy; they ramp
+                            // in again from the next tick as tracking resumes.
+                            d.v_cmd.seed(p_cmd);
+                            d.a_cmd.seed(0.0);
+                            d.v_cmd_fast.seed(p_cmd);
                             d.bp.reset();
-                            0.0
+                            (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+                        } else if tracked {
+                            // Match classic AxolArm.motion_control: friction uses
+                            // the 20 rad/s low-pass position derivative, inertia
+                            // uses a second identical derivative, and damping
+                            // uses its independent 80 rad/s desired-velocity
+                            // derivative.  Only the source position/rate differ:
+                            // the core can use the trajectory it really sends.
+                            let v_cmd = d.v_cmd.update(p_cmd, tick_dt);
+                            let a_cmd = d.a_cmd.update(v_cmd, tick_dt);
+                            let v_cmd_fast = d.v_cmd_fast.update(p_cmd, tick_dt);
+                            let friction_ff = filter::friction(v_cmd, m.fc, m.k, m.fv, m.fo);
+                            let inertia_ff = c.j_eff * a_cmd;
+                            let damp_ok = feedback_fresh[m.slot]
+                                && timing_on_time
+                                && !timing_health.degraded
+                                && !feedback_health[m.slot].degraded;
+                            let v_damp = if damp_ok {
+                                d.bp.update(v_cmd_fast - d.vel_meas, c.damp_w0, c.damp_q, tick_dt)
+                            } else {
+                                // A missing frame makes measured velocity stale.
+                                // Reset rather than carrying band-pass energy into
+                                // the first tick after feedback recovers. While the
+                                // joint is degraded, damping stays off for the whole
+                                // stretch: re-engaging a freshly reset band-pass
+                                // every few ticks is a torque transient, not damping.
+                                d.bp.reset();
+                                0.0
+                            };
+                            (v_cmd, a_cmd, v_cmd_fast, friction_ff, inertia_ff, v_damp)
+                        } else {
+                            d.v_cmd.seed(p_cmd);
+                            d.a_cmd.seed(0.0);
+                            d.v_cmd_fast.seed(p_cmd);
+                            d.bp.reset();
+                            (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
                         };
-                        (v_cmd, a_cmd, v_cmd_fast, friction_ff, inertia_ff, v_damp)
-                    } else {
-                        d.v_cmd.seed(p_cmd);
-                        d.a_cmd.seed(0.0);
-                        d.v_cmd_fast.seed(p_cmd);
-                        d.bp.reset();
-                        (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
-                    };
                     let damping_ff = c.kd_host * v_damp;
                     let t_ff = c.t_ff + friction_ff + inertia_ff + damping_ff;
                     if trace_this_tick && trace_tx.is_some() {
@@ -1940,7 +2199,7 @@ fn bus_loop(
             // must end the window at `reply_deadline`, never a jiffy or two
             // later, or the overrun lands on the next tick as lateness.
             let reply_deadline = began + period.saturating_sub(REPLY_GUARD);
-            let mut seen = vec![false; motors.len()];
+            seen.fill(false);
             let mut pending = expected.iter().filter(|&&value| value).count();
             while pending > 0 {
                 let now = Instant::now();
@@ -2111,7 +2370,7 @@ fn bus_loop(
                     out_tx,
                     b'L',
                     &format!(
-                        "{iface}: {ticks} ticks, {late} late ({:.2}%), {missed} missed replies, {degraded_ticks} degraded ticks in {degraded_episodes} episodes, {rejected} rejected targets, {trace_dropped} trace drops, seq {:?}",
+                        "{iface}: {ticks} ticks, {late} late ({:.2}%), {overruns} overruns, {timing_degraded_ticks} timing-degraded ticks in {timing_degraded_episodes} episodes, {missed} missed replies, {degraded_ticks} feedback-degraded ticks in {degraded_episodes} episodes, {rejected} rejected targets, {trace_dropped} trace drops, seq {:?}",
                         late as f64 / ticks as f64 * 100.0,
                         last_seq,
                     ),

--- a/rust/axol-rt/src/serve.rs
+++ b/rust/axol-rt/src/serve.rs
@@ -102,9 +102,9 @@
 //!   which is worse than any condition the checks detect. Torque comes off
 //!   only on an explicit `D` disarm of a healthy session (or an e-stop,
 //!   which removes motor power itself).
-//! - **Loss-of-trust faults go *limp*, not dead.** Unhealthy control timing
-//!   and a motor silent for a second both mean the core should no longer be
-//!   applying stiffness or phase-sensitive damping — so it stops doing
+//! - **A loss-of-trust fault goes *limp*, not dead.** A motor silent for a
+//!   second means the core should no longer be applying stiffness or
+//!   phase-sensitive damping to a joint it cannot see — so it stops doing
 //!   exactly that and nothing more: every arm joint on both buses goes to
 //!   kp = 0, firmware kd `LIMP_KD`, no host damping or inertia term, with
 //!   the streamed gravity `t_ff` still applied (Python keeps evaluating it
@@ -140,21 +140,22 @@
 //!   clean 32-tick window, the transition is logged, and the loop keeps
 //!   running on firmware kd. Only a motor silent for a full second takes
 //!   the session limp.
-//! - **Late ticks degrade first, limp on repeat.** Timing gets the same
-//!   two-tier treatment as feedback. A whole-cycle overrun (a wake a full
+//! - **Late ticks degrade, never limp.** Timing gets feedback's degraded
+//!   tier and nothing above it. A whole-cycle overrun (a wake a full
 //!   period or more late), three late ticks in a row, or 8 of the last 32
 //!   late marks the *bus* timing-degraded: host damping off on every joint
 //!   of that bus until a clean 32-tick window, and the overrun tick's
 //!   tracker advances one nominal period with its derivative chains
 //!   re-seeded at rest — the motors held the previous command across the
 //!   gap, so there is no trajectory to differentiate. Firmware kp/kd and
-//!   the streamed gravity `t_ff` are untouched, so the arm keeps holding.
-//!   The transition is logged as a warning with the thread's own
-//!   scheduler/memory counters across that wake (`stall.rs`: runnable-wait,
-//!   page faults, involuntary switches) so the line says whether the loop
-//!   was preempted, faulting, or blocked in the kernel. A *second* overrun
-//!   inside the window, or the loop late on 16 of 32 ticks, is timing that
-//!   stays unhealthy and takes the session limp as above.
+//!   the streamed gravity `t_ff` are untouched, so the arm keeps holding —
+//!   a late host is what the firmware is built to ride out, which is why
+//!   no amount of lateness is a loss of trust. The transition (and each
+//!   further overrun inside a degraded stretch, rate-limited) is logged as
+//!   a warning with the thread's own scheduler/memory counters across that
+//!   wake (`stall.rs`: runnable-wait, page faults, involuntary switches) so
+//!   the line says whether the loop was preempted, faulting, or blocked in
+//!   the kernel.
 //! - The process locks its memory (`mlockall`, `stall::lock_memory`) before
 //!   accepting a client, so a page reclaimed under the dataset writer's I/O
 //!   pressure can never fault a bus thread mid-tick. A failed lock (no
@@ -219,7 +220,7 @@ const SILENT_FEEDBACK_FAULT: Duration = Duration::from_secs(1);
 /// five-second stats line carries the cumulative count regardless.
 const DEGRADED_LOG_INTERVAL: Duration = Duration::from_secs(5);
 /// Firmware velocity damping (Nm·s/rad) on the arm joints while the core is
-/// *limp* — the fallback for a loss-of-trust fault (timing, silent motor).
+/// *limp* — the fallback for a loss-of-trust fault (a silent motor).
 /// Matches `VRTeleopConfig.reset_gravity_comp_kd`, the classic contact-hold
 /// gravity comp: enough to keep a hand-guided arm from feeling twitchy, far
 /// too little to hold it up. Gravity itself comes from the streamed `t_ff`.
@@ -239,17 +240,19 @@ const LATE_TICK: Duration = Duration::from_micros(500);
 /// ordering that tick was lost, so its damping and inertia terms are
 /// re-seeded rather than computed over the gap.
 const DEGRADED_RECENT_LATE_TICKS: u32 = 8;
-/// Timing that stays unhealthy is a loss of trust: a *second* whole-cycle
-/// overrun inside the window (two stalls within 133 ms), or the loop late on
-/// half its ticks, takes the session limp. One overrun does not: the field
-/// record (2026-09-04) is a single 20–60 ms stall in an otherwise perfect
-/// ~770k-tick session, each time while the dataset writer flushed a save,
-/// and answering it with a session-ending limp cost a full stop/restart per
-/// hiccup while the arms were holding still. Degraded covers what the
-/// overrun actually breaks (phase-sensitive terms); limp is for a loop that
-/// is demonstrably not being scheduled.
-const LIMP_RECENT_OVERRUNS: u32 = 2;
-const LIMP_RECENT_LATE_TICKS: u32 = 16;
+// Bad control timing never takes the session limp — degraded is the whole
+// response, however long it lasts. A late tick invalidates exactly the terms
+// degraded turns off (phase-sensitive damping, the derivative chains); the
+// motors themselves hold the last command on firmware kp/kd across any gap,
+// which is the same thing they do if the host dies. Limp is reserved for a
+// motor that has gone silent (`SILENT_FEEDBACK_FAULT`), where the core would
+// otherwise stream stiffness to a joint it cannot see. The field record
+// (2026-09-04) is single 20–60 ms stalls in otherwise perfect ~770k-tick
+// sessions, each while the dataset writer flushed a save; the old single-tick
+// limp turned each into a session-ending, hand-guide-and-restart fault while
+// the arms were holding still. Persistent lateness is still made visible: the
+// degraded warning carries the stall attribution, repeated overruns inside a
+// degraded stretch are logged (rate-limited), and the stats line counts them.
 
 static SHUTDOWN: AtomicBool = AtomicBool::new(false);
 
@@ -445,8 +448,6 @@ enum TimingVerdict {
     Degraded,
     /// A full clean window just closed out a degraded stretch.
     Recovered,
-    /// Timing is persistently unhealthy: take the session limp.
-    Limp,
 }
 
 #[derive(Clone, Copy, Default)]
@@ -461,11 +462,12 @@ struct TimingHealth {
 
 impl TimingHealth {
     /// Record one tick's wake-up lateness. The verdict includes the tick
-    /// itself: a fault diagnostic must describe the tick that triggered it.
+    /// itself: the degraded warning must describe the tick that triggered it.
     ///
-    /// Mirrors `FeedbackHealth`: degradation has hysteresis (it starts at
-    /// an overrun or a late cluster and only clears once the 32-tick window
-    /// has no late tick at all), and the fault sits well above it.
+    /// Mirrors `FeedbackHealth`'s degraded tier: hysteresis (it starts at an
+    /// overrun or a late cluster and only clears once the 32-tick window has
+    /// no late tick at all). Unlike feedback there is no fault tier above it
+    /// — see the note at `DEGRADED_RECENT_LATE_TICKS`.
     fn record(&mut self, lateness: Duration, period: Duration) -> TimingVerdict {
         let late = lateness > LATE_TICK;
         let overrun = lateness >= period;
@@ -475,11 +477,6 @@ impl TimingHealth {
             self.consecutive_late = self.consecutive_late.saturating_add(1);
         } else {
             self.consecutive_late = 0;
-        }
-        if self.recent_overruns.count_ones() >= LIMP_RECENT_OVERRUNS
-            || self.recent_late.count_ones() >= LIMP_RECENT_LATE_TICKS
-        {
-            return TimingVerdict::Limp;
         }
         let unhealthy = overrun
             || self.consecutive_late >= 3
@@ -1123,19 +1120,26 @@ mod tests {
     }
 
     #[test]
-    fn timing_health_limps_on_repeated_overruns_or_persistent_lateness() {
-        // Two whole-cycle overruns inside the window: the loop is not being
-        // scheduled; the verdict names the tick that made it two.
+    fn timing_health_never_escalates_past_degraded() {
+        // Repeated whole-cycle overruns inside one window: still degraded,
+        // never a fault — the loop stays in the degraded stretch (Steady,
+        // damping off) and the stretch is what the log reports.
         let mut health = TimingHealth::default();
         assert_eq!(health.record(PERIOD, PERIOD), TimingVerdict::Degraded);
         for _ in 0..20 {
             assert_eq!(health.record(ON_TIME, PERIOD), TimingVerdict::Steady);
         }
-        assert_eq!(health.record(PERIOD * 3, PERIOD), TimingVerdict::Limp);
+        assert_eq!(health.record(PERIOD * 3, PERIOD), TimingVerdict::Steady);
+        assert!(health.degraded);
         assert_eq!(health.recent_overruns.count_ones(), 2);
+        // The window must be clean again before it recovers.
+        for _ in 0..31 {
+            assert_eq!(health.record(ON_TIME, PERIOD), TimingVerdict::Steady);
+        }
+        assert_eq!(health.record(ON_TIME, PERIOD), TimingVerdict::Recovered);
 
         // Two overruns further apart than the window are two degraded
-        // episodes, not a fault.
+        // episodes.
         let mut spaced = TimingHealth::default();
         assert_eq!(spaced.record(PERIOD, PERIOD), TimingVerdict::Degraded);
         for _ in 0..31 {
@@ -1144,15 +1148,23 @@ mod tests {
         assert_eq!(spaced.record(ON_TIME, PERIOD), TimingVerdict::Recovered);
         assert_eq!(spaced.record(PERIOD, PERIOD), TimingVerdict::Degraded);
 
-        // Late on half the window.
+        // Late on every other tick for a long stretch: one Degraded
+        // transition, then Steady for as long as it lasts.
         let mut persistent = TimingHealth::default();
         let mut verdicts = Vec::new();
-        for _ in 0..16 {
+        for _ in 0..500 {
             verdicts.push(persistent.record(LATE, PERIOD));
             verdicts.push(persistent.record(ON_TIME, PERIOD));
         }
-        assert!(verdicts.contains(&TimingVerdict::Degraded));
-        assert_eq!(verdicts[30], TimingVerdict::Limp);
+        assert_eq!(
+            verdicts
+                .iter()
+                .filter(|v| **v == TimingVerdict::Degraded)
+                .count(),
+            1
+        );
+        assert!(!verdicts.contains(&TimingVerdict::Recovered));
+        assert!(persistent.degraded);
     }
 
     #[test]
@@ -1407,7 +1419,7 @@ pub fn run(socket_path: &str) -> io::Result<()> {
     // motors holding their last MIT command on firmware gains — dropping
     // the arms is never an acceptable failure response.
     let disarm = Arc::new(AtomicBool::new(false));
-    // Set by a bus thread on a loss-of-trust fault (timing, silent motor):
+    // Set by a bus thread on a loss-of-trust fault (a silent motor):
     // both buses drop to gravity comp (kp = 0, streamed gravity t_ff) and
     // keep serving so the operator can hand-guide the arms to rest. Never
     // cleared within a session; a disarm in this state leaves the motors
@@ -1856,14 +1868,29 @@ fn bus_loop(
             // every joint until a clean window, and the overrun tick's command
             // derivatives re-seeded rather than integrated across the gap
             // (firmware kp/kd and the streamed gravity t_ff are unaffected,
-            // so the arm keeps holding). Only timing that stays unhealthy —
-            // a second overrun within the window, or late on half the ticks
-            // — takes the session *limp*: kp = 0, firmware kd, gravity from
-            // the streamed t_ff; the operator hand-guides the arms to rest
-            // and restarts. Already limp: nothing left to protect.
+            // so the arm keeps holding). That is the whole response — timing
+            // never takes the session limp (see `DEGRADED_RECENT_LATE_TICKS`);
+            // a stretch that stays bad just stays degraded, with its repeat
+            // overruns logged so the persistence is visible.
             let is_limp = limp.load(Ordering::SeqCst);
             match timing_health.record(lateness, period) {
-                TimingVerdict::Steady => {}
+                TimingVerdict::Steady => {
+                    if overrun && timing_health.degraded && began >= next_timing_log {
+                        next_timing_log = began + DEGRADED_LOG_INTERVAL;
+                        timing_announced = true;
+                        send_text(
+                            out_tx,
+                            b'W',
+                            &format!(
+                                "{iface}: control timing still degraded ({:.3} ms late, {} of the last 32 ticks late, {} whole-cycle overruns; {}) — host damping stays off on this bus; firmware gains hold",
+                                lateness.as_secs_f64() * 1e3,
+                                timing_health.recent_late.count_ones(),
+                                timing_health.recent_overruns.count_ones(),
+                                stall.describe(lateness),
+                            ),
+                        );
+                    }
+                }
                 TimingVerdict::Degraded => {
                     timing_degraded_episodes += 1;
                     // Rate-limited like the feedback transitions; the stats
@@ -1894,26 +1921,10 @@ fn bus_loop(
                         );
                     }
                 }
-                TimingVerdict::Limp => {
-                    if !is_limp {
-                        go_limp(
-                            limp,
-                            out_tx,
-                            &format!(
-                                "{iface}: control timing unhealthy ({:.3} ms late, {} of the last 32 ticks late, {} whole-cycle overruns; {}) — going limp before phase-sensitive damping",
-                                lateness.as_secs_f64() * 1e3,
-                                timing_health.recent_late.count_ones(),
-                                timing_health.recent_overruns.count_ones(),
-                                stall.describe(lateness),
-                            ),
-                        );
-                    }
-                }
             }
             if timing_health.degraded {
                 timing_degraded_ticks += 1;
             }
-            let is_limp = is_limp || limp.load(Ordering::SeqCst);
             ticks += 1;
 
             // Adopt a newly arrived target: latest-wins — the tracker

--- a/rust/axol-rt/src/stall.rs
+++ b/rust/axol-rt/src/stall.rs
@@ -1,0 +1,310 @@
+//! Attribute a late bus tick to what kept the thread off the CPU.
+//!
+//! A `SCHED_FIFO` loop on a dedicated core that wakes tens of milliseconds
+//! late was stopped by one of three things, and the fault line alone cannot
+//! say which: it was *runnable but not scheduled* (preempted by a
+//! higher-priority task, or by IRQ / softirq work that landed on its core),
+//! it took a *page fault* that went into reclaim or compaction (nothing
+//! locked its memory), or it was *blocked inside the kernel* — a
+//! non-preemptible section, a timer that fired late, a deep idle exit. The
+//! kernel already keeps the counters that tell these apart, per thread:
+//!
+//! - `/proc/thread-self/schedstat` — CPU time run, time spent *runnable and
+//!   waiting* for the CPU, and the number of timeslices. The wait figure is
+//!   the same one the camera relay reads to attribute skipped exposures.
+//! - `getrusage(RUSAGE_THREAD)` — minor / major page faults and voluntary /
+//!   involuntary context switches.
+//!
+//! [`StallProbe`] samples both at the top of every tick (one `pread` on an
+//! already-open fd plus one syscall — a few microseconds, off the reply
+//! window) so that when a tick does come in late, the deltas across *that*
+//! sleep are already in hand and the log line can say what they read as.
+//! Sampling on demand would be too late: the counters must bracket the
+//! stall, and the stall is only known once the thread is running again.
+
+use std::fs::File;
+use std::io;
+use std::os::unix::fs::FileExt;
+use std::time::Duration;
+
+/// Per-thread scheduler and memory counters at one instant.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Sample {
+    /// Nanoseconds spent running on a CPU.
+    pub run_ns: u64,
+    /// Nanoseconds spent runnable but waiting for a CPU.
+    pub wait_ns: u64,
+    pub minflt: u64,
+    pub majflt: u64,
+    /// Voluntary context switches (the thread blocked or slept).
+    pub nvcsw: u64,
+    /// Involuntary context switches (the thread was preempted).
+    pub nivcsw: u64,
+}
+
+/// Counter deltas across one tick's sleep-and-wake.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Delta {
+    pub run: Duration,
+    pub wait: Duration,
+    pub minflt: u64,
+    pub majflt: u64,
+    pub nvcsw: u64,
+    pub nivcsw: u64,
+}
+
+/// What a late tick's counters read as. Coarse by design: the point is to
+/// tell a field log's readers which subsystem to look at next.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Reading {
+    /// Runnable for most of the lateness: something else had the CPU.
+    Preempted,
+    /// The thread faulted memory in during the stall.
+    PageFault,
+    /// Neither waiting nor faulting: blocked inside the kernel, or woken late.
+    KernelStall,
+}
+
+impl Delta {
+    /// Classify the stall behind `lateness`. Faults win over waiting — a
+    /// fault that goes into reclaim shows up as both — and waiting must
+    /// account for at least half the lateness to count as preemption.
+    pub fn reading(&self, lateness: Duration) -> Reading {
+        if self.majflt > 0 || self.minflt > 0 {
+            Reading::PageFault
+        } else if lateness > Duration::ZERO && self.wait * 2 >= lateness {
+            Reading::Preempted
+        } else {
+            Reading::KernelStall
+        }
+    }
+
+    /// One clause for the fault / degraded log line, e.g.
+    /// `runnable-waiting 58.9 ms, 0 minor / 0 major page faults, 1
+    /// involuntary switch — reads as preempted`.
+    pub fn describe(&self, lateness: Duration) -> String {
+        let reading = match self.reading(lateness) {
+            Reading::Preempted => "preempted (runnable, not scheduled — IRQ/softirq or higher-priority work on this CPU)",
+            Reading::PageFault => "page fault (memory reclaim/compaction; is the process mlocked?)",
+            Reading::KernelStall => "kernel stall (non-preemptible section, late timer, or idle-state exit)",
+        };
+        format!(
+            "runnable-waiting {:.1} ms, {} minor / {} major page faults, {} involuntary switch{} — reads as {reading}",
+            self.wait.as_secs_f64() * 1e3,
+            self.minflt,
+            self.majflt,
+            self.nivcsw,
+            if self.nivcsw == 1 { "" } else { "es" },
+        )
+    }
+}
+
+/// Per-thread stall counters, sampled once per tick.
+pub struct StallProbe {
+    schedstat: Option<File>,
+    prev: Option<Sample>,
+    // Reused read buffer: schedstat is three decimal u64s and two spaces.
+    buf: [u8; 96],
+}
+
+impl StallProbe {
+    /// Open the calling thread's counters. Must be called *on* the bus
+    /// thread: `/proc/thread-self` resolves to the opener, and
+    /// `RUSAGE_THREAD` reads the caller. A missing or unreadable schedstat
+    /// (kernel built without `CONFIG_SCHEDSTATS`) leaves the wait figure at
+    /// zero rather than failing the loop.
+    pub fn open() -> Self {
+        Self {
+            schedstat: File::open("/proc/thread-self/schedstat").ok(),
+            prev: None,
+            buf: [0; 96],
+        }
+    }
+
+    /// Read the counters now and return the deltas since the previous call
+    /// (all zero on the first call, or if a read fails).
+    pub fn sample(&mut self) -> Delta {
+        let now = self.read();
+        let delta = match (self.prev, now) {
+            (Some(prev), Some(now)) => Delta {
+                run: Duration::from_nanos(now.run_ns.saturating_sub(prev.run_ns)),
+                wait: Duration::from_nanos(now.wait_ns.saturating_sub(prev.wait_ns)),
+                minflt: now.minflt.saturating_sub(prev.minflt),
+                majflt: now.majflt.saturating_sub(prev.majflt),
+                nvcsw: now.nvcsw.saturating_sub(prev.nvcsw),
+                nivcsw: now.nivcsw.saturating_sub(prev.nivcsw),
+            },
+            _ => Delta::default(),
+        };
+        if now.is_some() {
+            self.prev = now;
+        }
+        delta
+    }
+
+    fn read(&mut self) -> Option<Sample> {
+        let mut sample = Sample::default();
+        let mut usage: libc::rusage = unsafe { std::mem::zeroed() };
+        let rc = unsafe { libc::getrusage(libc::RUSAGE_THREAD, &mut usage) };
+        if rc != 0 {
+            return None;
+        }
+        sample.minflt = usage.ru_minflt.max(0) as u64;
+        sample.majflt = usage.ru_majflt.max(0) as u64;
+        sample.nvcsw = usage.ru_nvcsw.max(0) as u64;
+        sample.nivcsw = usage.ru_nivcsw.max(0) as u64;
+        if let Some(file) = &self.schedstat {
+            if let Ok(n) = file.read_at(&mut self.buf, 0) {
+                if let Some((run, wait)) = parse_schedstat(&self.buf[..n]) {
+                    sample.run_ns = run;
+                    sample.wait_ns = wait;
+                }
+            }
+        }
+        Some(sample)
+    }
+}
+
+/// `schedstat` is `<run_ns> <wait_ns> <timeslices>\n`.
+fn parse_schedstat(text: &[u8]) -> Option<(u64, u64)> {
+    let text = std::str::from_utf8(text).ok()?;
+    let mut fields = text.split_ascii_whitespace();
+    let run = fields.next()?.parse().ok()?;
+    let wait = fields.next()?.parse().ok()?;
+    Some((run, wait))
+}
+
+/// The smallest `RLIMIT_MEMLOCK` under which locking is attempted without
+/// `CAP_IPC_LOCK`: the binary plus four 2 MiB thread stacks plus heap and
+/// socket buffers, with headroom. The common unprivileged default (8 MiB)
+/// is below it — see `lock_memory`.
+const MIN_MEMLOCK_LIMIT: u64 = 64 << 20;
+
+/// Lock every current and future page of the process into RAM.
+///
+/// Standard real-time hygiene the core lacked: with nothing locked, a page
+/// the bus thread touches after memory pressure has reclaimed it — or a
+/// fresh heap page under compaction — is a fault that can hold a
+/// `SCHED_FIFO` thread for tens of milliseconds, exactly while the dataset
+/// writer is flushing gigabytes of video. `MCL_FUTURE` also locks the bus
+/// threads' stacks as they are created, so they are faulted in at spawn.
+///
+/// Without `CAP_IPC_LOCK` (the production service runs as root; `axol
+/// rt.install` grants the capability to dev builds) every locked mapping
+/// counts against `RLIMIT_MEMLOCK`, and with `MCL_FUTURE` set a later
+/// `mmap` past the limit *fails* — a thread spawn would abort the session
+/// long after the lock call itself succeeded. So under a small limit this
+/// declines to lock at all rather than lock partially. Failure is reported,
+/// not fatal: an unlocked core is what every session ran with before.
+pub fn lock_memory() -> io::Result<()> {
+    let privileged = unsafe { libc::geteuid() } == 0 || has_cap_ipc_lock();
+    if !privileged {
+        let mut limit: libc::rlimit = unsafe { std::mem::zeroed() };
+        let rc = unsafe { libc::getrlimit(libc::RLIMIT_MEMLOCK, &mut limit) };
+        if rc == 0 && limit.rlim_cur != libc::RLIM_INFINITY && limit.rlim_cur < MIN_MEMLOCK_LIMIT {
+            return Err(io::Error::other(format!(
+                "RLIMIT_MEMLOCK is {} MiB (need {} MiB or CAP_IPC_LOCK)",
+                limit.rlim_cur >> 20,
+                MIN_MEMLOCK_LIMIT >> 20,
+            )));
+        }
+    }
+    let rc = unsafe { libc::mlockall(libc::MCL_CURRENT | libc::MCL_FUTURE) };
+    if rc == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+/// Whether the effective capability set holds `CAP_IPC_LOCK` (bit 14), read
+/// from `/proc/thread-self/status` (`CapEff:`) — no libcap dependency.
+fn has_cap_ipc_lock() -> bool {
+    const CAP_IPC_LOCK: u32 = 14;
+    let Ok(status) = std::fs::read_to_string("/proc/thread-self/status") else {
+        return false;
+    };
+    status
+        .lines()
+        .find_map(|line| line.strip_prefix("CapEff:"))
+        .and_then(|hex| u64::from_str_radix(hex.trim(), 16).ok())
+        .is_some_and(|caps| caps & (1 << CAP_IPC_LOCK) != 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_schedstat_fields() {
+        assert_eq!(
+            parse_schedstat(b"123456789 987654321 42\n"),
+            Some((123_456_789, 987_654_321))
+        );
+        assert_eq!(parse_schedstat(b"garbage"), None);
+        assert_eq!(parse_schedstat(b""), None);
+    }
+
+    #[test]
+    fn readings_follow_the_counters() {
+        let late = Duration::from_millis(60);
+        let preempted = Delta {
+            wait: Duration::from_millis(58),
+            nivcsw: 1,
+            ..Delta::default()
+        };
+        assert_eq!(preempted.reading(late), Reading::Preempted);
+        assert!(preempted.describe(late).contains("reads as preempted"));
+        assert!(preempted.describe(late).contains("1 involuntary switch —"));
+
+        let faulted = Delta {
+            wait: Duration::from_millis(58),
+            minflt: 3,
+            ..Delta::default()
+        };
+        assert_eq!(faulted.reading(late), Reading::PageFault);
+
+        let blocked = Delta {
+            wait: Duration::from_micros(200),
+            nvcsw: 1,
+            ..Delta::default()
+        };
+        assert_eq!(blocked.reading(late), Reading::KernelStall);
+        assert!(blocked.describe(late).contains("0 involuntary switches"));
+    }
+
+    #[test]
+    fn probe_samples_this_thread_and_reports_deltas() {
+        let mut probe = StallProbe::open();
+        // First sample has no baseline.
+        assert_eq!(probe.sample(), Delta::default());
+        // Burn a little CPU and fault a page so the counters move.
+        let mut v = vec![0u8; 1 << 20];
+        for (i, b) in v.iter_mut().enumerate().step_by(4096) {
+            *b = i as u8;
+        }
+        std::hint::black_box(&v);
+        let delta = probe.sample();
+        // A fresh 1 MiB mapping faults in as it is touched (THP or not).
+        assert!(delta.minflt > 0, "{delta:?}");
+        assert_eq!(delta.reading(Duration::from_millis(5)), Reading::PageFault);
+    }
+
+    /// Per-tick cost of the probe (one `pread` + one `getrusage`), for the
+    /// budget note in `serve.rs`: `cargo test --release stall -- --ignored
+    /// --nocapture`. A few µs on an x86 dev box; the 240 Hz tick has 4.17 ms.
+    #[test]
+    #[ignore]
+    fn probe_cost_per_sample() {
+        let mut probe = StallProbe::open();
+        probe.sample();
+        let n = 20_000;
+        let t0 = std::time::Instant::now();
+        for _ in 0..n {
+            std::hint::black_box(probe.sample());
+        }
+        let per = t0.elapsed() / n;
+        println!("stall probe: {per:?} per sample");
+        assert!(per < Duration::from_micros(200), "{per:?}");
+    }
+}

--- a/web/app/src/components/operation-panel.tsx
+++ b/web/app/src/components/operation-panel.tsx
@@ -365,6 +365,16 @@ const PHASE_STYLES: Record<string, { label: string; cls: string; kind: "dot" | "
       cls: "border-orange-400/60 bg-orange-400/15 text-orange-200",
       kind: "pulse",
     },
+    // The realtime core took the session limp on a loss-of-trust fault
+    // (persistently late control ticks, a silent motor): the arms are in
+    // gravity comp for good, nothing here restarts them — the operator
+    // hand-guides them to rest, then stops and starts the operation again.
+    // No episode buttons render in this phase; Stop is the only way out.
+    faulted: {
+      label: "Faulted",
+      cls: "border-red-500/60 bg-red-500/15 text-red-200",
+      kind: "pulse",
+    },
     saving: {
       label: "Saving",
       cls: "border-emerald-400/50 bg-emerald-400/10 text-emerald-200",


### PR DESCRIPTION
## Why

Two `collect-data` sessions on 2026-09-04 ended in limp on a single late tick — `control timing unhealthy (21.5 ms late, 1 of the last 32 ticks late)` and `(60.7 ms late, 1 of …)`, both on `can_alm_axol_l` during the post-save return home, both in sessions whose other ~770k ticks were on time. The core did what it was told (b5fa2c5: a whole-cycle overrun goes straight to limp, never cleared), but the response did not fit the event: the arms were holding still on firmware gains through the stall, and what the overrun actually invalidates is the phase-sensitive terms of that one tick. Limp cost a full stop/restart per hiccup — and the flows above the core did not notice it (fixed in axol-pi), so operators sat squeezing grips at a robot that would not move.

## What

**Policy — bad timing degrades, and that is the whole response.** `TimingHealth::record` returns a verdict like `FeedbackHealth`, but with no fault tier above degraded:

- **Degraded** — a whole-cycle overrun, three late (> 0.5 ms) ticks in a row, or 8 of the last 32 late. Host damping off on every joint of *that bus* until a clean 32-tick window (hysteresis, like feedback). On the overrun tick itself the tracker advances one nominal period instead of rendering a max-velocity catch-up over the wall-clock it lost, and the command derivative chains (`v_cmd`, `a_cmd`, `v_cmd_fast`, band-pass) are re-seeded at rest rather than differentiated across the gap — the motors held the previous command, there is no trajectory there. Firmware kp/kd and the streamed gravity `t_ff` are untouched. Rate-limited `W` line + counted in the five-second stats line (`N overruns, N timing-degraded ticks in N episodes`).
- **Never limp.** A late tick invalidates exactly the terms degraded turns off; the motors ride out a late host on their own firmware gains, which is what they do if the host dies. So timing is not a loss of trust at any duration — limp stays reserved for a motor that has gone silent for a second. Persistence is still visible: each further overrun inside a degraded stretch is logged (`control timing still degraded (…)`, rate-limited, with attribution), and the stats line counts them.

**Attribution — the line says what kept the thread off the CPU.** New `stall.rs` samples the thread's own counters at every wake (`/proc/thread-self/schedstat` runnable-wait via `pread` on an open fd; `getrusage(RUSAGE_THREAD)` page faults + involuntary switches — ~1.5–2 µs/tick, `cargo test --release stall -- --ignored --nocapture`), so the deltas across the late sleep are in hand when the tick turns out late, and classifies them:

```
can_alm_axol_l: control timing degraded (60.653 ms late, 1 of the last 32 ticks late, 1 whole-cycle overrun; runnable-waiting 58.9 ms, 0 minor / 0 major page faults, 1 involuntary switch — reads as preempted (runnable, not scheduled — IRQ/softirq or higher-priority work on this CPU)) — host damping off on this bus until a clean window; firmware gains hold
```

Shipped on a new `W` message tag that `rt/link.py` logs at WARNING (older link: "unknown message tag", still visible).

**mlockall.** `serve` locks memory (`MCL_CURRENT | MCL_FUTURE`) before accepting a client; the per-tick reply bookkeeping is preallocated so the loop never grows the heap. Without `CAP_IPC_LOCK` a small `RLIMIT_MEMLOCK` (8 MiB default — less than the thread stacks) would make a later `mmap` *fail* under `MCL_FUTURE`, so the lock is declined and reported rather than taken partially; `axol rt.install` now grants `cap_ipc_lock` alongside `cap_sys_nice` (production runs as root and is unaffected).

**Also:** `AxolRobot.limp` (public mirror of `RtAxol.limp` for the recording flows; axol-pi currently reaches `_axol.limp`) and a red **Faulted** badge for the panel's core-limp phase (`faulted`, the id axol-pi's flows now report).

## Verification

- `cargo test` (32 pass; new: isolated overrun degrades + recovers after a clean window, repeated in-window overruns stay degraded and never escalate, spaced overruns are two degraded episodes, 500 alternating late/on-time ticks is one degraded transition and no fault, schedstat parse, reading classification, live probe), `cargo fmt --check`, clippy adds nothing beyond the pre-existing doc-indent class.
- `rt_proto_check.py` against the release binary: OK.
- Unprivileged start: `could not lock memory (RLIMIT_MEMLOCK is 8 MiB (need 64 MiB or CAP_IPC_LOCK)); running unlocked` — then serves as before.
- Not yet run on a station: the interesting data point is the first `W` line's `reads as …` on a Jetson during a save. If it reads as *preempted* on the left CAN core, the next look is what else runs on that core (the CAN IRQ is steered to the *right* CAN core per `affinity.py`, so left-side preemption would point at softirq/timer work); *page fault* would have been fixed by the lock; *kernel stall* points at the storage path.
