### PR TITLE
Give the gripper open-stop sweep room to press when the jaws start closed

### DIFF
--- a/almond_axol/cli/collect_data.py
+++ b/almond_axol/cli/collect_data.py
@@ -92,7 +92,13 @@ from ..teleop.core import TCPPoseSnapshot
 from ..utils import affinity
 from ..utils.jetson_diag import TegraStatsDiag
 from ..utils.proc_diag import SystemDiag
-from .config import DatasetResolution, LogLevel, MantisSource, parse
+from .config import (
+    DatasetResolution,
+    LogLevel,
+    MantisSource,
+    normalize_bool_flags,
+    parse,
+)
 
 if TYPE_CHECKING:
     from ..lerobot.robot.robot_axol import AxolRobot
@@ -963,6 +969,9 @@ Control = _NullCollectControl | _QueueCollectControl
 
 def main(argv: list[str]) -> None:
     """Parse the CLI config and run a data-collection session."""
+    # Accept the bare ``--mantis`` / ``--mantis_allow_uncalibrated`` spelling
+    # that ``axol teleop --mantis`` already takes.
+    argv = normalize_bool_flags(argv, "mantis", "mantis_allow_uncalibrated")
     cfg = parse(CollectDataConfig, argv)
     if cfg.mantis:
         from .mantis_bridge import (

--- a/almond_axol/robot/axol.py
+++ b/almond_axol/robot/axol.py
@@ -57,7 +57,21 @@ GRIPPER_TRAVEL = math.radians(290)
 _GRIPPER_TORQUE_THRESHOLD = 0.5  # Nm
 _GRIPPER_CALIB_STEP = 0.005  # rad per step
 _GRIPPER_CALIB_SETTLE = 0.001  # s per step
-_GRIPPER_CALIB_MAX_STEPS = math.ceil(GRIPPER_TRAVEL / _GRIPPER_CALIB_STEP)
+# Sweep headroom beyond the nominal travel. Torque only builds once the jaw
+# is against the open stop and the impedance target keeps moving past it, so
+# a gripper that starts at the closed stop needs budget *after* covering
+# GRIPPER_TRAVEL or the sweep ends with the jaws open but no stop detected.
+# Also absorbs unit-to-unit travel variation (~0.035 rad measured). Costs
+# ~60 ms in the no-stop failure case and nothing on success (the loop exits
+# at the torque threshold).
+_GRIPPER_CALIB_OVERTRAVEL = 0.3  # rad
+_GRIPPER_CALIB_MAX_STEPS = math.ceil(
+    (GRIPPER_TRAVEL + _GRIPPER_CALIB_OVERTRAVEL) / _GRIPPER_CALIB_STEP
+)
+# A sweep that moved at least this fraction of GRIPPER_TRAVEL without meeting
+# the torque threshold ran out of jaw, not out of budget: the fingers are not
+# coupled to the motor. Anything shorter stalled against something.
+_GRIPPER_CALIB_FULL_TRAVEL_FRACTION = 0.9
 
 # Impedance gains used only during gripper open-stop calibration.
 _GRIPPER_CALIB_KP = 50.0
@@ -191,19 +205,25 @@ async def calibrate_gripper_open_stop(motor: Motor) -> float:
     """Find a gripper's open hard-stop and return its raw motor position (rad).
 
     Steps the motor incrementally toward open until the torque magnitude
-    reaches ``_GRIPPER_TORQUE_THRESHOLD`` (the open hard-stop). Exhausting the
-    full expected travel without observing that stop fails calibration rather
-    than treating an arbitrary final encoder reading as the open position.
-    Shared by :class:`AxolArm` and the Mantis
+    reaches ``_GRIPPER_TORQUE_THRESHOLD`` (the open hard-stop). The sweep
+    budget is the full expected travel plus ``_GRIPPER_CALIB_OVERTRAVEL`` so a
+    gripper starting at the closed stop still has room to press into the open
+    one. Exhausting that budget without observing the stop fails calibration
+    rather than treating an arbitrary final encoder reading as the open
+    position. Shared by :class:`AxolArm` and the Mantis
     (:mod:`almond_axol.robot.mantis`), whose grippers are the same Damiao unit.
 
     Must be called with the motor already enabled and in IMPEDANCE mode.
 
     Raises:
         MotorError: If the full calibration sweep completes without detecting
-            the open hard-stop torque threshold.
+            the open hard-stop torque threshold. The message distinguishes a
+            motor that covered the whole travel range unopposed (fingers not
+            coupled to the shaft) from one that stalled short of it
+            (obstruction or slipping coupling).
     """
-    target = await motor.get_position()
+    start = await motor.get_position()
+    target = start
     stop_found = False
     last_torque = 0.0
     for _ in range(_GRIPPER_CALIB_MAX_STEPS):
@@ -216,16 +236,31 @@ async def calibrate_gripper_open_stop(motor: Motor) -> float:
         if abs(last_torque) >= _GRIPPER_TORQUE_THRESHOLD:
             stop_found = True
             break
+    final = await motor.get_position()
     if not stop_found:
         commanded_travel = _GRIPPER_CALIB_MAX_STEPS * _GRIPPER_CALIB_STEP
+        travelled = start - final
+        if travelled >= _GRIPPER_CALIB_FULL_TRAVEL_FRACTION * GRIPPER_TRAVEL:
+            hint = (
+                "The motor moved through the whole open/close range without "
+                "meeting resistance — check that the fingers are fitted and "
+                "coupled to the motor shaft"
+            )
+        else:
+            hint = (
+                "The motor stopped short of the full range without reaching "
+                "the torque threshold — check for an obstruction between the "
+                "jaws or a slipping coupling"
+            )
         raise MotorError(
             "Gripper open-stop calibration failed: no hard stop was detected "
-            f"during the {commanded_travel:.3f} rad sweep "
-            f"(last torque {last_torque:.3f} Nm, required "
-            f"{_GRIPPER_TORQUE_THRESHOLD:.3f} Nm); the gripper remains "
+            f"during the {commanded_travel:.3f} rad sweep (motor moved "
+            f"{travelled:.3f} rad of the {GRIPPER_TRAVEL:.3f} rad range; last "
+            f"torque {last_torque:.3f} Nm, required "
+            f"{_GRIPPER_TORQUE_THRESHOLD:.3f} Nm). {hint}; the gripper remains "
             "uncalibrated"
         )
-    return await motor.get_position()
+    return final
 
 
 def arm_limits(joint: Joint, is_left: bool) -> tuple[float, float]:

--- a/docs/mantis/tracking.mdx
+++ b/docs/mantis/tracking.mdx
@@ -29,7 +29,7 @@ The Tracking tab walks each source through a **step-by-step flow**. Each step re
         Choose **Quest** (the selection saves immediately). The Quest headset and the host must be on the same LAN (or use the wired [Quest-over-USB](/guides/quest-over-usb) link, managed under **General settings → Quest**).
       </Step>
       <Step title="Headset">
-        Start a Quest **bring-up collection run**: `axol collect-data --mantis --mantis_allow_uncalibrated true` (or Start **Collect data** with `mantis_allow_uncalibrated` set under Advanced); teleop never starts the VR server. Then in the Quest browser open [axol.almond.bot](https://axol.almond.bot), enter the host, connect, accept the host's certificate the first time, and choose **Enter VR**. Hold both Touch controllers.
+        Start a Quest **bring-up collection run**: `axol collect-data --mantis true --mantis_allow_uncalibrated true` (or Start **Collect data** with `mantis_allow_uncalibrated` set under Advanced); teleop never starts the VR server. Then in the Quest browser open [axol.almond.bot](https://axol.almond.bot), enter the host, connect, accept the host's certificate the first time, and choose **Enter VR**. Hold both Touch controllers.
 
         The step shows each controller's reported WebXR profile and pose space and, when both match, a copyable **common calibration key** (for example `quest:oculus-touch-v3:grip`). Press **Use this key**, then **Save settings**. The step resolves once the saved key is a **grip-space** datum matching the live controllers; a stale report, a `target-ray` fallback, or two controllers reporting different keys is held rather than accepted.
       </Step>
@@ -125,7 +125,7 @@ Overrides and Quest measurements live in `~/.almond/mantis/tcp_transform.json`, 
 
 ## Acceptance
 
-Before recording training data, run a short **bring-up collection run** (`axol collect-data --mantis --mantis_allow_uncalibrated true`, discarding every take) with the workspace clear and check, with the selected live source:
+Before recording training data, run a short **bring-up collection run** (`axol collect-data --mantis true --mantis_allow_uncalibrated true`, discarding every take) with the workspace clear and check, with the selected live source:
 
 1. Physical **left/right**, scale, every translation axis, wrist rotation, and tracker→TCP alignment. With Quest, the headset's live URDF overlay shows the virtual arms; with Lighthouse/Ultimate, use the control panel's mirrored view.
 2. **Recovery**: deliberately occlude or de-localize one side and confirm both freeze; restore tracking and confirm nothing moves until the start gesture is repeated.

--- a/docs/operations/train-policy.mdx
+++ b/docs/operations/train-policy.mdx
@@ -40,6 +40,34 @@ Training writes checkpoints under `outputs/train/.../checkpoints`, and (with `--
   No local GPU? The ACT tutorial links a [Google Colab notebook](https://huggingface.co/docs/lerobot/en/act#train-using-google-colab) you can use to train in the cloud.
 </Note>
 
+## Mantis datasets: use `axol mantis.train`
+
+Episodes recorded with the [Mantis](/mantis/hardware) handheld rigs (`axol collect-data --mantis true`) store **absolute base-frame end-effector poses** in the Cartesian schema. Each take is anchored to wherever the demonstrator engaged, so a policy trained on absolute targets learns positions in that one world frame and does not transfer when the robot starts somewhere else.
+
+`axol mantis.train` fixes that at training time. It wraps `lerobot-train` — same CLI surface (draccus dotted overrides, `--config_path`, wandb, resume), same checkpoint format — and installs a **chunk-relative end-effector** processor in the policy's pipeline: every predicted action chunk is expressed relative to the observation it was predicted from, and the action/state normalisation statistics are recomputed over the relativised values. The relativisation lives in the checkpoint's processor pipeline, so deployment is unchanged: `axol run-policy --policy_path <ckpt> ...` as usual.
+
+```bash
+axol mantis.train \
+  --dataset.repo_id=${HF_USER}/mantis-pick-place \
+  --policy.type=act \
+  --output_dir=outputs/train/act_mantis_pick_place \
+  --job_name=act_mantis_pick_place \
+  --policy.device=cuda \
+  --wandb.enable=true \
+  --policy.repo_id=${HF_USER}/act_mantis_pick_place
+```
+
+<Warning>
+  Plain `lerobot-train` also runs on a Mantis dataset without error, but it produces a **world-anchored** policy with no start-pose invariance. Use `axol mantis.train` for anything recorded with the rigs (or with `--robot_config.observe_cartesian true` on the robot, if you want the same relative-action generalisation).
+</Warning>
+
+Two things to know:
+
+- **Local only.** Remote HF Jobs (`--job.target` other than `local`) are rejected: the remote pod runs stock `lerobot-train` and cannot carry the processor patch. Run the command on the training machine.
+- **Chunk execution.** With relative actions, chunks predicted from different observations are anchored to different reference poses. The default chunk-queue execution in `run-policy` is exact; `--aggregate_fn temporal_ensemble` blends near-identical absolute actions from overlapping chunks and works well in practice, but the blend is an approximation.
+
+The dataset itself stays standard LeRobot format, so rig-collected and on-robot Cartesian episodes mix freely in one dataset.
+
 ## LeRobotTutorials
 
 <CardGroup cols={2}>


### PR DESCRIPTION
## Summary

A customer's new Mantis kit failed `axol teleop --mantis` on both grippers with:

```
MotorError: Gripper open-stop calibration failed: no hard stop was detected during the
5.065 rad sweep (last torque -0.173 Nm, required 0.500 Nm); the gripper remains uncalibrated
```

Hardware was fine. `calibrate_gripper_open_stop()` budgets `ceil(GRIPPER_TRAVEL / STEP)` steps — 5.065 rad against 5.0615 rad of nominal travel, i.e. less than one step of headroom. Torque only builds once the jaw is *against* the open stop and the impedance target keeps moving past it, so a gripper that starts at the closed stop spends the whole budget arriving at the open stop and never gets to press. Hand-opening the jaws partway made the same command succeed.

The function is shared with `AxolArm`, whose cold `enable()` always sweeps, so a robot gripper that is fully closed at power-on fails the same way. Mantis just hits it every time because handheld grippers get put down closed.

## Changes

**`almond_axol/robot/axol.py`**
- `_GRIPPER_CALIB_OVERTRAVEL = 0.3` rad added to the sweep budget (1013 → 1073 steps). The loop still exits at the 0.5 Nm threshold, so success behaviour is unchanged; only the genuine no-stop failure runs ~60 ms longer.
- The failure message now reports how far the motor actually moved and distinguishes the two remaining causes: covered the whole range unopposed → "check that the fingers are fitted and coupled to the motor shaft"; stalled short → "check for an obstruction between the jaws or a slipping coupling". The `no hard stop was detected` prefix is kept.

**`almond_axol/cli/collect_data.py`, `docs/mantis/tracking.mdx`**
- `main()` runs `normalize_bool_flags(argv, "mantis", "mantis_allow_uncalibrated")` so the bare `--mantis` spelling `teleop` already accepts works for `collect-data` too. The tracking doc's bring-up command (which used the bare form and failed with `argument --mantis: expected one argument`) now reads `--mantis true`, matching the other pages.

**`docs/operations/train-policy.mdx`**
- New "Mantis datasets: use `axol mantis.train`" section explaining why plain `lerobot-train` on a Mantis dataset silently yields a world-anchored policy, with the command, the local-only restriction, and the chunk-execution caveat.

## Verification

- Fake-motor harness at the closed stop: the old code reproduces the customer's failure and roughly their numbers (travel 5.0265 rad → last torque −0.192 Nm vs observed −0.173); the new code succeeds for travel 5.0265 / 5.0615 / 5.0915 rad, and the no-stop and soft-stall cases produce the intended hints.
- `python -m unittest tests.test_motion_command_safety tests.test_mantis_gripper_preopen tests.test_mantis_grippers_only tests.test_cli_dispatch`: 63 tests OK.
- `ruff check` / `ruff format --check` at the pinned 0.9.7: clean.

## Not in this PR

From the same customer report, deliberately left out:
- `axol serve` TLS cert SAN only covers `localhost`/`127.0.0.1`, so connecting the panel by LAN IP is a name mismatch. Needs its own change in `utils/certs.py` (build SAN from hostname + LAN IPs, regenerate when they change).
- Persisting Mantis gripper calibration across processes. `AxolArm` only trusts the persisted value when the gripper is already live and holding (proof of no power cycle); Mantis force-disables at every stop, so a file-based restore could silently apply a wrong mapping after a re-zero. With the budget fixed, the sweep from closed is a one-second open-and-done motion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared gripper calibration used on Axol and Mantis bring-up; success path is unchanged but every cold gripper sweep uses a longer budget and new failure logic.
> 
> **Overview**
> Fixes **gripper open-stop calibration** when jaws start fully closed: the sweep budget now includes **0.3 rad overtravel** beyond nominal `GRIPPER_TRAVEL`, so the impedance target can press into the open hard stop and torque can build. Successful calibrations behave the same; only true no-stop failures run slightly longer. **`calibrate_gripper_open_stop`** also reports actual travel moved and adds targeted failure hints (uncoupled fingers vs obstruction).
> 
> **`axol collect-data`** now normalizes bare **`--mantis`** / **`--mantis_allow_uncalibrated`** flags like **`axol teleop`**, and Mantis tracking docs use **`--mantis true`** in bring-up examples.
> 
> Adds a **train-policy** doc section recommending **`axol mantis.train`** over plain **`lerobot-train`** for rig datasets (chunk-relative EE actions), with local-only and chunk-execution caveats.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f662b9d62d58b9b50972138b91e2e2863c8d7f8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->