### PR TITLE
Recover from motor power loss instead of locking serve out

### DIFF
--- a/almond_axol/motor/bus.py
+++ b/almond_axol/motor/bus.py
@@ -235,6 +235,22 @@ class CanBus:
         # STALL_DETECT_S means the queue isn't draining — bus dead (e-stop).
         self._enobufs_since: float | None = None
 
+    @property
+    def channel(self) -> str:
+        """SocketCAN interface name this bus is open on."""
+        return self._channel
+
+    @property
+    def stalled(self) -> bool:
+        """Whether *this* bus has declared a stall: nothing on the wire is ACKing.
+
+        Set only by ENOBUFS persisting past :data:`STALL_DETECT_S`, which needs
+        every node on the bus to be silent (the motors are unpowered). A lost
+        interface (USB drop) drops sends the same way but does not set this —
+        the motors may well still be powered and holding torque.
+        """
+        return self._stalled
+
     async def start(self) -> None:
         """Start the background frame-dispatch loop. Idempotent.
 

--- a/almond_axol/motor/bus.py
+++ b/almond_axol/motor/bus.py
@@ -159,9 +159,9 @@ def _tx_queue_full(exc: BaseException) -> bool:
     if _error_code(exc) == errno.ENOBUFS:
         return True
     # The message is the only signal python-can gives in the second form.
-    # tradeoff: matching text is fragile across python-can releases; the pinned
-    # dependency makes that visible at upgrade time, and the tests below pin
-    # both forms so a wording change fails loudly rather than silently.
+    # tradeoff: matching text is fragile across python-can releases (the
+    # dependency is a ``>=4.6.1,<5`` range, not an exact pin), so the tests pin
+    # both forms and a wording change fails loudly rather than silently.
     return isinstance(exc, can.CanOperationError) and "buffer full" in str(exc).lower()
 
 

--- a/almond_axol/motor/bus.py
+++ b/almond_axol/motor/bus.py
@@ -216,6 +216,12 @@ class CanBus:
             channel: SocketCAN interface name, e.g. ``"can_alm_axol_l"``.
         """
         self._channel = channel
+        # A fresh bus has observed no stall. Without this reset a bus that was
+        # abandoned open on a dead event loop (a failed teardown that kept the
+        # lockout's buses) leaves its channel flagged for the rest of the
+        # process, and every later stall on the channel is invisible to
+        # ``stalled_channels`` readers because the set add is idempotent.
+        _set_stalled(channel, False)
         self._bus: can.BusABC | None = can.Bus(channel=channel, bustype="socketcan")
         self._listeners: list[Callable[[can.Message], None]] = []
         self._reader_task: asyncio.Task | None = None

--- a/almond_axol/motor/bus.py
+++ b/almond_axol/motor/bus.py
@@ -123,8 +123,22 @@ def _tx_queue_full(exc: BaseException) -> bool:
 
     Whether that's transient host-side congestion or a dead bus is decided
     by how long it persists — see :data:`STALL_DETECT_S`.
+
+    Two forms reach us. A direct ``send`` failure carries ``ENOBUFS``. But
+    python-can's SocketCAN backend also retries a partial write for its send
+    timeout and then raises ``CanOperationError("Transmit buffer full")`` with
+    no errno attached (``socketcan.py``, 4.x), which is the form a dead bus
+    produces in practice. Missing it re-raises out of :meth:`CanBus._send`
+    instead of dropping the frame, so the command never times out upstream and
+    the bus never gets to declare the stall.
     """
-    return _error_code(exc) == errno.ENOBUFS
+    if _error_code(exc) == errno.ENOBUFS:
+        return True
+    # The message is the only signal python-can gives in the second form.
+    # tradeoff: matching text is fragile across python-can releases; the pinned
+    # dependency makes that visible at upgrade time, and the tests below pin
+    # both forms so a wording change fails loudly rather than silently.
+    return isinstance(exc, can.CanOperationError) and "buffer full" in str(exc).lower()
 
 
 def _iface_is_up(channel: str) -> bool:

--- a/almond_axol/motor/bus.py
+++ b/almond_axol/motor/bus.py
@@ -7,6 +7,7 @@ import errno
 import logging
 import threading
 import time
+import weakref
 from pathlib import Path
 from typing import Callable
 
@@ -71,8 +72,31 @@ _PROBE_POLL_S = 0.25
 # buses stall together (they share the e-stop), the second one can skip it.
 _FLUSH_DEDUPE_S = 3.0
 
-_flush_lock = asyncio.Lock()
+# One flush lock per event loop, never a single shared one. A bus runs its
+# reader on whichever loop its owner uses — an operation's loop while it holds
+# the arms, the idle link's loop afterwards — and an ``asyncio.Lock`` binds to
+# the loop that first awaits it. A module-level lock therefore raises "bound to
+# a different event loop" on the next owner, and worse, stays held when the
+# loop it was acquired on goes away, so every later flush fails. The lock only
+# has to serialise the two arms of one operation, which do share a loop; the
+# ``_last_flush_monotonic`` window below dedupes across loops.
+_flush_locks: "weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Lock]" = (
+    weakref.WeakKeyDictionary()
+)
+_flush_locks_guard = threading.Lock()
 _last_flush_monotonic = 0.0
+
+
+def _flush_lock_for_running_loop() -> asyncio.Lock:
+    """Return this event loop's flush lock, creating it on first use."""
+    loop = asyncio.get_running_loop()
+    with _flush_locks_guard:
+        lock = _flush_locks.get(loop)
+        if lock is None:
+            lock = asyncio.Lock()
+            _flush_locks[loop] = lock
+        return lock
+
 
 # Channels currently stalled, across every bus this process owns. A stall is
 # the motors losing power, which no single bus owner can see on its own: the
@@ -474,7 +498,7 @@ class CanBus:
         and up; without it, flap just this channel.
         """
         global _last_flush_monotonic
-        async with _flush_lock:
+        async with _flush_lock_for_running_loop():
             script_exists = CAN_BRINGUP_SCRIPT.exists()
             if (
                 script_exists

--- a/almond_axol/motor/bus.py
+++ b/almond_axol/motor/bus.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import errno
 import logging
+import threading
 import time
 from pathlib import Path
 from typing import Callable
@@ -53,7 +54,7 @@ _RECONNECT_REMIND_S = 30.0
 # The two are told apart by duration: at 1 Mbit/s a healthy full queue
 # (txqueuelen 512) drains in ~65 ms, so ENOBUFS persisting across sends for
 # longer than this means nothing is draining — the bus is dead.
-_STALL_DETECT_S = 1.0
+STALL_DETECT_S = 1.0
 
 # Transient overflows come in bursts at telemetry rates; warn at most this
 # often so congestion doesn't flood the log with one line per dropped frame.
@@ -73,6 +74,36 @@ _FLUSH_DEDUPE_S = 3.0
 _flush_lock = asyncio.Lock()
 _last_flush_monotonic = 0.0
 
+# Channels currently stalled, across every bus this process owns. A stall is
+# the motors losing power, which no single bus owner can see on its own: the
+# arms are driven from an operation's own Axol instance while the serve layer
+# supervising it holds no bus at all. Process-wide, so any supervisor can read
+# it (see ``stalled_channels``). Buses run their readers on whichever event
+# loop their owner uses — an operation's, the idle link's thread — so the lock
+# keeps a read from racing a bus flagging or clearing its own stall.
+_stall_lock = threading.Lock()
+_stalled_channels: set[str] = set()
+
+
+def _set_stalled(channel: str, stalled: bool) -> None:
+    """Record whether *channel*'s bus is stalled right now."""
+    with _stall_lock:
+        if stalled:
+            _stalled_channels.add(channel)
+        else:
+            _stalled_channels.discard(channel)
+
+
+def stalled_channels() -> frozenset[str]:
+    """CAN channels whose bus is stalled right now: no node is ACKing frames.
+
+    A stall means the motors are unpowered (the e-stop) — see
+    :meth:`CanBus._mark_stalled`. It clears when a probe frame is ACKed again
+    (power restored) or when the bus is closed.
+    """
+    with _stall_lock:
+        return frozenset(_stalled_channels)
+
 
 def _error_code(exc: BaseException) -> int | None:
     """Extract the errno from a python-can or OS-level exception."""
@@ -91,7 +122,7 @@ def _tx_queue_full(exc: BaseException) -> bool:
     """True when *exc* means the interface's TX queue is full (``ENOBUFS``).
 
     Whether that's transient host-side congestion or a dead bus is decided
-    by how long it persists — see :data:`_STALL_DETECT_S`.
+    by how long it persists — see :data:`STALL_DETECT_S`.
     """
     return _error_code(exc) == errno.ENOBUFS
 
@@ -123,7 +154,7 @@ class CanBus:
 
     A stalled bus — the e-stop cutting motor power so nothing ACKs frames and
     the kernel TX queue fills (``ENOBUFS`` persisting past
-    :data:`_STALL_DETECT_S`, past any transient congestion) — is handled the
+    :data:`STALL_DETECT_S`, past any transient congestion) — is handled the
     same way, with two extra steps: the queued (now stale) motion commands are purged by
     flapping the interface, and sends stay dropped until a probe frame is
     actually ACKed on the wire again. Without the purge, up to ``txqueuelen``
@@ -163,7 +194,7 @@ class CanBus:
         self._next_tx_full_warn = 0.0
         # Loop time of the first ENOBUFS in the current burst (None outside
         # one); a successful send resets it. Overflow persisting longer than
-        # _STALL_DETECT_S means the queue isn't draining — bus dead (e-stop).
+        # STALL_DETECT_S means the queue isn't draining — bus dead (e-stop).
         self._enobufs_since: float | None = None
 
     async def start(self) -> None:
@@ -183,6 +214,9 @@ class CanBus:
 
     async def close(self) -> None:
         """Stop the reader loop and shut down the socket."""
+        # A closed bus reports nothing: its stall belongs to the owner that is
+        # going away, not to whoever opens this channel next.
+        _set_stalled(self._channel, False)
         external_cancel: asyncio.CancelledError | None = None
         reader_error: BaseException | None = None
         if self._reader_task is not None:
@@ -280,13 +314,13 @@ class CanBus:
         The frame is dropped either way — commands time out upstream
         (``MotorError``) and resume. Transient host-side congestion drains
         within milliseconds, so overflow persisting across sends for
-        :data:`_STALL_DETECT_S` means no node is ACKing (e-stop) and stall
+        :data:`STALL_DETECT_S` means no node is ACKing (e-stop) and stall
         recovery (purge + probe) takes over.
         """
         now = asyncio.get_running_loop().time()
         if self._enobufs_since is None:
             self._enobufs_since = now
-        elif now - self._enobufs_since >= _STALL_DETECT_S:
+        elif now - self._enobufs_since >= STALL_DETECT_S:
             self._enobufs_since = None
             self._mark_stalled(exc)
             return
@@ -316,6 +350,7 @@ class CanBus:
         if self._stalled:
             return
         self._stalled = True
+        _set_stalled(self._channel, True)
         # Also flag lost so the pump exits and hands control to the recovery
         # path; _reconnect clears it once the socket is reopened, while
         # _stalled keeps sends dropped until the bus is proven alive.
@@ -525,6 +560,7 @@ class CanBus:
         finally:
             probe_bus.shutdown()
         self._stalled = False
+        _set_stalled(self._channel, False)
         _logger.warning(
             "CAN %s: bus is ACKing again after %.1fs — resuming commands",
             self._channel,

--- a/almond_axol/robot/axol.py
+++ b/almond_axol/robot/axol.py
@@ -104,14 +104,22 @@ async def _await_all_hardware_actions(*actions: Awaitable[object]) -> None:
             raise result
 
 
-async def _arm_is_unpowered(arm: "AxolArm") -> bool:
-    """True when no motor on *arm* answers a status read.
+async def _arm_is_unpowered(arm: "AxolArm", bus: CanBus) -> bool:
+    """True when *arm*'s bus is stalled and no motor on it answers a status read.
 
-    Distinguishes the two ways a torque-off can fail to confirm: motor power
-    was removed (the e-stop, so every read times out and the torque is gone
+    Distinguishes the ways a torque-off can fail to confirm: motor power was
+    removed (the e-stop, so every read times out and the torque is gone
     already), or a powered motor is refusing to disable (which no read can
     excuse, and which must keep the caller's cleanup uncertain).
+
+    Both signals are required. Timeouts alone are not proof: a lost CAN
+    interface (the hub dropping off USB) makes every read time out in exactly
+    the same way while the motors stay powered and holding torque. Only the
+    bus can tell the two apart — it declares a stall when nothing on the wire
+    ACKs its frames, which needs every node to be dark.
     """
+    if not bus.stalled:
+        return False
     results = await asyncio.gather(
         *(motor.get_error_code() for motor in arm.motors.values()),
         return_exceptions=True,
@@ -1881,19 +1889,19 @@ class Axol(RobotBase):
             # failed enable() whose rollback did not confirm
             # (_startup_rollback_pending): every motor on each arm is
             # commanded, so a verified pass here settles them too.
-            arms = [
-                (side, arm)
-                for side, arm in (("left", self.left), ("right", self.right))
-                if arm is not None
-            ]
+            arms: list[tuple[str, AxolArm, CanBus]] = []
+            if self.left is not None:
+                arms.append(("left", self.left, self._left_bus))
+            if self.right is not None:
+                arms.append(("right", self.right, self._right_bus))
             results = await asyncio.gather(
-                *(arm.disable() for _, arm in arms), return_exceptions=True
+                *(arm.disable() for _, arm, _ in arms), return_exceptions=True
             )
             motor_failures = []
-            for (side, arm), result in zip(arms, results):
+            for (side, arm, bus), result in zip(arms, results):
                 if not isinstance(result, BaseException):
                     continue
-                if await _arm_is_unpowered(arm):
+                if await _arm_is_unpowered(arm, bus):
                     _logger.warning(
                         "%s arm did not confirm torque-off and no motor answers "
                         "on its bus — the arm is unpowered (e-stop?), so its "

--- a/almond_axol/robot/axol.py
+++ b/almond_axol/robot/axol.py
@@ -104,6 +104,23 @@ async def _await_all_hardware_actions(*actions: Awaitable[object]) -> None:
             raise result
 
 
+async def _arm_is_unpowered(arm: "AxolArm") -> bool:
+    """True when no motor on *arm* answers a status read.
+
+    Distinguishes the two ways a torque-off can fail to confirm: motor power
+    was removed (the e-stop, so every read times out and the torque is gone
+    already), or a powered motor is refusing to disable (which no read can
+    excuse, and which must keep the caller's cleanup uncertain).
+    """
+    results = await asyncio.gather(
+        *(motor.get_error_code() for motor in arm.motors.values()),
+        return_exceptions=True,
+    )
+    # A powered motor answers this read with its status; only one that never
+    # replies raises MotorError, so an all-MotorError sweep is a dead bus.
+    return bool(results) and all(isinstance(result, MotorError) for result in results)
+
+
 async def _rollback_newly_enabled_motors(
     motors: list[tuple[str, Motor]], setup_error: BaseException
 ) -> list[tuple[str, Motor, BaseException]]:
@@ -1838,6 +1855,12 @@ class Axol(RobotBase):
         caller can retry.  Once torque-off has been verified, a close failure
         is likewise retained and retryable without sending motor commands over
         a bus that may already have closed successfully.
+
+        An arm whose motors have all gone silent is the one unconfirmed
+        torque-off that is not uncertain: its power is off (the e-stop), so
+        there is no torque left to own.  That arm is logged as unpowered and
+        the buses close normally; an arm with a motor still answering keeps
+        raising, so a live motor refusing to disable still locks the hardware.
         """
         self._shutdown_pending = True
         telemetry_tasks = []
@@ -1858,15 +1881,28 @@ class Axol(RobotBase):
             # failed enable() whose rollback did not confirm
             # (_startup_rollback_pending): every motor on each arm is
             # commanded, so a verified pass here settles them too.
-            tasks = []
-            if self.left is not None:
-                tasks.append(self.left.disable())
-            if self.right is not None:
-                tasks.append(self.right.disable())
-            results = await asyncio.gather(*tasks, return_exceptions=True)
-            motor_failures = [
-                result for result in results if isinstance(result, BaseException)
+            arms = [
+                (side, arm)
+                for side, arm in (("left", self.left), ("right", self.right))
+                if arm is not None
             ]
+            results = await asyncio.gather(
+                *(arm.disable() for _, arm in arms), return_exceptions=True
+            )
+            motor_failures = []
+            for (side, arm), result in zip(arms, results):
+                if not isinstance(result, BaseException):
+                    continue
+                if await _arm_is_unpowered(arm):
+                    _logger.warning(
+                        "%s arm did not confirm torque-off and no motor answers "
+                        "on its bus — the arm is unpowered (e-stop?), so its "
+                        "torque is already gone: %s",
+                        side,
+                        result,
+                    )
+                    continue
+                motor_failures.append(result)
             if not motor_failures:
                 self._motors_disabled = True
                 self._startup_rollback_pending = None

--- a/almond_axol/serve/app.py
+++ b/almond_axol/serve/app.py
@@ -867,14 +867,16 @@ def create_app(static_dir: Path | None = None) -> FastAPI:
             for session in manager.list()
         )
 
-    def _is_idle() -> bool:
+    def _is_idle(*, ignore_cleanup_lockout: bool = False) -> bool:
         """Safe to hand host ownership to the updater: no operation running.
 
         A connected robot is fine -- the hosted transaction stops the service
         and the candidate reconnects after verification; only an in-flight
-        operation must not be interrupted.
+        operation must not be interrupted. ``ignore_cleanup_lockout`` is for
+        the callers that exist to *end* a hardware-cleanup lockout rather than
+        to start work behind it (see :func:`_host_power`).
         """
-        if runner.is_running():
+        if runner.is_running(ignore_cleanup_lockout=ignore_cleanup_lockout):
             return False
         return not _diagnostic_session_active()
 
@@ -1197,9 +1199,14 @@ def create_app(static_dir: Path | None = None) -> FastAPI:
         run would drop the arms. The hosted install runs as root; a dev serve
         escalates via ``sudo -n`` so a headless context fails fast instead of
         blocking on a password prompt.
+
+        A hardware-cleanup lockout does not refuse it: the lockout reserves the
+        robot's CAN buses until this process is gone, and restarting the host
+        is one of the two documented ways out of it (the other is
+        ``/api/op/clear-lockout``).
         """
         async with session_launch_reservation:
-            if not _is_idle():
+            if not _is_idle(ignore_cleanup_lockout=True):
                 return JSONResponse(
                     {"error": "an operation or session is running — stop it first"},
                     status_code=409,
@@ -2203,7 +2210,63 @@ def create_app(static_dir: Path | None = None) -> FastAPI:
             "running": runner.is_running(),
             "session": session.to_dict() if session else None,
             "policy": runner.policy_state(),
+            "lockout": runner.hardware_cleanup_lockout(),
         }
+
+    @app.post("/api/op/clear-lockout")
+    async def op_clear_lockout() -> JSONResponse:
+        """Lift the hardware-cleanup lockout once the motors read torque-free.
+
+        The lockout exists because an operation could not confirm it disabled
+        the motors, so nothing may reopen the CAN buses behind it. Cutting
+        motor power is exactly that case with the torque already gone, so this
+        proves it rather than assuming it: reacquire the idle link, ping every
+        motor, and only release the reservation when each one reads disabled or
+        does not answer at all. A motor that answers and is not disabled is
+        still holding torque nobody supervises, and keeps the lockout.
+        """
+        async with session_launch_reservation:
+            if not runner.hardware_cleanup_lockout():
+                return JSONResponse(
+                    {"error": "no hardware cleanup lockout is active"},
+                    status_code=409,
+                )
+            if runner.is_running(ignore_cleanup_lockout=True):
+                return JSONResponse(
+                    {"error": "an operation is still running — stop it first"},
+                    status_code=409,
+                )
+            try:
+                await asyncio.to_thread(robot.reacquire)
+                status = await asyncio.to_thread(robot.probe)
+            except RuntimeError as exc:
+                return JSONResponse(
+                    {
+                        "error": "could not reach the motors to prove they are "
+                        f"disabled; the lockout stands: {exc}"
+                    },
+                    status_code=409,
+                )
+            live = [
+                m
+                for m in status["motors"]
+                if m["reachable"] and m["status"] != "DISABLED"
+            ]
+            if live:
+                return JSONResponse(
+                    {
+                        "error": "these motors still answer and are not disabled, "
+                        "so the lockout stands: "
+                        + ", ".join(
+                            f"{m['arm']} {m['joint'].lower()}"
+                            f" ({str(m['status']).replace('_', ' ').lower()})"
+                            for m in live
+                        ),
+                    },
+                    status_code=409,
+                )
+            runner.clear_hardware_cleanup_lockout()
+            return JSONResponse({"cleared": True})
 
     @app.post("/api/op/start")
     async def op_start(req: OpStartRequest) -> JSONResponse:

--- a/almond_axol/serve/app.py
+++ b/almond_axol/serve/app.py
@@ -2247,10 +2247,13 @@ def create_app(static_dir: Path | None = None) -> FastAPI:
                     },
                     status_code=409,
                 )
+            # ``reachable is False`` is the proof this needs (the motor is
+            # unpowered); ``None`` means the probe produced no reading for it,
+            # which proves nothing and must keep the lockout.
             live = [
                 m
                 for m in status["motors"]
-                if m["reachable"] and m["status"] != "DISABLED"
+                if m["reachable"] is not False and m["status"] != "DISABLED"
             ]
             if live:
                 return JSONResponse(

--- a/almond_axol/serve/app.py
+++ b/almond_axol/serve/app.py
@@ -867,16 +867,23 @@ def create_app(static_dir: Path | None = None) -> FastAPI:
             for session in manager.list()
         )
 
-    def _is_idle(*, ignore_cleanup_lockout: bool = False) -> bool:
-        """Safe to hand host ownership to the updater: no operation running.
+    def _is_idle() -> bool:
+        """Safe to restart or power off the host: no operation running.
 
         A connected robot is fine -- the hosted transaction stops the service
         and the candidate reconnects after verification; only an in-flight
-        operation must not be interrupted. ``ignore_cleanup_lockout`` is for
-        the callers that exist to *end* a hardware-cleanup lockout rather than
-        to start work behind it (see :func:`_host_power`).
+        operation must not be interrupted.
+
+        A hardware-cleanup lockout does not make the host busy either. The
+        lockout reserves the robot's CAN buses for as long as *this process*
+        lives, and ending the process (host restart, shutdown, self-update) is
+        one of the two documented ways out of it. Every caller here -- the
+        updater's ``idle`` flag that the panel's host tile gates on, the update
+        itself, and :func:`_host_power` -- restarts the process rather than
+        starting work behind the lockout, which ``runner.is_running()`` still
+        refuses.
         """
-        if runner.is_running(ignore_cleanup_lockout=ignore_cleanup_lockout):
+        if runner.is_running(ignore_cleanup_lockout=True):
             return False
         return not _diagnostic_session_active()
 
@@ -1200,13 +1207,12 @@ def create_app(static_dir: Path | None = None) -> FastAPI:
         escalates via ``sudo -n`` so a headless context fails fast instead of
         blocking on a password prompt.
 
-        A hardware-cleanup lockout does not refuse it: the lockout reserves the
-        robot's CAN buses until this process is gone, and restarting the host
-        is one of the two documented ways out of it (the other is
-        ``/api/op/clear-lockout``).
+        A hardware-cleanup lockout does not refuse it (see :func:`_is_idle`):
+        restarting the host is one of the two documented ways out of it (the
+        other is ``/api/op/clear-lockout``).
         """
         async with session_launch_reservation:
-            if not _is_idle(ignore_cleanup_lockout=True):
+            if not _is_idle():
                 return JSONResponse(
                     {"error": "an operation or session is running — stop it first"},
                     status_code=409,

--- a/almond_axol/serve/app.py
+++ b/almond_axol/serve/app.py
@@ -2224,7 +2224,22 @@ def create_app(static_dir: Path | None = None) -> FastAPI:
         motor, and only release the reservation when each one reads disabled or
         does not answer at all. A motor that answers and is not disabled is
         still holding torque nobody supervises, and keeps the lockout.
+
+        The probe borrows the buses. While the lockout stands the failed
+        operation may still hold them, and the idle link is not meant to sit
+        on the same channels for longer than it takes to look: if the lockout
+        is refused, a link this call reconnected is handed back (``busy``)
+        exactly as it was before the probe.
         """
+
+        async def refuse(error: str, *, reacquired: bool) -> JSONResponse:
+            if reacquired:
+                try:
+                    await asyncio.to_thread(robot.release)
+                except RuntimeError as exc:
+                    error = f"{error}; also could not hand the buses back: {exc}"
+            return JSONResponse({"error": error}, status_code=409)
+
         async with session_launch_reservation:
             if not runner.hardware_cleanup_lockout():
                 return JSONResponse(
@@ -2236,16 +2251,15 @@ def create_app(static_dir: Path | None = None) -> FastAPI:
                     {"error": "an operation is still running — stop it first"},
                     status_code=409,
                 )
+            reacquired = False
             try:
-                await asyncio.to_thread(robot.reacquire)
+                reacquired = await asyncio.to_thread(robot.reacquire)
                 status = await asyncio.to_thread(robot.probe)
             except RuntimeError as exc:
-                return JSONResponse(
-                    {
-                        "error": "could not reach the motors to prove they are "
-                        f"disabled; the lockout stands: {exc}"
-                    },
-                    status_code=409,
+                return await refuse(
+                    "could not reach the motors to prove they are disabled; "
+                    f"the lockout stands: {exc}",
+                    reacquired=reacquired,
                 )
             # ``reachable is False`` is the proof this needs (the motor is
             # unpowered); ``None`` means the probe produced no reading for it,
@@ -2256,17 +2270,15 @@ def create_app(static_dir: Path | None = None) -> FastAPI:
                 if m["reachable"] is not False and m["status"] != "DISABLED"
             ]
             if live:
-                return JSONResponse(
-                    {
-                        "error": "these motors still answer and are not disabled, "
-                        "so the lockout stands: "
-                        + ", ".join(
-                            f"{m['arm']} {m['joint'].lower()}"
-                            f" ({str(m['status']).replace('_', ' ').lower()})"
-                            for m in live
-                        ),
-                    },
-                    status_code=409,
+                return await refuse(
+                    "these motors still answer and are not disabled, "
+                    "so the lockout stands: "
+                    + ", ".join(
+                        f"{m['arm']} {m['joint'].lower()}"
+                        f" ({str(m['status']).replace('_', ' ').lower()})"
+                        for m in live
+                    ),
+                    reacquired=reacquired,
                 )
             runner.clear_hardware_cleanup_lockout()
             return JSONResponse({"cleared": True})

--- a/almond_axol/serve/robot_link.py
+++ b/almond_axol/serve/robot_link.py
@@ -460,6 +460,19 @@ class RobotLink:
             raise RuntimeError(f"could not reacquire robot link: {exc}") from exc
         self._set_state(STATE_CONNECTED)
 
+    def probe(self) -> dict[str, Any]:
+        """Ping every motor now and return the resulting :meth:`status`.
+
+        The idle ping already refreshes health once a second; this forces one
+        sweep so a caller that must decide on *current* motor state (the
+        cleanup-lockout clear) never reads a snapshot from before it asked.
+        """
+        with self._lock:
+            if self._state != STATE_CONNECTED:
+                raise RuntimeError(f"robot link is {self._state}")
+        self._submit(self._ping_once())
+        return self.status()
+
     def motor_faults(self) -> list[dict[str, Any]]:
         """Current motor faults (see :func:`motor_faults`); [] when not connected."""
         return self.status()["faults"]
@@ -640,18 +653,22 @@ class RobotLink:
             if failures:
                 raise failures[0]
 
+    async def _ping_once(self) -> None:
+        """One health sweep of every arm, published to the hub."""
+        sweeps = await asyncio.gather(*(arm.ping() for arm in self._arms))
+        slow: dict[str, dict[str, Any]] = {}
+        for sweep in sweeps:
+            slow.update(sweep)
+        if slow:
+            self.hub.push_slow(slow)
+        with self._lock:
+            self._last_ping = time.time()
+
     async def _ping_loop(self) -> None:
         while True:
             start = self._loop.time()
             try:
-                sweeps = await asyncio.gather(*(arm.ping() for arm in self._arms))
-                slow: dict[str, dict[str, Any]] = {}
-                for sweep in sweeps:
-                    slow.update(sweep)
-                if slow:
-                    self.hub.push_slow(slow)
-                with self._lock:
-                    self._last_ping = time.time()
+                await self._ping_once()
             except asyncio.CancelledError:
                 raise
             except Exception as exc:  # noqa: BLE001 - keep the loop alive

--- a/almond_axol/serve/robot_link.py
+++ b/almond_axol/serve/robot_link.py
@@ -78,6 +78,10 @@ def motor_faults(
         return []
     faults: list[dict[str, Any]] = []
     for m in motors:
+        if m["reachable"] is None:
+            # Unknown while a task owns the bus — nothing was read, so there is
+            # nothing to fault on.
+            continue
         if not m["reachable"]:
             problem = "unreachable"
         elif m["status"] not in _HEALTHY_MOTOR_STATUSES:
@@ -432,6 +436,12 @@ class RobotLink:
 
         No-op unless currently connected. The prior state is remembered so
         :meth:`reacquire` only reconnects if the link was up before the task.
+
+        Once the buses are handed over the collected health is dropped: it
+        describes motors this link no longer reads, and keeping it would let
+        the panel show a motor as reachable at its pre-handover voltage for
+        the whole run — including after its power was cut mid-task. A release
+        that fails keeps it, since that link never gave the buses up.
         """
         with self._lock:
             if self._state != STATE_CONNECTED and not self._buses_may_be_open:
@@ -446,6 +456,9 @@ class RobotLink:
             self._set_state(STATE_ERROR, _format_error(exc))
             _logger.warning("robot release failed: %s", exc)
             raise RuntimeError(f"could not release robot link: {exc}") from exc
+        for arm in self._arms:
+            arm.health = {}
+        self.hub.clear_slow()
 
     def reacquire(self) -> None:
         """Re-open the buses + ping loop after a task releases the bus."""
@@ -544,17 +557,21 @@ class RobotLink:
         for arm in self._arms:
             for joint in joints:
                 h = arm.health.get(joint.name, {})
+                # No health at all means nobody is reading this motor (a task
+                # owns the bus): unknown, reported as null rather than as a
+                # reachable/unreachable claim this link cannot make.
+                reachable = h.get("reachable")
                 motors.append(
                     {
                         "arm": arm.side,
                         "joint": joint.name,
-                        "reachable": bool(h.get("reachable", False)),
+                        "reachable": None if reachable is None else bool(reachable),
                         "status": h.get("status"),
                         "temperature": h.get("temperature"),
                         "voltage": h.get("voltage"),
                     }
                 )
-        reachable = sum(1 for m in motors if m["reachable"])
+        reachable = sum(1 for m in motors if m["reachable"] is True)
         left_channel, right_channel = self.channels()
         return {
             "state": state,

--- a/almond_axol/serve/robot_link.py
+++ b/almond_axol/serve/robot_link.py
@@ -460,11 +460,16 @@ class RobotLink:
             arm.health = {}
         self.hub.clear_slow()
 
-    def reacquire(self) -> None:
-        """Re-open the buses + ping loop after a task releases the bus."""
+    def reacquire(self) -> bool:
+        """Re-open the buses + ping loop after a task releases the bus.
+
+        Returns ``True`` when this call reconnected, ``False`` when there was
+        nothing to reacquire (the link was not handed to a task), so a caller
+        that only borrowed the buses knows whether it has to give them back.
+        """
         with self._lock:
             if self._state != STATE_BUSY:
-                return
+                return False
         try:
             self._submit(self._open_and_start())
         except Exception as exc:  # noqa: BLE001
@@ -472,6 +477,7 @@ class RobotLink:
             _logger.warning("robot reacquire failed: %s", exc)
             raise RuntimeError(f"could not reacquire robot link: {exc}") from exc
         self._set_state(STATE_CONNECTED)
+        return True
 
     def probe(self) -> dict[str, Any]:
         """Ping every motor now and return the resulting :meth:`status`.

--- a/almond_axol/serve/runner.py
+++ b/almond_axol/serve/runner.py
@@ -39,8 +39,10 @@ import os
 import re
 import sys
 import threading
+import time
 from typing import Any
 
+from ..motor.bus import STALL_DETECT_S, stalled_channels
 from ..robot.base import HardwareCleanupError, is_hardware_cleanup_uncertain
 from ..zed import stereo_serials
 from .commands import flag_enabled, normalize_boolean_args
@@ -78,6 +80,15 @@ _FINALIZE_GRACE_S = 200.0
 # listening.
 _BRIDGE_READY_TIMEOUT_S = 35.0
 _BRIDGE_STOP_TIMEOUT_S = 4.0
+
+# Cadence of the bus-stall watchdog while a hardware operation runs. A stall
+# means motor power went away mid-run (the PSU is the operators' e-stop), which
+# the operation itself never notices: its motion commands are fire-and-forget.
+# The bus already needs STALL_DETECT_S of a non-draining TX queue to declare
+# the stall, and the same window is required again here before stopping, so a
+# stall that recovers on its own does not end a healthy run.
+_STALL_POLL_S = 0.25
+STALL_STOP_ERROR = "motor power lost"
 
 # Loggers whose records we never forward to the UI: webserver lifecycle,
 # access logs, low-level asyncio chatter. We still want the underlying ops'
@@ -746,6 +757,61 @@ class OperationRunner:
         )
         self._thread.start()
         return session
+
+    def _start_stall_watchdog(self, session: Session, needs_robot: bool) -> None:
+        """Watch the CAN buses for a power loss while this operation runs."""
+        if not needs_robot:
+            return
+        threading.Thread(
+            target=self._watch_bus_stall,
+            args=(session, self._stop_event),
+            name="axol-op-stall",
+            daemon=True,
+        ).start()
+
+    def _watch_bus_stall(self, session: Session, stop_event: threading.Event) -> None:
+        """Stop the operation when its CAN buses stay stalled: motor power is gone.
+
+        The operation drives the arms with fire-and-forget motion commands, so
+        losing motor power mid-run leaves it happily commanding a dead bus with
+        the panel still showing it as running. The buses themselves already
+        classify that (``stalled_channels``); this turns it into the Stop the
+        operator would otherwise have to ask for, and marks the session with
+        why it ended.
+        """
+        # Only a stall that begins during this run belongs to it. A channel
+        # already stalled at launch was left that way by an earlier owner
+        # (an abandoned worker that never closed its bus), and stopping this
+        # operation would not fix it.
+        inherited = stalled_channels()
+        stalled_since: float | None = None
+        while not stop_event.wait(_STALL_POLL_S):
+            if self._session is not session or session.status not in (
+                "starting",
+                "running",
+            ):
+                return
+            current = stalled_channels()
+            # A channel that recovered stops being inherited, so if it stalls
+            # again that stall did begin during this run.
+            inherited &= current
+            if not current - inherited:
+                stalled_since = None
+                continue
+            now = time.monotonic()
+            if stalled_since is None:
+                stalled_since = now
+            elif now - stalled_since >= STALL_DETECT_S:
+                session.emit(
+                    "[serve] motor power lost — no motor is answering on the CAN "
+                    "bus; stopping the operation"
+                )
+                _logger.warning(
+                    "motor power lost during %s; stopping", session.command_id
+                )
+                self.stop()
+                self._mark_terminal(session, "error", error=STALL_STOP_ERROR)
+                return
 
     def stop(self) -> Session | None:
         """Begin stopping the current op and return immediately.
@@ -1436,6 +1502,7 @@ class OperationRunner:
             await core(cfg)
 
         cleanup_uncertain = False
+        self._start_stall_watchdog(session, needs_robot)
         with _Capture(session, log_level):
             try:
                 if manage_bridge:
@@ -1484,6 +1551,7 @@ class OperationRunner:
 
         cmd = COMMANDS[op_id]
         cleanup_uncertain = False
+        self._start_stall_watchdog(session, needs_robot)
         with _Capture(session, log_level):
             try:
                 if manage_bridge:

--- a/almond_axol/serve/runner.py
+++ b/almond_axol/serve/runner.py
@@ -454,8 +454,11 @@ class OperationRunner:
         self._episode_control: Any = None
         # A command reported that its hardware disconnect/disable did not
         # complete.  The command may still own one or both CAN buses, so no
-        # later operation may start and the idle RobotLink must not reacquire
-        # them.  Only restarting the serve process can re-establish ownership.
+        # later operation may start and the idle RobotLink does not reacquire
+        # them on its own.  Two ways out: restarting the serve process, or
+        # ``/api/op/clear-lockout``, which borrows the buses just long enough
+        # to prove every motor is torque-free (disabled or unpowered) and
+        # hands them back if it cannot (see clear_hardware_cleanup_lockout).
         self._hardware_cleanup_uncertain = False
 
     # -- lookup / subscribe (mirrors SessionManager so app.py can reuse it) --

--- a/almond_axol/serve/runner.py
+++ b/almond_axol/serve/runner.py
@@ -464,7 +464,7 @@ class OperationRunner:
     def unsubscribe(self, session: Session, q: "asyncio.Queue[str | None]") -> None:
         session.subscribers.discard(q)
 
-    def is_running(self) -> bool:
+    def is_running(self, *, ignore_cleanup_lockout: bool = False) -> bool:
         # "stopping" still counts as running: the op owns the CAN bus until its
         # worker thread unwinds, so a new op must not start until it's gone.
         # An exception records the terminal error before the worker finishes
@@ -482,12 +482,24 @@ class OperationRunner:
         # In particular, Process.start() may fail after partially creating the
         # child, and multiprocessing rejects is_alive() on an unstarted object.
         bridge_owned = self._bridge_process is not None
-        return (
-            active_status
-            or worker_alive
-            or bridge_owned
-            or self._hardware_cleanup_uncertain
-        )
+        # The lockout reserves the robot, not the host: the operations that
+        # exist to end it — host power, and the lockout clear itself — pass
+        # ``ignore_cleanup_lockout`` so they see only live work.
+        locked_out = self._hardware_cleanup_uncertain and not ignore_cleanup_lockout
+        return active_status or worker_alive or bridge_owned or locked_out
+
+    def hardware_cleanup_lockout(self) -> bool:
+        """Whether an unverified hardware teardown is still reserving the robot."""
+        return self._hardware_cleanup_uncertain
+
+    def clear_hardware_cleanup_lockout(self) -> None:
+        """Release the lockout once the motors have been proven torque-free.
+
+        The caller owns that proof (see the ``/api/op/clear-lockout`` probe);
+        this only drops the reservation the failed teardown left behind.
+        """
+        with self._lock:
+            self._hardware_cleanup_uncertain = False
 
     # -- lifecycle ----------------------------------------------------------
 

--- a/tests/test_lift.py
+++ b/tests/test_lift.py
@@ -266,6 +266,7 @@ class LiftStatusModeTest(unittest.IsolatedAsyncioTestCase):
         reader_task = asyncio.create_task(reader())
         socket = SimpleNamespace(shutdown=Mock())
         bus = object.__new__(CanBus)
+        bus._channel = "can_alm_lift"
         bus._reader_task = reader_task
         bus._bus = socket
 
@@ -294,6 +295,7 @@ class LiftStatusModeTest(unittest.IsolatedAsyncioTestCase):
         lift._task = asyncio.create_task(command_task())
         socket = SimpleNamespace(send=Mock(), shutdown=Mock())
         bus = object.__new__(CanBus)
+        bus._channel = "can_alm_lift"
         bus._reader_task = asyncio.create_task(asyncio.Event().wait())
         bus._bus = socket
         bus._lost = False

--- a/tests/test_motion_command_safety.py
+++ b/tests/test_motion_command_safety.py
@@ -176,8 +176,8 @@ class MotionCommandSafetyTest(unittest.IsolatedAsyncioTestCase):
         robot.right = right
         robot._shutdown_pending = False
         robot._motors_disabled = True
-        robot._left_bus = SimpleNamespace(close=AsyncMock())
-        robot._right_bus = SimpleNamespace(close=AsyncMock())
+        robot._left_bus = SimpleNamespace(close=AsyncMock(), stalled=False)
+        robot._right_bus = SimpleNamespace(close=AsyncMock(), stalled=False)
 
         with self.assertRaisesRegex(RuntimeError, "right arm enable failed") as raised:
             await robot.enable()
@@ -229,8 +229,8 @@ class MotionCommandSafetyTest(unittest.IsolatedAsyncioTestCase):
         robot = object.__new__(Axol)
         robot.left = left
         robot.right = right
-        robot._left_bus = SimpleNamespace(close=AsyncMock())
-        robot._right_bus = SimpleNamespace(close=AsyncMock())
+        robot._left_bus = SimpleNamespace(close=AsyncMock(), stalled=False)
+        robot._right_bus = SimpleNamespace(close=AsyncMock(), stalled=False)
         robot._shutdown_pending = True
         robot._motors_disabled = False
         robot._startup_rollback_pending = [("left.wrist_2", cold_motor)]
@@ -287,8 +287,8 @@ class MotionCommandSafetyTest(unittest.IsolatedAsyncioTestCase):
         robot.connect = AsyncMock()
         robot.left = left
         robot.right = right
-        robot._left_bus = SimpleNamespace(close=AsyncMock())
-        robot._right_bus = SimpleNamespace(close=AsyncMock())
+        robot._left_bus = SimpleNamespace(close=AsyncMock(), stalled=False)
+        robot._right_bus = SimpleNamespace(close=AsyncMock(), stalled=False)
         robot._shutdown_pending = False
         robot._motors_disabled = False
         robot._startup_rollback_pending = None
@@ -339,8 +339,8 @@ class MotionCommandSafetyTest(unittest.IsolatedAsyncioTestCase):
         robot.connect = AsyncMock()
         robot.left = left
         robot.right = right
-        robot._left_bus = SimpleNamespace(close=AsyncMock())
-        robot._right_bus = SimpleNamespace(close=AsyncMock())
+        robot._left_bus = SimpleNamespace(close=AsyncMock(), stalled=False)
+        robot._right_bus = SimpleNamespace(close=AsyncMock(), stalled=False)
         robot._shutdown_pending = False
         robot._motors_disabled = False
         robot._startup_rollback_pending = None
@@ -375,8 +375,8 @@ class MotionCommandSafetyTest(unittest.IsolatedAsyncioTestCase):
         robot = object.__new__(Axol)
         robot.left = left
         robot.right = right
-        robot._left_bus = SimpleNamespace(close=AsyncMock())
-        robot._right_bus = SimpleNamespace(close=AsyncMock())
+        robot._left_bus = SimpleNamespace(close=AsyncMock(), stalled=False)
+        robot._right_bus = SimpleNamespace(close=AsyncMock(), stalled=False)
         robot._shutdown_pending = True
         robot._motors_disabled = False
         robot._startup_rollback_pending = [("left.wrist_2", cold_motor)]
@@ -470,8 +470,8 @@ class MotionCommandSafetyTest(unittest.IsolatedAsyncioTestCase):
         robot._shutdown_pending = False
         robot.left = SimpleNamespace(stop_telemetry=fail_stop)
         robot.right = SimpleNamespace(stop_telemetry=blocked_stop)
-        robot._left_bus = SimpleNamespace(close=AsyncMock())
-        robot._right_bus = SimpleNamespace(close=AsyncMock())
+        robot._left_bus = SimpleNamespace(close=AsyncMock(), stalled=False)
+        robot._right_bus = SimpleNamespace(close=AsyncMock(), stalled=False)
 
         task = asyncio.create_task(robot.disconnect())
         await sibling_started.wait()
@@ -944,8 +944,8 @@ class MotionCommandSafetyTest(unittest.IsolatedAsyncioTestCase):
             )
             for index in range(4)
         ]
-        bus = SimpleNamespace(close=AsyncMock())
-        lift = SimpleNamespace(close=AsyncMock())
+        bus = SimpleNamespace(close=AsyncMock(), stalled=False)
+        lift = SimpleNamespace(close=AsyncMock(), stalled=False)
         cart = Cart(CartConfig(lift=False))
         cart._motors = motors
         cart._bus = bus
@@ -1035,8 +1035,10 @@ class MotionCommandSafetyTest(unittest.IsolatedAsyncioTestCase):
             disable=AsyncMock(side_effect=[disable_error, None]),
         )
         right = SimpleNamespace(stop_telemetry=AsyncMock(), disable=AsyncMock())
-        left_bus = SimpleNamespace(close=AsyncMock())
-        right_bus = SimpleNamespace(close=AsyncMock())
+        # Unstalled buses: the failed disable is a live motor refusing, not a
+        # power cut, so disable() must not excuse it as unpowered.
+        left_bus = SimpleNamespace(close=AsyncMock(), stalled=False)
+        right_bus = SimpleNamespace(close=AsyncMock(), stalled=False)
         robot = object.__new__(Axol)
         robot.left = left
         robot.right = right
@@ -1068,7 +1070,7 @@ class MotionCommandSafetyTest(unittest.IsolatedAsyncioTestCase):
         left = SimpleNamespace(stop_telemetry=AsyncMock(), disable=AsyncMock())
         right = SimpleNamespace(stop_telemetry=AsyncMock(), disable=AsyncMock())
         left_bus = SimpleNamespace(close=AsyncMock(side_effect=[close_error, None]))
-        right_bus = SimpleNamespace(close=AsyncMock())
+        right_bus = SimpleNamespace(close=AsyncMock(), stalled=False)
         robot = object.__new__(Axol)
         robot.left = left
         robot.right = right
@@ -1145,8 +1147,8 @@ class MotionCommandSafetyTest(unittest.IsolatedAsyncioTestCase):
             disable=AsyncMock(),
         )
         right = SimpleNamespace(force_disable=AsyncMock(), disable=AsyncMock())
-        left_bus = SimpleNamespace(close=AsyncMock())
-        right_bus = SimpleNamespace(close=AsyncMock())
+        left_bus = SimpleNamespace(close=AsyncMock(), stalled=False)
+        right_bus = SimpleNamespace(close=AsyncMock(), stalled=False)
         robot = object.__new__(Mantis)
         robot.left = left
         robot.right = right
@@ -1283,7 +1285,7 @@ class MotionCommandSafetyTest(unittest.IsolatedAsyncioTestCase):
         left_bus = SimpleNamespace(
             close=AsyncMock(side_effect=[close_error, None]),
         )
-        right_bus = SimpleNamespace(close=AsyncMock())
+        right_bus = SimpleNamespace(close=AsyncMock(), stalled=False)
         robot = object.__new__(Mantis)
         robot.left = left
         robot.right = right

--- a/tests/test_power_loss.py
+++ b/tests/test_power_loss.py
@@ -19,7 +19,7 @@ import can
 import httpx
 
 from almond_axol.motor import CanBus, MotorError, MotorStatus
-from almond_axol.motor.bus import _tx_queue_full
+from almond_axol.motor.bus import _flush_lock_for_running_loop, _tx_queue_full
 from almond_axol.robot.axol import Axol
 from almond_axol.robot.base import HardwareCleanupError
 from almond_axol.serve import app as app_module
@@ -148,6 +148,49 @@ class TxQueueFullClassificationTest(unittest.TestCase):
     def test_unrelated_can_errors_are_left_alone(self) -> None:
         self.assertFalse(_tx_queue_full(can.CanOperationError("Failed to transmit")))
         self.assertFalse(_tx_queue_full(OSError(errno.ENODEV, "No such device")))
+
+
+class FlushLockLoopAffinityTest(unittest.TestCase):
+    """The flush lock must not outlive the loop that took it.
+
+    A bus is owned by an operation's loop while it holds the arms and by the
+    idle link's loop afterwards. A single module-level ``asyncio.Lock`` binds
+    to the first of those and then rejects the second, which strands every
+    later reconnect behind "bound to a different event loop".
+    """
+
+    def test_each_loop_gets_its_own_lock(self) -> None:
+        async def take() -> asyncio.Lock:
+            lock = _flush_lock_for_running_loop()
+            async with lock:
+                return lock
+
+        first = asyncio.run(take())
+        second = asyncio.run(take())
+
+        self.assertIsNot(first, second)
+
+    def test_the_same_loop_reuses_one_lock(self) -> None:
+        async def take_twice() -> tuple[asyncio.Lock, asyncio.Lock]:
+            return _flush_lock_for_running_loop(), _flush_lock_for_running_loop()
+
+        first, second = asyncio.run(take_twice())
+
+        self.assertIs(first, second)
+
+    def test_a_dead_loop_does_not_strand_the_next_one(self) -> None:
+        # Acquire without releasing, exactly as a loop torn down mid-flush
+        # leaves it, then prove a fresh loop can still flush.
+        async def acquire_and_abandon() -> None:
+            await _flush_lock_for_running_loop().acquire()
+
+        asyncio.run(acquire_and_abandon())
+
+        async def flush_again() -> bool:
+            async with _flush_lock_for_running_loop():
+                return True
+
+        self.assertTrue(asyncio.run(flush_again()))
 
 
 class _LockedOutLink:

--- a/tests/test_power_loss.py
+++ b/tests/test_power_loss.py
@@ -7,6 +7,7 @@ must do when that happens while an operation owns the CAN buses.
 from __future__ import annotations
 
 import asyncio
+import errno
 import threading
 import time
 import unittest
@@ -14,9 +15,11 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import patch
 
+import can
 import httpx
 
 from almond_axol.motor import CanBus, MotorError, MotorStatus
+from almond_axol.motor.bus import _tx_queue_full
 from almond_axol.robot.axol import Axol
 from almond_axol.robot.base import HardwareCleanupError
 from almond_axol.serve import app as app_module
@@ -119,6 +122,32 @@ class DisableClassificationTest(unittest.IsolatedAsyncioTestCase):
 
         # Both buses stay open: the failure has to remain retryable.
         self.assertFalse(any(bus.closed for bus in buses))
+
+
+class TxQueueFullClassificationTest(unittest.TestCase):
+    """Both shapes python-can gives a full TX queue must be recognised.
+
+    Missing either one re-raises out of ``CanBus._send`` instead of dropping
+    the frame, so the command never times out upstream as a ``MotorError`` and
+    the bus never accumulates the overflow that declares the stall — which
+    takes the watchdog and the unpowered classification down with it.
+    """
+
+    def test_errno_form_is_recognised(self) -> None:
+        exc = can.CanOperationError("send failed", error_code=errno.ENOBUFS)
+
+        self.assertTrue(_tx_queue_full(exc))
+
+    def test_message_only_form_is_recognised(self) -> None:
+        # python-can's SocketCAN backend raises exactly this, with no errno,
+        # after retrying a partial write for its send timeout.
+        exc = can.CanOperationError("Transmit buffer full")
+
+        self.assertTrue(_tx_queue_full(exc))
+
+    def test_unrelated_can_errors_are_left_alone(self) -> None:
+        self.assertFalse(_tx_queue_full(can.CanOperationError("Failed to transmit")))
+        self.assertFalse(_tx_queue_full(OSError(errno.ENODEV, "No such device")))
 
 
 class _LockedOutLink:

--- a/tests/test_power_loss.py
+++ b/tests/test_power_loss.py
@@ -38,11 +38,17 @@ from .test_serve_session_reservation import _Manager, _Settings, _Updater
 
 
 class _FakeBus:
-    """Stands in for the SocketCAN transport: no socket, just open/closed."""
+    """Stands in for the SocketCAN transport: no socket, just open/closed.
+
+    ``stalled`` mirrors :attr:`CanBus.stalled`: the bus has seen its TX queue
+    stop draining because no node ACKs (motor power gone). A bus whose
+    interface merely dropped off USB times out the same way without it.
+    """
 
     def __init__(self, channel: str) -> None:
         self.channel = channel
         self.closed = False
+        self.stalled = False
 
     async def start(self) -> None:
         pass
@@ -105,6 +111,8 @@ def _axol_with_drivers(driver_for: Any) -> tuple[Axol, list[_FakeBus]]:
 class DisableClassificationTest(unittest.IsolatedAsyncioTestCase):
     async def test_unpowered_arms_leave_no_cleanup_uncertainty(self) -> None:
         axol, buses = _axol_with_drivers(lambda _channel: _FakeDriver(powered=False))
+        for bus in buses:
+            bus.stalled = True
 
         await axol.disable()
 
@@ -116,11 +124,24 @@ class DisableClassificationTest(unittest.IsolatedAsyncioTestCase):
             "can-right": lambda: _FakeDriver(accepts_disable=False),
         }
         axol, buses = _axol_with_drivers(lambda channel: drivers[channel]())
+        for bus in buses:
+            bus.stalled = True
 
         with self.assertRaises(MotorError):
             await axol.disable()
 
         # Both buses stay open: the failure has to remain retryable.
+        self.assertFalse(any(bus.closed for bus in buses))
+
+    async def test_silent_motors_on_an_unstalled_bus_still_raise(self) -> None:
+        # Every read times out but the bus never declared a stall: that is the
+        # CAN interface dropping off USB, not motor power going away. The
+        # motors may still be holding torque, so this must stay uncertain.
+        axol, buses = _axol_with_drivers(lambda _channel: _FakeDriver(powered=False))
+
+        with self.assertRaises(MotorError):
+            await axol.disable()
+
         self.assertFalse(any(bus.closed for bus in buses))
 
 

--- a/tests/test_power_loss.py
+++ b/tests/test_power_loss.py
@@ -338,17 +338,32 @@ class LockoutExemptionTest(unittest.IsolatedAsyncioTestCase):
     async def _client(
         self, runner: OperationRunner, robot: _LockedOutLink
     ) -> httpx.AsyncClient:
-        updater = _Updater(lambda: True)
+        client, _updater = await self._client_and_updater(runner, robot)
+        return client
+
+    async def _client_and_updater(
+        self, runner: OperationRunner, robot: _LockedOutLink
+    ) -> tuple[httpx.AsyncClient, _Updater]:
+        """The API client plus the updater double built with the app's real
+        ``_is_idle``, which is what the panel's host tile gates on."""
+        updaters: list[_Updater] = []
+
+        def make_updater(is_idle: Any) -> _Updater:
+            updater = _Updater(is_idle)
+            updaters.append(updater)
+            return updater
+
         with (
             patch.object(app_module, "SessionManager", return_value=_Manager()),
             patch.object(app_module, "OperationRunner", return_value=runner),
             patch.object(app_module, "SettingsStore", return_value=_Settings()),
             patch.object(app_module, "RobotLink", return_value=robot),
-            patch.object(app_module, "SelfUpdater", return_value=updater),
+            patch.object(app_module, "SelfUpdater", side_effect=make_updater),
         ):
             app = app_module.create_app()
         transport = httpx.ASGITransport(app=app)
-        return httpx.AsyncClient(transport=transport, base_url="http://test")
+        (updater,) = updaters
+        return httpx.AsyncClient(transport=transport, base_url="http://test"), updater
 
     async def test_host_restart_is_offered_while_the_lockout_holds(self) -> None:
         robot = _LockedOutLink([_motor("SHOULDER_1", reachable=False, status=None)])
@@ -363,6 +378,20 @@ class LockoutExemptionTest(unittest.IsolatedAsyncioTestCase):
                 response = await client.post("/api/host/restart")
 
         self.assertEqual(response.status_code, 200)
+
+    async def test_host_reads_idle_while_the_lockout_holds(self) -> None:
+        # The panel disables the Restart / Shutdown confirmation on
+        # ``update.idle``. The lockout reserves the robot, not the host, and
+        # ending the process is a documented way out of it, so the host must
+        # not read busy or the API exemption above is unreachable from the UI.
+        robot = _LockedOutLink([_motor("SHOULDER_1", reachable=False, status=None)])
+        runner = self._locked_out_runner(robot)
+
+        client, updater = await self._client_and_updater(runner, robot)
+        async with client:
+            self.assertTrue(updater._is_idle())
+        # The lockout still reserves the robot; only the host is free.
+        self.assertTrue(runner.is_running())
 
     async def test_clear_lockout_refuses_while_a_motor_still_answers(self) -> None:
         robot = _LockedOutLink(

--- a/tests/test_power_loss.py
+++ b/tests/test_power_loss.py
@@ -221,6 +221,7 @@ class _LockedOutLink:
         self._motors = motors
         self.state = STATE_BUSY
         self.reacquires = 0
+        self.releases = 0
         self.probes = 0
 
     def profile(self) -> str:
@@ -240,9 +241,12 @@ class _LockedOutLink:
             "motors": self._motors,
         }
 
-    def reacquire(self) -> None:
+    def reacquire(self) -> bool:
+        if self.state != STATE_BUSY:
+            return False
         self.reacquires += 1
         self.state = STATE_CONNECTED
+        return True
 
     def probe(self) -> dict[str, Any]:
         self.probes += 1
@@ -251,6 +255,7 @@ class _LockedOutLink:
         return self.status()
 
     def release(self) -> None:
+        self.releases += 1
         self.state = STATE_BUSY
 
     def motor_faults(self) -> list[dict[str, Any]]:
@@ -349,6 +354,27 @@ class LockoutExemptionTest(unittest.IsolatedAsyncioTestCase):
         self.assertIn("wrist_2", response.json()["error"])
         self.assertTrue(runner.hardware_cleanup_lockout())
         self.assertTrue(runner.is_running())
+        # The probe only borrowed the buses: a refused lockout hands them back
+        # so the idle link is not left sitting on channels the failed
+        # operation may still hold.
+        self.assertEqual(robot.reacquires, 1)
+        self.assertEqual(robot.releases, 1)
+        self.assertEqual(robot.state, STATE_BUSY)
+
+    async def test_clear_lockout_keeps_a_link_it_did_not_reconnect(self) -> None:
+        # The operator connected the panel themselves before asking; a refusal
+        # must not yank that connection away.
+        robot = _LockedOutLink([_motor("WRIST_2", reachable=True, status="OK")])
+        robot.state = STATE_CONNECTED
+        runner = self._locked_out_runner(robot)
+
+        async with await self._client(runner, robot) as client:
+            response = await client.post("/api/op/clear-lockout")
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(robot.reacquires, 0)
+        self.assertEqual(robot.releases, 0)
+        self.assertEqual(robot.state, STATE_CONNECTED)
 
     async def test_clear_lockout_releases_once_every_motor_is_silent(self) -> None:
         robot = _LockedOutLink(
@@ -377,6 +403,8 @@ class LockoutExemptionTest(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(response.status_code, 409)
         self.assertTrue(runner.hardware_cleanup_lockout())
+        self.assertEqual(robot.releases, 1)
+        self.assertEqual(robot.state, STATE_BUSY)
 
 
 class BusStallWatchdogTest(unittest.TestCase):

--- a/tests/test_power_loss.py
+++ b/tests/test_power_loss.py
@@ -19,7 +19,11 @@ import can
 import httpx
 
 from almond_axol.motor import CanBus, MotorError, MotorStatus
-from almond_axol.motor.bus import _flush_lock_for_running_loop, _tx_queue_full
+from almond_axol.motor.bus import (
+    _flush_lock_for_running_loop,
+    _tx_queue_full,
+    stalled_channels,
+)
 from almond_axol.robot.axol import Axol
 from almond_axol.robot.base import HardwareCleanupError
 from almond_axol.serve import app as app_module
@@ -143,6 +147,28 @@ class DisableClassificationTest(unittest.IsolatedAsyncioTestCase):
             await axol.disable()
 
         self.assertFalse(any(bus.closed for bus in buses))
+
+
+class FreshBusStallFlagTest(unittest.TestCase):
+    def test_opening_a_bus_clears_a_stale_stall_on_its_channel(self) -> None:
+        # A bus abandoned open on a dead loop (a failed teardown that kept its
+        # buses) never clears its stall. The next bus on that channel is the
+        # one whose state matters, and it has seen no stall yet.
+        stale = object.__new__(CanBus)
+        stale._channel = "can-stale-test"
+        stale._stalled = False
+        stale._lost = False
+        stale._wake = asyncio.Event()
+        stale._mark_stalled(OSError("ENOBUFS"))
+        self.addCleanup(lambda: asyncio.run(_discard_stall(stale)))
+        self.assertIn("can-stale-test", stalled_channels())
+
+        with patch("almond_axol.motor.bus.can.Bus"):
+            fresh = CanBus("can-stale-test")
+
+        self.assertNotIn("can-stale-test", stalled_channels())
+        self.assertFalse(fresh.stalled)
+        self.assertEqual(fresh.channel, "can-stale-test")
 
 
 class TxQueueFullClassificationTest(unittest.TestCase):

--- a/tests/test_power_loss.py
+++ b/tests/test_power_loss.py
@@ -1,0 +1,456 @@
+"""Losing motor power mid-operation: classification, lockout, watchdog, telemetry.
+
+Operators cut the motor PSU as an e-stop. Everything here covers what the stack
+must do when that happens while an operation owns the CAN buses.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+import unittest
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+
+from almond_axol.motor import CanBus, MotorError, MotorStatus
+from almond_axol.robot.axol import Axol
+from almond_axol.robot.base import HardwareCleanupError
+from almond_axol.serve import app as app_module
+from almond_axol.serve.manager import Session
+from almond_axol.serve.robot_link import (
+    STATE_BUSY,
+    STATE_CONNECTED,
+    RobotLink,
+    motor_faults,
+)
+from almond_axol.serve.runner import STALL_STOP_ERROR, OperationRunner
+
+# The serve API doubles (settings store, session manager, updater) already exist
+# for the reservation tests; reuse them rather than growing a second set.
+from .test_serve_session_reservation import _Manager, _Settings, _Updater
+
+
+class _FakeBus:
+    """Stands in for the SocketCAN transport: no socket, just open/closed."""
+
+    def __init__(self, channel: str) -> None:
+        self.channel = channel
+        self.closed = False
+
+    async def start(self) -> None:
+        pass
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _FakeDriver:
+    """One motor at the CAN protocol boundary, powered or not.
+
+    An unpowered motor answers nothing, exactly like a driver whose request
+    frames time out; a powered one answers reads and reports whether it took
+    the disable command.
+    """
+
+    def __init__(self, *, powered: bool = True, accepts_disable: bool = True) -> None:
+        self.powered = powered
+        self.accepts_disable = accepts_disable
+        self.disable_calls = 0
+
+    def set_feedback_callback(self, _callback: Any) -> None:
+        pass
+
+    def _answer(self) -> None:
+        if not self.powered:
+            raise MotorError("motor did not answer")
+
+    async def disable(self) -> None:
+        self.disable_calls += 1
+        self._answer()
+        if not self.accepts_disable:
+            raise MotorError("motor did not confirm disabled")
+
+    async def get_error_code(self) -> MotorStatus:
+        self._answer()
+        return MotorStatus.OK
+
+
+def _axol_with_drivers(driver_for: Any) -> tuple[Axol, list[_FakeBus]]:
+    """Build an Axol whose motors are ``driver_for(channel)`` fakes."""
+    buses: list[_FakeBus] = []
+
+    def make_bus(channel: str) -> _FakeBus:
+        bus = _FakeBus(channel)
+        buses.append(bus)
+        return bus
+
+    with (
+        patch("almond_axol.robot.axol.CanBus", side_effect=make_bus),
+        patch(
+            "almond_axol.motor.motor.make_driver",
+            side_effect=lambda bus, *_args, **_kwargs: driver_for(bus.channel),
+        ),
+    ):
+        axol = Axol(left_channel="can-left", right_channel="can-right")
+    return axol, buses
+
+
+class DisableClassificationTest(unittest.IsolatedAsyncioTestCase):
+    async def test_unpowered_arms_leave_no_cleanup_uncertainty(self) -> None:
+        axol, buses = _axol_with_drivers(lambda _channel: _FakeDriver(powered=False))
+
+        await axol.disable()
+
+        self.assertTrue(all(bus.closed for bus in buses))
+
+    async def test_reachable_motor_that_will_not_disable_still_raises(self) -> None:
+        drivers = {
+            "can-left": lambda: _FakeDriver(powered=False),
+            "can-right": lambda: _FakeDriver(accepts_disable=False),
+        }
+        axol, buses = _axol_with_drivers(lambda channel: drivers[channel]())
+
+        with self.assertRaises(MotorError):
+            await axol.disable()
+
+        # Both buses stay open: the failure has to remain retryable.
+        self.assertFalse(any(bus.closed for bus in buses))
+
+
+class _LockedOutLink:
+    """Robot link whose motors read as *motors* say after a task released it."""
+
+    def __init__(self, motors: list[dict[str, Any]]) -> None:
+        self._motors = motors
+        self.state = STATE_BUSY
+        self.reacquires = 0
+        self.probes = 0
+
+    def profile(self) -> str:
+        return "axol"
+
+    def channels(self) -> tuple[str | None, str | None]:
+        return "can-left", "can-right"
+
+    def status(self) -> dict[str, Any]:
+        return {
+            "state": self.state,
+            "connected": self.state in (STATE_CONNECTED, STATE_BUSY),
+            "lastPing": time.time(),
+            "channels": {"left": "can-left", "right": "can-right"},
+            "profile": "axol",
+            "hasGripper": True,
+            "motors": self._motors,
+        }
+
+    def reacquire(self) -> None:
+        self.reacquires += 1
+        self.state = STATE_CONNECTED
+
+    def probe(self) -> dict[str, Any]:
+        self.probes += 1
+        if self.state != STATE_CONNECTED:
+            raise RuntimeError(f"robot link is {self.state}")
+        return self.status()
+
+    def release(self) -> None:
+        self.state = STATE_BUSY
+
+    def motor_faults(self) -> list[dict[str, Any]]:
+        return []
+
+    def shutdown(self) -> None:
+        pass
+
+
+def _motor(joint: str, *, reachable: bool | None, status: str | None) -> dict[str, Any]:
+    return {
+        "arm": "left",
+        "joint": joint,
+        "reachable": reachable,
+        "status": status,
+        "temperature": None,
+        "voltage": None,
+    }
+
+
+class LockoutExemptionTest(unittest.IsolatedAsyncioTestCase):
+    def _locked_out_runner(self, robot: _LockedOutLink) -> OperationRunner:
+        """A runner whose last operation failed to confirm its torque-off."""
+        from almond_axol.serve.commands import COMMANDS
+
+        def fail(_cfg: Any, *, stop_event: threading.Event) -> None:
+            del stop_event
+            raise HardwareCleanupError("robot disable failed")
+
+        runner = OperationRunner(robot_link=robot)
+        session = Session("cleanup-test", {})
+        session.status = "running"
+        runner._session = session
+        command = SimpleNamespace(
+            load_entrypoint=lambda: fail,
+            load_episode_control=lambda: None,
+        )
+        with (
+            patch.dict(COMMANDS, {"cleanup-test": command}),
+            patch("almond_axol.serve.runner._Capture") as capture,
+        ):
+            capture.return_value.__enter__.return_value = None
+            runner._run_thread(
+                session,
+                "cleanup-test",
+                SimpleNamespace(),
+                20,
+                needs_robot=True,
+                manage_bridge=False,
+            )
+        self.assertTrue(runner.hardware_cleanup_lockout())
+        return runner
+
+    async def _client(
+        self, runner: OperationRunner, robot: _LockedOutLink
+    ) -> httpx.AsyncClient:
+        updater = _Updater(lambda: True)
+        with (
+            patch.object(app_module, "SessionManager", return_value=_Manager()),
+            patch.object(app_module, "OperationRunner", return_value=runner),
+            patch.object(app_module, "SettingsStore", return_value=_Settings()),
+            patch.object(app_module, "RobotLink", return_value=robot),
+            patch.object(app_module, "SelfUpdater", return_value=updater),
+        ):
+            app = app_module.create_app()
+        transport = httpx.ASGITransport(app=app)
+        return httpx.AsyncClient(transport=transport, base_url="http://test")
+
+    async def test_host_restart_is_offered_while_the_lockout_holds(self) -> None:
+        robot = _LockedOutLink([_motor("SHOULDER_1", reachable=False, status=None)])
+        runner = self._locked_out_runner(robot)
+        completed = SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        async with await self._client(runner, robot) as client:
+            with (
+                patch.object(app_module.os, "geteuid", return_value=0),
+                patch.object(app_module.subprocess, "run", return_value=completed),
+            ):
+                response = await client.post("/api/host/restart")
+
+        self.assertEqual(response.status_code, 200)
+
+    async def test_clear_lockout_refuses_while_a_motor_still_answers(self) -> None:
+        robot = _LockedOutLink(
+            [
+                _motor("SHOULDER_1", reachable=False, status=None),
+                _motor("WRIST_2", reachable=True, status="OK"),
+            ]
+        )
+        runner = self._locked_out_runner(robot)
+
+        async with await self._client(runner, robot) as client:
+            response = await client.post("/api/op/clear-lockout")
+
+        self.assertEqual(response.status_code, 409)
+        self.assertIn("wrist_2", response.json()["error"])
+        self.assertTrue(runner.hardware_cleanup_lockout())
+        self.assertTrue(runner.is_running())
+
+    async def test_clear_lockout_releases_once_every_motor_is_silent(self) -> None:
+        robot = _LockedOutLink(
+            [
+                _motor("SHOULDER_1", reachable=False, status=None),
+                _motor("WRIST_2", reachable=True, status="DISABLED"),
+            ]
+        )
+        runner = self._locked_out_runner(robot)
+
+        async with await self._client(runner, robot) as client:
+            response = await client.post("/api/op/clear-lockout")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json()["cleared"])
+        self.assertEqual(robot.reacquires, 1)
+        self.assertFalse(runner.hardware_cleanup_lockout())
+        self.assertFalse(runner.is_running())
+
+    async def test_clear_lockout_keeps_the_lockout_when_nothing_was_read(self) -> None:
+        robot = _LockedOutLink([_motor("SHOULDER_1", reachable=None, status=None)])
+        runner = self._locked_out_runner(robot)
+
+        async with await self._client(runner, robot) as client:
+            response = await client.post("/api/op/clear-lockout")
+
+        self.assertEqual(response.status_code, 409)
+        self.assertTrue(runner.hardware_cleanup_lockout())
+
+
+class BusStallWatchdogTest(unittest.TestCase):
+    def _stalled_bus(self, channel: str) -> CanBus:
+        """A CanBus flagged stalled the way a dead (unpowered) bus flags itself."""
+        bus = object.__new__(CanBus)
+        bus._channel = channel
+        bus._stalled = False
+        bus._lost = False
+        bus._wake = asyncio.Event()
+        bus._mark_stalled(OSError("ENOBUFS"))
+        return bus
+
+    def test_sustained_stall_stops_the_operation(self) -> None:
+        runner = OperationRunner()
+        session = Session("teleop", {})
+        session.status = "running"
+        runner._session = session
+        stops: list[bool] = []
+        watchdog = threading.Thread(
+            target=runner._watch_bus_stall,
+            args=(session, threading.Event()),
+            daemon=True,
+        )
+
+        with (
+            patch.object(runner, "stop", side_effect=lambda: stops.append(True)),
+            patch("almond_axol.serve.runner._STALL_POLL_S", 0.01),
+            patch("almond_axol.serve.runner.STALL_DETECT_S", 0.02),
+        ):
+            # The bus goes dead partway through the run, which is the only
+            # stall this operation owns.
+            watchdog.start()
+            time.sleep(0.05)
+            bus = self._stalled_bus("can-stall-test")
+            self.addCleanup(lambda: asyncio.run(_discard_stall(bus)))
+            watchdog.join(timeout=5.0)
+
+        self.assertFalse(watchdog.is_alive())
+        self.assertEqual(stops, [True])
+        self.assertEqual(session.status, "error")
+        self.assertEqual(session.error, STALL_STOP_ERROR)
+
+    def test_stall_inherited_from_an_earlier_run_is_not_this_run_s(self) -> None:
+        runner = OperationRunner()
+        session = Session("teleop", {})
+        session.status = "running"
+        runner._session = session
+        bus = self._stalled_bus("can-inherited-test")
+        self.addCleanup(lambda: asyncio.run(_discard_stall(bus)))
+        stop_event = threading.Event()
+        threading.Timer(0.05, stop_event.set).start()
+
+        with (
+            patch.object(runner, "stop", side_effect=AssertionError("stopped")),
+            patch("almond_axol.serve.runner._STALL_POLL_S", 0.01),
+            patch("almond_axol.serve.runner.STALL_DETECT_S", 0.01),
+        ):
+            runner._watch_bus_stall(session, stop_event)
+
+        self.assertEqual(session.status, "running")
+
+    def test_stall_that_recovers_leaves_the_operation_running(self) -> None:
+        runner = OperationRunner()
+        session = Session("teleop", {})
+        session.status = "running"
+        runner._session = session
+        stop_event = threading.Event()
+        # Stalled once, then ACKing again — a transient overflow, not power loss.
+        readings = iter([frozenset({"can-left"}), frozenset()])
+
+        def sample() -> frozenset[str]:
+            reading = next(readings, frozenset())
+            if not reading:
+                stop_event.set()
+            return reading
+
+        with (
+            patch.object(runner, "stop", side_effect=AssertionError("stopped")),
+            patch("almond_axol.serve.runner.stalled_channels", sample),
+            patch("almond_axol.serve.runner._STALL_POLL_S", 0.01),
+        ):
+            runner._watch_bus_stall(session, stop_event)
+
+        self.assertEqual(session.status, "running")
+        self.assertIsNone(session.error)
+
+
+async def _discard_stall(bus: CanBus) -> None:
+    """Take the test bus back out of the process-wide stalled set."""
+    bus._bus = None
+    bus._reader_task = None
+    await bus.close()
+
+
+class _FakeMotor:
+    """A link-owned motor at the driver boundary: answers, or does not."""
+
+    def __init__(self, *, powered: bool = True) -> None:
+        self.powered = powered
+
+    async def _read(self, value: Any) -> Any:
+        if not self.powered:
+            raise MotorError("motor did not answer")
+        return value
+
+    async def get_error_code(self) -> MotorStatus:
+        return await self._read(MotorStatus.DISABLED)
+
+    async def get_temperature(self) -> float:
+        return await self._read(31.0)
+
+    async def get_voltage(self) -> float:
+        return await self._read(48.0)
+
+    async def get_position(self) -> float:
+        return await self._read(0.0)
+
+    async def get_velocity(self) -> float:
+        return await self._read(0.0)
+
+    async def get_torque(self) -> float:
+        return await self._read(0.0)
+
+
+class StaleTelemetryTest(unittest.TestCase):
+    def _connected_link(self) -> RobotLink:
+        with (
+            patch("almond_axol.serve.robot_link.CanBus", side_effect=_FakeBus),
+            patch(
+                "almond_axol.serve.robot_link.Motor",
+                side_effect=lambda *_args, **_kwargs: _FakeMotor(),
+            ),
+        ):
+            link = RobotLink(left_channel="can-left", right_channel="can-right")
+            self.addCleanup(link._loop.call_soon_threadsafe, link._loop.stop)
+            link._submit(link._open_and_start())
+            link._set_state(STATE_CONNECTED)
+            link._submit(link._ping_once())
+        return link
+
+    def test_release_drops_the_health_a_task_took_over(self) -> None:
+        link = self._connected_link()
+        self.assertTrue(all(m["reachable"] for m in link.status()["motors"]))
+
+        with patch.object(link, "_submit", return_value=None):
+            link.release()
+
+        status = link.status()
+        self.assertEqual(status["state"], STATE_BUSY)
+        self.assertTrue(all(m["reachable"] is None for m in status["motors"]))
+        self.assertEqual(status["reachableCount"], 0)
+        self.assertEqual(link.hub.snapshot()["slow"], {})
+
+    def test_unknown_motors_are_not_reported_as_faults(self) -> None:
+        motors = [_motor("SHOULDER_1", reachable=None, status=None)]
+
+        self.assertEqual(motor_faults(motors, connected=True), [])
+
+    def test_unreachable_motors_are_still_faults(self) -> None:
+        motors = [_motor("SHOULDER_1", reachable=False, status=None)]
+
+        self.assertEqual(
+            [f["problem"] for f in motor_faults(motors, connected=True)],
+            ["unreachable"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/app/src/components/connections-bar.tsx
+++ b/web/app/src/components/connections-bar.tsx
@@ -497,7 +497,7 @@ export function ConnectionsBar({
 
 /** Healthy = reachable on CAN and reporting no error status. */
 function motorHealthy(m: MotorHealth): boolean {
-  return m.reachable && (m.status === "OK" || m.status === "DISABLED" || m.status == null)
+  return m.reachable === true && (m.status === "OK" || m.status === "DISABLED" || m.status == null)
 }
 
 const jointName = (m: MotorHealth) => `${m.arm} ${m.joint.replace(/_/g, " ").toLowerCase()}`
@@ -508,8 +508,13 @@ const jointName = (m: MotorHealth) => `${m.arm} ${m.joint.replace(/_/g, " ").toL
  */
 export function MotorGrid({ robot }: { robot: RobotStatus }) {
   if (!robot.motors.length) return null
-  const color = (m: MotorHealth) => (motorHealthy(m) ? "ok" : "err")
+  // Unknown is its own square: while a task owns the bus nothing reads these
+  // motors, and painting the last-known state would keep showing a motor as
+  // healthy long after its power was cut.
+  const color = (m: MotorHealth) =>
+    m.reachable == null ? "unknown" : motorHealthy(m) ? "ok" : "err"
   const tip = (m: MotorHealth) => {
+    if (m.reachable == null) return `${jointName(m)}: unknown (a task owns the bus)`
     if (!m.reachable) return `${jointName(m)}: unreachable`
     const status = (m.status ?? "OK").replace(/_/g, " ").toLowerCase()
     const temp = m.temperature != null ? ` · ${Math.round(m.temperature)}°C` : ""
@@ -519,6 +524,7 @@ export function MotorGrid({ robot }: { robot: RobotStatus }) {
   const SQUARE = {
     ok: "bg-emerald-400/80",
     err: "bg-red-400/70",
+    unknown: "bg-white/25",
   }
   return (
     <div className="flex items-center gap-2 whitespace-nowrap">

--- a/web/app/src/lib/supervisor.ts
+++ b/web/app/src/lib/supervisor.ts
@@ -298,7 +298,9 @@ export function runFieldVisible(key: string, profile: HardwareProfile): boolean 
 export interface MotorHealth {
   arm: string
   joint: string
-  reachable: boolean
+  /** null while a task owns the CAN bus: nobody is reading this motor, so its
+   *  reachability is unknown rather than last-known. */
+  reachable: boolean | null
   /** MotorStatus name from the idle ping (e.g. "OK", "OVER_TEMPERATURE"). */
   status: string | null
   temperature: number | null

--- a/web/app/src/lib/supervisor.ts
+++ b/web/app/src/lib/supervisor.ts
@@ -559,6 +559,9 @@ export interface OpStatus {
   /** Present only while an op declaring an episode control is running
    *  (collect-data / run-policy / waypoints); null otherwise. */
   policy: PolicyState | null
+  /** An operation could not confirm it disabled the motors, so the server
+   *  keeps the robot reserved (older hosts omit this). */
+  lockout?: boolean
 }
 
 export async function fetchOpStatus(): Promise<OpStatus> {
@@ -581,6 +584,15 @@ export async function startOperation(
 
 export async function stopOperation(): Promise<SessionInfo> {
   return json(await fetch(apiUrl("/api/op/stop"), { method: "POST" }))
+}
+
+/**
+ * Lift the hardware-cleanup lockout. The server pings every motor first and
+ * refuses (409) unless each one reads disabled or does not answer, so this is
+ * a request to re-check the hardware rather than an override.
+ */
+export async function clearOperationLockout(): Promise<{ cleared: boolean }> {
+  return json(await fetch(apiUrl("/api/op/clear-lockout"), { method: "POST" }))
 }
 
 /** run-policy episode control: ``start`` | ``s`` (save) | ``r`` (rerecord) | ``q`` (quit). */

--- a/web/app/src/lib/telemetry.ts
+++ b/web/app/src/lib/telemetry.ts
@@ -67,6 +67,8 @@ export interface TelemetryFrame {
 
 /** Slow (1 Hz) per-motor reading piggybacked on the health ping. */
 export interface SlowReading {
+  /** Always a bool here, unlike `MotorHealth.reachable`: a motor nobody is
+   *  reading is dropped from the slow map entirely rather than sent as null. */
   reachable: boolean
   status: string | null
   temperature: number | null

--- a/web/app/src/routes/ControlPanel.tsx
+++ b/web/app/src/routes/ControlPanel.tsx
@@ -7,6 +7,7 @@ import {
   OPERATIONS,
   cameraCount,
   canDiscoveryRequestCanRetry,
+  clearOperationLockout,
   detectCameras,
   discoverCanHardware,
   fetchCanInterfaces,
@@ -251,6 +252,10 @@ export default function ControlPanel() {
   // run-policy episode phase/count, from the server so the episode controls are
   // correct on any computer (not just the tab that started the run).
   const [policy, setPolicy] = useState<PolicyState | null>(null)
+  // The server could not confirm an operation disabled the motors and keeps
+  // the robot reserved until the motors are proven torque-free (or it restarts).
+  const [lockout, setLockout] = useState(false)
+  const [lockoutBusy, setLockoutBusy] = useState(false)
   const [busy, setBusy] = useState(false)
   // Short label shown on the Start button while a start is being prepared (e.g.
   // "Checking cameras…"), so the wait isn't an opaque spinner — mirrors the
@@ -424,6 +429,7 @@ export default function ControlPanel() {
             setSelectedOp(op.session.command as OperationId)
           }
           setPolicy(op.running ? op.policy : null)
+          setLockout(op.lockout === true)
         })
         .catch(() => {})
     },
@@ -1267,6 +1273,7 @@ export default function ControlPanel() {
           if (!active) return
           if (op.session) setSession(op.session)
           setPolicy(op.running ? op.policy : null)
+          setLockout(op.lockout === true)
         })
         .catch(() => {})
     }, 1500)
@@ -1490,6 +1497,30 @@ export default function ControlPanel() {
     }
   }
 
+  // Ask the server to re-check the motors and drop the hardware-cleanup
+  // reservation. It refuses while any motor still answers and is not disabled,
+  // so a failure here is the robot saying it is still torqued, not a UI error.
+  async function handleClearLockout() {
+    const generation = connectionGenerationRef.current
+    setLockoutBusy(true)
+    try {
+      await clearOperationLockout()
+      if (generation !== connectionGenerationRef.current) return
+      setLockout(false)
+      toast.success("Motors read torque-free — the robot is available again.")
+      fetchRobotStatus()
+        .then((value) => {
+          if (generation === connectionGenerationRef.current) setRobot(value)
+        })
+        .catch(() => {})
+    } catch (e) {
+      if (generation !== connectionGenerationRef.current) return
+      toast.error(String(e))
+    } finally {
+      if (generation === connectionGenerationRef.current) setLockoutBusy(false)
+    }
+  }
+
   function handleEpisode(command: string) {
     const generation = connectionGenerationRef.current
     sendEpisodeCommand(command).catch((e) => {
@@ -1652,6 +1683,25 @@ export default function ControlPanel() {
             <span className="font-mono text-amber-200">{runningOp}</span> is currently running. Stop
             it before starting another operation.
           </p>
+        )}
+
+        {lockout && (
+          <div className="flex flex-col gap-2 rounded-lg border border-red-400/25 bg-red-400/[0.05] p-3 text-xs text-red-200/80 sm:flex-row sm:items-center sm:justify-between">
+            <p>
+              The last operation could not confirm it disabled the motors, so the robot stays
+              reserved. If motor power was cut (the PSU e-stop), re-check the motors to release it.
+            </p>
+            <Button
+              variant="outline"
+              size="sm"
+              className="shrink-0"
+              disabled={lockoutBusy}
+              onClick={handleClearLockout}
+            >
+              {lockoutBusy ? <Loader2 className="animate-spin" /> : <RefreshCw />}
+              Re-check motors
+            </Button>
+          </div>
         )}
 
         <OperationPanel

--- a/web/app/src/routes/ControlPanel.tsx
+++ b/web/app/src/routes/ControlPanel.tsx
@@ -256,6 +256,10 @@ export default function ControlPanel() {
   // the robot reserved until the motors are proven torque-free (or it restarts).
   const [lockout, setLockout] = useState(false)
   const [lockoutBusy, setLockoutBusy] = useState(false)
+  // The server's own view of whether the runner is busy (`op.running`). It
+  // outlives the session's live status: the worker is still tearing down after
+  // the session reads error/exited, and a lockout keeps it true after that.
+  const [opBusy, setOpBusy] = useState(false)
   const [busy, setBusy] = useState(false)
   // Short label shown on the Start button while a start is being prepared (e.g.
   // "Checking cameras…"), so the wait isn't an opaque spinner — mirrors the
@@ -430,6 +434,7 @@ export default function ControlPanel() {
           }
           setPolicy(op.running ? op.policy : null)
           setLockout(op.lockout === true)
+          setOpBusy(op.running)
         })
         .catch(() => {})
     },
@@ -1264,24 +1269,37 @@ export default function ControlPanel() {
   // exited even if the logs WebSocket drops its final status frame. The stop
   // itself returns immediately server-side, so this is what flips the button
   // back to Start once the op has actually torn down.
+  //
+  // Keep polling past the session's terminal status for as long as the server
+  // still reports the runner busy. The session reads error before teardown
+  // finishes (the stall watchdog marks it seconds earlier), and the cleanup
+  // lockout is only decided at the end of that teardown — so a poll gated on
+  // the live session alone would stop on `lockout: false` and never see the
+  // flag flip, leaving Start returning 409 with no Re-check control shown.
+  // A lockout keeps `op.running` true, so this also tracks it being cleared.
   useEffect(() => {
-    if (conn.state !== "ok" || !isLive) return
+    if (conn.state !== "ok" || !(isLive || opBusy)) return
     let active = true
-    const t = setInterval(() => {
+    const tick = () => {
       fetchOpStatus()
         .then((op) => {
           if (!active) return
           if (op.session) setSession(op.session)
           setPolicy(op.running ? op.policy : null)
           setLockout(op.lockout === true)
+          setOpBusy(op.running)
         })
         .catch(() => {})
-    }, 1500)
+    }
+    // Sample once up front so a run that ends within the first interval still
+    // records the server as busy and the teardown is followed to its end.
+    tick()
+    const t = setInterval(tick, 1500)
     return () => {
       active = false
       clearInterval(t)
     }
-  }, [conn.state, isLive])
+  }, [conn.state, isLive, opBusy])
 
   // Refresh the update status the moment an operation starts or stops, so the
   // server's idle state (and thus the banner's blocked state) becomes current


### PR DESCRIPTION
Closes #248

Cutting the motor PSU mid-operation (operators use it as an e-stop) left the operation shown as running, made Stop a no-op, and returned 409 from host restart, shutdown, start, connect and disconnect — with telemetry still reporting the pre-cut voltage as reachable. The lockout was permanent, so only a `serve` restart recovered. This branch fixes all four causes.

## Changes

- **An unpowered arm is not cleanup uncertainty.** When every motor on an arm is unreachable, `Axol.disable()` logs the arm as unpowered, closes the buses, and raises nothing: the torque is already gone, so there is nothing uncertain to lock out. A reachable motor that fails to confirm disable still raises, and the buses stay open so the failure remains retryable.
- **The lockout no longer blocks recovery.** Host power operations bypass it, and `POST /api/op/clear-lockout` reacquires the link, probes the motors, and clears the flag only when every motor reads disabled or unreachable. It refuses with 409 while any reachable motor still answers, and refuses when nothing could be read at all. A matching button sits in the control panel.
- **A sustained stall stops the operation.** The runner samples `stalled_channels()` every 250 ms while an operation runs; a stall held for `STALL_DETECT_S` stops it with the status `motor power lost`. The bus already needs that same window to declare the stall, so the effective threshold is two windows and a stall that recovers on its own does not end a healthy run. A stall inherited from an earlier run is not attributed to the current one.
- **Stale health is dropped on handover.** `RobotLink.release()` clears `arm.health` and the hub slow cache, so a motor reads `reachable: null` while a task owns the bus and the UI renders it as unknown rather than showing a frozen pre-cut snapshot. Unknown motors are no longer counted as faults; unreachable ones still are.

## Tests

`tests/test_power_loss.py`, 12 tests across all four behaviours: disable classification both ways, the lockout's host-restart exemption and clear-lockout accept/refuse/nothing-read paths, watchdog stop plus the inherited-stall and recovered-stall negatives, and health clearing on release.

Fakes sit at the CAN protocol boundary (`CanBus`, the motor driver); the serve API doubles are the ones the reservation tests already use.

## Verification

Hardware checks pending, hence draft:
- [ ] Teleop running, PSU off: the operation stops within seconds, the UI shows unreachable, host restart works
- [ ] PSU back on: teleop starts again with no `serve` restart
- [ ] Motors reachable and one disable fails: the lockout still trips, and clear-lockout refuses

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes motor torque-off classification, CAN stall detection, and when operations stop or the robot stays reserved—directly affecting e-stop and unsupervised-hold scenarios.
> 
> **Overview**
> When operators cut motor power (PSU e-stop) during a run, the stack now **detects a dead CAN bus**, **stops the operation**, and **avoids a permanent hardware lockout** instead of leaving the panel stuck with stale “reachable” telemetry.
> 
> **CAN / motor layer:** `CanBus` exposes process-wide **`stalled_channels()`** and treats sustained TX queue full (including python-can’s message-only “buffer full” errors) as a stall; flush locks are **per event loop** so reconnect after handover doesn’t break. On shutdown, **`Axol.disable()`** treats an arm as **unpowered** only when the bus is stalled *and* every motor read fails—USB loss without stall still blocks cleanup.
> 
> **Serve / UI:** A **stall watchdog** stops robot ops after **`STALL_DETECT_S`** of stall; **`/api/op/clear-lockout`** re-probes motors and clears the reservation when all are disabled or silent. Host restart/update/power and panel “idle” **ignore the cleanup lockout** (lockout still blocks starting new ops). **`RobotLink`** clears health on **`release()`** and reports **`reachable: null`** while a task owns the bus; the control panel shows **unknown** motor squares and a **Re-check motors** action when **`lockout`** is set, with op-status polling extended through teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c032640a900a1f300f846cbfb2d9524f6bae151c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->