### PR TITLE
Document the screw and mount pin needed to fasten a VIVE tracker to its Mantis mount

### DIFF
--- a/docs/mantis/hardware.mdx
+++ b/docs/mantis/hardware.mdx
@@ -36,6 +36,15 @@ The kit includes the mount for the pose source you purchased: Quest, Lighthouse 
 | **VIVE Tracker 3.0** (Lighthouse) | Flat-back mount in the controller's place. | Built-in factory transform; nothing to measure for the standard mount. |
 | **VIVE Ultimate Tracker** | Same flat-back mount and orientation as Tracker 3.0. | Built-in factory transform (includes the 11 mm origin difference from Tracker 3.0). |
 
+#### Fastening a VIVE tracker to its mount
+
+Both VIVE trackers fasten to the flat-back mount the same way. You need:
+
+- **1× 1/4"-20 × 1/2" screw**, threaded into the tracker's standard 1/4"-20 socket from below the mount.
+- **1× mount pin** ([`mantis_mount_pin.stl`](https://www.almond.bot/resources/mantis_mount_pin.stl), a 5 mm × 10 mm 3D-printed pin). It sits in the locating hole next to the 1/4"-20 socket and stops the tracker rotating on the screw, which keeps the factory tracker → gripper transform valid.
+
+Press the pin into the mount first, seat the tracker on it, then tighten the screw.
+
 #### Printing your own mount
 
 If you ordered Mantis without a tracker and are supplying your own, you can 3D-print the mount instead. Download the model for your pose source:
@@ -44,7 +53,7 @@ If you ordered Mantis without a tracker and are supplying your own, you can 3D-p
 - [VIVE Tracker 3.0 mount](https://www.almond.bot/resources/mantis_vive_3_mount.step) (STEP)
 - [VIVE Ultimate Tracker mount](https://www.almond.bot/resources/mantis_vive_ultimate_mount.step) (STEP)
 
-Each mount attaches to the rig with **M3×8 screws** ([McMaster-Carr 97763A813](https://www.mcmaster.com/97763A813/)). For the VIVE Ultimate Tracker, use the optional **1/4"-20 UNC screw-in mount** that HTC includes in the tracker's box to fasten the tracker to the printed mount.
+Each mount attaches to the rig with **M3×8 screws** ([McMaster-Carr 97763A813](https://www.mcmaster.com/97763A813/)). For either VIVE tracker, print the mount pin alongside the mount and fasten the tracker with a 1/4"-20 × 1/2" screw as described [above](#fastening-a-vive-tracker-to-its-mount).
 
 ## Installation
 


### PR DESCRIPTION
## Summary

- Adds a **Fastening a VIVE tracker to its mount** subsection to the Mantis hardware page: both the VIVE Tracker 3.0 and the VIVE Ultimate Tracker fasten to the flat-back mount with a **1/4"-20 × 1/2" screw** plus the 3D-printed **mount pin** ([`mantis_mount_pin.stl`](https://www.almond.bot/resources/mantis_mount_pin.stl)) in the locating hole next to the 1/4"-20 socket, which stops the tracker rotating and keeps the factory tracker → gripper transform valid.
- Updates the *Printing your own mount* paragraph to point at that subsection for either VIVE tracker, replacing the previous advice to use HTC's included screw-in mount for the Ultimate.

## Notes

- Docs-only change (`docs/mantis/hardware.mdx`).
- At the time of writing, `https://www.almond.bot/resources/mantis_mount_pin.stl` returned 404 while the sibling resources returned 200; confirm the upload has landed before merging.

Made with [Cursor](https://cursor.com)