### PR TITLE
Drop ZED Box pre-install notes and document power requirements

### DIFF
--- a/docs/guides/quest-over-usb.mdx
+++ b/docs/guides/quest-over-usb.mdx
@@ -23,7 +23,7 @@ When USB is selected, the headset sends every pose frame over **both** the cable
   </Step>
 
   <Step title="Confirm adb is installed on the robot machine">
-    Nothing to do on the **Perception Kit ZED Box** or any [one-command install](/installation) — [`axol provision`](/cli/provision) sets up `adb` and the Quest udev rule for you. On a development install, run `axol provision` once.
+    Nothing to do after a [one-command install](/installation) — [`axol provision`](/cli/provision) sets up `adb` and the Quest udev rule for you. On a development install, run `axol provision` once.
   </Step>
 </Steps>
 

--- a/docs/hardware.mdx
+++ b/docs/hardware.mdx
@@ -20,7 +20,7 @@ Axol ships fully assembled and ready to mount. It attaches with four **M8×12 bo
 The back of the robot exposes the connectors used for power and camera control:
 
 - **2× GMSL2 ports** for the wrist cameras.
-- **1× XT90 connector** for power.
+- **1× XT90 connector** for power (**24V DC, 60A peak**).
 - **1× Locking USB-C connector** for control.
 
 ### Reference diagrams
@@ -180,15 +180,48 @@ Adjust the robot's height with the manual lift: insert the crank into the hole a
   Make sure the crank is inserted **all the way in** before turning it. It's easy to leave it partially seated, which can slip or damage the mechanism.
 </Warning>
 
+### Power
+
+This section applies to every configuration.
+
+Axol is powered at **24V DC, 60A peak** through the XT90 on the back of the robot. A matching supply ships in the box:
+
+| | |
+|---|---|
+| **Robot input** | 24V DC, 60A peak, XT90 |
+| **Included supply** | 1500W (24V, 62.5A) |
+| **DC cable** | 1.5m XT90 male–female |
+| **AC** | Power-supply AC cord |
+
+<Steps>
+  <Step title="Place the power supply">
+    Set the supply near the robot (on the cart, if you have one) so the XT90 cable comfortably reaches the back of the robot.
+  </Step>
+  <Step title="Connect DC">
+    Plug the XT90 cable from the robot into the power supply.
+  </Step>
+  <Step title="Connect AC">
+    Plug the AC cord from the supply into a wall outlet, then switch the supply on.
+  </Step>
+</Steps>
+
+<Note>
+  The supply is 1500W. Use a dedicated wall outlet.
+</Note>
+
+<Warning>
+  The Perception Kit's ZED Box is powered separately. Use the DC adapter that ships with it (**12–19V**, up to 60W).
+</Warning>
+
 ### Wiring
 
 This section applies to configurations with the **Perception Kit**.
 
-Place the ZED Box and the power supply near the robot (on the cart, if you have one), then connect the cables:
+Place the ZED Box near the robot (on the cart, if you have one), then connect the cables:
 
 <Steps>
-  <Step title="Position the ZED Box and power supply">
-    Set the ZED Box and the power supply down so their cables comfortably reach the back of the robot.
+  <Step title="Position the ZED Box">
+    Set the ZED Box down so its camera, USB, and power cables comfortably reach the back of the robot.
   </Step>
   <Step title="Connect the head camera">
     Run the head camera's **GMSL** cable from the camera to the ZED Box.
@@ -196,8 +229,8 @@ Place the ZED Box and the power supply near the robot (on the cart, if you have 
   <Step title="Connect the wrist cameras">
     Run the shorter **GMSL** cable from the wrist cameras to the GMSL port on the wrist.
   </Step>
-  <Step title="Connect the robot to the ZED Box and power">
-    From the back of the robot, run the **power** and **USB** cables to the ZED Box and power supply.
+  <Step title="Connect USB and ZED Box power">
+    From the back of the robot, run the **USB** cable to the ZED Box. Plug the ZED Box into its own DC adapter (see [Power](#power)).
   </Step>
 </Steps>
 

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -16,7 +16,7 @@ Axol installs with a single command on the machine wired to the robot (typically
 
 ## ZED Box login
 
-If you're setting up a ZED Box from Almond, log in with the default credentials. (Perception Kit boxes ship with axol already installed — see the note under [Install](#install).)
+If you're setting up a ZED Box from Almond, log in with the default credentials.
 
 | Field | Value |
 |---|---|
@@ -28,10 +28,6 @@ If you're setting up a ZED Box from Almond, log in with the default credentials.
 </Warning>
 
 ## Install
-
-<Note>
-  The ZED Box that ships with the **Perception Kit** comes with axol already installed and the control-panel service running — skip straight to [First connection](#first-connection). Run the command below only to set up a fresh machine, or to upgrade an existing one (re-running upgrades in place).
-</Note>
 
 Run this on the robot machine:
 


### PR DESCRIPTION
## Summary
- The ZED Box no longer ships with axol pre-installed: removed the "skip the install" notes from the installation guide and the Perception Kit special case from the Quest-over-USB guide — every machine now goes through the one-command install.
- Added a **Power** section to the hardware guide: 24V DC / 60A peak XT90 input, the included 1500W (24V, 62.5A) supply, hookup steps, and a note that the Perception Kit ZED Box uses its own 12–19V adapter.
- Reworked the Perception Kit wiring steps to reference the new Power section.

## Test plan
- [ ] Docs preview renders the new Power section and steps correctly
- [ ] No remaining references to axol shipping pre-installed on the ZED Box

Made with [Cursor](https://cursor.com)