### PR TITLE
Link the separate left and right Quest 3 mount STLs

### DIFF
--- a/docs/mantis/hardware.mdx
+++ b/docs/mantis/hardware.mdx
@@ -40,7 +40,7 @@ The kit includes the mount for the pose source you purchased: Quest, Lighthouse 
 
 If you ordered Mantis without a tracker and are supplying your own, you can 3D-print the mount instead. Download the model for your pose source:
 
-- [Quest 3 controller mount](https://www.almond.bot/resources/mantis_quest_3_mount.stl) (STL)
+- Quest 3 controller mount, [left](https://www.almond.bot/resources/mantis_quest_3_mount_l.stl) and [right](https://www.almond.bot/resources/mantis_quest_3_mount_r.stl) (STL). The Touch controllers are mirror images, so print one of each.
 - [VIVE Tracker 3.0 mount](https://www.almond.bot/resources/mantis_vive_3_mount.step) (STEP)
 - [VIVE Ultimate Tracker mount](https://www.almond.bot/resources/mantis_vive_ultimate_mount.step) (STEP)
 


### PR DESCRIPTION
## Summary

- The website now ships the Quest 3 controller mount as two handed files (`mantis_quest_3_mount_l.stl` / `mantis_quest_3_mount_r.stl`) instead of one; the Mantis hardware page now links both and notes to print one of each.
- Both URLs verified live (200).

## Test plan

- [ ] Preview `/mantis/hardware` and click both mount links

Made with [Cursor](https://cursor.com)