### PR TITLE
Make Quest USB certificate authorization work without WiFi

### DIFF
--- a/almond_axol/cli/mantis_session.py
+++ b/almond_axol/cli/mantis_session.py
@@ -32,10 +32,13 @@ import sys
 import time
 from pathlib import Path
 
+from ..utils.ports import CONTROL_PORT, VR_PORT
 from ..utils.sudo import run_root
 
-_VR_PORT = 8000
-_SERVE_PORT = 8001
+# Same pair ``utils.adb`` forwards for the control panel's Quest-over-USB flow;
+# sourced from ``utils.ports`` so the tunnel targets can't drift from the binds.
+_VR_PORT = VR_PORT
+_SERVE_PORT = CONTROL_PORT
 _BROWSER_URL = f"https://localhost:{_SERVE_PORT}/vr?host=localhost&autoconnect=1"
 _SERVICE_PATH = Path("/etc/systemd/system/axol-mantis.service")
 _MANAGED_SERVE_SERVICE = "axol.service"

--- a/almond_axol/cli/serve.py
+++ b/almond_axol/cli/serve.py
@@ -24,6 +24,7 @@ import webbrowser
 from pathlib import Path
 
 from ..utils.certs import CERTFILE, KEYFILE, PreparedTLSFiles, prepare_tls_files
+from ..utils.ports import CONTROL_PORT
 
 # The VR server and this control-panel API share one self-signed certificate
 # (see ``almond_axol.utils.certs``) so a single browser cert acceptance covers both.
@@ -43,8 +44,8 @@ def add_parser(subparsers) -> None:  # type: ignore[type-arg]
     parser.add_argument(
         "--port",
         type=int,
-        default=8001,
-        help="Port to listen on (default: 8001).",
+        default=CONTROL_PORT,
+        help=f"Port to listen on (default: {CONTROL_PORT}).",
     )
     parser.add_argument(
         "--open",

--- a/almond_axol/utils/adb.py
+++ b/almond_axol/utils/adb.py
@@ -4,8 +4,11 @@ The Quest headset can stream controller poses to the robot over a USB cable
 instead of WiFi, sidestepping the 802.11 power-save buffering behind the
 ~150 ms pose gaps. The mechanism is ``adb reverse``: the headset's
 ``localhost:8000`` is forwarded over the cable to the robot's VR server, so the
-WebXR app reaches it at ``wss://localhost:8000``. Camera video still rides the
-LAN (WebRTC can't cross the TCP port-forward), so USB is pose-only.
+WebXR app reaches it at ``wss://localhost:8000``. The control panel's
+``localhost:8001`` is forwarded too, so the headset can reach the shared
+self-signed certificate even when no operation is running to hold port 8000
+open. Camera video still rides the LAN (WebRTC can't cross the TCP
+port-forward), so USB is pose-only.
 
 This module is the single place that knows how to install adb (used by
 ``axol provision``) and how to query/establish the reverse tunnel (used by the
@@ -24,15 +27,17 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from .paths import ALMOND_HOME_ENV, almond_home
-from .ports import VR_PORT
+from .ports import CONTROL_PORT, VR_PORT
 from .sudo import prime_sudo, run_root
 
 _logger = logging.getLogger(__name__)
 
-# ``VR_PORT`` (the port we forward the headset's loopback copy of) is owned by
-# ``utils.ports`` so the tunnel target and the VR server's bind can't drift.
+# The forwarded ports are owned by ``utils.ports`` so the tunnel targets and
+# the servers' binds can't drift.
 __all__ = [
     "VR_PORT",
+    "CONTROL_PORT",
+    "TUNNEL_PORTS",
     "AdbStatus",
     "install",
     "status",
@@ -60,6 +65,12 @@ _OCULUS_RULE = (
 # Android udev rules. Those use ``plugdev``; our Oculus rule above supersedes
 # them for the Quest's vendor id.
 _APT_PACKAGES = ("adb", "android-sdk-platform-tools-common")
+
+# Ports forwarded to the headset's loopback. The VR server (``VR_PORT``) carries
+# the poses, but it only exists while a teleop or collect operation runs — the
+# control panel (``CONTROL_PORT``) is always up, so it is the origin a freshly
+# cabled headset can reach to authorize the shared self-signed certificate.
+TUNNEL_PORTS = (VR_PORT, CONTROL_PORT)
 
 
 def _adb() -> str | None:
@@ -185,7 +196,7 @@ class AdbStatus:
 
     @property
     def ready(self) -> bool:
-        """True when a headset is authorized and the pose tunnel is live."""
+        """True when a headset is authorized and the tunnels are live."""
         return self.state == "device" and self.reverse_active
 
 
@@ -218,16 +229,19 @@ def _first_device() -> tuple[str | None, str]:
     return None, "none"
 
 
-def _reverse_active(port: int) -> bool:
+def _reverse_active(ports: tuple[int, ...]) -> bool:
+    """True when every port in ``ports`` is forwarded to the host."""
     proc = _run(["reverse", "--list"])
     if proc is None or proc.returncode != 0:
         return False
-    needle = f"tcp:{port} tcp:{port}"
-    return any(needle in line for line in proc.stdout.splitlines())
+    listed = proc.stdout.splitlines()
+    return all(
+        any(f"tcp:{port} tcp:{port}" in line for line in listed) for port in ports
+    )
 
 
-def status(port: int = VR_PORT) -> AdbStatus:
-    """Return the current adb device + reverse-tunnel status."""
+def status(ports: tuple[int, ...] = TUNNEL_PORTS) -> AdbStatus:
+    """Return the adb device state and whether every ``ports`` tunnel is up."""
     if _adb() is None:
         return AdbStatus(
             installed=False, serial=None, state="none", reverse_active=False
@@ -237,7 +251,7 @@ def status(port: int = VR_PORT) -> AdbStatus:
         installed=True,
         serial=serial,
         state=state,
-        reverse_active=_reverse_active(port),
+        reverse_active=_reverse_active(ports),
     )
 
 
@@ -268,22 +282,24 @@ def set_proximity_disabled(disabled: bool) -> tuple[bool, str | None]:
     return True, None
 
 
-def connect(port: int = VR_PORT) -> AdbStatus:
-    """Establish the reverse tunnel (headset localhost:port → this host:port).
+def connect(ports: tuple[int, ...] = TUNNEL_PORTS) -> AdbStatus:
+    """Establish a reverse tunnel per port (headset localhost:port → host:port).
 
     The first adb command against a freshly connected headset also triggers the
     USB-debugging authorization popup on the device. Returns the resulting
     status so the caller can surface "authorize on headset" vs "ready".
 
-    Self-healing: any existing reverse for this port is removed first, then a
+    Self-healing: any existing reverse for a port is removed first, then a
     fresh one is added. ``adb reverse`` keys on the device-side spec, so a plain
     re-add already replaces a prior mapping, but removing first also clears a
     *wedged* tunnel (e.g. one left pointing at a server we since reclaimed/killed
     on a different run) so reconnect reliably yields a working forward rather
     than trusting whatever stale state the device held.
     """
-    # ``--remove`` of a non-existent reverse exits non-zero; that's expected and
-    # harmless (``_run`` only warns on spawn/timeout errors, not exit codes).
-    _run(["reverse", "--remove", f"tcp:{port}"])
-    _run(["reverse", f"tcp:{port}", f"tcp:{port}"])
-    return status(port)
+    for port in ports:
+        # ``--remove`` of a non-existent reverse exits non-zero; that's expected
+        # and harmless (``_run`` only warns on spawn/timeout errors, not exit
+        # codes).
+        _run(["reverse", "--remove", f"tcp:{port}"])
+        _run(["reverse", f"tcp:{port}", f"tcp:{port}"])
+    return status(ports)

--- a/almond_axol/utils/adb.py
+++ b/almond_axol/utils/adb.py
@@ -5,10 +5,12 @@ instead of WiFi, sidestepping the 802.11 power-save buffering behind the
 ~150 ms pose gaps. The mechanism is ``adb reverse``: the headset's
 ``localhost:8000`` is forwarded over the cable to the robot's VR server, so the
 WebXR app reaches it at ``wss://localhost:8000``. The control panel's
-``localhost:8001`` is forwarded too, so the headset can reach the shared
-self-signed certificate even when no operation is running to hold port 8000
-open. Camera video still rides the LAN (WebRTC can't cross the TCP
-port-forward), so USB is pose-only.
+``localhost:8001`` is forwarded too: port 8000 exists only while an operation
+runs, so the panel is what proves the cable path works while idle, and it lets
+the headset load the panel over the cable. It does not stand in for the pose
+certificate — browser overrides are per-origin including port, so
+``https://localhost:8000`` still needs its own approval. Camera video still
+rides the LAN (WebRTC can't cross the TCP port-forward), so USB is pose-only.
 
 This module is the single place that knows how to install adb (used by
 ``axol provision``) and how to query/establish the reverse tunnel (used by the
@@ -69,7 +71,9 @@ _APT_PACKAGES = ("adb", "android-sdk-platform-tools-common")
 # Ports forwarded to the headset's loopback. The VR server (``VR_PORT``) carries
 # the poses, but it only exists while a teleop or collect operation runs — the
 # control panel (``CONTROL_PORT``) is always up, so it is the origin a freshly
-# cabled headset can reach to authorize the shared self-signed certificate.
+# cabled headset can reach to confirm the tunnel is live (and to use the panel
+# over the cable). Its certificate approval does not carry over to ``VR_PORT``:
+# browser overrides are per-origin, port included.
 TUNNEL_PORTS = (VR_PORT, CONTROL_PORT)
 
 

--- a/almond_axol/utils/certs.py
+++ b/almond_axol/utils/certs.py
@@ -128,6 +128,33 @@ def create_self_signed_cert(certfile: str, keyfile: str) -> None:
         secure_atomic_write_bytes(keyfile, temporary_key.read_bytes(), mode=0o600)
 
 
+def certificate_lacks_san(certfile: str) -> bool:
+    """True when ``certfile`` carries no ``subjectAltName`` extension.
+
+    Certificates issued before the SAN was added match no hostname at all in
+    Chromium, so the Quest headset can never accept one — not even on
+    ``localhost``. Such a certificate is rotated rather than reused. Anything
+    unreadable (no openssl, an unparseable file) answers False so a host that
+    cannot be inspected is left alone instead of regenerating on every start.
+
+    The timeout matters on the unprivileged path, where the certificate path is
+    operator-owned: without it a path pointed at a FIFO would hang the read —
+    and with it, ``axol serve`` starts on the certificate it already has.
+    """
+    try:
+        proc = subprocess.run(
+            ["openssl", "x509", "-in", certfile, "-noout", "-ext", "subjectAltName"],
+            capture_output=True,
+            text=True,
+            timeout=10.0,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    if proc.returncode != 0:
+        return False
+    return "Subject Alternative Name" not in proc.stdout
+
+
 def prepare_tls_files(certfile: str, keyfile: str) -> PreparedTLSFiles:
     """Return TLS files that remain stable until :meth:`close` is called.
 
@@ -139,7 +166,8 @@ def prepare_tls_files(certfile: str, keyfile: str) -> PreparedTLSFiles:
     ``/tmp`` is explicit so an operator-controlled ``TMPDIR`` cannot choose
     the privileged staging parent.
 
-    If either default file is genuinely absent, the pair is generated with
+    If either default file is genuinely absent — or the existing certificate
+    predates the ``subjectAltName`` extension — the pair is generated with
     :func:`create_self_signed_cert` and then snapshotted.  An unsafe existing
     entry fails before generation, so it is never silently replaced.
     """
@@ -154,7 +182,8 @@ def prepare_tls_files(certfile: str, keyfile: str) -> PreparedTLSFiles:
     )
     if not requires_snapshot:
         generated = False
-        if not os.path.isfile(certfile) or not os.path.isfile(keyfile):
+        missing = not os.path.isfile(certfile) or not os.path.isfile(keyfile)
+        if missing or certificate_lacks_san(certfile):
             create_self_signed_cert(certfile, keyfile)
             generated = True
         return PreparedTLSFiles(certfile, keyfile, generated=generated)
@@ -176,7 +205,10 @@ def prepare_tls_files(certfile: str, keyfile: str) -> PreparedTLSFiles:
             except FileNotFoundError:
                 missing = True
 
-        if missing:
+        # Inspect the snapshot, not the source: the copy above already proved
+        # it safe, and re-reading the operator-owned path would reopen the
+        # check/use race the snapshot exists to close.
+        if missing or certificate_lacks_san(str(snapshot_cert)):
             # All existing entries were already proven safe above.  The
             # no-follow atomic writer also rechecks them during publication.
             create_self_signed_cert(certfile, keyfile)

--- a/almond_axol/utils/ports.py
+++ b/almond_axol/utils/ports.py
@@ -32,6 +32,12 @@ _logger = logging.getLogger(__name__)
 # ``utils.adb`` import it) so they can't drift and silently break USB teleop.
 VR_PORT = 8000
 
+# The control panel (``axol serve``) binds this one. The Quest-over-USB tunnel
+# forwards it too: the VR port only exists while a teleop/collect operation is
+# running, so the panel is the origin whose certificate a freshly cabled headset
+# can always reach on ``localhost``.
+CONTROL_PORT = 8001
+
 # How hard ``open_listen_socket`` tries before giving up. A couple of plain
 # retries absorb a previous server still releasing the socket; after that we
 # evict whatever is squatting on the port.

--- a/almond_axol/utils/ports.py
+++ b/almond_axol/utils/ports.py
@@ -34,8 +34,9 @@ VR_PORT = 8000
 
 # The control panel (``axol serve``) binds this one. The Quest-over-USB tunnel
 # forwards it too: the VR port only exists while a teleop/collect operation is
-# running, so the panel is the origin whose certificate a freshly cabled headset
-# can always reach on ``localhost``.
+# running, so the panel is the origin a freshly cabled headset can always reach
+# on ``localhost`` to confirm the cable path works. (The pose origin on
+# ``VR_PORT`` still needs its own certificate approval; overrides are per-port.)
 CONTROL_PORT = 8001
 
 # How hard ``open_listen_socket`` tries before giving up. A couple of plain

--- a/docs/guides/quest-over-usb.mdx
+++ b/docs/guides/quest-over-usb.mdx
@@ -38,11 +38,11 @@ When USB is selected, the headset sends every pose frame over **both** the cable
     In the [control panel](/guides/control-panel#quest-usb), the **Quest** tab under **General settings** shows the headset state. The first time, accept the **Allow USB debugging?** prompt in the headset (check **Always allow from this computer**). Once authorized, the tunnels come up **automatically** and the status turns green (*Controller over USB*); the tab's **Connect** button is a manual fallback / reconnect.
   </Step>
 
-  <Step title="Accept the certificate on localhost">
-    In the headset browser, open `https://localhost:8001` — the control panel, reached over the cable — and proceed past the certificate warning. This confirms the tunnel is up and gets the self-signed certificate accepted while nothing else has to be running.
+  <Step title="Confirm the tunnel on localhost">
+    In the headset browser, open `https://localhost:8001` — the control panel, reached over the cable — and proceed past the certificate warning. If the panel loads, the tunnel is up. This works while nothing else is running, and it also lets you drive the panel from the headset.
 
     <Note>
-      Do this before anything else. The browser's override is per-origin (scheme + host + port), so accepting `:8001` does not cover `:8000`, but reaching the panel on `localhost` proves the cable path works — and it is the origin that is always available.
+      Do this before anything else. The browser's override is per-origin (scheme + host + port), so accepting `:8001` does not cover `:8000` — the USB pose link gets its own approval in a later step. Reaching the panel on `localhost` is what proves the cable path works, and it is the origin that is always available.
     </Note>
   </Step>
 
@@ -51,7 +51,7 @@ When USB is selected, the headset sends every pose frame over **both** the cable
   </Step>
 
   <Step title="Authorize the USB certificate">
-    The USB link uses `wss://localhost:8000`. The certificate is the one you just accepted, but the browser's approval is **per-origin**, so this port needs its own. Until it's approved the app runs on Wi-Fi and shows *WiFi fallback — USB link down*. Tap **Authorize USB certificate** and proceed past the warning (equivalently, open `https://localhost:8000` in the headset browser). The status then flips to *controller over cable*.
+    The USB link uses `wss://localhost:8000`. It serves the same certificate you just saw on `:8001`, but the browser's approval is **per-origin**, so this port needs its own. Until it's approved the app runs on Wi-Fi and shows *WiFi fallback — USB link down*. Tap **Authorize USB certificate** and proceed past the warning (equivalently, open `https://localhost:8000` in the headset browser). The status then flips to *controller over cable*.
 
     <Warning>
       Port 8000 only exists while a teleop or data-collection operation is running — the VR server is started and stopped with the operation, not by `axol serve`. Start the operation from the control panel first, otherwise the certificate page cannot load and the poses stay on Wi-Fi.

--- a/docs/guides/quest-over-usb.mdx
+++ b/docs/guides/quest-over-usb.mdx
@@ -35,15 +35,27 @@ When USB is selected, the headset sends every pose frame over **both** the cable
   </Step>
 
   <Step title="Authorize and connect from the control panel">
-    In the [control panel](/guides/control-panel#quest-usb), the **Quest** tab under **General settings** shows the headset state. The first time, accept the **Allow USB debugging?** prompt in the headset (check **Always allow from this computer**). Once authorized, the tunnel comes up **automatically** and the status turns green (*Controller over USB*); the tab's **Connect** button is a manual fallback / reconnect.
+    In the [control panel](/guides/control-panel#quest-usb), the **Quest** tab under **General settings** shows the headset state. The first time, accept the **Allow USB debugging?** prompt in the headset (check **Always allow from this computer**). Once authorized, the tunnels come up **automatically** and the status turns green (*Controller over USB*); the tab's **Connect** button is a manual fallback / reconnect.
+  </Step>
+
+  <Step title="Accept the certificate on localhost">
+    In the headset browser, open `https://localhost:8001` — the control panel, reached over the cable — and proceed past the certificate warning. This confirms the tunnel is up and gets the self-signed certificate accepted while nothing else has to be running.
+
+    <Note>
+      Do this before anything else. The browser's override is per-origin (scheme + host + port), so accepting `:8001` does not cover `:8000`, but reaching the panel on `localhost` proves the cable path works — and it is the origin that is always available.
+    </Note>
   </Step>
 
   <Step title="Enable USB in the VR app">
-    Open the VR app at [axol.almond.bot](https://axol.almond.bot), enter the robot's address as usual, and tick **Quest over USB** before connecting.
+    Open the VR app at [axol.almond.bot](https://axol.almond.bot), enter the robot's address as usual, and tick **Quest over USB**. The USB panel and its **Authorize USB certificate** button appear immediately, before you connect.
   </Step>
 
   <Step title="Authorize the USB certificate">
-    The USB link uses `wss://localhost:8000`, whose self-signed certificate is a **separate origin** from the host cert you already approved. Until it's approved the app runs on Wi-Fi and shows *WiFi fallback — USB link down* with an **Authorize USB certificate** button — tap it and proceed past the warning (equivalently, open `https://localhost:8000` in the headset browser and proceed). The status then flips to *controller over cable*.
+    The USB link uses `wss://localhost:8000`. The certificate is the one you just accepted, but the browser's approval is **per-origin**, so this port needs its own. Until it's approved the app runs on Wi-Fi and shows *WiFi fallback — USB link down*. Tap **Authorize USB certificate** and proceed past the warning (equivalently, open `https://localhost:8000` in the headset browser). The status then flips to *controller over cable*.
+
+    <Warning>
+      Port 8000 only exists while a teleop or data-collection operation is running — the VR server is started and stopped with the operation, not by `axol serve`. Start the operation from the control panel first, otherwise the certificate page cannot load and the poses stay on Wi-Fi.
+    </Warning>
   </Step>
 
   <Step title="Enter VR">

--- a/tests/test_quest_usb.py
+++ b/tests/test_quest_usb.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from almond_axol.utils import adb, certs
+
+
+def _completed(stdout: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(["adb"], 0, stdout, "")
+
+
+class AdbReverseTunnelTest(unittest.TestCase):
+    def test_both_tunnel_ports_are_forwarded_on_connect(self) -> None:
+        calls: list[list[str]] = []
+
+        def run(args: list[str], timeout: float = 10.0):
+            calls.append(args)
+            if args == ["devices"]:
+                return _completed("List of devices attached\n1WMHH\tdevice\n")
+            return _completed("")
+
+        with (
+            patch.object(adb, "_adb", return_value="/usr/bin/adb"),
+            patch.object(adb, "_run", side_effect=run),
+        ):
+            adb.connect()
+
+        for port in (adb.VR_PORT, adb.CONTROL_PORT):
+            self.assertIn(["reverse", "--remove", f"tcp:{port}"], calls)
+            self.assertIn(["reverse", f"tcp:{port}", f"tcp:{port}"], calls)
+
+    def test_a_reverse_list_missing_the_control_port_is_not_ready(self) -> None:
+        vr_only = f"tcp:{adb.VR_PORT} tcp:{adb.VR_PORT}\n"
+        both = vr_only + f"tcp:{adb.CONTROL_PORT} tcp:{adb.CONTROL_PORT}\n"
+
+        for listing, expected in ((vr_only, False), (both, True)):
+            with self.subTest(listing=listing):
+
+                def run(args: list[str], timeout: float = 10.0, listing=listing):
+                    if args == ["devices"]:
+                        return _completed("List of devices attached\n1WMHH\tdevice\n")
+                    return _completed(listing)
+
+                with (
+                    patch.object(adb, "_adb", return_value="/usr/bin/adb"),
+                    patch.object(adb, "_run", side_effect=run),
+                ):
+                    status = adb.status()
+
+                self.assertEqual(status.reverse_active, expected)
+                self.assertEqual(status.ready, expected)
+
+
+@unittest.skipIf(shutil.which("openssl") is None, "openssl is required")
+class CertificateRotationTest(unittest.TestCase):
+    def _certificate_directory(self, directory: str) -> Path:
+        """Resolve the temporary directory so no path component is a symlink.
+
+        The certificate writer opens every component with ``O_NOFOLLOW``, and
+        macOS puts the temporary directory behind the ``/var`` symlink.
+        """
+        return Path(directory).resolve()
+
+    def _legacy_certificate(self, directory: Path) -> tuple[str, str]:
+        """Write the pre-SAN certificate an older install still carries."""
+        certfile = directory / "cert.pem"
+        keyfile = directory / "key.pem"
+        subprocess.run(
+            [
+                "openssl",
+                "req",
+                "-x509",
+                "-newkey",
+                "rsa:2048",
+                "-keyout",
+                str(keyfile),
+                "-out",
+                str(certfile),
+                "-days",
+                "365",
+                "-nodes",
+                "-subj",
+                "/CN=localhost",
+            ],
+            check=True,
+            capture_output=True,
+        )
+        return str(certfile), str(keyfile)
+
+    def test_only_a_certificate_without_a_san_is_reported_stale(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = self._certificate_directory(directory)
+            legacy_cert, _ = self._legacy_certificate(root)
+            current_cert = str(root / "current-cert.pem")
+            certs.create_self_signed_cert(current_cert, str(root / "current-key.pem"))
+
+            self.assertTrue(certs.certificate_lacks_san(legacy_cert))
+            self.assertFalse(certs.certificate_lacks_san(current_cert))
+
+    def test_an_unreadable_certificate_is_left_alone(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            garbage = Path(directory) / "cert.pem"
+            garbage.write_text("not a certificate")
+
+            self.assertFalse(certs.certificate_lacks_san(str(garbage)))
+
+    def test_preparing_tls_files_rotates_a_certificate_without_a_san(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = self._certificate_directory(directory)
+            certfile, keyfile = self._legacy_certificate(root)
+            legacy_bytes = Path(certfile).read_bytes()
+
+            with patch.object(certs, "privileged_service_active", return_value=False):
+                prepared = certs.prepare_tls_files(certfile, keyfile)
+
+            with prepared:
+                self.assertTrue(prepared.generated)
+                self.assertNotEqual(Path(certfile).read_bytes(), legacy_bytes)
+                self.assertFalse(certs.certificate_lacks_san(certfile))
+
+    def test_preparing_tls_files_keeps_a_certificate_that_has_a_san(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = self._certificate_directory(directory)
+            certfile = str(root / "cert.pem")
+            keyfile = str(root / "key.pem")
+            certs.create_self_signed_cert(certfile, keyfile)
+            current_bytes = Path(certfile).read_bytes()
+
+            with patch.object(certs, "privileged_service_active", return_value=False):
+                prepared = certs.prepare_tls_files(certfile, keyfile)
+
+            with prepared:
+                self.assertFalse(prepared.generated)
+                self.assertEqual(Path(certfile).read_bytes(), current_bytes)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/app/src/App.tsx
+++ b/web/app/src/App.tsx
@@ -1461,11 +1461,11 @@ export default function App() {
                 <p className="rounded-lg border border-red-400/25 bg-red-400/10 p-3 text-xs text-red-300">
                   Could not connect to <span className="font-mono">{hostname || "the server"}</span>
                   . Check that <span className="font-mono">axol teleop</span> is running
-                  {hostCertAuthorizeVisible(usbPoses, hostname)
+                  {hostCertAuthorizeVisible(hostname)
                     ? ", then authorize its self-signed certificate below."
                     : "."}
                 </p>
-                {hostCertAuthorizeVisible(usbPoses, hostname) && (
+                {hostCertAuthorizeVisible(hostname) && (
                   <Button
                     variant="outline"
                     className="w-full"

--- a/web/app/src/App.tsx
+++ b/web/app/src/App.tsx
@@ -36,6 +36,7 @@ import { Input } from "@/components/ui/input"
 import { RobotModel } from "@/components/robot-model"
 import { SiteNav } from "@/components/site-nav"
 import { authorizeCert } from "@/lib/cert-accept"
+import { hostCertAuthorizeVisible, usbCertOrigin } from "@/lib/usb-transport"
 import { cn } from "@/lib/utils"
 
 // Pin drei's <Text> (troika) to a locally-bundled font. By default troika
@@ -1251,11 +1252,11 @@ export default function App() {
     connect()
   }, [bootParams, hostname, status, connect])
   // Controller poses can ride a wired USB `adb reverse` tunnel (localhost) to
-  // avoid WiFi latency; camera video keeps using the LAN host above. The pose
-  // socket comes up once the main connection is open and the operator opts in.
-  const { poseWsRef, status: poseStatus } = useAxolPoseSocket(
-    usbPoses && status === AxolConnectionStatus.Open
-  )
+  // avoid WiFi latency; camera video keeps using the LAN host above. The tunnel
+  // is independent of the WiFi connection, so the socket opens as soon as the
+  // operator opts in — that is what surfaces the certificate prompt before the
+  // first connect, instead of after poses have already fallen back to WiFi.
+  const { poseWsRef, status: poseStatus } = useAxolPoseSocket(usbPoses)
   // Low-latency WebRTC pose data channel — negotiated once the teleop
   // connection is up (independent of cameras / presenting). AxolVRClient prefers
   // it over the main WebSocket, which stays as the fallback.
@@ -1347,38 +1348,6 @@ export default function App() {
                 <Button variant="ghost" className="w-full" onClick={disconnect}>
                   Disconnect
                 </Button>
-                {usbPoses && (
-                  <div className="flex flex-col gap-2">
-                    <p className="text-center text-xs text-white/40">
-                      Quest over USB:{" "}
-                      <span
-                        className={cn(
-                          "font-medium",
-                          poseStatus === AxolConnectionStatus.Open
-                            ? "text-emerald-400"
-                            : "text-amber-400"
-                        )}
-                      >
-                        {poseStatus === AxolConnectionStatus.Open
-                          ? "controller over cable"
-                          : poseStatus === AxolConnectionStatus.Connecting
-                            ? "connecting USB link… (on WiFi)"
-                            : "WiFi fallback — USB link down"}
-                      </span>
-                    </p>
-                    {poseStatus !== AxolConnectionStatus.Open && (
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        className="w-full"
-                        onClick={() => authorizeCert(`https://localhost:${VR_WS_PORT}`)}
-                      >
-                        <ShieldCheck />
-                        Authorize USB certificate
-                      </Button>
-                    )}
-                  </div>
-                )}
               </div>
             ) : status === AxolConnectionStatus.Connecting ? (
               <Button variant="secondary" className="w-full" onClick={disconnect}>
@@ -1421,6 +1390,42 @@ export default function App() {
               </form>
             )}
 
+            {/* Shown in every connection state: the cable certificate is
+                approved here, and approving it before connecting is what keeps
+                the first session off the WiFi fallback. */}
+            {usbPoses && (
+              <div className="flex flex-col gap-2">
+                <p className="text-center text-xs text-white/40">
+                  Quest over USB:{" "}
+                  <span
+                    className={cn(
+                      "font-medium",
+                      poseStatus === AxolConnectionStatus.Open
+                        ? "text-emerald-400"
+                        : "text-amber-400"
+                    )}
+                  >
+                    {poseStatus === AxolConnectionStatus.Open
+                      ? "controller over cable"
+                      : poseStatus === AxolConnectionStatus.Connecting
+                        ? "connecting USB link… (on WiFi)"
+                        : "WiFi fallback — USB link down"}
+                  </span>
+                </p>
+                {poseStatus !== AxolConnectionStatus.Open && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="w-full"
+                    onClick={() => authorizeCert(usbCertOrigin(VR_WS_PORT))}
+                  >
+                    <ShieldCheck />
+                    Authorize USB certificate
+                  </Button>
+                )}
+              </div>
+            )}
+
             {status === AxolConnectionStatus.Open && (
               <div className="grid grid-cols-2 gap-3 text-left text-xs">
                 <ControlHints
@@ -1455,10 +1460,12 @@ export default function App() {
               <div className="flex flex-col gap-2">
                 <p className="rounded-lg border border-red-400/25 bg-red-400/10 p-3 text-xs text-red-300">
                   Could not connect to <span className="font-mono">{hostname || "the server"}</span>
-                  . Check that <span className="font-mono">axol teleop</span> is running, then
-                  authorize its self-signed certificate below.
+                  . Check that <span className="font-mono">axol teleop</span> is running
+                  {hostCertAuthorizeVisible(usbPoses, hostname)
+                    ? ", then authorize its self-signed certificate below."
+                    : "."}
                 </p>
-                {hostname.trim() && (
+                {hostCertAuthorizeVisible(usbPoses, hostname) && (
                   <Button
                     variant="outline"
                     className="w-full"

--- a/web/app/src/lib/usb-transport.ts
+++ b/web/app/src/lib/usb-transport.ts
@@ -1,0 +1,24 @@
+/**
+ * Gating for the wired Quest-over-USB pose link.
+ *
+ * The USB link runs over `adb reverse`, so the headset reaches the VR server at
+ * `https://localhost:8000` no matter what the WiFi connection is doing. Its
+ * self-signed certificate is therefore a separate origin from the LAN host's,
+ * and it can — and must — be authorized before the operator connects, otherwise
+ * the poses silently fall back to WiFi.
+ */
+
+/** Origin whose certificate the headset must trust for the USB pose link. */
+export function usbCertOrigin(port: number): string {
+  return `https://localhost:${port}`
+}
+
+/**
+ * Whether to offer the LAN host's certificate button.
+ *
+ * In USB mode the host origin is the wrong one to authorize, so only the USB
+ * button is shown.
+ */
+export function hostCertAuthorizeVisible(usbSelected: boolean, hostname: string): boolean {
+  return !usbSelected && hostname.trim() !== ""
+}

--- a/web/app/src/lib/usb-transport.ts
+++ b/web/app/src/lib/usb-transport.ts
@@ -1,11 +1,12 @@
 /**
- * Gating for the wired Quest-over-USB pose link.
+ * Certificate-origin helpers for the wired Quest-over-USB pose link.
  *
  * The USB link runs over `adb reverse`, so the headset reaches the VR server at
  * `https://localhost:8000` no matter what the WiFi connection is doing. Its
  * self-signed certificate is therefore a separate origin from the LAN host's,
  * and it can — and must — be authorized before the operator connects, otherwise
- * the poses silently fall back to WiFi.
+ * the poses silently fall back to WiFi. The LAN host origin is still required
+ * for the session itself and camera video, so both buttons stay available.
  */
 
 /** Origin whose certificate the headset must trust for the USB pose link. */

--- a/web/app/src/lib/usb-transport.ts
+++ b/web/app/src/lib/usb-transport.ts
@@ -16,9 +16,11 @@ export function usbCertOrigin(port: number): string {
 /**
  * Whether to offer the LAN host's certificate button.
  *
- * In USB mode the host origin is the wrong one to authorize, so only the USB
- * button is shown.
+ * USB carries the controller poses only: the session itself, and all camera
+ * video, still run over `wss://{hostname}:8000`. So the host certificate has to
+ * be authorizable in USB mode too — hiding it there leaves a headset that has
+ * not already trusted the LAN origin with no way to connect at all.
  */
-export function hostCertAuthorizeVisible(usbSelected: boolean, hostname: string): boolean {
-  return !usbSelected && hostname.trim() !== ""
+export function hostCertAuthorizeVisible(hostname: string): boolean {
+  return hostname.trim() !== ""
 }

--- a/web/app/test/usb-transport.test.mjs
+++ b/web/app/test/usb-transport.test.mjs
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { hostCertAuthorizeVisible, usbCertOrigin } from "../src/lib/usb-transport.ts"
+
+test("the USB certificate is always authorized on localhost, never the LAN address", () => {
+  assert.equal(usbCertOrigin(8000), "https://localhost:8000")
+  assert.equal(usbCertOrigin(8001), "https://localhost:8001")
+})
+
+test("the host certificate button is hidden in USB mode", () => {
+  assert.equal(hostCertAuthorizeVisible(true, "axol-host.local"), false)
+  assert.equal(hostCertAuthorizeVisible(false, "axol-host.local"), true)
+})
+
+test("the host certificate button needs a host to authorize", () => {
+  assert.equal(hostCertAuthorizeVisible(false, ""), false)
+  assert.equal(hostCertAuthorizeVisible(false, "   "), false)
+})

--- a/web/app/test/usb-transport.test.mjs
+++ b/web/app/test/usb-transport.test.mjs
@@ -8,12 +8,11 @@ test("the USB certificate is always authorized on localhost, never the LAN addre
   assert.equal(usbCertOrigin(8001), "https://localhost:8001")
 })
 
-test("the host certificate button is hidden in USB mode", () => {
-  assert.equal(hostCertAuthorizeVisible(true, "axol-host.local"), false)
-  assert.equal(hostCertAuthorizeVisible(false, "axol-host.local"), true)
+test("the host certificate button stays available in USB mode", () => {
+  assert.equal(hostCertAuthorizeVisible("axol-host.local"), true)
 })
 
 test("the host certificate button needs a host to authorize", () => {
-  assert.equal(hostCertAuthorizeVisible(false, ""), false)
-  assert.equal(hostCertAuthorizeVisible(false, "   "), false)
+  assert.equal(hostCertAuthorizeVisible(""), false)
+  assert.equal(hostCertAuthorizeVisible("   "), false)
 })


### PR DESCRIPTION
Closes #250

Authorizing the Quest certificate over USB pointed at an unreachable LAN URL and was gated behind a WiFi connection, so poses fell back to WiFi. This branch makes the USB path work on its own.

## Changes

- **USB works before WiFi.** `useAxolPoseSocket` no longer requires the connection to be Open, and the USB status panel and "Authorize USB certificate" button render in every connection state. The LAN-host authorize button stays available in USB mode too: USB carries poses only, so the session and camera video still need the LAN origin trusted. The accept origin is now built by one helper rather than inlined.
  - Lifecycle change: the USB pose socket now lives as long as the checkbox is ticked, not as long as the session. It keeps retrying `wss://localhost:8000` (1 s backoff) before connect and after Disconnect, so on the VR server `_client_count` no longer drops to 0 on Disconnect; per-client cleanup in `_drop_pose_client` plus the 1 s owner-takeover window make this benign.
- **Both ports reversed.** `adb.connect()` and `adb.status()` take the port tuple `(8000, 8001)`; the readiness check requires every port present. This makes the control panel itself reachable over the cable at `https://localhost:8001` while idle. It does not move the pose certificate: browser overrides are per-origin including port, so `:8000` still needs its own approval, and `:8000` exists only while an operation runs.
- **SAN-less certificates rotate.** `certificate_lacks_san()` inspects the certificate and `prepare_tls_files()` regenerates when the SAN extension is missing. Installs predating #71 carry a SAN-less certificate that Chromium rejects even on localhost.
- **`CONTROL_PORT = 8001`** now lives in `utils/ports.py` as the single source, used by `adb.py`, `mantis_session.py`, and the `axol serve --port` default.
- **Guide corrected.** `docs/guides/quest-over-usb.mdx` puts the `localhost:8001` tunnel check first and states that port 8000 exists only during an operation. The guide and code comments are explicit that the `:8001` forward proves the tunnel is live and exposes the panel over the cable; it does not stand in for the `:8000` certificate approval.

## Upgrade note

Installs carrying a SAN-less certificate get a new one on the first `axol serve` start after this lands, so every browser that trusted the old one will see a fresh interstitial on both `:8000` and `:8001`. One-time.

## Tests

- `tests/test_quest_usb.py`: both ports forwarded on connect; a reverse list missing 8001 is not ready; SAN detection against a real legacy certificate and a current one; rotation happens, and a good certificate is left alone.
- `web/app/test/usb-transport.test.mjs`: USB gating and accept-origin construction.

No new dependencies, Python or npm.

## Known gaps

- No render-level test that the USB panel mounts before connect — `web/app` has no DOM test harness, and adding one would be a new dependency. The gating logic is unit-tested through extracted helpers; the pose-socket change is covered by type-check and review only.
- Verifying the accept-popup outcome remains impossible (cross-origin, no signal), so `cert-accept.ts` still resolves on popup close.
- The certificate keeps its `localhost,127.0.0.1` SAN; no LAN IP or `.local` name was added.

## Verification

Bench-verified on a ZED Box Duo with a Quest 3 (see comments):
- [x] Both ports reverse while idle
- [x] With teleop running, poses ride the cable and camera video rides the LAN, confirmed from the VR server's connection log
- [x] A certificate with no SAN is replaced on serve start

USB carries the controller poses only. The session and all camera video still use the LAN host, so this is a latency path rather than a WiFi replacement.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Quest teleop USB tunneling, TLS certificate rotation on serve start, and VR client connection timing—core operator paths with new tests but behavior shifts for existing installs (cert regen, stricter adb readiness).
> 
> **Overview**
> Fixes Quest-over-USB so operators can trust certificates and verify the cable path **without** relying on Wi‑Fi first.
> 
> **USB pose link and UI.** The VR app opens the localhost pose WebSocket as soon as **Quest over USB** is enabled (not only after the main session is connected), and the USB status plus **Authorize USB certificate** block appears in every connection state so approval can happen before connect. Certificate URLs are centralized in `usb-transport.ts` (`https://localhost:{port}`).
> 
> **Dual `adb reverse`.** `TUNNEL_PORTS` forwards both **8000** (VR poses, only while teleop/collect runs) and **8001** (control panel, always on). `connect`/`status` require every listed port to be reversed; `CONTROL_PORT` and `VR_PORT` are shared via `utils.ports` for `axol serve`, Mantis session, and adb.
> 
> **TLS on upgrade.** `certificate_lacks_san()` detects legacy certs without `subjectAltName`; `prepare_tls_files()` regenerates them so Chromium/Quest can accept `localhost`.
> 
> **Docs and tests.** The Quest-over-USB guide adds a `https://localhost:8001` tunnel check and clarifies per-port cert approval. New Python tests cover multi-port adb and cert rotation; small JS tests cover USB cert origin helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e3033bd263f03b02e5a1bd3c81d41cba4ccb739. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

