### PR TITLE
Recorder: fail open — mitigate and log per-row defects, end a take only on a 1 s camera/state loss

### DIFF
--- a/almond_axol/cli/collect_data.py
+++ b/almond_axol/cli/collect_data.py
@@ -817,8 +817,10 @@ _PANEL_START_COUNTDOWN_S = 3.0
 # Control-tick heartbeat age that counts as a stall worth a stack trace: six
 # ticks at 120 Hz. The recorder pairs each camera exposure with the state
 # snapshot the control loop published within 50 ms of it and gives up after a
-# 100 ms wait, so a tick gap this long is already what ends an episode
-# ("no retained robot-state snapshot brackets camera exposure").
+# 100 ms wait, so a tick gap this long is already enough to make the recorder
+# drop a dataset row ("no retained robot-state snapshot brackets camera
+# exposure") — no longer fatal to the episode (see record_proc.py), but still
+# worth a stack trace so a chronic stall gets tracked down.
 _TICK_STALL_S = 0.05
 
 # Buttons the panel renders per phase (see EpisodeControls in the web app):

--- a/almond_axol/recording/record_proc.py
+++ b/almond_axol/recording/record_proc.py
@@ -1562,7 +1562,14 @@ def run_capture_loop(
             if recording_start is None:
                 # First tick, or first tick after a resume: anchor so the
                 # current tick's target is "now" and the cadence continues.
-                recording_start = time.perf_counter() - tick * frame_interval
+                anchor = time.perf_counter()
+                recording_start = anchor - tick * frame_interval
+                # The camera-silence clock measures time *while capturing*.
+                # Nobody read the cameras during a pause, so a pause longer
+                # than _CAMERA_LOSS_FATAL_S must not turn the first late frame
+                # after resume into a discarded take.
+                for cam_key in last_fresh_frame_at:
+                    last_fresh_frame_at[cam_key] = anchor
 
             now = time.perf_counter()
             if now - cap_last_log >= 1.0:

--- a/almond_axol/recording/record_proc.py
+++ b/almond_axol/recording/record_proc.py
@@ -164,21 +164,22 @@ def _shutdown_process(
 # the rest of the camera/control stack remains healthy.  Holding the last IDR
 # for those missing cadence slots is bounded corruption (at most 33 ms at
 # 60 Hz) and, unlike accepting the future AU early, does not shift that camera
-# against every subsequent robot-state/dataset row.  A single hole longer than
-# two frames is fatal, and so is a camera that is losing frames faster than a
-# rare hiccup: the ZED sources have been observed dropping one exposure every
-# one to four seconds during a teleoperated take (both stereo eyes together,
-# so the loss is in the source, not the relay's queues or transport), and a
-# fixed handful of events per episode aborted every take within seconds and
-# homed the arms mid-teleop.  The budget is therefore a rate: a burst of
-# events inside a short window, or concealed frames above a small fraction of
-# the episode, means the stream is unhealthy and still fails closed.
-_ENCODED_MAX_CONCEALED_FRAMES_PER_EVENT = 2
+# against every subsequent robot-state/dataset row.  The ZED sources have been
+# observed dropping one exposure every one to four seconds during a
+# teleoperated take (both stereo eyes together, so the loss is in the source,
+# not the relay's queues or transport), and a fixed handful of events per
+# episode aborted every take within seconds and homed the arms mid-teleop.
+# The budget below is therefore a rate: a burst of events inside a short
+# window, or concealed frames above a small fraction of the episode, marks the
+# stream as unhealthy.  Under the fail-open policy (see _CAMERA_LOSS_FATAL_S)
+# that no longer ends the take — the hole is still repaired — but the event is
+# logged at ERROR and counted so the source gets looked at.  Holes of any
+# length up to _ENCODED_MAX_CONCEALED_GAP_S are repaired the same way; only a
+# hole longer than that ends the episode.
 _ENCODED_MAX_CONCEALMENT_EVENTS_PER_WINDOW = 3
 _ENCODED_CONCEALMENT_WINDOW_S = 2.0
 _ENCODED_MIN_CONCEALED_FRAMES_PER_CAMERA = 6
 _ENCODED_MAX_CONCEALED_FRACTION = 0.02
-_ENCODED_GAP_GRID_TOLERANCE_FRAMES = 0.25
 # A just-arrived exposure can precede the newest control snapshot by one control
 # tick. Briefly poll the state ring for the upper bracket; never clamp outside
 # its retained range.
@@ -192,6 +193,26 @@ _SNAPSHOT_HISTORY_SIZE = 512
 # headroom for lower configured control rates, but surface clock/history failures
 # before they silently contaminate a whole episode.
 _STATE_ALIGNMENT_WARN_S = 0.050
+
+# Fail-open recording policy. A take is a scarce, operator-driven artefact; a
+# single imperfect row is not. Both capture loops therefore *mitigate* every
+# per-row defect they can (repeat the prior IDR into a bounded hole, discard a
+# stale AU and take the next one, hold the previous row's state when the exact
+# bracket is gone, and as a last resort drop the row for every camera at once
+# so the streams stay index-aligned) and record it in the
+# episode's capture-quality counters (logged at the end of the take and, for
+# the worst cases, per event) so it can be tracked down later — without ending
+# the episode. Only a *drastic* loss ends a take: a camera that delivers no
+# usable exposure for this long, or a control loop that publishes no state for
+# this long. Those match the "silent motor" threshold the realtime core uses
+# to go limp — past that point the rows would describe a robot nobody is
+# observing.
+_CAMERA_LOSS_FATAL_S = 1.0
+_STATE_LOSS_FATAL_S = 1.0
+# Concealment past the historical per-camera budget is still applied (the
+# alternative is discarding the take), but the log escalates from WARNING to
+# ERROR once per camera per episode so an unhealthy source stands out.
+_ENCODED_MAX_CONCEALED_GAP_S = _CAMERA_LOSS_FATAL_S
 
 # A capture row that goes this long without a heartbeat is a stall worth a
 # stack trace: 30 frame periods at 60 fps, well under the 2 s encoded-AU
@@ -1024,96 +1045,258 @@ def _describe_snapshot_miss(
     )
 
 
+def _classify_snapshot_miss(
+    target_ts: float,
+    read_latest: Callable[[], tuple[dict, dict, float, bool] | None],
+    now: float | None = None,
+) -> tuple[str, bool, tuple[dict, dict, float, bool] | None]:
+    """Describe a bracket miss and decide whether it ends the take.
+
+    Returns ``(detail, fatal, latest)`` from a *single* ``read_latest`` so the
+    logged attribution and the decision can never disagree (the writer may
+    publish between two reads).
+
+    Only one miss is drastic enough to end an episode: the control loop has
+    published nothing for :data:`_STATE_LOSS_FATAL_S` — the robot is moving
+    (or not) with nobody recording its state, and every later row would pair a
+    fresh image with the same stale pose. Everything else is a per-row defect:
+    the exposure aged out of the ring while the recorder was descheduled, the
+    ring copy raced the writer for every retry, or the writer paused briefly
+    and has since resumed. Those cost one row (or one row's exact pairing),
+    not the take.
+    """
+    latest = read_latest()
+    detail = _describe_snapshot_miss(target_ts, lambda: latest, now)
+    if latest is None:
+        # Nothing readable right now. Mid-episode this is a transient (a raced
+        # ring copy); the startup wait already proved the writer publishes.
+        return detail, False, None
+    reference = now if now is not None else time.perf_counter()
+    silent_for = reference - latest[2]
+    fatal = silent_for >= _STATE_LOSS_FATAL_S
+    if fatal:
+        detail += (
+            f"; no robot state has been published for {silent_for:.2f}s "
+            f"(limit {_STATE_LOSS_FATAL_S:.1f}s)"
+        )
+    return detail, fatal, latest
+
+
+class _RowStatePairer:
+    """Choose the robot state for one dataset row under the fail-open policy.
+
+    The normal case is the snapshot nearest the row's camera exposure, within
+    :data:`_STATE_ALIGNMENT_WARN_S`. When that is unavailable (the exact
+    bracket aged out of the ring, the ring copy raced the writer, the writer
+    paused briefly) the fallbacks are, in order:
+
+    1. **Hold the previous row's state** if it is still within the same
+       tolerance of this exposure. That is at most one or two frames stale —
+       no worse than a pairing the loop accepts on any ordinary row — and, like
+       repeating the prior IDR for a lost exposure, it keeps the row so the
+       dataset's ``frame_index / fps`` timeline stays true to wall time.
+    2. **Drop the row** (every camera together, so mp4s and parquet stay
+       index-aligned) when nothing within tolerance exists and the transport
+       allows skipping an AU.
+    3. **Keep the row with the degraded pairing** on a predictive stream that
+       cannot skip an AU.
+
+    Each outcome is counted in ``quality`` and logged with the row's reason so
+    it can be tracked down later.
+    """
+
+    def __init__(
+        self, *, label: str, can_drop: bool, quality: "dict[str, int] | None"
+    ) -> None:
+        self._label = label
+        self._can_drop = can_drop
+        self._quality = quality
+        self._last_fresh: tuple[dict, dict, float, bool] | None = None
+        self._held_run = 0
+        self.misses = 0
+
+    def resolve(
+        self,
+        row_capture_ts: float,
+        candidate: tuple[dict, dict, float, bool] | None,
+        miss_detail: str | None,
+    ) -> tuple[tuple[dict, dict, float, bool] | None, float]:
+        """Return ``(snapshot, skew_s)``; ``snapshot`` is ``None`` to drop the row.
+
+        ``candidate`` is the best snapshot available (the nearest bracket, or
+        the newest published when no bracket exists); ``miss_detail`` carries
+        :func:`_classify_snapshot_miss`'s attribution when the bracket was
+        missing.
+        """
+        skew = abs(candidate[2] - row_capture_ts) if candidate is not None else math.inf
+        if skew <= _STATE_ALIGNMENT_WARN_S:
+            self._last_fresh = candidate
+            self._held_run = 0
+            return candidate, skew
+        self.misses += 1
+        if miss_detail is not None:
+            reason = (
+                f"no retained robot-state snapshot brackets {self._label} "
+                f"{row_capture_ts:.6f}: {miss_detail}"
+            )
+        else:
+            reason = (
+                f"nearest robot state is {skew * 1e3:.1f}ms from the {self._label} "
+                f"(limit {_STATE_ALIGNMENT_WARN_S * 1e3:.1f}ms)"
+            )
+        if self._last_fresh is not None:
+            held_skew = abs(self._last_fresh[2] - row_capture_ts)
+            if held_skew <= _STATE_ALIGNMENT_WARN_S:
+                self._held_run += 1
+                _note_quality(self._quality, "rows_with_held_state")
+                _logger.warning(
+                    "holding the previous row's robot state for this dataset row "
+                    "(%.1fms from the %s, %d consecutive): %s (%d state pairing "
+                    "miss(es) this episode)",
+                    held_skew * 1e3,
+                    self._label,
+                    self._held_run,
+                    reason,
+                    self.misses,
+                )
+                return self._last_fresh, held_skew
+        if self._can_drop or candidate is None:
+            key = (
+                "rows_dropped_state_miss"
+                if miss_detail is not None
+                else "rows_dropped_state_skew"
+            )
+            _note_quality(self._quality, key)
+            _logger.warning(
+                "dropping one dataset row: %s (%d state pairing miss(es) this episode)",
+                reason,
+                self.misses,
+            )
+            return None, skew
+        _note_quality(self._quality, "rows_kept_with_state_skew")
+        _logger.warning(
+            "keeping dataset row with a %.1fms state skew (a predictive stream "
+            "cannot skip the row): %s (%d state pairing miss(es) this episode)",
+            skew * 1e3,
+            reason,
+            self.misses,
+        )
+        return candidate, skew
+
+
+def _note_quality(quality: "dict[str, int] | None", key: str, n: int = 1) -> int:
+    """Bump one capture-quality counter; returns the new value (0 if unused)."""
+    if quality is None:
+        return 0
+    value = quality.get(key, 0) + n
+    quality[key] = value
+    return value
+
+
+def format_capture_quality(quality: "dict[str, int]") -> str:
+    """One-line summary of an episode's mitigated capture defects."""
+    if not quality:
+        return "clean (no mitigated capture defects)"
+    return ", ".join(f"{key}={value}" for key, value in sorted(quality.items()))
+
+
+def _log_capture_quality(
+    quality: "dict[str, int]",
+    rows: int,
+    cameras: "dict[str, Any]",
+    capture_error: str | None,
+) -> None:
+    """Summarize a finished take's mitigated defects in one log line.
+
+    Folds in each encoded reader's transport-side losses (upstream frames the
+    relay dropped before the recorder saw them) so the summary covers the
+    whole path. INFO for a clean take, WARNING when anything was mitigated —
+    the operator did not see any of it, so this line is how a take that needs
+    a second look gets found later.
+    """
+    for cam_key, cam in cameras.items():
+        lost = getattr(cam, "lost_exposures", 0)
+        if isinstance(lost, int) and lost > 0:
+            quality[f"{cam_key}.transport_lost_exposures"] = lost
+    summary = format_capture_quality(quality)
+    if capture_error is not None:
+        _logger.warning(
+            "capture quality: %d row(s) before the take ended on %s; %s",
+            rows,
+            capture_error,
+            summary,
+        )
+    elif quality:
+        _logger.warning("capture quality: %d row(s); %s", rows, summary)
+    else:
+        _logger.info("capture quality: %d row(s); %s", rows, summary)
+
+
 def _camera_alignment_limit(fps: int) -> float:
     """Maximum allowed exposure spread within a multi-camera dataset row."""
     return max(0.010, 1.5 / fps) if fps > 0 else 0.050
 
 
-def _validate_encoded_cadence_step(
-    name: str,
+def _missing_cadence_slots(
+    *,
+    previous_ts: float,
+    capture_ts: float,
+    fps: int,
+    capture_fps: int,
+) -> int:
+    """Number of dataset cadence slots skipped between two consecutive AUs.
+
+    Zero for a normal step (including the alternating source-frame spacings a
+    non-divisor decimation such as 60 -> 50 legitimately produces: its largest
+    planned spacing plus a quarter source interval is allowed). Otherwise the
+    gap is rounded to the nearest whole number of dataset periods — source PTS
+    jitter is far below half a period, so a real loss is never mistaken for
+    jitter or vice versa — and the count of slots with no exposure is
+    returned. Callers decide how to repair the hole; this helper only measures
+    it.
+    """
+    if fps <= 0 or not math.isfinite(previous_ts) or not math.isfinite(capture_ts):
+        return 0
+    delta = capture_ts - previous_ts
+    if delta <= 0:
+        return 0
+    if capture_fps > fps:
+        planned_steps = (capture_fps + fps - 1) // fps
+        gap_limit = (planned_steps + 0.25) / capture_fps
+        if delta <= gap_limit:
+            return 0
+    periods = int(math.floor(delta * fps + 0.5))
+    return max(0, periods - 1)
+
+
+def _encoded_cadence_deviation(
     *,
     first_ts: float,
-    previous_ts: float,
     capture_ts: float,
     intervals: int,
     fps: int,
     capture_fps: int,
-) -> None:
-    """Fail closed when one encoded exposure is missing or off cadence."""
-    if not math.isfinite(capture_ts):
-        raise RuntimeError(f"camera {name!r} produced an invalid capture timestamp")
-    delta = capture_ts - previous_ts
-    if delta <= 0:
-        raise RuntimeError(
-            f"camera {name!r} capture PTS did not advance "
-            f"({delta * 1e3:.2f}ms); episode discarded"
-        )
-    # A non-divisor decimation (e.g. 60 -> 50) legitimately alternates
-    # source-frame spacings. Allow its largest planned spacing plus a quarter
-    # source interval. A whole extra source interval means a selected frame was
-    # lost.
-    planned_steps = (capture_fps + fps - 1) // fps
-    gap_limit = (planned_steps + 0.25) / capture_fps
-    if delta > gap_limit:
-        raise RuntimeError(
-            f"camera {name!r} dropped an encoded frame: capture PTS jumped "
-            f"{delta * 1e3:.2f}ms (limit {gap_limit * 1e3:.2f}ms); "
-            "episode discarded"
-        )
+) -> str | None:
+    """Describe a long-run cadence drift off the dataset grid, else ``None``.
+
+    videorate preserves the selected source PTS. Its phase may differ from an
+    ideal dataset-rate grid by roughly one source interval, but sustained
+    capture-rate output (for example after reopening a stale downstream
+    videorate) must not be silently stretched onto the dataset timeline. The
+    caller logs the deviation and re-anchors the check; it is not fatal.
+    """
     elapsed = capture_ts - first_ts
-    # videorate preserves the selected source PTS. Its phase may differ from
-    # an ideal dataset-rate grid by roughly one source interval, but sustained
-    # capture-rate output (for example after reopening a stale downstream
-    # videorate) must not be silently stretched onto the dataset timeline.
     cadence_slack = 1.5 / capture_fps
     minimum_elapsed = intervals / fps - cadence_slack
     maximum_elapsed = intervals / fps + cadence_slack
-    if elapsed < minimum_elapsed or elapsed > maximum_elapsed:
-        direction = "too fast" if elapsed < minimum_elapsed else "too slow"
-        raise RuntimeError(
-            f"camera {name!r} encoded cadence is {direction}: "
-            f"{intervals + 1} frames span {elapsed * 1e3:.2f}ms at requested "
-            f"{fps}fps (allowed {max(0.0, minimum_elapsed) * 1e3:.2f}–"
-            f"{maximum_elapsed * 1e3:.2f}ms); episode discarded"
-        )
-
-
-def _concealable_encoded_gap_frames(
-    *,
-    previous_ts: float,
-    capture_ts: float,
-    fps: int,
-    capture_fps: int,
-    frames_are_independent: bool,
-) -> int:
-    """Return the number of bounded missing cadence slots, else zero.
-
-    This is intentionally narrower than the cadence validator.  A repair is
-    safe for the encoded transport only when every source frame is a standalone
-    IDR and the dataset consumes every captured exposure.  Rate-converted
-    streams can legitimately alternate source-frame spacings, so they retain
-    the exact/fail-closed path rather than having that selection pattern
-    mistaken for loss.
-    """
-    if (
-        not frames_are_independent
-        or fps <= 0
-        or capture_fps != fps
-        or not math.isfinite(previous_ts)
-        or not math.isfinite(capture_ts)
-    ):
-        return 0
-    delta = capture_ts - previous_ts
-    if delta <= 0:
-        return 0
-    periods = round(delta * fps)
-    missing = periods - 1
-    if not 1 <= missing <= _ENCODED_MAX_CONCEALED_FRAMES_PER_EVENT:
-        return 0
-    residual = abs(delta - periods / fps)
-    if residual > _ENCODED_GAP_GRID_TOLERANCE_FRAMES / capture_fps:
-        return 0
-    return missing
+    if minimum_elapsed <= elapsed <= maximum_elapsed:
+        return None
+    direction = "too fast" if elapsed < minimum_elapsed else "too slow"
+    return (
+        f"{direction}: {intervals + 1} frames span {elapsed * 1e3:.2f}ms at "
+        f"requested {fps}fps (allowed {max(0.0, minimum_elapsed) * 1e3:.2f}–"
+        f"{maximum_elapsed * 1e3:.2f}ms)"
+    )
 
 
 def _concealment_within_budget(
@@ -1166,8 +1349,6 @@ def _align_independent_encoded_start(
     if len(packets) <= 1:
         return packets, dropped
     boundary = max(packet[1] for packet in packets.values())
-    first_ts = {name: packet[1] for name, packet in packets.items()}
-    intervals = dict.fromkeys(packets, 0)
     for name in packets:
         while packets[name][1] < boundary:
             previous_ts = packets[name][1]
@@ -1176,17 +1357,27 @@ def _align_independent_encoded_start(
                 raise TimeoutError(
                     f"camera {name!r} did not catch up to the row-zero exposure window"
                 )
-            next_interval = intervals[name] + 1
-            _validate_encoded_cadence_step(
-                name,
-                first_ts=first_ts[name],
+            if not math.isfinite(packet[1]) or packet[1] <= previous_ts:
+                # Unusable prefix AU (no/duplicate timestamp): nothing before
+                # row zero is recorded, so just keep advancing.
+                dropped[name] = dropped.get(name, 0) + 1
+                continue
+            missing = _missing_cadence_slots(
                 previous_ts=previous_ts,
                 capture_ts=packet[1],
-                intervals=next_interval,
                 fps=fps,
                 capture_fps=capture_fps[name],
             )
-            intervals[name] = next_interval
+            if missing:
+                # A hole in the discarded prefix costs nothing; note it so a
+                # camera that is already losing exposures at start is visible.
+                _logger.info(
+                    "camera %r skipped %d exposure(s) before row zero (PTS gap "
+                    "%.2fms); nothing recorded yet, continuing alignment",
+                    name,
+                    missing,
+                    1e3 * (packet[1] - previous_ts),
+                )
             packets[name] = packet
             dropped[name] = dropped.get(name, 0) + 1
     return packets, dropped
@@ -1256,6 +1447,7 @@ def run_capture_loop(
     on_error: Callable[[str], None] | None = None,
     heartbeat: Callable[[], None] | None = None,
     row_times: "list[float] | None" = None,
+    quality: "dict[str, int] | None" = None,
 ) -> None:
     """Capture dataset rows at ``fps`` Hz until ``stop_event`` is set.
 
@@ -1272,9 +1464,16 @@ def run_capture_loop(
     frame with ``capture_perf_ts >= T_n`` from every camera. The row is paired
     with the joint/action snapshot nearest the median camera exposure, rather
     than whichever control tick happens to be latest after camera delivery.
-    Every row requires one fresh frame per camera; a timeout/stale frame aborts
-    the episode instead of silently duplicating images or state. Any fatal error
-    is reported via ``on_error``.
+    Every row requires one fresh frame per camera. Under the fail-open policy
+    (see :data:`_CAMERA_LOSS_FATAL_S`) a tick whose frames are missing, stale,
+    or unsynchronized is *skipped* — no image and no row is written for any
+    camera, so the dataset stays self-consistent — and a tick without an exact
+    state bracket holds the previous row's state while that is within
+    tolerance (:class:`_RowStatePairer`), else is skipped too. Everything is
+    counted in ``quality``. Only a camera that produces no fresh frame
+    for :data:`_CAMERA_LOSS_FATAL_S`, a transport failure, or a control loop
+    silent for :data:`_STATE_LOSS_FATAL_S` ends the episode (reported via
+    ``on_error``).
 
     ``record_event`` (optional) gates mid-episode capture: while cleared the
     loop idles without appending rows, and on the next set it re-anchors its
@@ -1328,6 +1527,12 @@ def run_capture_loop(
         timeout_ms = int(2 * frame_interval * 1000 + 200)
         recording_start: float | None = None
         last_capture_ts: dict[str, float] = {}
+        # When each camera last produced a usable fresh frame (perf_counter):
+        # a camera silent for _CAMERA_LOSS_FATAL_S ends the take; anything
+        # shorter costs the ticks it missed.
+        last_fresh_frame_at: dict[str, float] = dict.fromkeys(
+            cameras, time.perf_counter()
+        )
         tick = 0
 
         tick_cost_sum = 0.0
@@ -1337,6 +1542,11 @@ def run_capture_loop(
         snapshot_skew_max = 0.0
         camera_skew_max = 0.0
         skew_warning_issued = False
+        # The raw path writes each row's images itself, so skipping a tick is
+        # always alignment-safe.
+        state_pairer = _RowStatePairer(
+            label="raw camera exposure", can_drop=True, quality=quality
+        )
         cap_last_log = time.perf_counter()
 
         while not stop_event.is_set():
@@ -1388,75 +1598,112 @@ def run_capture_loop(
             body_t0 = time.perf_counter()
             frames: dict[str, tuple[Any, float, float]] = {}
             capture_ts: list[float] = []
+            # Set when this tick cannot become a row. The tick is skipped for
+            # every camera at once (no image, no row), which keeps the dataset
+            # self-consistent; the reason is logged and counted.
+            skip_tick: tuple[str, str] | None = None
             for cam_key, cam in cameras.items():
                 try:
                     frame, cap_ts, recv_ts = cam.read_at_or_after(
                         target_perf_ts, timeout_ms=timeout_ms
                     )
-                except (TimeoutError, RuntimeError) as exc:
-                    raise RuntimeError(
+                except TimeoutError as exc:
+                    silent_for = time.perf_counter() - last_fresh_frame_at[cam_key]
+                    if silent_for >= _CAMERA_LOSS_FATAL_S:
+                        raise RuntimeError(
+                            f"camera {cam_key!r} produced no fresh frame for "
+                            f"{silent_for:.2f}s (limit {_CAMERA_LOSS_FATAL_S:.1f}s, "
+                            f"last miss at tick {tick}: {exc}); episode discarded"
+                        ) from exc
+                    skip_tick = (
+                        f"{cam_key}.ticks_without_frame",
                         f"camera {cam_key!r} produced no fresh frame for tick "
+                        f"{tick} ({exc}; silent for {silent_for * 1e3:.0f}ms)",
+                    )
+                    break
+                except RuntimeError as exc:
+                    # The frame transport itself failed (not a late frame).
+                    raise RuntimeError(
+                        f"camera {cam_key!r} frame transport failed at tick "
                         f"{tick}: {exc}; episode discarded"
                     ) from exc
                 if not np.isfinite(cap_ts):
-                    raise RuntimeError(
-                        f"camera {cam_key!r} produced an invalid capture timestamp"
+                    skip_tick = (
+                        f"{cam_key}.ticks_with_invalid_timestamp",
+                        f"camera {cam_key!r} produced an invalid capture "
+                        f"timestamp at tick {tick}",
                     )
+                    break
                 previous = last_capture_ts.get(cam_key)
                 if previous is not None and cap_ts <= previous:
-                    raise RuntimeError(
+                    skip_tick = (
+                        f"{cam_key}.ticks_with_stale_frame",
                         f"camera {cam_key!r} repeated a stale frame at tick {tick} "
-                        f"(PTS delta {(cap_ts - previous) * 1e3:.2f}ms); "
-                        "episode discarded"
+                        f"(PTS delta {(cap_ts - previous) * 1e3:.2f}ms)",
                     )
+                    break
+                last_fresh_frame_at[cam_key] = time.perf_counter()
                 frames[cam_key] = (frame, cap_ts, recv_ts)
                 capture_ts.append(cap_ts)
                 last_capture_ts[cam_key] = cap_ts
 
-            if capture_ts:
-                row_capture_ts = float(median(capture_ts))
+            if skip_tick is None and capture_ts:
                 camera_skew = max(capture_ts) - min(capture_ts)
                 camera_skew_max = max(camera_skew_max, camera_skew)
                 camera_limit = _camera_alignment_limit(fps)
                 if camera_skew > camera_limit:
-                    raise RuntimeError(
+                    skip_tick = (
+                        "ticks_with_camera_skew",
                         "raw camera exposures are not synchronized "
                         f"(spread {camera_skew * 1e3:.1f}ms, limit "
-                        f"{camera_limit * 1e3:.1f}ms); episode discarded"
+                        f"{camera_limit * 1e3:.1f}ms) at tick {tick}",
                     )
-                snap = _wait_snapshot_nearest(
-                    row_capture_ts,
-                    read_snapshot,
-                    read_snapshot_nearest,
-                    stop_event,
+            if skip_tick is not None:
+                key, reason = skip_tick
+                skipped = _note_quality(quality, key)
+                _logger.warning(
+                    "skipping one dataset tick: %s (%d such tick(s) this episode)",
+                    reason,
+                    skipped,
                 )
-            elif not cameras:
+                tick += 1
+                continue
+
+            if capture_ts:
+                row_capture_ts = float(median(capture_ts))
+            else:
                 # Joint-only datasets have no exposure clock; retain their
                 # original scheduled-tick association.
                 row_capture_ts = target_perf_ts
-                snap = _wait_snapshot_nearest(
-                    row_capture_ts,
-                    read_snapshot,
-                    read_snapshot_nearest,
-                    stop_event,
-                )
+            snap = _wait_snapshot_nearest(
+                row_capture_ts,
+                read_snapshot,
+                read_snapshot_nearest,
+                stop_event,
+            )
+            miss_detail: str | None = None
             if snap is None:
                 if stop_event.is_set():
                     return
-                raise RuntimeError(
-                    "no retained robot-state snapshot brackets raw camera "
-                    f"exposure {row_capture_ts:.6f}: "
-                    f"{_describe_snapshot_miss(row_capture_ts, read_snapshot)}; "
-                    "episode discarded"
+                miss_detail, fatal, snap = _classify_snapshot_miss(
+                    row_capture_ts, read_snapshot
                 )
+                if fatal:
+                    raise RuntimeError(
+                        "no retained robot-state snapshot brackets raw camera "
+                        f"exposure {row_capture_ts:.6f}: {miss_detail}; episode "
+                        "discarded"
+                    )
+            # A missing or distant bracket is a transient: hold the previous
+            # row's state, or skip this one tick — never the take. See
+            # _RowStatePairer.
+            snap, snapshot_skew = state_pairer.resolve(
+                row_capture_ts, snap, miss_detail
+            )
+            if snap is None:
+                tick += 1
+                continue
             joint_obs, action, _snap_ts, intervention = snap
-            snapshot_skew = abs(_snap_ts - row_capture_ts)
-            if snapshot_skew > _STATE_ALIGNMENT_WARN_S:
-                raise RuntimeError(
-                    "nearest robot state is too far from raw camera exposure "
-                    f"({snapshot_skew * 1e3:.1f}ms, limit "
-                    f"{_STATE_ALIGNMENT_WARN_S * 1e3:.1f}ms); episode discarded"
-                )
             snapshot_skew_sum += snapshot_skew
             snapshot_skew_max = max(snapshot_skew_max, snapshot_skew)
 
@@ -1515,6 +1762,7 @@ def run_encoded_capture_loop(
     on_armed: Callable[[], None] | None = None,
     heartbeat: Callable[[], None] | None = None,
     row_times: "list[float] | None" = None,
+    quality: "dict[str, int] | None" = None,
 ) -> None:
     """Frame-driven capture for the relay-encoded (gstshm-h264) transport.
 
@@ -1534,16 +1782,25 @@ def run_encoded_capture_loop(
     camera per dataset row. GDP preserves each AU's sensor-exposure PTS; the row
     is paired with the joint/action snapshot nearest the median camera exposure,
     independent of encoder, shm, and scheduler latency. The blocking per-camera
-    read naturally paces the loop to the dataset cadence. A timeout, missing PTS,
-    cross-camera phase error, or excessive state skew aborts the episode.  The
-    sole exception is a bounded one/two-frame hole on an equal-rate all-intra
-    camera, within a per-camera rate budget (no burst of events inside a short
-    window, concealed frames a small fraction of the episode): the prior IDR is
-    repeated on the missing cadence slots while the future AU is held,
-    preserving all subsequent image/camera/state alignment. The repair is
-    warned and returned through ``repair_events`` for a save-time audit log;
-    larger holes, a camera past its budget, predictive, rate-converted,
-    transport, or non-grid losses remain fatal.
+    read naturally paces the loop to the dataset cadence.
+
+    Fail-open policy (see :data:`_CAMERA_LOSS_FATAL_S`): per-row defects are
+    mitigated and counted in ``quality``, never fatal. A hole in an all-intra
+    camera's exposures is concealed by repeating the prior IDR on the missing
+    cadence slots while the future AU is held (preserving every later
+    image/camera/state alignment; audited through ``repair_events``); past the
+    per-camera rate budget the repair still happens but is logged at ERROR. A
+    stale or duplicate AU is discarded and the next one taken. A camera that
+    lags its peers by a frame is advanced to them. A row whose exact
+    robot-state bracket is gone holds the previous row's state while that is
+    still within the alignment tolerance (:class:`_RowStatePairer`), keeping
+    the ``frame_index / fps`` timeline true. A row whose exposures still do
+    not line up, or with no state within tolerance, is dropped for *every*
+    camera at once (the mp4s and the parquet stay index-aligned) — or, on a
+    predictive stream that cannot skip an AU, kept with the degraded pairing.
+    What does end the take: a camera with no usable exposure
+    for :data:`_CAMERA_LOSS_FATAL_S`, a hole that long, a control loop silent
+    for :data:`_STATE_LOSS_FATAL_S`, or a transport/encoder failure.
 
     The muxer assigns each AU a constant-fps PTS (``k / fps``), so the mp4
     timeline is exact regardless of arrival jitter; its physical exposure PTS is
@@ -1616,6 +1873,55 @@ def run_encoded_capture_loop(
         previous_packets: dict[str, tuple[bytes, float, float]] = {}
         first_capture_ts: dict[str, float] = {}
         capture_intervals: dict[str, int] = {}
+
+        def read_usable_au(
+            cam_key: str, cam: Any, deadline: float
+        ) -> tuple[bytes, float, float] | None:
+            """Pop AUs until one carries a finite exposure newer than the last.
+
+            An AU whose PTS is not finite, or did not advance past the previous
+            exposure (a duplicated or reordered frame), cannot be placed on the
+            row grid. It is discarded and counted, and the next AU is taken;
+            ``deadline`` bounds the retries, so a camera that only produces
+            unusable AUs still ends the take through the row timeout.
+            """
+            previous = previous_capture_ts.get(cam_key)
+            while True:
+                packet = read_au(cam, deadline)
+                if packet is None:
+                    return None
+                cap_ts = packet[1]
+                if np.isfinite(cap_ts) and (previous is None or cap_ts > previous):
+                    return packet
+                skipped = _note_quality(quality, f"{cam_key}.unusable_aus_skipped")
+                if not np.isfinite(cap_ts):
+                    why = "is not a finite timestamp"
+                else:
+                    why = (
+                        "did not advance past the previous exposure "
+                        f"({(cap_ts - previous) * 1e3:+.2f}ms)"
+                    )
+                _logger.warning(
+                    "camera %r: discarding an AU whose exposure %s; taking the "
+                    "next one (%d unusable AU(s) skipped this episode)",
+                    cam_key,
+                    why,
+                    skipped,
+                )
+
+        def reanchor_cadence(cam_key: str) -> None:
+            """Restart the long-run cadence check after an out-of-band skip."""
+            first_capture_ts.pop(cam_key, None)
+            capture_intervals.pop(cam_key, None)
+
+        # Dropping a whole row (every camera's AU together) keeps the mp4s and
+        # the parquet index-aligned only if no stream needs that AU to decode
+        # the next one. Predictive streams instead keep the row and degrade
+        # the state pairing.
+        row_drop_is_safe = all(
+            bool(getattr(cam, "frames_are_independent", False))
+            for cam in cameras.values()
+        )
         # A detected future AU stays here until every missing logical cadence
         # slot has emitted the previous independently-decodable IDR.  Reading
         # peers continues normally, so the existing cross-camera validator
@@ -1632,6 +1938,9 @@ def run_encoded_capture_loop(
         snapshot_skew_sum = 0.0
         snapshot_skew_max = 0.0
         camera_skew_max = 0.0
+        state_pairer = _RowStatePairer(
+            label="camera exposure", can_drop=row_drop_is_safe, quality=quality
+        )
         last_log = time.perf_counter()
 
         while not stop_event.is_set():
@@ -1663,7 +1972,7 @@ def run_encoded_capture_loop(
                         packet = future
                         del held_packets[cam_key]
                 else:
-                    packet = read_au(cam, row_deadline)
+                    packet = read_usable_au(cam_key, cam, row_deadline)
                 if packet is None:
                     if stop_event.is_set():
                         return
@@ -1671,11 +1980,6 @@ def run_encoded_capture_loop(
                     raise RuntimeError(
                         f"camera {cam_key!r} produced no fresh encoded frame "
                         f"within {budget:.1f}s during {phase}; episode discarded"
-                    )
-                _au, cap_ts, _recv_ts = packet
-                if not np.isfinite(cap_ts):
-                    raise RuntimeError(
-                        f"camera {cam_key!r} produced an invalid capture timestamp"
                     )
                 packets[cam_key] = packet
                 pending = cam.pending
@@ -1744,26 +2048,55 @@ def run_encoded_capture_loop(
                     previous = previous_packets[cam_key]
                     camera = cameras[cam_key]
                     capture_fps = int(getattr(camera, "capture_fps", fps))
-                    missing = _concealable_encoded_gap_frames(
+                    missing = _missing_cadence_slots(
                         previous_ts=previous[1],
                         capture_ts=packet[1],
                         fps=fps,
                         capture_fps=capture_fps,
-                        frames_are_independent=bool(
-                            getattr(camera, "frames_are_independent", False)
-                        ),
                     )
+                    if missing == 0:
+                        continue
+                    gap_s = packet[1] - previous[1]
+                    if gap_s > _ENCODED_MAX_CONCEALED_GAP_S:
+                        # Drastic: the camera produced nothing for as long as
+                        # the row timeout tolerates; the rows in between would
+                        # be a frozen image over a moving robot.
+                        raise RuntimeError(
+                            f"camera {cam_key!r} delivered no exposure for "
+                            f"{gap_s:.2f}s (limit "
+                            f"{_ENCODED_MAX_CONCEALED_GAP_S:.1f}s): capture PTS "
+                            f"jumped {gap_s * 1e3:.1f}ms at dataset row "
+                            f"{total_rows}; episode discarded"
+                        )
+                    if not bool(getattr(camera, "frames_are_independent", False)):
+                        # A predictive AU can neither be repeated nor skipped
+                        # without breaking the decode chain: accept the hole
+                        # and say so. This camera now leads the row grid.
+                        unrepaired = _note_quality(
+                            quality, f"{cam_key}.unrepaired_missing_frames", missing
+                        )
+                        _logger.error(
+                            "camera %r lost %d exposure(s) at dataset row %d "
+                            "(PTS gap %.2fms) on a predictive stream that cannot "
+                            "be repaired; its video now leads the row grid by "
+                            "%d frame(s) for the rest of the episode",
+                            cam_key,
+                            missing,
+                            total_rows,
+                            1e3 * gap_s,
+                            unrepaired,
+                        )
+                        continue
                     already_concealed = concealed_frames.get(cam_key, 0)
                     prior_rows = concealment_rows.setdefault(cam_key, [])
-                    if missing == 0 or not _concealment_within_budget(
+                    within_budget = _concealment_within_budget(
                         event_rows=prior_rows,
                         row=total_rows,
                         concealed_frames=already_concealed,
                         missing=missing,
                         total_rows=total_rows,
                         fps=fps,
-                    ):
-                        continue
+                    )
                     event: dict[str, Any] = {
                         "camera": cam_key,
                         "frame_index": total_rows,
@@ -1771,9 +2104,10 @@ def run_encoded_capture_loop(
                         # This keeps a save that lands midway through a two-row
                         # repair honest, and records nothing if add_frame fails.
                         "missing_frames": 0,
-                        "gap_ms": 1e3 * (packet[1] - previous[1]),
+                        "gap_ms": 1e3 * gap_s,
                         "concealed_ms": 0.0,
                         "method": "repeat_previous_idr",
+                        "within_budget": within_budget,
                     }
                     held_packets[cam_key] = (packet, missing - 1, event)
                     packets[cam_key] = (
@@ -1784,17 +2118,76 @@ def run_encoded_capture_loop(
                     synthetic_repairs[cam_key] = event
                     concealed_frames[cam_key] = already_concealed + missing
                     prior_rows.append(total_rows)
-                    _logger.warning(
-                        "camera %r omitted %d all-intra frame(s) at dataset "
-                        "row %d (PTS gap %.2fms); repeating the prior IDR for "
-                        "%.2fms and holding the future AU to preserve camera/"
-                        "state alignment",
-                        cam_key,
-                        missing,
-                        total_rows,
-                        event["gap_ms"],
-                        1e3 * missing / fps,
-                    )
+                    _note_quality(quality, f"{cam_key}.concealed_frames", missing)
+                    if within_budget:
+                        _logger.warning(
+                            "camera %r omitted %d all-intra frame(s) at dataset "
+                            "row %d (PTS gap %.2fms); repeating the prior IDR for "
+                            "%.2fms and holding the future AU to preserve camera/"
+                            "state alignment",
+                            cam_key,
+                            missing,
+                            total_rows,
+                            event["gap_ms"],
+                            1e3 * missing / fps,
+                        )
+                    else:
+                        # Past the rate budget the source is unhealthy. The
+                        # fail-open policy still repairs the hole rather than
+                        # discarding the take, but says so at ERROR (once per
+                        # camera per episode, then WARNING) so it gets fixed.
+                        over = _note_quality(
+                            quality, f"{cam_key}.concealment_over_budget_events"
+                        )
+                        _logger.log(
+                            logging.ERROR if over == 1 else logging.WARNING,
+                            "camera %r is losing exposures faster than a rare "
+                            "hiccup: %d more frame(s) omitted at dataset row %d "
+                            "(PTS gap %.2fms, %d concealed so far this episode, "
+                            "%d over-budget event(s)); repeating the prior IDR "
+                            "anyway under the fail-open policy — check the "
+                            "camera source",
+                            cam_key,
+                            missing,
+                            total_rows,
+                            event["gap_ms"],
+                            already_concealed + missing,
+                            over,
+                        )
+
+            camera_limit = _camera_alignment_limit(fps)
+            if primed and row_drop_is_safe and len(packets) > 1:
+                # A camera whose exposure trails its peers by more than the
+                # alignment limit has an extra AU in its stream (a source clock
+                # running fast, or a startup phase the row-zero alignment did
+                # not see). On an all-intra stream the surplus AU can simply be
+                # skipped: advance the camera until it rejoins the row.
+                newest = max(packet[1] for packet in packets.values())
+                for cam_key, packet in tuple(packets.items()):
+                    if cam_key in held_packets:
+                        continue  # a planned synthetic slot; never advance it
+                    while packet[1] < newest - camera_limit:
+                        candidate = read_au(cameras[cam_key], row_deadline)
+                        if candidate is None:
+                            break  # nothing queued: the skew check decides
+                        if not np.isfinite(candidate[1]) or candidate[1] <= packet[1]:
+                            _note_quality(quality, f"{cam_key}.unusable_aus_skipped")
+                            continue
+                        skipped = _note_quality(
+                            quality, f"{cam_key}.exposures_skipped_to_realign"
+                        )
+                        _logger.warning(
+                            "camera %r exposure trails the row by %.2fms at "
+                            "dataset row %d; skipping it and taking the next AU "
+                            "(%d skipped to realign this episode)",
+                            cam_key,
+                            1e3 * (newest - packet[1]),
+                            total_rows,
+                            skipped,
+                        )
+                        packet = candidate
+                        packets[cam_key] = packet
+                        reanchor_cadence(cam_key)
 
             aus = {name: packet[0] for name, packet in packets.items()}
             capture_ts = {name: packet[1] for name, packet in packets.items()}
@@ -1805,18 +2198,37 @@ def run_encoded_capture_loop(
                 capture_fps = max(
                     fps, int(getattr(cameras[cam_key], "capture_fps", fps))
                 )
-                if previous is not None:
+                first_ts = first_capture_ts.get(cam_key)
+                if previous is not None and first_ts is not None:
                     intervals = capture_intervals[cam_key] + 1
-                    _validate_encoded_cadence_step(
-                        cam_key,
-                        first_ts=first_capture_ts[cam_key],
-                        previous_ts=previous,
+                    deviation = _encoded_cadence_deviation(
+                        first_ts=first_ts,
                         capture_ts=cap_ts,
                         intervals=intervals,
                         fps=fps,
                         capture_fps=capture_fps,
                     )
-                    capture_intervals[cam_key] = intervals
+                    if deviation is None:
+                        capture_intervals[cam_key] = intervals
+                    else:
+                        # The long-run cadence drifted off the dataset grid
+                        # (e.g. a decimated source briefly delivering at its
+                        # capture rate). Not fatal: log, count, and re-anchor
+                        # so the check keeps watching from here.
+                        reanchors = _note_quality(
+                            quality, f"{cam_key}.cadence_reanchors"
+                        )
+                        _logger.warning(
+                            "camera %r encoded cadence is %s at dataset row %d; "
+                            "re-anchoring the cadence check (%d re-anchor(s) "
+                            "this episode)",
+                            cam_key,
+                            deviation,
+                            total_rows,
+                            reanchors,
+                        )
+                        first_capture_ts[cam_key] = cap_ts
+                        capture_intervals[cam_key] = 0
                 else:
                     first_capture_ts[cam_key] = cap_ts
                     capture_intervals[cam_key] = 0
@@ -1831,16 +2243,39 @@ def run_encoded_capture_loop(
                 else 0.0
             )
             camera_skew_max = max(camera_skew_max, camera_skew)
-            camera_limit = _camera_alignment_limit(fps)
             if camera_skew > camera_limit:
                 detail = ", ".join(
                     f"{name}={1e3 * (ts - row_capture_ts):+.1f}ms"
                     for name, ts in sorted(capture_ts.items())
                 )
-                raise RuntimeError(
-                    f"camera exposures are not synchronized (spread "
-                    f"{camera_skew * 1e3:.1f}ms, limit "
-                    f"{camera_limit * 1e3:.1f}ms; {detail}); episode discarded"
+                if row_drop_is_safe:
+                    # The exposures still do not form one row after the
+                    # realignment above. Pairing them with a single state
+                    # would be wrong for at least one camera; dropping every
+                    # camera's AU together costs one row and keeps the mp4s
+                    # and parquet index-aligned.
+                    dropped = _note_quality(quality, "rows_dropped_camera_skew")
+                    _logger.warning(
+                        "dropping one dataset row: camera exposures are not "
+                        "synchronized (spread %.1fms, limit %.1fms; %s; %d "
+                        "row(s) dropped for skew this episode)",
+                        camera_skew * 1e3,
+                        camera_limit * 1e3,
+                        detail,
+                        dropped,
+                    )
+                    continue
+                # A predictive stream needs this AU muxed; keep the row and
+                # accept the skew (the state pairs with the median exposure).
+                accepted = _note_quality(quality, "rows_kept_with_camera_skew")
+                _logger.error(
+                    "camera exposures are not synchronized (spread %.1fms, "
+                    "limit %.1fms; %s) and a predictive stream cannot skip the "
+                    "row; keeping it (%d skewed row(s) kept this episode)",
+                    camera_skew * 1e3,
+                    camera_limit * 1e3,
+                    detail,
+                    accepted,
                 )
 
             snap = _wait_snapshot_nearest(
@@ -1849,22 +2284,29 @@ def run_encoded_capture_loop(
                 read_snapshot_nearest,
                 stop_event,
             )
+            miss_detail: str | None = None
             if snap is None:
                 if stop_event.is_set():
                     return
-                raise RuntimeError(
-                    "no retained robot-state snapshot brackets camera exposure "
-                    f"{row_capture_ts:.6f}: "
-                    f"{_describe_snapshot_miss(row_capture_ts, read_snapshot)}"
+                miss_detail, fatal, snap = _classify_snapshot_miss(
+                    row_capture_ts, read_snapshot
                 )
+                if fatal:
+                    raise RuntimeError(
+                        "no retained robot-state snapshot brackets camera "
+                        f"exposure {row_capture_ts:.6f}: {miss_detail}; episode "
+                        "discarded"
+                    )
+            # A missing or distant bracket is a transient (the exposure aged
+            # out of the ring while the recorder was descheduled, a raced ring
+            # copy, a brief writer pause): hold the previous row's state, or
+            # drop this one row — never the take. See _RowStatePairer.
+            snap, snapshot_skew = state_pairer.resolve(
+                row_capture_ts, snap, miss_detail
+            )
+            if snap is None:
+                continue
             joint_obs, action, _snap_ts, intervention = snap
-            snapshot_skew = abs(_snap_ts - row_capture_ts)
-            if snapshot_skew > _STATE_ALIGNMENT_WARN_S:
-                raise RuntimeError(
-                    "nearest robot state is too far from camera exposure "
-                    f"({snapshot_skew * 1e3:.1f}ms, limit "
-                    f"{_STATE_ALIGNMENT_WARN_S * 1e3:.1f}ms); episode discarded"
-                )
             snapshot_skew_sum += snapshot_skew
             snapshot_skew_max = max(snapshot_skew_max, snapshot_skew)
 
@@ -2683,6 +3125,8 @@ class InProcessRecorder:
         self._frames: dict[str, int] = {"n": 0}
         # Per-row capture times for the current episode (see trim_episode_after).
         self._row_times: list[float] = []
+        # Mitigated per-row defects of the current take (see _CAMERA_LOSS_FATAL_S).
+        self._quality: dict[str, int] = {}
         self._capture_error: str | None = None
         self._episodes_recorded = 0
         self._fatal_error: EpisodeDurabilityError | None = None
@@ -2710,6 +3154,7 @@ class InProcessRecorder:
         self._record.set()
         self._frames["n"] = 0
         self._row_times.clear()
+        self._quality.clear()
         self._capture_error = None
         reset_dropped_frames()
         self._stop = threading.Event()
@@ -2729,6 +3174,7 @@ class InProcessRecorder:
                 frame_counter=self._frames,
                 on_error=lambda message: setattr(self, "_capture_error", message),
                 row_times=self._row_times,
+                quality=self._quality,
             ),
             name="axol-capture",
             daemon=True,
@@ -2757,7 +3203,15 @@ class InProcessRecorder:
         # forever on a wedged camera read, and never forget the exact writer
         # until a bounded retry proves it exited (the raise happens before the
         # assignment, so ``_thread`` keeps pointing at the live writer).
+        was_capturing = self._thread is not None
         self._thread = _stop_capture_thread(self._thread, self._stop)
+        if was_capturing:
+            _log_capture_quality(
+                self._quality,
+                self._frames["n"],
+                dict(getattr(self._robot, "cameras", None) or {}),
+                self._capture_error,
+            )
         # Nothing records now: let the previous episode's verify continue.
         self._verifier.resume()
 
@@ -3193,6 +3647,10 @@ def _recorder_main(
     stop: threading.Event | None = None
     capture_error: dict[str, str | None] = {"v": None}
     capture_repairs: list[dict[str, Any]] = []
+    # Mitigated per-row defects of the current take (see _CAMERA_LOSS_FATAL_S);
+    # summarized once when capture stops so a take that needed repairs is easy
+    # to find in the session log.
+    capture_quality: dict[str, int] = {}
     episodes_recorded = 0
     save_poisoned = False
     # Mid-episode capture gate + row counter (see run_capture_loop). The gate
@@ -3220,7 +3678,12 @@ def _recorder_main(
         # Assignment happens only after _stop_capture_thread has proved exit.
         # On timeout it raises and leaves ``thread`` pointing at the live
         # writer, which makes every destructive command below fail closed.
+        was_capturing = thread is not None
         thread = _stop_capture_thread(thread, stop)
+        if was_capturing:
+            _log_capture_quality(
+                capture_quality, frame_counter["n"], cameras, capture_error["v"]
+            )
         # The take is over: sweep the garbage deferred during it now, while
         # nothing time-critical runs in this process.
         gc_hold.end()
@@ -3246,6 +3709,11 @@ def _recorder_main(
                 dataset.clear_episode_buffer()
                 capture_error["v"] = None
                 capture_repairs.clear()
+                capture_quality.clear()
+                for cam in cameras.values():
+                    reset_lost = getattr(cam, "reset_lost_exposures", None)
+                    if callable(reset_lost):
+                        reset_lost()
                 record_event.set()
                 frame_counter["n"] = 0
                 row_times.clear()
@@ -3270,6 +3738,7 @@ def _recorder_main(
                     on_error=report_capture_error,
                     heartbeat=watchdog.beat,
                     row_times=row_times,
+                    quality=capture_quality,
                 )
                 loop_kwargs["frame_counter"] = frame_counter
                 if not encoded_mode:
@@ -3428,13 +3897,17 @@ def _recorder_main(
                         verifier.submit(episode_row)
                         if capture_repairs:
                             _logger.warning(
-                                "saved episode %d with bounded camera-gap "
-                                "repair(s): %s",
+                                "saved episode %d with camera-gap repair(s): %s",
                                 dataset.num_episodes - 1,
                                 ", ".join(
                                     f"{event['camera']}@row "
                                     f"{event['frame_index']}="
                                     f"{event['missing_frames']} frame(s)"
+                                    + (
+                                        ""
+                                        if event.get("within_budget", True)
+                                        else " (over budget)"
+                                    )
                                     for event in capture_repairs
                                 ),
                             )

--- a/almond_axol/video/shm_frames.py
+++ b/almond_axol/video/shm_frames.py
@@ -683,6 +683,13 @@ class EncodedAuReader:
         self._since_keyframe = 0
         self._delivered = 0
         self._seen_first_au = False
+        # Exposures the transport lost or delivered unusable *within the
+        # current episode* (an upstream drop marked DISCONT, an AU that could
+        # not be mapped, a PTS the sender lost). Under the recorder's fail-open
+        # policy these are not fatal: the capture loop sees the resulting PTS
+        # gap and repeats the prior IDR into it. Counted here so the recorder's
+        # end-of-take quality summary can attribute the hole to the transport.
+        self._lost_exposures = 0
         # gdpdepay restores the sender's serialized caps and buffer metadata.
         # Keep a fixed H.264 filter as an integrity check; h264parse re-derives
         # dimensions from the SPS and preserves the exposure PTS.
@@ -702,6 +709,38 @@ class EncodedAuReader:
     def frames_are_independent(self) -> bool:
         """Whether callers may discard an AU without breaking later frames."""
         return self._expected_gop == 1
+
+    @property
+    def lost_exposures(self) -> int:
+        """Exposures the transport lost or delivered unusable this episode."""
+        with self._cond:
+            return self._lost_exposures
+
+    def reset_lost_exposures(self) -> None:
+        """Start a new episode's transport-loss count."""
+        with self._cond:
+            self._lost_exposures = 0
+
+    def _note_lost_exposure(self, what: str) -> None:
+        """Count a single unusable/lost exposure and say so; not fatal.
+
+        The exposure's cadence slot is simply empty from the recorder's point
+        of view — the same PTS gap a source-side drop leaves — and the capture
+        loop conceals it. Only the transport itself failing (pipeline error,
+        no/invalid PTS on every AU, a predictive picture on an all-intra
+        contract) remains a reader error.
+        """
+        with self._cond:
+            self._lost_exposures += 1
+            count = self._lost_exposures
+        _logger.warning(
+            "encoded-AU reader %s: %s near frame %d; the capture loop will "
+            "conceal the missing exposure (%d lost this episode)",
+            self._name,
+            what,
+            self._delivered,
+            count,
+        )
 
     @property
     def is_connected(self) -> bool:
@@ -843,10 +882,8 @@ class EncodedAuReader:
             discont = buf.has_flags(Gst.BufferFlags.DISCONT)
             ok, mapinfo = buf.map(Gst.MapFlags.READ)
             if not ok:
-                self._fail(
-                    f"encoded AU on {self._name} could not be mapped; an "
-                    "encoded exposure was lost"
-                )
+                if self._episode_cutoff_active and self._seen_first_au:
+                    self._note_lost_exposure("an AU could not be mapped")
                 continue
             try:
                 au = bytes(mapinfo.data)
@@ -875,13 +912,16 @@ class EncodedAuReader:
             # gdppay/gdpdepay normalizes a missing input PTS to zero. Zero is a
             # legitimate value only for the pipeline's very first frame; once
             # flush() establishes an episode boundary, seeing it means the
-            # sender lost a timestamp. Silently filtering it as an old frame
-            # would also destroy exact exposure/row accounting.
+            # sender lost this AU's timestamp. The AU cannot be placed on the
+            # row grid, so it is dropped and counted: the capture loop sees
+            # the PTS gap and conceals the exposure instead of silently
+            # filing the AU as an old frame (which would break exposure/row
+            # accounting) or ending the take over one lost timestamp.
             if buf.pts == 0 and self._episode_cutoff_active:
-                self._fail(
-                    f"encoded AU on {self._name} reset to PTS 0; exact "
-                    "image/state alignment is unavailable"
-                )
+                if self._seen_first_au:
+                    self._note_lost_exposure(
+                        "an AU arrived with PTS 0 (timestamp lost)"
+                    )
                 continue
             capture_perf = buf.pts / 1e9 + self._pts_perf_offset_s
             if not np.isfinite(capture_perf):
@@ -928,15 +968,16 @@ class EncodedAuReader:
                         self._fail_keyframe_gap()
                         continue
                 # A shmsrc DISCONT after the first AU means an upstream buffer was
-                # dropped between the relay and here. Even though later all-intra
-                # frames decode, row/exposure accounting is no longer exact. Surface
-                # it (the first AU legitimately carries the startup discontinuity).
+                # dropped between the relay and here. This AU itself is intact
+                # (all-intra), and the exposure(s) before it are simply absent:
+                # the capture loop sees the PTS gap and repeats the prior IDR
+                # into it. Count it so the loss is attributed to the transport
+                # rather than the source (the first AU legitimately carries the
+                # startup discontinuity).
                 if discont and self._seen_first_au:
-                    self._fail(
-                        f"encoded-AU discontinuity on {self._name} near frame "
-                        f"{self._delivered}; an upstream frame was dropped"
+                    self._note_lost_exposure(
+                        "shmsrc marked a discontinuity (an upstream frame was dropped)"
                     )
-                    continue
                 if len(self._queue) >= self._queue_limit:
                     self._error = (
                         f"encoded-AU backlog on {self._name} exceeded "
@@ -965,8 +1006,11 @@ class EncodedAuReader:
         Returns ``(au_bytes, capture_perf_ts, recv_perf_ts)``. The capture time
         is the sender's sensor-exposure PTS mapped onto ``perf_counter``; receive
         time is retained for latency diagnostics. Raises :class:`RuntimeError`
-        on any transport/PTS/reference discontinuity and :class:`TimeoutError`
-        if no fresh AU arrives in time. Predictive AUs are never duplicated.
+        on a transport failure (pipeline error, predictive picture on the
+        all-intra contract, no/invalid PTS, or a backlog the recorder stopped
+        draining) and :class:`TimeoutError` if no fresh AU arrives in time. A
+        single lost or unusable exposure is counted (:attr:`lost_exposures`)
+        and left for the capture loop to conceal, not raised.
         """
         deadline = time.perf_counter() + timeout_ms / 1000.0
         with self._cond:

--- a/tests/test_encoded_au_reader.py
+++ b/tests/test_encoded_au_reader.py
@@ -102,7 +102,14 @@ class EncodedAuReaderDiscontinuityTest(unittest.TestCase):
         self.assertFalse(reader._seen_first_au)
         self.assertIsNone(reader._error)
 
-    def test_episode_discontinuity_after_first_idr_remains_fatal(self) -> None:
+    def test_episode_discontinuity_after_first_idr_is_counted_not_fatal(self) -> None:
+        """An upstream drop costs the lost exposure, not the episode.
+
+        The DISCONT-flagged AU itself is intact (all-intra) and is delivered;
+        the capture loop sees the PTS gap in front of it and repeats the prior
+        IDR. The reader only counts the loss so the end-of-take quality summary
+        can attribute the hole to the transport.
+        """
         reader = _reader()
         reader._flush_requested.set()
         reader._complete_flush()
@@ -118,17 +125,44 @@ class EncodedAuReaderDiscontinuityTest(unittest.TestCase):
         self.assertEqual(reader.pending, 2)
         self.assertEqual(reader._delivered, 2)
         self.assertIsNone(reader._error)
+        self.assertEqual(reader.lost_exposures, 0)
 
         _pull(
             reader,
-            [_FakeBuffer(_IDR, 1_048_000_000, discont=True)],
+            [_FakeBuffer(_IDR, 1_064_000_000, discont=True)],
         )
 
-        self.assertEqual(reader.pending, 0)
-        with self.assertRaisesRegex(
-            RuntimeError, "encoded-AU discontinuity.*near frame 2"
-        ):
-            reader.read_next_au(timeout_ms=0)
+        self.assertEqual(reader.pending, 3)
+        self.assertEqual(reader._delivered, 3)
+        self.assertIsNone(reader._error)
+        self.assertEqual(reader.lost_exposures, 1)
+        # The AU after the drop is still delivered, with its own exposure PTS,
+        # so the capture loop can measure the hole in front of it.
+        reader.read_next_au(timeout_ms=0)
+        reader.read_next_au(timeout_ms=0)
+        _au, capture_ts, _recv = reader.read_next_au(timeout_ms=0)
+        self.assertAlmostEqual(capture_ts, 1.064)
+
+        reader.reset_lost_exposures()
+        self.assertEqual(reader.lost_exposures, 0)
+
+    def test_lost_timestamp_mid_episode_drops_that_au_only(self) -> None:
+        reader = _reader()
+        reader._flush_requested.set()
+        reader._complete_flush()
+
+        _pull(
+            reader,
+            [
+                _FakeBuffer(_IDR, 1_016_000_000),
+                _FakeBuffer(_IDR, 0),  # gdpdepay normalized a lost PTS to 0
+                _FakeBuffer(_IDR, 1_048_000_000),
+            ],
+        )
+
+        self.assertEqual(reader.pending, 2)
+        self.assertIsNone(reader._error)
+        self.assertEqual(reader.lost_exposures, 1)
 
     def test_predictive_frame_violates_all_intra_contract(self) -> None:
         reader = _reader()

--- a/tests/test_recorder_capture_error.py
+++ b/tests/test_recorder_capture_error.py
@@ -1162,6 +1162,7 @@ class RawCaptureLoopFailOpenTest(unittest.TestCase):
         fps: int = 60,
         bracket_missing: Callable[[float], bool] = lambda _ts: False,
         latest_ts: Callable[[], float] = time.perf_counter,
+        record_event: threading.Event | None = None,
     ) -> tuple[_CaptureDataset, list[str], dict[str, int]]:
         stop = threading.Event()
         dataset = _CaptureDataset(stop, stop_after=rows)
@@ -1193,6 +1194,7 @@ class RawCaptureLoopFailOpenTest(unittest.TestCase):
                 task="test",
                 rerun_ip=None,
                 stop_event=stop,
+                record_event=record_event,
                 on_error=errors.append,
                 quality=quality,
             )
@@ -1260,6 +1262,43 @@ class RawCaptureLoopFailOpenTest(unittest.TestCase):
         self.assertEqual(states[0], states[1])
         self.assertGreater(states[2], states[1])
         self.assertEqual(quality, {"rows_with_held_state": 1})
+
+    def test_pause_is_not_counted_as_camera_silence(self) -> None:
+        """A late frame right after a long pause skips a tick, not the take.
+
+        The camera-silence clock must measure time while capturing: nobody
+        reads the cameras during a record_event pause (the DAgger freeze this
+        path exists to survive), so a pause longer than _CAMERA_LOSS_FATAL_S
+        followed by one late frame is an ordinary skipped tick.
+        """
+        record = threading.Event()
+        record.set()
+        paused = threading.Event()
+
+        class _PausingCamera(_RawCamera):
+            def read_at_or_after(
+                self, target_perf_ts: float, timeout_ms: float
+            ) -> tuple[object, float, float]:
+                result = super().read_at_or_after(target_perf_ts, timeout_ms)
+                if self.calls == 2 and not paused.is_set():
+                    # Row 1 is captured; now pause the take for longer than
+                    # the fatal limit, and make the first frame after the
+                    # resume a late one.
+                    paused.set()
+                    record.clear()
+                    threading.Timer(0.06, record.set).start()
+                    self.script.append(TimeoutError)
+                return result
+
+        cam = _PausingCamera([])
+        with patch("almond_axol.recording.record_proc._CAMERA_LOSS_FATAL_S", 0.03):
+            dataset, errors, quality = self._run_raw(
+                {"cam": cam}, rows=3, record_event=record
+            )
+
+        self.assertEqual(errors, [])
+        self.assertEqual(len(dataset.rows), 3)
+        self.assertEqual(quality, {"cam.ticks_without_frame": 1})
 
     def test_camera_silent_for_the_loss_limit_ends_the_take(self) -> None:
         cam = _RawCamera([TimeoutError] * 4)

--- a/tests/test_recorder_capture_error.py
+++ b/tests/test_recorder_capture_error.py
@@ -4,6 +4,7 @@ import multiprocessing
 import threading
 import time
 import unittest
+from collections.abc import Callable
 from unittest.mock import patch
 
 from almond_axol.recording.record_proc import (
@@ -14,10 +15,15 @@ from almond_axol.recording.record_proc import (
     _ENCODED_CONCEALMENT_WINDOW_S,
     _ENCODED_MAX_CONCEALMENT_EVENTS_PER_WINDOW,
     _ENCODED_MIN_CONCEALED_FRAMES_PER_CAMERA,
+    _STATE_LOSS_FATAL_S,
+    _RowStatePairer,
     _align_independent_encoded_start,
-    _concealable_encoded_gap_frames,
+    _classify_snapshot_miss,
     _concealment_within_budget,
     _describe_snapshot_miss,
+    _missing_cadence_slots,
+    format_capture_quality,
+    run_capture_loop,
     run_encoded_capture_loop,
 )
 
@@ -45,6 +51,32 @@ class SnapshotMissAttributionTest(unittest.TestCase):
             "no robot-state snapshot", _describe_snapshot_miss(1.0, lambda: None)
         )
 
+    def test_only_a_control_loop_silent_for_a_second_is_fatal(self) -> None:
+        # A writer that paused briefly (newest snapshot 300 ms old) is a
+        # per-row defect: attributed to the control loop, but not fatal.
+        detail, fatal, latest = _classify_snapshot_miss(
+            10.0, lambda: ({}, {}, 9.7, False), now=10.05
+        )
+        self.assertIn("control loop stopped publishing", detail)
+        self.assertFalse(fatal)
+        self.assertEqual(latest[2], 9.7)
+        # Silent for the fatal threshold: the robot is moving unobserved.
+        detail, fatal, _ = _classify_snapshot_miss(
+            10.0, lambda: ({}, {}, 9.7, False), now=9.7 + _STATE_LOSS_FATAL_S
+        )
+        self.assertTrue(fatal)
+        self.assertIn("no robot state has been published for", detail)
+        # A live writer the recorder fell behind is never fatal.
+        detail, fatal, _ = _classify_snapshot_miss(
+            10.0, lambda: ({}, {}, 14.5, False), now=14.6
+        )
+        self.assertIn("recorder fell behind", detail)
+        self.assertFalse(fatal)
+        # A transiently unreadable ring (raced copy) is not fatal either.
+        detail, fatal, latest = _classify_snapshot_miss(1.0, lambda: None)
+        self.assertFalse(fatal)
+        self.assertIsNone(latest)
+
     def test_encoded_loop_error_carries_the_attribution(self) -> None:
         stop = threading.Event()
         dataset = _CaptureDataset(stop, stop_after=10)
@@ -56,8 +88,9 @@ class SnapshotMissAttributionTest(unittest.TestCase):
                 for i in range(6)
             ]
         )
-        # The control loop's last publish predates every exposure.
-        stale = ({"state": 1}, {"target": 2}, base - 0.3, False)
+        # The control loop's last publish predates every exposure by more
+        # than the fatal silence threshold.
+        stale = ({"state": 1}, {"target": 2}, base - 1.5 * _STATE_LOSS_FATAL_S, False)
         with (
             patch(
                 "lerobot.utils.feature_utils.build_dataset_frame",
@@ -87,6 +120,206 @@ class SnapshotMissAttributionTest(unittest.TestCase):
             )
         self.assertEqual(len(errors), 1)
         self.assertIn("control loop stopped publishing", errors[0])
+        self.assertIn("no robot state has been published for", errors[0])
+
+    def test_brief_control_loop_pause_drops_rows_and_continues(self) -> None:
+        """A writer pause shorter than the fatal threshold costs rows only.
+
+        The pause covers the first exposures, so there is no previous row's
+        state to hold and the rows are dropped (see the held-state tests for
+        the mid-take case).
+        """
+        stop = threading.Event()
+        dataset = _CaptureDataset(stop, stop_after=2)
+        errors: list[str] = []
+        quality: dict[str, int] = {}
+        base = time.perf_counter() + 0.05
+        step = 1.0 / 60.0
+        cam = _EncodedCamera(
+            [
+                (b"\x00\x00\x00\x01\x65au", base + i * step, base + i * step)
+                for i in range(4)
+            ]
+        )
+        # The writer publishes a fresh snapshot at the episode start, then goes
+        # quiet: its newest snapshot is 300 ms behind the first two exposures
+        # (well past the pairing tolerance, well short of the fatal silence),
+        # after which every exposure brackets normally.
+        pause_until = base + 2 * step
+        quiet = ({"state": 1}, {"target": 2}, base - 0.3, False)
+
+        def read_latest() -> tuple[dict, dict, float, bool]:
+            if cam.reads:
+                return quiet
+            return {"state": 1}, {"target": 2}, time.perf_counter(), False
+
+        def read_nearest(target_ts: float) -> tuple[dict, dict, float, bool] | None:
+            if target_ts < pause_until - step / 2:
+                return None
+            return {"state": 1}, {"target": 2}, target_ts, False
+
+        with (
+            patch(
+                "lerobot.utils.feature_utils.build_dataset_frame",
+                side_effect=lambda _f, values, prefix: dict(values),
+            ),
+            patch("lerobot.utils.visualization_utils.log_rerun_data"),
+            patch(
+                "almond_axol.recording.record_proc._SNAPSHOT_BRACKET_TIMEOUT_S",
+                0.01,
+            ),
+        ):
+            run_encoded_capture_loop(
+                cameras={"cam": cam},
+                read_snapshot=read_latest,
+                read_snapshot_nearest=read_nearest,
+                dataset=dataset,
+                robot_obs_proc=lambda obs: obs,
+                fps=60,
+                task="test",
+                rerun_ip=None,
+                stop_event=stop,
+                on_error=errors.append,
+                quality=quality,
+            )
+
+        self.assertEqual(errors, [])
+        self.assertEqual(len(dataset.rows), 2)
+        self.assertEqual(quality, {"rows_dropped_state_miss": 2})
+        self.assertIn("rows_dropped_state_miss=2", format_capture_quality(quality))
+
+    def test_mid_take_state_miss_holds_the_previous_state_and_keeps_the_row(
+        self,
+    ) -> None:
+        """A lost bracket mid-take costs neither the take nor the timeline.
+
+        LeRobot stamps rows ``frame_index / fps``, so a dropped row silently
+        shortens the episode by a frame. The previous row's state is at most a
+        frame or two old — within the skew accepted on any ordinary row — so
+        it is held instead and the row is kept.
+        """
+        stop = threading.Event()
+        dataset = _CaptureDataset(stop, stop_after=4)
+        errors: list[str] = []
+        quality: dict[str, int] = {}
+        base = time.perf_counter() + 0.05
+        step = 1.0 / 60.0
+        cam = _EncodedCamera(
+            [
+                (b"\x00\x00\x00\x01\x65au", base + i * step, base + i * step)
+                for i in range(4)
+            ]
+        )
+        missing = base + 2 * step  # exposure 2's bracket is gone
+
+        def read_latest() -> tuple[dict, dict, float, bool]:
+            return {"state": "latest"}, {"target": 0}, time.perf_counter(), False
+
+        def read_nearest(target_ts: float) -> tuple[dict, dict, float, bool] | None:
+            if abs(target_ts - missing) < step / 2:
+                return None
+            index = round((target_ts - base) / step)
+            return {"state": f"s{index}"}, {"target": index}, target_ts, False
+
+        with (
+            patch(
+                "lerobot.utils.feature_utils.build_dataset_frame",
+                side_effect=lambda _f, values, prefix: {
+                    f"{prefix}.{k}": v for k, v in values.items()
+                },
+            ),
+            patch("lerobot.utils.visualization_utils.log_rerun_data"),
+            patch(
+                "almond_axol.recording.record_proc._SNAPSHOT_BRACKET_TIMEOUT_S",
+                0.01,
+            ),
+        ):
+            run_encoded_capture_loop(
+                cameras={"cam": cam},
+                read_snapshot=read_latest,
+                read_snapshot_nearest=read_nearest,
+                dataset=dataset,
+                robot_obs_proc=lambda obs: obs,
+                fps=60,
+                task="test",
+                rerun_ip=None,
+                stop_event=stop,
+                on_error=errors.append,
+                quality=quality,
+            )
+
+        self.assertEqual(errors, [])
+        self.assertEqual(len(dataset.rows), 4)
+        self.assertEqual(
+            [row["observation.state"] for row in dataset.rows],
+            ["s0", "s1", "s1", "s3"],
+        )
+        self.assertEqual(quality, {"rows_with_held_state": 1})
+
+    def test_recorder_backlog_drops_the_row_instead_of_the_episode(self) -> None:
+        """A live writer that simply aged one exposure out must not reset.
+
+        Regression for a customer session that lost episode 18 to exactly
+        this: the writer never stopped (0 late/missed CAN ticks throughout),
+        but a scheduling hiccup on the recorder side made one exposure age out
+        of the retained history. That must drop one dataset row and keep
+        capturing — not raise, discard the take, and send the operator
+        through a return-to-rest/re-record cycle.
+        """
+        stop = threading.Event()
+        dataset = _CaptureDataset(stop, stop_after=2)
+        errors: list[str] = []
+        base = time.perf_counter() + 0.05
+        step = 1.0 / 60.0
+        cam = _EncodedCamera(
+            [
+                (b"\x00\x00\x00\x01\x65au", base + i * step, base + i * step)
+                for i in range(3)
+            ]
+        )
+
+        # A fixed timestamp well ahead of every camera exposure below: the
+        # writer is alive and always ahead of whatever exposure the recorder
+        # is currently pairing, i.e. a recorder backlog, not a control-process
+        # stall.
+        writer_latest_ts = base + 10.0
+
+        def read_latest() -> tuple[dict, dict, float, bool]:
+            return {"state": 1}, {"target": 2}, writer_latest_ts, False
+
+        def read_nearest(target_ts: float) -> tuple[dict, dict, float, bool] | None:
+            # Only the very first exposure aged out of the retained history;
+            # every later one brackets fine.
+            if target_ts < base + step / 2:
+                return None
+            return {"state": 1}, {"target": 2}, target_ts, False
+
+        with (
+            patch(
+                "lerobot.utils.feature_utils.build_dataset_frame",
+                side_effect=lambda _f, values, prefix: dict(values),
+            ),
+            patch("lerobot.utils.visualization_utils.log_rerun_data"),
+            patch(
+                "almond_axol.recording.record_proc._SNAPSHOT_BRACKET_TIMEOUT_S",
+                0.01,
+            ),
+        ):
+            run_encoded_capture_loop(
+                cameras={"cam": cam},
+                read_snapshot=read_latest,
+                read_snapshot_nearest=read_nearest,
+                dataset=dataset,
+                robot_obs_proc=lambda obs: obs,
+                fps=60,
+                task="test",
+                rerun_ip=None,
+                stop_event=stop,
+                on_error=errors.append,
+            )
+
+        self.assertEqual(errors, [])
+        self.assertEqual(len(dataset.rows), 2)
 
 
 class _FakeDataset:
@@ -179,11 +412,24 @@ class DatasetRecorderCaptureErrorTest(unittest.TestCase):
         fps: int,
         rows: int,
     ) -> tuple[_CaptureDataset, list[str], list[dict], list[float]]:
+        dataset, errors, repairs, snapshot_times, _quality = self._run_encoded_q(
+            cameras, fps=fps, rows=rows
+        )
+        return dataset, errors, repairs, snapshot_times
+
+    def _run_encoded_q(
+        self,
+        cameras: dict[str, _EncodedCamera],
+        *,
+        fps: int,
+        rows: int,
+    ) -> tuple[_CaptureDataset, list[str], list[dict], list[float], dict[str, int]]:
         stop = threading.Event()
         dataset = _CaptureDataset(stop, stop_after=rows)
         errors: list[str] = []
         repairs: list[dict] = []
         snapshot_times: list[float] = []
+        quality: dict[str, int] = {}
 
         def snapshot(ts: float) -> tuple[dict, dict, float, bool]:
             snapshot_times.append(ts)
@@ -216,8 +462,9 @@ class DatasetRecorderCaptureErrorTest(unittest.TestCase):
                 stop_event=stop,
                 repair_events=repairs,
                 on_error=errors.append,
+                quality=quality,
             )
-        return dataset, errors, repairs, snapshot_times
+        return dataset, errors, repairs, snapshot_times, quality
 
     def test_bounded_gap_concealment_holds_future_au_and_state_grid(self) -> None:
         base = time.perf_counter() + 0.1
@@ -281,46 +528,35 @@ class DatasetRecorderCaptureErrorTest(unittest.TestCase):
         self.assertEqual(repairs[0]["missing_frames"], 1)
         self.assertAlmostEqual(repairs[0]["concealed_ms"], 1000 / 60)
 
-    def test_only_small_equal_rate_independent_grid_gaps_are_concealable(self) -> None:
+    def test_missing_cadence_slots_measures_whole_periods_only(self) -> None:
         step = 1.0 / 60.0
 
-        self.assertEqual(
-            _concealable_encoded_gap_frames(
-                previous_ts=1.0,
-                capture_ts=1.0 + 3 * step - 0.0002,
-                fps=60,
-                capture_fps=60,
-                frames_are_independent=True,
-            ),
-            2,
-        )
-        for kwargs in (
-            {"capture_ts": 1.0 + 4 * step},
-            {"capture_ts": 1.0 + 2.5 * step},
-            {"capture_ts": 1.0 + 2 * step, "capture_fps": 120},
-            {"capture_ts": 1.0 + 2 * step, "capture_fps": 30},
-            {
-                "capture_ts": 1.0 + 2 * step,
-                "frames_are_independent": False,
-            },
-        ):
-            args = dict(
-                previous_ts=1.0,
-                capture_ts=1.0 + 2 * step,
-                fps=60,
-                capture_fps=60,
-                frames_are_independent=True,
+        def slots(capture_ts: float, capture_fps: int = 60) -> int:
+            return _missing_cadence_slots(
+                previous_ts=1.0, capture_ts=capture_ts, fps=60, capture_fps=capture_fps
             )
-            args.update(kwargs)
-            self.assertEqual(_concealable_encoded_gap_frames(**args), 0)
 
-    def test_invalid_lower_capture_rate_cannot_enable_concealment(self) -> None:
+        # Normal step and sub-half-period jitter: nothing missing.
+        self.assertEqual(slots(1.0 + step), 0)
+        self.assertEqual(slots(1.0 + 1.4 * step), 0)
+        # Whole missing periods, rounded to the nearest grid slot (any size:
+        # the caller bounds the repair, this helper only measures).
+        self.assertEqual(slots(1.0 + 2 * step), 1)
+        self.assertEqual(slots(1.0 + 3 * step - 0.0002), 2)
+        self.assertEqual(slots(1.0 + 2.5 * step), 2)  # a half period rounds up
+        self.assertEqual(slots(1.0 + 30 * step), 29)
+        # A 120 -> 60 decimation legitimately spans two source intervals.
+        self.assertEqual(slots(1.0 + 2 * (1 / 120), capture_fps=120), 0)
+        self.assertEqual(slots(1.0 + 4 * (1 / 120), capture_fps=120), 1)
+        # Non-advancing or non-finite timestamps are not a gap.
+        self.assertEqual(slots(1.0), 0)
+        self.assertEqual(slots(float("nan")), 0)
+
+    def test_hole_longer_than_the_camera_loss_limit_is_fatal(self) -> None:
         base = time.perf_counter() + 0.1
-        step = 1.0 / 60.0
         cameras = {
             "camera": _EncodedCamera(
-                [(b"a0", base, base), (b"a2", base + 2 * step, base)],
-                capture_fps=30,
+                [(b"a0", base, base), (b"late", base + 1.5, base)],
             )
         }
 
@@ -328,7 +564,78 @@ class DatasetRecorderCaptureErrorTest(unittest.TestCase):
 
         self.assertEqual(len(dataset.rows), 1)
         self.assertEqual(repairs, [])
-        self.assertRegex(errors[0], "dropped an encoded frame")
+        self.assertRegex(errors[0], "delivered no exposure for 1.50s")
+
+    def test_duplicate_au_is_skipped_and_the_next_one_taken(self) -> None:
+        base = time.perf_counter() + 0.1
+        step = 1.0 / 60.0
+        cameras = {
+            "camera": _EncodedCamera(
+                [
+                    (b"a0", base, base),
+                    (b"a0-again", base, base),  # duplicated exposure
+                    (b"a1", base + step, base),
+                    (b"a2", base + 2 * step, base),
+                ]
+            )
+        }
+
+        dataset, errors, repairs, _, quality = self._run_encoded_q(
+            cameras, fps=60, rows=3
+        )
+
+        self.assertEqual(errors, [])
+        self.assertEqual(
+            [row["observation.camera"] for row in dataset.rows], [b"a0", b"a1", b"a2"]
+        )
+        self.assertEqual(repairs, [])
+        self.assertEqual(quality, {"camera.unusable_aus_skipped": 1})
+
+    def test_lagging_camera_is_advanced_to_its_peers(self) -> None:
+        """A camera with a surplus AU rejoins the row instead of ending it."""
+        base = time.perf_counter() + 0.1
+        step = 1.0 / 60.0
+        cameras = {
+            # camera_a delivers a burst of three surplus exposures after row
+            # zero, so it soon trails camera_b by more than the alignment
+            # limit (1.5 frames). Each such row skips camera_a's stale AU(s)
+            # until it is back within the limit.
+            "camera_a": _EncodedCamera(
+                [
+                    (b"a0", base, base),
+                    (b"x1", base + 0.2 * step, base),
+                    (b"x2", base + 0.4 * step, base),
+                    (b"x3", base + 0.6 * step, base),
+                    (b"a1", base + step, base),
+                    (b"a2", base + 2 * step, base),
+                    (b"a3", base + 3 * step, base),
+                ]
+            ),
+            "camera_b": _EncodedCamera(
+                [
+                    (b"b0", base, base),
+                    (b"b1", base + step, base),
+                    (b"b2", base + 2 * step, base),
+                    (b"b3", base + 3 * step, base),
+                ]
+            ),
+        }
+
+        dataset, errors, _, _, quality = self._run_encoded_q(cameras, fps=60, rows=4)
+
+        self.assertEqual(errors, [])
+        # Row 1 accepts x1 (0.8 frames behind, within the limit); row 2 skips
+        # x2 for x3; row 3 skips a1 for a2. camera_b is never touched.
+        self.assertEqual(
+            [row["observation.camera_a"] for row in dataset.rows],
+            [b"a0", b"x1", b"x3", b"a2"],
+        )
+        self.assertEqual(
+            [row["observation.camera_b"] for row in dataset.rows],
+            [b"b0", b"b1", b"b2", b"b3"],
+        )
+        self.assertEqual(quality.get("camera_a.exposures_skipped_to_realign"), 2)
+        self.assertNotIn("rows_dropped_camera_skew", quality)
 
     def test_repeated_isolated_gaps_within_budget_are_concealed(self) -> None:
         # The ZED sources drop isolated frames in clusters around a record
@@ -356,7 +663,14 @@ class DatasetRecorderCaptureErrorTest(unittest.TestCase):
         self.assertEqual([event["missing_frames"] for event in repairs], [1, 1])
         self.assertEqual([event["frame_index"] for event in repairs], [1, 3])
 
-    def test_gap_burst_inside_window_is_fatal(self) -> None:
+    def test_gap_burst_over_budget_is_still_repaired_and_flagged(self) -> None:
+        """Past the rate budget the take survives; the source is flagged.
+
+        The budget used to end the episode. Under the fail-open policy the
+        hole is repaired the same way, the repair event carries
+        ``within_budget=False``, and the quality counters record the
+        over-budget event so the unhealthy camera is found in the log.
+        """
         base = time.perf_counter() + 0.1
         step = 1.0 / 60.0
         packets = [(b"a0", base, base)]
@@ -364,17 +678,49 @@ class DatasetRecorderCaptureErrorTest(unittest.TestCase):
         for i in range(_ENCODED_MAX_CONCEALMENT_EVENTS_PER_WINDOW + 1):
             ts = base + 2 * (i + 1) * step
             packets.append((f"a{2 * (i + 1)}".encode(), ts, base))
+        n_packets = len(packets)
         cameras = {"camera": _EncodedCamera(packets)}
 
-        dataset, errors, repairs, _ = self._run_encoded(
-            cameras, fps=60, rows=len(packets) * 2
+        dataset, errors, repairs, _, quality = self._run_encoded_q(
+            cameras, fps=60, rows=2 * n_packets - 1
         )
 
-        self.assertEqual(len(repairs), _ENCODED_MAX_CONCEALMENT_EVENTS_PER_WINDOW)
+        self.assertEqual(errors, [])
+        self.assertEqual(len(repairs), _ENCODED_MAX_CONCEALMENT_EVENTS_PER_WINDOW + 1)
+        self.assertEqual(len(dataset.rows), 2 * n_packets - 1)
         self.assertEqual(
-            len(dataset.rows), 2 * _ENCODED_MAX_CONCEALMENT_EVENTS_PER_WINDOW + 1
+            [event["within_budget"] for event in repairs],
+            [True] * _ENCODED_MAX_CONCEALMENT_EVENTS_PER_WINDOW + [False],
         )
-        self.assertRegex(errors[0], "dropped an encoded frame")
+        self.assertEqual(quality["camera.concealment_over_budget_events"], 1)
+        self.assertEqual(
+            quality["camera.concealed_frames"],
+            _ENCODED_MAX_CONCEALMENT_EVENTS_PER_WINDOW + 1,
+        )
+
+    def test_long_hole_within_the_loss_limit_is_repaired(self) -> None:
+        # A 20-frame (333 ms) hole used to be fatal (holes were capped at two
+        # frames). It is now repaired: the prior IDR fills every missing slot.
+        base = time.perf_counter() + 0.1
+        step = 1.0 / 60.0
+        cameras = {
+            "camera": _EncodedCamera(
+                [(b"a0", base, base), (b"a21", base + 21 * step, base)]
+            )
+        }
+
+        dataset, errors, repairs, _, quality = self._run_encoded_q(
+            cameras, fps=60, rows=22
+        )
+
+        self.assertEqual(errors, [])
+        self.assertEqual(len(dataset.rows), 22)
+        self.assertEqual(
+            [row["observation.camera"] for row in dataset.rows],
+            [b"a0"] * 21 + [b"a21"],
+        )
+        self.assertEqual([event["missing_frames"] for event in repairs], [20])
+        self.assertEqual(quality["camera.concealed_frames"], 20)
 
     def test_isolated_gaps_every_few_seconds_survive_a_long_take(self) -> None:
         # Today's overhead pattern: one exposure lost every 1-4 s for the whole
@@ -503,16 +849,22 @@ class DatasetRecorderCaptureErrorTest(unittest.TestCase):
                 capture_fps=dict.fromkeys(packets, 30),
             )
 
-    def test_row_zero_alignment_rejects_a_dropped_prefix_frame(self) -> None:
+    def test_row_zero_alignment_tolerates_a_dropped_prefix_frame(self) -> None:
+        # Nothing before row zero is recorded, so a hole (or a duplicate) in
+        # the discarded prefix must not end the take before it starts.
         packets = {"overhead": (b"o", 1.0, 1.0), "wrist": (b"w", 1.1, 1.0)}
+        queued = [(b"jump", 1.075, 1.1), (b"dup", 1.075, 1.15), (b"o1", 1.1, 1.2)]
 
-        with self.assertRaisesRegex(RuntimeError, "dropped an encoded frame"):
-            _align_independent_encoded_start(
-                packets,
-                lambda _name: (b"jump", 1.075, 1.1),
-                fps=30,
-                capture_fps=dict.fromkeys(packets, 60),
-            )
+        aligned, dropped = _align_independent_encoded_start(
+            packets,
+            lambda _name: queued.pop(0),
+            fps=30,
+            capture_fps=dict.fromkeys(packets, 60),
+        )
+
+        self.assertEqual(aligned["overhead"][0], b"o1")
+        self.assertEqual(aligned["wrist"][0], b"w")
+        self.assertEqual(dropped, {"overhead": 3})
 
     def test_encoded_capture_saves_the_aligned_access_units_verbatim(self) -> None:
         stop = threading.Event()
@@ -714,6 +1066,224 @@ class DatasetRecorderCaptureErrorTest(unittest.TestCase):
         finally:
             send_conn.close()
             recv_conn.close()
+
+
+class _RawCamera:
+    """Scripted ``read_at_or_after`` camera for the raw (tick-paced) loop.
+
+    ``script`` holds one entry per call: a ``(frame, capture_ts)`` tuple, or
+    ``TimeoutError`` to simulate no fresh frame arriving within the timeout.
+    Once the script is exhausted the camera keeps delivering fresh frames at
+    the requested tick time so the dataset can reach its row target.
+    """
+
+    def __init__(self, script: list[object]) -> None:
+        self.script = list(script)
+        self.calls = 0
+
+    def read_at_or_after(
+        self, target_perf_ts: float, timeout_ms: float
+    ) -> tuple[object, float, float]:
+        del timeout_ms
+        self.calls += 1
+        if self.script:
+            entry = self.script.pop(0)
+            if entry is TimeoutError:
+                raise TimeoutError("no frame")
+            frame, cap_ts = entry  # type: ignore[misc]
+            return frame, cap_ts, cap_ts
+        return b"fresh", target_perf_ts, target_perf_ts
+
+
+class RowStatePairerTest(unittest.TestCase):
+    def _snap(self, ts: float, tag: str) -> tuple[dict, dict, float, bool]:
+        return {"state": tag}, {"target": tag}, ts, False
+
+    def test_holds_previous_state_only_while_within_tolerance(self) -> None:
+        quality: dict[str, int] = {}
+        pairer = _RowStatePairer(label="exposure", can_drop=True, quality=quality)
+        step = 1.0 / 60.0
+
+        fresh = self._snap(10.0, "fresh")
+        self.assertEqual(pairer.resolve(10.0, fresh, None), (fresh, 0.0))
+
+        # Bracket gone one and two frames later: hold the fresh state.
+        snap, skew = pairer.resolve(10.0 + step, None, "aged out")
+        self.assertIs(snap, fresh)
+        self.assertAlmostEqual(skew, step)
+        snap, _ = pairer.resolve(10.0 + 2 * step, None, "aged out")
+        self.assertIs(snap, fresh)
+        # A distant candidate is no better than a missing one.
+        snap, _ = pairer.resolve(10.0 + 2.5 * step, self._snap(10.4, "far"), None)
+        self.assertIs(snap, fresh)
+        # Past the tolerance the held state is as stale as any other: drop.
+        snap, skew = pairer.resolve(10.0 + 4 * step, None, "aged out")
+        self.assertIsNone(snap)
+        self.assertEqual(skew, float("inf"))
+        snap, _ = pairer.resolve(10.0 + 4 * step, self._snap(10.4, "far"), None)
+        self.assertIsNone(snap)
+
+        self.assertEqual(
+            quality,
+            {
+                "rows_with_held_state": 3,
+                "rows_dropped_state_miss": 1,
+                "rows_dropped_state_skew": 1,
+            },
+        )
+        self.assertEqual(pairer.misses, 5)
+
+    def test_no_previous_row_drops_or_keeps_by_transport(self) -> None:
+        droppable = _RowStatePairer(label="exposure", can_drop=True, quality={})
+        self.assertEqual(
+            droppable.resolve(1.0, None, "nothing yet"), (None, float("inf"))
+        )
+        far = self._snap(1.3, "far")
+        snap, skew = droppable.resolve(1.0, far, None)
+        self.assertIsNone(snap)
+        self.assertAlmostEqual(skew, 0.3)
+
+        predictive = _RowStatePairer(label="exposure", can_drop=False, quality={})
+        # Nothing to pair with at all still drops; a distant candidate is kept.
+        self.assertEqual(
+            predictive.resolve(1.0, None, "nothing yet"), (None, float("inf"))
+        )
+        snap, skew = predictive.resolve(1.0, far, None)
+        self.assertIs(snap, far)
+        self.assertAlmostEqual(skew, 0.3)
+
+
+class RawCaptureLoopFailOpenTest(unittest.TestCase):
+    def _run_raw(
+        self,
+        cameras: dict[str, _RawCamera],
+        *,
+        rows: int,
+        fps: int = 60,
+        bracket_missing: Callable[[float], bool] = lambda _ts: False,
+        latest_ts: Callable[[], float] = time.perf_counter,
+    ) -> tuple[_CaptureDataset, list[str], dict[str, int]]:
+        stop = threading.Event()
+        dataset = _CaptureDataset(stop, stop_after=rows)
+        errors: list[str] = []
+        quality: dict[str, int] = {}
+
+        def read_latest() -> tuple[dict, dict, float, bool]:
+            return {"state": "latest"}, {"target": 2}, latest_ts(), False
+
+        def read_nearest(target_ts: float) -> tuple[dict, dict, float, bool] | None:
+            if bracket_missing(target_ts):
+                return None
+            return {"state": target_ts}, {"target": 2}, target_ts, False
+
+        with (
+            patch(
+                "lerobot.utils.feature_utils.build_dataset_frame",
+                side_effect=lambda _f, values, prefix: dict(values),
+            ),
+            patch("lerobot.utils.visualization_utils.log_rerun_data"),
+        ):
+            run_capture_loop(
+                cameras=cameras,
+                read_snapshot=read_latest,
+                read_snapshot_nearest=read_nearest,
+                dataset=dataset,
+                robot_obs_proc=lambda obs: obs,
+                fps=fps,
+                task="test",
+                rerun_ip=None,
+                stop_event=stop,
+                on_error=errors.append,
+                quality=quality,
+            )
+        return dataset, errors, quality
+
+    def test_one_missing_frame_skips_the_tick_not_the_take(self) -> None:
+        cam = _RawCamera([TimeoutError])
+
+        dataset, errors, quality = self._run_raw({"cam": cam}, rows=3)
+
+        self.assertEqual(errors, [])
+        self.assertEqual(len(dataset.rows), 3)
+        self.assertEqual(quality, {"cam.ticks_without_frame": 1})
+
+    def test_stale_and_invalid_frames_skip_their_ticks(self) -> None:
+        # The scripted exposures sit before the loop's tick clock so the
+        # camera's later (tick-timed) frames still advance past them.
+        first = time.perf_counter() - 1.0
+        cam = _RawCamera(
+            [
+                (b"f0", first),
+                (b"f0-again", first),  # repeated exposure
+                (b"bad", float("nan")),  # unusable timestamp
+            ]
+        )
+
+        dataset, errors, quality = self._run_raw({"cam": cam}, rows=3)
+
+        self.assertEqual(errors, [])
+        self.assertEqual(len(dataset.rows), 3)
+        self.assertEqual(
+            quality,
+            {"cam.ticks_with_stale_frame": 1, "cam.ticks_with_invalid_timestamp": 1},
+        )
+
+    def test_mid_take_state_miss_holds_the_previous_state(self) -> None:
+        # Exposures are the tick times themselves (see _RawCamera); the second
+        # tick's bracket is gone and the writer's newest snapshot is 300 ms
+        # stale (a brief pause). The row keeps the first tick's state instead
+        # of being skipped, so the timeline stays true.
+        seen: list[float] = []
+
+        def bracket_missing(target_ts: float) -> bool:
+            if not seen or target_ts > seen[-1]:
+                seen.append(target_ts)
+            return len(seen) == 2 and target_ts == seen[1]
+
+        def latest_ts() -> float:
+            # Fresh for the episode-start gate, then quiet.
+            return time.perf_counter() - (0.3 if seen else 0.0)
+
+        with patch(
+            "almond_axol.recording.record_proc._SNAPSHOT_BRACKET_TIMEOUT_S", 0.01
+        ):
+            dataset, errors, quality = self._run_raw(
+                {"cam": _RawCamera([])},
+                rows=3,
+                bracket_missing=bracket_missing,
+                latest_ts=latest_ts,
+            )
+
+        self.assertEqual(errors, [])
+        self.assertEqual(len(dataset.rows), 3)
+        states = [row["state"] for row in dataset.rows]
+        self.assertEqual(states[0], states[1])
+        self.assertGreater(states[2], states[1])
+        self.assertEqual(quality, {"rows_with_held_state": 1})
+
+    def test_camera_silent_for_the_loss_limit_ends_the_take(self) -> None:
+        cam = _RawCamera([TimeoutError] * 4)
+
+        with patch("almond_axol.recording.record_proc._CAMERA_LOSS_FATAL_S", 0.0):
+            dataset, errors, quality = self._run_raw({"cam": cam}, rows=3)
+
+        self.assertEqual(dataset.rows, [])
+        self.assertEqual(len(errors), 1)
+        self.assertRegex(errors[0], "produced no fresh frame for .*s \\(limit 0.0s")
+        self.assertEqual(quality, {})
+
+
+class CaptureQualitySummaryTest(unittest.TestCase):
+    def test_format_is_sorted_and_names_a_clean_take(self) -> None:
+        self.assertEqual(
+            format_capture_quality({}), "clean (no mitigated capture defects)"
+        )
+        self.assertEqual(
+            format_capture_quality(
+                {"rows_dropped_state_miss": 2, "cam.concealed_frames": 1}
+            ),
+            "cam.concealed_frames=1, rows_dropped_state_miss=2",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

Operators kept losing takes to resets. Almost every recorder-side defect — a dropped exposure past a two-frame cap, a duplicated AU, a relay DISCONT, a camera trailing its peers, a missing robot-state bracket, a 50 ms state skew, a raw-camera timeout of a few hundred ms — raised, discarded the episode, and sent the operator through a return-to-rest/re-record cycle. The realtime core degrades and never disables the arms; the recorder now follows the same policy.

## Policy

Only a **drastic** loss ends an episode (`_CAMERA_LOSS_FATAL_S` / `_STATE_LOSS_FATAL_S` = 1 s):
- a camera with no usable exposure for a second, or a PTS hole that long;
- a control loop that has published no state for a second;
- a transport/encoder failure (pipeline error, predictive picture on the all-intra contract, missing/invalid PTS, 2 s AU backlog, muxer push failure, NVENC drop at save).

Everything else is mitigated, counted, and logged.

## What changed

**Encoded path** (`run_encoded_capture_loop`)
- Duplicate / non-advancing / non-finite AU → discard it, take the next one (`<cam>.unusable_aus_skipped`).
- Any hole up to 1 s → repeat the prior IDR, hold the future AU (was capped at 2 frames). Past the per-camera rate budget the repair still happens; the log escalates to ERROR once per camera (`<cam>.concealment_over_budget_events`) and the repair event carries `within_budget=False`.
- Camera trailing its peers by > 1.5 frames → skip its surplus AUs until it rejoins the row (`<cam>.exposures_skipped_to_realign`).
- Long-run cadence drift → warn and re-anchor (`<cam>.cadence_reanchors`).
- Exposures still unsynchronized → drop the row for every camera at once so the mp4s and parquet stay index-aligned; predictive streams keep the row.
- Row-zero alignment tolerates a hole/duplicate in the discarded prefix.

**Robot state** (`_RowStatePairer`, both loops)
- Missing bracket or > 50 ms skew → hold the previous row's state while it is still within the 50 ms tolerance (`rows_with_held_state`). That is no staler than a pairing any ordinary row accepts, and it keeps the row so LeRobot's `frame_index / fps` timeline stays true to wall time. Otherwise drop the row (`rows_dropped_state_*`; row 0 has nothing to hold); predictive streams keep the row with the degraded pairing.
- `_classify_snapshot_miss` decides attribution and fatality from a single `read_latest`, so the log and the decision cannot disagree.

**Raw path** (`run_capture_loop`): timeout, stale frame, invalid timestamp, or skew skips the tick for every camera (`<cam>.ticks_*`); fatal only after a second without a fresh frame.

**AU reader** (`EncodedAuReader`): DISCONT, un-mappable AU, and PTS-0 reset count `lost_exposures` and let the capture loop conceal the gap instead of poisoning the episode.

**Logging for later triage**: every mitigated event is a per-event WARNING with row and cause; each take ends with one `capture quality: N row(s); ...` line (INFO when clean, WARNING otherwise, including the readers' transport losses) from both the recorder child and `InProcessRecorder`. The save-time repair audit line marks over-budget repairs.

## Tests

`uv run python -m unittest discover -s tests`: 1038 tests OK. Tests that pinned the old fail-closed behaviour were updated; regression tests added for each mitigation, the two fatal thresholds, the pairer's hold/drop/keep decisions and tolerance edge, and the reader's non-fatal losses. Ruff clean.

## Notes

- Base is `rust` (this branch sits on its tip); the integration PR is #232.
- The NVENC drop-at-save rejection (raw path only) is left fatal: by save time the video is already a frame short and there is no cheap post-hoc alignment fix.
- A camera trailing by ≤ 1.5 frames is accepted as before (existing sync tolerance).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core episode capture semantics and what ends up in saved datasets; mitigations are logged and bounded, but mis-tuned thresholds could hide unhealthy streams or accept degraded alignments.
> 
> **Overview**
> Teleop dataset recording no longer **discards whole episodes** for most capture glitches. The recorder now **mitigates per-row problems**, bumps **quality counters**, and logs warnings; a take ends only when a camera has no usable frame for **~1s**, robot state goes silent for **~1s**, or the transport/encoder truly fails.
> 
> **Encoded capture** repeats the prior IDR for exposure holes up to that limit (not just two frames), still repairs over-budget ZED-style drop bursts but escalates to ERROR, skips duplicate/stale AUs, realigns cameras that trail peers, drops whole rows when multi-camera skew cannot be fixed, and re-anchors cadence drift instead of aborting. **Raw capture** skips ticks for short timeouts, stale PTS, or skew. **`_RowStatePairer`** holds the previous row’s state when a bracket is missing but still within alignment tolerance; otherwise it drops the row (or keeps a degraded row on predictive streams). **`EncodedAuReader`** counts relay DISCONT / bad map / lost PTS as `lost_exposures` for end-of-take summaries instead of killing the episode.
> 
> Each episode gets a **`capture quality:`** log line (plus save-time repair notes); **`collect_data`** comments reflect that tick stalls are triage signals, not automatic take failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4e5566a56c4a8508f175c755f344fe987df6077. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->