### PR TITLE
Bound serve shutdown so systemctl stop returns in seconds

### DIFF
--- a/almond_axol/cli/serve.py
+++ b/almond_axol/cli/serve.py
@@ -139,7 +139,14 @@ def run(args: argparse.Namespace) -> None:
                 "ssl_keyfile": tls_files.keyfile,
             }
         config = uvicorn.Config(
-            app, host=args.host, port=args.port, log_level="info", **ssl_kwargs
+            app,
+            host=args.host,
+            port=args.port,
+            log_level="info",
+            # Without a bound uvicorn waits forever for open streaming
+            # WebSockets, so `systemctl stop axol` sat until its 240s kill.
+            timeout_graceful_shutdown=5,
+            **ssl_kwargs,
         )
         server = uvicorn.Server(config)
         server.run(sockets=[sock])

--- a/almond_axol/serve/app.py
+++ b/almond_axol/serve/app.py
@@ -635,6 +635,10 @@ _CAN_DISCOVERY_STATUSES = {
     "error",
 }
 _CAN_DISCOVERY_FORCE_RETRY_SECONDS = 2.0
+# Discovery renames interfaces under a udev lock it can lose to a slow or
+# wedged host. Shutdown joins it so the rename is not cut in half, but the
+# join is bounded: systemd kills the service outright if the stop overruns.
+_CAN_DISCOVERY_SHUTDOWN_TIMEOUT_SECONDS = 30.0
 
 
 @dataclass
@@ -2506,7 +2510,17 @@ def create_app(static_dir: Path | None = None) -> FastAPI:
     @app.on_event("shutdown")
     async def _shutdown() -> None:
         if can_discovery_task is not None and not can_discovery_task.done():
-            await asyncio.shield(can_discovery_task)
+            try:
+                await asyncio.wait_for(
+                    asyncio.shield(can_discovery_task),
+                    _CAN_DISCOVERY_SHUTDOWN_TIMEOUT_SECONDS,
+                )
+            except asyncio.TimeoutError:
+                _logger.warning(
+                    "CAN hardware discovery did not finish within %.0fs; "
+                    "shutting down without it",
+                    _CAN_DISCOVERY_SHUTDOWN_TIMEOUT_SECONDS,
+                )
         await runner.shutdown()
         await manager.shutdown()
         await asyncio.to_thread(robot.shutdown)

--- a/almond_axol/serve/app.py
+++ b/almond_axol/serve/app.py
@@ -8,6 +8,7 @@ is available it is served too, with SPA-style fallback to ``index.html``.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import math
 import os
@@ -15,6 +16,7 @@ import secrets
 import socket
 import subprocess
 import time
+from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal
@@ -795,6 +797,44 @@ def _usb_status_dict(status: adb.AdbStatus) -> dict[str, Any]:
     }
 
 
+async def _wait_for_disconnect(ws: WebSocket) -> None:
+    """Return once the client's close frame arrives."""
+    try:
+        while (await ws.receive())["type"] != "websocket.disconnect":
+            pass
+    except (WebSocketDisconnect, RuntimeError):
+        # Starlette reports the close as a disconnect message on a live socket,
+        # but raises once the connection has already gone: WebSocketDisconnect
+        # from its own helpers, RuntimeError from receiving on a socket whose
+        # disconnect it has already delivered. Every case means the same thing.
+        pass
+
+
+async def _stream_until_disconnect(
+    ws: WebSocket, queue: asyncio.Queue[Any]
+) -> AsyncIterator[Any]:
+    """Yield queued messages until the client disconnects.
+
+    The streaming endpoints only send, so nothing else reads the socket. Without
+    this race the close frame -- including the one uvicorn sends while draining
+    on SIGTERM -- is never observed, and an idle stream holds its handler task
+    (and the server shutdown) open indefinitely.
+    """
+    disconnect = asyncio.ensure_future(_wait_for_disconnect(ws))
+    try:
+        while True:
+            pending = asyncio.ensure_future(queue.get())
+            done, _ = await asyncio.wait(
+                (pending, disconnect), return_when=asyncio.FIRST_COMPLETED
+            )
+            if pending not in done:
+                pending.cancel()
+                return
+            yield pending.result()
+    finally:
+        disconnect.cancel()
+
+
 def create_app(static_dir: Path | None = None) -> FastAPI:
     # ``create_app`` is the public embedding surface as well as the factory
     # used by ``axol serve``. Mark a root embedding before constructing any
@@ -1471,8 +1511,11 @@ def create_app(static_dir: Path | None = None) -> FastAPI:
         queue = hub.subscribe()
         try:
             await ws.send_json({"type": "hello", **hub.snapshot()})
-            while True:
-                await ws.send_json(await queue.get())
+            async with contextlib.aclosing(
+                _stream_until_disconnect(ws, queue)
+            ) as stream:
+                async for message in stream:
+                    await ws.send_json(message)
         except WebSocketDisconnect:
             pass
         finally:
@@ -2445,12 +2488,16 @@ def create_app(static_dir: Path | None = None) -> FastAPI:
                 await ws.send_json({"type": "log", "line": line})
             await ws.send_json({"type": "status", "session": session.to_dict()})
 
-            while True:
-                line = await queue.get()
-                if line is None:
-                    await ws.send_json({"type": "status", "session": session.to_dict()})
-                    break
-                await ws.send_json({"type": "log", "line": line})
+            async with contextlib.aclosing(
+                _stream_until_disconnect(ws, queue)
+            ) as stream:
+                async for line in stream:
+                    if line is None:
+                        await ws.send_json(
+                            {"type": "status", "session": session.to_dict()}
+                        )
+                        break
+                    await ws.send_json({"type": "log", "line": line})
         except WebSocketDisconnect:
             pass
         finally:

--- a/tests/test_serve_shutdown.py
+++ b/tests/test_serve_shutdown.py
@@ -1,0 +1,146 @@
+"""Shutdown bounds for ``axol serve``: streaming WebSockets and the CAN wait.
+
+A stop must not sit until systemd's kill timeout. The streaming endpoints have
+to end on the client's close frame even with nothing queued, and the shutdown
+hook has to give up on an unfinished CAN discovery instead of joining it
+forever.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+import unittest
+from typing import Any
+from unittest.mock import Mock, patch
+
+import httpx
+
+from almond_axol.cli.can import setup
+from almond_axol.serve import app as app_module
+from almond_axol.serve.manager import Session
+from tests.test_serve_session_reservation import (
+    _Manager,
+    _Robot,
+    _Runner,
+    _hub_state,
+    _test_app,
+)
+
+_TIMEOUT_S = 5.0
+# The bound the shutdown hook is held to under test, small enough that the
+# assertion fails on a wait that is not actually honouring it.
+_TEST_DISCOVERY_BOUND_S = 0.1
+
+
+async def _drive_websocket(app: Any, path: str) -> list[dict[str, Any]]:
+    """Open ``path``, disconnect with nothing published, return the sent frames.
+
+    Drives the ASGI protocol directly: a websocket client is the only way to
+    observe that the handler task ends, and every timeout here is what would
+    otherwise hang a stop.
+    """
+    incoming: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+    incoming.put_nowait({"type": "websocket.connect"})
+    sent: list[dict[str, Any]] = []
+    accepted = asyncio.Event()
+
+    async def receive() -> dict[str, Any]:
+        return await incoming.get()
+
+    async def send(message: dict[str, Any]) -> None:
+        sent.append(message)
+        if message["type"] in ("websocket.accept", "websocket.close"):
+            accepted.set()
+
+    scope = {
+        "type": "websocket",
+        "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "http_version": "1.1",
+        "scheme": "ws",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "root_path": "",
+        "headers": [(b"host", b"test")],
+        "client": ("127.0.0.1", 50000),
+        "server": ("test", 80),
+        "subprotocols": [],
+    }
+    handler = asyncio.create_task(app(scope, receive, send))
+    await asyncio.wait_for(accepted.wait(), _TIMEOUT_S)
+    incoming.put_nowait({"type": "websocket.disconnect", "code": 1000})
+    await asyncio.wait_for(handler, _TIMEOUT_S)
+    return sent
+
+
+class WebSocketDisconnectTest(unittest.IsolatedAsyncioTestCase):
+    async def test_telemetry_stream_ends_on_client_disconnect(self) -> None:
+        app = _test_app(_Manager(), _Runner())
+
+        sent = await _drive_websocket(app, "/api/telemetry/ws")
+
+        self.assertEqual(sent[0]["type"], "websocket.accept")
+        self.assertIn("hello", sent[1]["text"])
+
+    async def test_log_stream_ends_on_client_disconnect(self) -> None:
+        session = Session("tracker.identify", {})
+        session.status = "running"
+        app = _test_app(_Manager([session]), _Runner())
+
+        sent = await _drive_websocket(app, f"/api/sessions/{session.id}/logs")
+
+        self.assertEqual(sent[0]["type"], "websocket.accept")
+        self.assertIn("status", sent[1]["text"])
+
+
+class CanDiscoveryShutdownBoundTest(unittest.IsolatedAsyncioTestCase):
+    async def test_shutdown_gives_up_on_unfinished_can_discovery(self) -> None:
+        attached = _hub_state(profiles={"axol"}, candidates=(("usb-2", "UNRESOLVED"),))
+        entered = threading.Event()
+        release = threading.Event()
+
+        def never_finishes() -> setup.HeadlessHubSetupResult:
+            entered.set()
+            release.wait(_TIMEOUT_S)
+            raise RuntimeError("discovery was released only by the test")
+
+        robot = _Robot()
+        robot.shutdown = Mock()  # type: ignore[method-assign]
+        app = _test_app(_Manager(), _Runner(), robot)
+        transport = httpx.ASGITransport(app=app)
+        with (
+            patch.object(app_module.os, "geteuid", return_value=0),
+            patch.object(app_module, "_list_can_interfaces", return_value=[]),
+            patch.object(app_module, "_attached_hub_state", return_value=attached),
+            patch.object(
+                setup, "setup_detected_hubs", Mock(side_effect=never_finishes)
+            ),
+            patch.object(
+                app_module,
+                "_CAN_DISCOVERY_SHUTDOWN_TIMEOUT_SECONDS",
+                _TEST_DISCOVERY_BOUND_S,
+            ),
+        ):
+            async with httpx.AsyncClient(
+                transport=transport, base_url="http://test"
+            ) as client:
+                discover = asyncio.create_task(client.post("/api/can/discover"))
+                try:
+                    await asyncio.wait_for(
+                        asyncio.to_thread(entered.wait, _TIMEOUT_S), _TIMEOUT_S
+                    )
+                    started = time.monotonic()
+                    await asyncio.wait_for(app.router.on_shutdown[-1](), _TIMEOUT_S)
+                    elapsed = time.monotonic() - started
+                finally:
+                    release.set()
+                    await asyncio.wait_for(discover, _TIMEOUT_S)
+
+        self.assertLess(elapsed, _TEST_DISCOVERY_BOUND_S * 10)
+        robot.shutdown.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #249

`systemctl stop axol` waited up to `TimeoutStopSec=240` because nothing bounded the shutdown. This branch bounds all three causes.

## Changes

- **Websocket handlers observe disconnect.** `/api/telemetry/ws` and `/api/sessions/{id}/logs` blocked on `queue.get()` and never called `receive()`, so the close frame uvicorn sends on SIGTERM went unread. With an idle robot there is no publish, so the task never ended. Both handlers now stream through a shared helper that races `ws.receive()` against `queue.get()` and ends on the close frame, cancelling the loser.
- **Bounded drain.** `uvicorn.Config` gains `timeout_graceful_shutdown=5`, so uvicorn stops waiting on handler tasks.
- **Bounded CAN discovery wait.** The shutdown hook awaited `asyncio.shield(can_discovery_task)` with no bound, and discovery holds a flock across udev restarts. The wait is now capped at 30 s; a timeout is logged and shutdown continues. The shield still keeps the discovery task itself alive.

## Tests

`tests/test_serve_shutdown.py`:
- Each websocket handler returns when the client disconnects with nothing published. Both fail with timeouts against the pre-fix handlers.
- The shutdown hook returns inside its bound when CAN discovery never completes.

Mocks sit at system boundaries only (`os.geteuid`, CAN interface listing, hub state, `setup_detected_hubs`).

## What `timeout_graceful_shutdown=5` does and does not bound

uvicorn applies the 5 s only to draining connection-handler tasks (`_wait_tasks_to_complete`). The lifespan `shutdown` hook runs afterwards and is not subject to it. That hook is where `runner.shutdown()` → `_await_stop` runs, with its own grace ladder (`_STOP_GRACE_S=6`, `_FINALIZE_GRACE_S=200`, `_FORCE_GRACE_S=5`), so a mid-recording restart still gives the dataset recorder 200 s to finalize. The drain bound does not shorten recorder finalize.

## Known gaps

- `manager.shutdown()` and `robot.shutdown()` in the same hook remain unbounded (`runner.shutdown()` is bounded at ~211 s by its grace ladder). Out of scope here, but the 240 s exposure returns if either of them wedges.
- Nothing pins `timeout_graceful_shutdown=5` in a test; it is a single passthrough kwarg to uvicorn.
- The remaining 240 s stop during recording sessions is `speech-dispatcher` surviving in the service cgroup, tracked in #260.

## Verification

- [x] `systemctl restart axol` with the panel open, idle, completes under 5 s (fm-rob-02: ~4 s; same host hit the 240 s SIGKILL on release code the day before)
- [ ] Restart mid-recording, dataset intact — blocked by #259 (no episode can be recorded on the bench host). Not a risk introduced by this PR; see the section above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shutdown and WebSocket streaming behavior on a long-running service; mis-handling disconnect races could drop in-flight messages at panel close, though mid-recording finalize paths are unchanged.
> 
> **Overview**
> Fixes **`systemctl stop axol`** hanging until systemd’s 240s kill when the control panel left idle streaming WebSockets open or CAN discovery was still running.
> 
> **Uvicorn** now sets **`timeout_graceful_shutdown=5`** so the server stops waiting on connection handlers instead of blocking forever on open streams.
> 
> **Telemetry and session log WebSockets** no longer block only on `queue.get()`; they use a shared **`_stream_until_disconnect`** helper that races socket **`receive()`** against the queue so SIGTERM/close frames are observed even with no queued traffic. Messages that race the disconnect are dropped to avoid post-close sends that uvicorn treats as protocol errors.
> 
> **Shutdown** waits at most **30s** for in-flight CAN hardware discovery (still **`asyncio.shield`ed** so the task can finish) then logs and continues; **`runner` / `manager` / `robot` teardown** still runs afterward.
> 
> New **`tests/test_serve_shutdown.py`** covers disconnect-driven handler exit, the disconnect-vs-queue race, and the bounded CAN discovery wait.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95caacc69ce109cf166c5862ca39ae68a2f81bea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

