### PR TITLE
web: install from the committed lockfile on Vercel (npm ci)

### DIFF
--- a/docs/guides/vr-interface.mdx
+++ b/docs/guides/vr-interface.mdx
@@ -60,7 +60,7 @@ The hosted app is built on Vercel; `vercel.json` builds the client package first
 {
   "buildCommand": "npm run build --workspace=packages/axol-vr-client && npm run build --workspace=app",
   "outputDirectory": "app/dist",
-  "installCommand": "rm -f package-lock.json && npm install"
+  "installCommand": "npm ci"
 }
 ```
 

--- a/web/README.md
+++ b/web/README.md
@@ -197,11 +197,11 @@ The app is deployed on Vercel. `vercel.json` builds the client package first so 
 {
   "buildCommand": "npm run build --workspace=packages/axol-vr-client && npm run build --workspace=app",
   "outputDirectory": "app/dist",
-  "installCommand": "rm -f package-lock.json && npm install"
+  "installCommand": "npm ci"
 }
 ```
 
-The `installCommand` removes any macOS-generated lock file to avoid missing Linux rollup binaries on the Vercel build machine.
+The `installCommand` installs from the committed `package-lock.json` rather than re-resolving from the version ranges, so a new release outside a peer range (react 19.3.0 vs `@react-three/fiber`'s `<19.3`) can't break the deploy — bump dependencies deliberately and commit the lockfile. The lockfile carries every platform's optional binaries (rollup, tailwind oxide, lightningcss), so one generated on macOS installs fine on the Linux build machine.
 
 ## Python SDK
 

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,7 +1,7 @@
 {
   "buildCommand": "npm run build --workspace=packages/axol-vr-client && npm run build --workspace=app",
   "outputDirectory": "app/dist",
-  "installCommand": "rm -f package-lock.json && npm install",
+  "installCommand": "npm ci",
   "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }],
   "headers": [
     {


### PR DESCRIPTION
## Problem

Vercel builds of `web/` fail at install:

```
Running "install" command: rm -f package-lock.json && npm install...
npm error ERESOLVE unable to resolve dependency tree
npm error Found: react@19.3.0
npm error peer react@">=19 <19.3" from @react-three/fiber@9.7.0
```

`vercel.json`'s `installCommand` discards the lockfile and re-resolves from the version ranges on every build. react 19.3.0 was just published, `react@"^19.2.0"` picks it up, and `@react-three/fiber` (9.7.0 is latest; still `<19.3`) rejects it. The committed lockfile (react 19.2.5 / fiber 9.6.1) is fine — `npm ci` + both workspace builds succeed on Linux from it.

## Fix

`installCommand: "npm ci"` — install what the lockfile says. The `rm -f package-lock.json` was a workaround for macOS-generated lockfiles missing the Linux rollup optional binaries (an old npm bug); the current lockfile carries every platform's optionals (rollup, tailwind oxide, lightningcss), so that's no longer needed. Docs updated to match.

Going forward, dependency bumps are deliberate: update `package.json`, run `npm install`, commit the lockfile.

Related: almond-bot/axol-pi#65 works around the same failure on the pi.axol.almond.bot deploy by rewriting the install command in its workflow; it can drop that once the pin includes this.

Made with [Cursor](https://cursor.com)