### PR TITLE
Let packages built on almond-axol extend the serve app and link their pages from the panel

### DIFF
--- a/almond_axol/serve/__init__.py
+++ b/almond_axol/serve/__init__.py
@@ -26,9 +26,29 @@ built-ins, with no changes needed here or in ``web/``::
 
 See :class:`~almond_axol.serve.commands.CommandDef` for the full set of
 declarations and the entrypoint protocol.
+
+A package can also extend the app itself — extra ``/api/...`` routes or a
+page it serves — with :func:`register_app_extension`, whose callable runs
+inside ``create_app`` ahead of the web bundle's SPA catch-all, and advertise
+such a page to the panel's navigation with :func:`register_page` (reported
+by ``GET /api/info`` as ``pages``; see :mod:`almond_axol.serve.extensions`)::
+
+    from almond_axol.serve import PanelPage, register_app_extension, register_page
+
+    register_app_extension(lambda app: app.include_router(my_router))
+    register_page(PanelPage("My page", "/my-page"))
 """
 
 from .app import create_app
 from .commands import CommandDef, operation_ids, register
+from .extensions import PanelPage, register_app_extension, register_page
 
-__all__ = ["CommandDef", "create_app", "operation_ids", "register"]
+__all__ = [
+    "CommandDef",
+    "PanelPage",
+    "create_app",
+    "operation_ids",
+    "register",
+    "register_app_extension",
+    "register_page",
+]

--- a/almond_axol/serve/app.py
+++ b/almond_axol/serve/app.py
@@ -48,6 +48,7 @@ from .commands import (
     normalize_boolean_args,
     operation_ids,
 )
+from .extensions import app_extensions, panel_pages
 from .manager import Session, SessionManager
 from .robot_link import STATE_ERROR, RobotLink, scoped_motor_faults
 from .runner import OperationRunner
@@ -1185,6 +1186,10 @@ def create_app(static_dir: Path | None = None) -> FastAPI:
             # differs between releases.
             "commit": updater.commit,
             "releaseInstall": updater.release_install,
+            # Backend-served pages a downstream package registered
+            # (``almond_axol.serve.register_page``); the panel links to them
+            # against its server base, since it may run on another origin.
+            "pages": [page.to_dict() for page in panel_pages()],
         }
 
     @app.get("/api/update/status")
@@ -2723,6 +2728,12 @@ def create_app(static_dir: Path | None = None) -> FastAPI:
         await runner.shutdown()
         await manager.shutdown()
         await asyncio.to_thread(robot.shutdown)
+
+    # Downstream route additions go in ahead of the SPA catch-all so a page a
+    # package serves itself (see ``almond_axol.serve.extensions``) resolves
+    # like the built-in routes do instead of falling through to index.html.
+    for extension in app_extensions():
+        extension(app)
 
     if static_dir is not None:
         _mount_spa(app, static_dir)

--- a/almond_axol/serve/extensions.py
+++ b/almond_axol/serve/extensions.py
@@ -38,7 +38,7 @@ _PATH_RE = re.compile(r"^/[A-Za-z0-9._~%!$&'()*+,;=:@/?#-]*$")
 class PanelPage:
     """A backend-served page the web panel links to.
 
-    ``path`` is absolute on the backend origin (``/finetune``); ``label`` is the
+    ``path`` is absolute on the backend origin (``/datasets``); ``label`` is the
     navigation text. ``description`` is optional hover text.
     """
 
@@ -52,7 +52,7 @@ class PanelPage:
         if not _PATH_RE.fullmatch(self.path) or self.path.startswith("//"):
             raise ValueError(
                 f"PanelPage.path must be an absolute path on the backend "
-                f"(e.g. '/finetune'), got {self.path!r}"
+                f"(e.g. '/datasets'), got {self.path!r}"
             )
         if self.path.startswith("/api/"):
             raise ValueError("PanelPage.path must not live under /api/")

--- a/almond_axol/serve/extensions.py
+++ b/almond_axol/serve/extensions.py
@@ -1,0 +1,102 @@
+"""Downstream extension points for ``axol serve`` beyond the command catalog.
+
+:func:`~almond_axol.serve.commands.register` lets a package built on
+``almond-axol`` add operations to the panel. Two more hooks cover what a
+command can't express:
+
+- :func:`register_app_extension` — a callable that receives the FastAPI app
+  from :func:`~almond_axol.serve.create_app` after every built-in route is
+  registered and *before* the web bundle's SPA catch-all is mounted, so the
+  routes it adds (extra ``/api/...`` endpoints, a server-rendered page) win
+  over the catch-all like the built-ins do. Without this a downstream package
+  had to wrap ``create_app`` and reorder ``app.router.routes`` by hand.
+- :func:`register_page` — a :class:`PanelPage` the web panel links to from
+  its navigation. The panel is often served from another origin than the
+  backend it drives (axol.almond.bot against a station on the LAN), so a page
+  a backend serves itself is not reachable by a relative link in the bundle;
+  the backend advertises it through ``GET /api/info`` (``pages``) and the
+  panel builds the link against its configured server base.
+
+Both registries are process-global like the command catalog and idempotent
+(re-registering the same path / callable replaces it), so a downstream
+``register_*`` step can run before every ``create_app``.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Callable
+
+AppExtension = Callable[[Any], None]
+
+# An absolute path with an optional query / fragment (RFC 3986 pchar set).
+_PATH_RE = re.compile(r"^/[A-Za-z0-9._~%!$&'()*+,;=:@/?#-]*$")
+
+
+@dataclass(frozen=True)
+class PanelPage:
+    """A backend-served page the web panel links to.
+
+    ``path`` is absolute on the backend origin (``/finetune``); ``label`` is the
+    navigation text. ``description`` is optional hover text.
+    """
+
+    label: str
+    path: str
+    description: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.label.strip():
+            raise ValueError("PanelPage.label must not be empty")
+        if not _PATH_RE.fullmatch(self.path) or self.path.startswith("//"):
+            raise ValueError(
+                f"PanelPage.path must be an absolute path on the backend "
+                f"(e.g. '/finetune'), got {self.path!r}"
+            )
+        if self.path.startswith("/api/"):
+            raise ValueError("PanelPage.path must not live under /api/")
+
+    def to_dict(self) -> dict[str, str]:
+        data = {"label": self.label, "path": self.path}
+        if self.description:
+            data["description"] = self.description
+        return data
+
+
+_APP_EXTENSIONS: dict[int, AppExtension] = {}
+_PAGES: dict[str, PanelPage] = {}
+
+
+def register_app_extension(extension: AppExtension) -> None:
+    """Run ``extension(app)`` inside every subsequent ``create_app`` call.
+
+    Extensions run in registration order after the built-in routes and
+    before the SPA catch-all (when a bundle is served). Registering the same
+    callable twice keeps a single entry.
+    """
+    _APP_EXTENSIONS[id(extension)] = extension
+
+
+def app_extensions() -> tuple[AppExtension, ...]:
+    return tuple(_APP_EXTENSIONS.values())
+
+
+def register_page(page: PanelPage) -> None:
+    """Advertise a backend-served page in ``/api/info`` for the panel's nav.
+
+    Re-registering a path replaces its entry, so a label change applies on
+    the next app.
+    """
+    _PAGES[page.path] = page
+
+
+def panel_pages() -> tuple[PanelPage, ...]:
+    """Registered pages in registration order."""
+    return tuple(_PAGES.values())
+
+
+def clear_extensions() -> None:
+    """Forget every registered extension and page (tests)."""
+    _APP_EXTENSIONS.clear()
+    _PAGES.clear()

--- a/tests/test_serve_extensions.py
+++ b/tests/test_serve_extensions.py
@@ -35,9 +35,9 @@ def _add_page_route(app: FastAPI) -> None:
 
 class PanelPageTest(unittest.TestCase):
     def test_validates_path(self) -> None:
-        PanelPage("Finetuning", "/finetune")
-        PanelPage("Nested", "/tools/finetune?tab=runs")
-        for bad in ("finetune", "//evil.example", "/api/finetune", "http://x/y", ""):
+        PanelPage("Datasets", "/datasets")
+        PanelPage("Nested", "/tools/datasets?tab=recent")
+        for bad in ("datasets", "//evil.example", "/api/datasets", "http://x/y", ""):
             with self.subTest(path=bad):
                 with self.assertRaises(ValueError):
                     PanelPage("x", bad)
@@ -46,12 +46,16 @@ class PanelPageTest(unittest.TestCase):
 
     def test_to_dict_omits_empty_description(self) -> None:
         self.assertEqual(
-            PanelPage("Finetuning", "/finetune").to_dict(),
-            {"label": "Finetuning", "path": "/finetune"},
+            PanelPage("Datasets", "/datasets").to_dict(),
+            {"label": "Datasets", "path": "/datasets"},
         )
         self.assertEqual(
-            PanelPage("Finetuning", "/finetune", "Train on Pi").to_dict(),
-            {"label": "Finetuning", "path": "/finetune", "description": "Train on Pi"},
+            PanelPage("Datasets", "/datasets", "Browse recorded datasets").to_dict(),
+            {
+                "label": "Datasets",
+                "path": "/datasets",
+                "description": "Browse recorded datasets",
+            },
         )
 
 

--- a/tests/test_serve_extensions.py
+++ b/tests/test_serve_extensions.py
@@ -1,0 +1,124 @@
+"""Downstream app extensions and advertised pages (``almond_axol.serve.extensions``)."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.responses import HTMLResponse
+from fastapi.testclient import TestClient
+
+from almond_axol.serve import (
+    PanelPage,
+    create_app,
+    register_app_extension,
+    register_page,
+)
+from almond_axol.serve.extensions import (
+    app_extensions,
+    clear_extensions,
+    panel_pages,
+)
+
+
+def _add_page_route(app: FastAPI) -> None:
+    @app.get("/my-page", response_model=None)
+    def my_page() -> HTMLResponse:
+        return HTMLResponse("EXTENSION PAGE")
+
+    @app.get("/api/my-page/status")
+    def my_status() -> dict[str, bool]:
+        return {"ok": True}
+
+
+class PanelPageTest(unittest.TestCase):
+    def test_validates_path(self) -> None:
+        PanelPage("Finetuning", "/finetune")
+        PanelPage("Nested", "/tools/finetune?tab=runs")
+        for bad in ("finetune", "//evil.example", "/api/finetune", "http://x/y", ""):
+            with self.subTest(path=bad):
+                with self.assertRaises(ValueError):
+                    PanelPage("x", bad)
+        with self.assertRaises(ValueError):
+            PanelPage("  ", "/ok")
+
+    def test_to_dict_omits_empty_description(self) -> None:
+        self.assertEqual(
+            PanelPage("Finetuning", "/finetune").to_dict(),
+            {"label": "Finetuning", "path": "/finetune"},
+        )
+        self.assertEqual(
+            PanelPage("Finetuning", "/finetune", "Train on Pi").to_dict(),
+            {"label": "Finetuning", "path": "/finetune", "description": "Train on Pi"},
+        )
+
+
+class RegistryTest(unittest.TestCase):
+    def setUp(self) -> None:
+        clear_extensions()
+        self.addCleanup(clear_extensions)
+
+    def test_registration_is_idempotent_and_ordered(self) -> None:
+        def a(app: FastAPI) -> None: ...
+
+        def b(app: FastAPI) -> None: ...
+
+        register_app_extension(a)
+        register_app_extension(b)
+        register_app_extension(a)
+        self.assertEqual(app_extensions(), (a, b))
+
+        register_page(PanelPage("One", "/one"))
+        register_page(PanelPage("Two", "/two"))
+        register_page(PanelPage("One again", "/one"))
+        self.assertEqual([page.label for page in panel_pages()], ["One again", "Two"])
+
+
+class CreateAppExtensionTest(unittest.TestCase):
+    def setUp(self) -> None:
+        clear_extensions()
+        self.addCleanup(clear_extensions)
+        self._temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self._temporary.cleanup)
+        self.static = Path(self._temporary.name) / "static"
+        self.static.mkdir()
+        (self.static / "index.html").write_text("SPA INDEX", encoding="utf-8")
+
+    def test_extension_routes_win_over_the_spa_catch_all(self) -> None:
+        register_app_extension(_add_page_route)
+        register_page(PanelPage("My page", "/my-page", "Served by the extension"))
+        app = create_app(self.static)
+        with TestClient(app) as client:
+            page = client.get("/my-page")
+            status = client.get("/api/my-page/status")
+            spa = client.get("/control")
+            info = client.get("/api/info")
+
+        self.assertEqual(page.status_code, 200)
+        self.assertEqual(page.text, "EXTENSION PAGE")
+        self.assertEqual(status.json(), {"ok": True})
+        self.assertEqual(spa.text, "SPA INDEX")
+        self.assertEqual(
+            info.json()["pages"],
+            [
+                {
+                    "label": "My page",
+                    "path": "/my-page",
+                    "description": "Served by the extension",
+                }
+            ],
+        )
+
+    def test_no_extensions_means_no_pages(self) -> None:
+        app = create_app()
+        with TestClient(app) as client:
+            info = client.get("/api/info")
+            missing = client.get("/my-page")
+        self.assertEqual(info.json()["pages"], [])
+        self.assertEqual(missing.status_code, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/app/src/build-info.d.ts
+++ b/web/app/src/build-info.d.ts
@@ -5,3 +5,6 @@ declare const __AXOL_BUILD_COMMIT__: string | null
 
 /** pyproject.toml version at build time; null when unknown. */
 declare const __AXOL_BUILD_VERSION__: string | null
+
+/** The `axol serve` origin the dev server proxies /api to (AXOL_SERVE_URL). */
+declare const __AXOL_DEV_SERVE_URL__: string

--- a/web/app/src/components/site-nav.tsx
+++ b/web/app/src/components/site-nav.tsx
@@ -2,6 +2,8 @@ import { useState, type ReactNode } from "react"
 import { ExternalLink, Menu, Rocket, X } from "lucide-react"
 import { buttonVariants } from "@/components/ui/button"
 import { QuickstartDialog } from "@/components/quickstart-dialog"
+import { type ServerPage } from "@/lib/server-pages"
+import { serverPageHref } from "@/lib/supervisor"
 import { cn } from "@/lib/utils"
 
 /**
@@ -9,8 +11,11 @@ import { cn } from "@/lib/utils"
  * which cross-link is shown (control panel <-> VR app). Uses plain anchors so
  * switching routes does a full navigation (each route lazy-loads its bundle).
  * ``right`` injects route-specific controls (e.g. the connection pill) just
- * before the Docs / cross-link buttons. On narrow screens the links collapse
- * into a hamburger menu so the bar never overflows the viewport.
+ * before the Docs / cross-link buttons. ``pages`` are the backend-served
+ * pages ``/api/info`` advertises (lib/server-pages.ts): they link against the
+ * connected server's origin, so when the panel runs on another host they open
+ * in a new tab and keep this one connected. On narrow screens the links
+ * collapse into a hamburger menu so the bar never overflows the viewport.
  */
 const PAGE_LABEL: Record<string, string> = {
   control: "Control Panel",
@@ -20,16 +25,35 @@ const PAGE_LABEL: Record<string, string> = {
 
 function NavLinks({
   current,
+  pages,
   onQuickstart,
   itemClass,
 }: {
   current: string
+  pages: ServerPage[]
   onQuickstart: () => void
   itemClass?: string
 }) {
   const item = cn(buttonVariants({ variant: "ghost", size: "sm" }), itemClass)
   return (
     <>
+      {pages.map((page) => {
+        const href = serverPageHref(page.path)
+        const external = href !== page.path
+        return (
+          <a
+            key={page.path}
+            href={href}
+            title={page.description}
+            target={external ? "_blank" : undefined}
+            rel={external ? "noreferrer" : undefined}
+            className={item}
+          >
+            {page.label}
+            {external && <ExternalLink />}
+          </a>
+        )
+      })}
       <a href="https://docs.almond.bot" target="_blank" rel="noreferrer" className={item}>
         Docs
         <ExternalLink />
@@ -62,9 +86,12 @@ function NavLinks({
 export function SiteNav({
   current,
   right,
+  pages = [],
 }: {
   current: "control" | "vr" | "diagnostics"
   right?: ReactNode
+  /** Backend-served pages to link (``ServerInfo.pages``); none by default. */
+  pages?: ServerPage[]
 }) {
   const [menuOpen, setMenuOpen] = useState(false)
   // Owned here, not by the menu item: closing the menu unmounts its contents,
@@ -85,7 +112,11 @@ export function SiteNav({
         <div className="flex shrink-0 items-center gap-2">
           {right}
           <nav className="hidden items-center gap-2 md:flex">
-            <NavLinks current={current} onQuickstart={() => setQuickstartOpen(true)} />
+            <NavLinks
+              current={current}
+              pages={pages}
+              onQuickstart={() => setQuickstartOpen(true)}
+            />
           </nav>
           <button
             type="button"
@@ -104,6 +135,7 @@ export function SiteNav({
           >
             <NavLinks
               current={current}
+              pages={pages}
               onQuickstart={() => setQuickstartOpen(true)}
               itemClass="w-full justify-start"
             />

--- a/web/app/src/lib/server-pages.ts
+++ b/web/app/src/lib/server-pages.ts
@@ -1,0 +1,58 @@
+/**
+ * Backend-served pages the panel links to from its navigation.
+ *
+ * A package built on `almond-axol` can serve pages of its own from the
+ * `axol serve` process (`almond_axol.serve.register_app_extension`) and
+ * advertise them with `register_page`; `GET /api/info` then lists them as
+ * `pages: [{label, path, description?}]`. This panel is often not served by
+ * that backend — the hosted site drives a station on the LAN — so such a page
+ * is reachable only on the backend's origin, never as a relative link here.
+ * `serverPageUrl` builds the right href for either case.
+ */
+
+export interface ServerPage {
+  /** Navigation text. */
+  label: string
+  /** Absolute path on the backend origin, e.g. "/finetune". */
+  path: string
+  /** Optional hover text. */
+  description?: string
+}
+
+/**
+ * Validate the `pages` field of `/api/info` (an untrusted JSON value) into the
+ * entries the nav can render: non-empty label, absolute non-API path.
+ */
+export function normalizeServerPages(raw: unknown): ServerPage[] {
+  if (!Array.isArray(raw)) return []
+  const pages: ServerPage[] = []
+  const seen = new Set<string>()
+  for (const item of raw) {
+    if (!item || typeof item !== "object") continue
+    const { label, path, description } = item as Record<string, unknown>
+    if (typeof label !== "string" || !label.trim()) continue
+    if (typeof path !== "string" || !isAbsolutePagePath(path)) continue
+    if (seen.has(path)) continue
+    seen.add(path)
+    const page: ServerPage = { label: label.trim(), path }
+    if (typeof description === "string" && description.trim()) page.description = description.trim()
+    pages.push(page)
+  }
+  return pages
+}
+
+/** "/x", "/x/y?q" — but not "//host", "x", or anything under /api/. */
+export function isAbsolutePagePath(path: string): boolean {
+  return path.startsWith("/") && !path.startsWith("//") && !path.startsWith("/api/")
+}
+
+/**
+ * The href for a backend page given the panel's server base (`""` when the
+ * panel is served by the backend itself, otherwise its `https://host:port`
+ * origin). A same-origin page keeps the relative path so dev proxies and
+ * local bundles work unchanged.
+ */
+export function serverPageUrl(serverBase: string, path: string): string {
+  if (!serverBase) return path
+  return `${serverBase.replace(/\/+$/, "")}${path}`
+}

--- a/web/app/src/lib/server-pages.ts
+++ b/web/app/src/lib/server-pages.ts
@@ -13,7 +13,7 @@
 export interface ServerPage {
   /** Navigation text. */
   label: string
-  /** Absolute path on the backend origin, e.g. "/finetune". */
+  /** Absolute path on the backend origin, e.g. "/datasets". */
   path: string
   /** Optional hover text. */
   description?: string

--- a/web/app/src/lib/supervisor.ts
+++ b/web/app/src/lib/supervisor.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react"
+import { normalizeServerPages, serverPageUrl, type ServerPage } from "./server-pages.ts"
 
 export type FieldType = "boolean" | "number" | "select" | "text" | "vector"
 
@@ -181,10 +182,24 @@ export interface ServerInfo {
   commit?: string | null
   /** Tag-pinned git tool install (true) vs dev checkout (false). */
   releaseInstall?: boolean
+  /**
+   * Pages the backend serves itself and wants linked from the panel's nav
+   * (registered by a package built on almond-axol). Normalized on fetch; see
+   * lib/server-pages.ts for why these need the server base, not a relative link.
+   */
+  pages: ServerPage[]
 }
 
 export async function fetchInfo(): Promise<ServerInfo> {
-  return json(await fetch(apiUrl("/api/info")))
+  const info = await json<Omit<ServerInfo, "pages"> & { pages?: unknown }>(
+    await fetch(apiUrl("/api/info"))
+  )
+  return { ...info, pages: normalizeServerPages(info.pages) }
+}
+
+/** Href for a backend-served page (see lib/server-pages.ts). */
+export function serverPageHref(path: string): string {
+  return serverPageUrl(apiBase, path)
 }
 
 // ---------------------------------------------------------------------------

--- a/web/app/src/lib/supervisor.ts
+++ b/web/app/src/lib/supervisor.ts
@@ -197,9 +197,15 @@ export async function fetchInfo(): Promise<ServerInfo> {
   return { ...info, pages: normalizeServerPages(info.pages) }
 }
 
-/** Href for a backend-served page (see lib/server-pages.ts). */
+/**
+ * Href for a backend-served page (see lib/server-pages.ts). An empty server
+ * base means same-origin — except under the Vite dev server, which proxies
+ * only /api: there the page lives on the proxy target, so the link goes
+ * straight at it (relative would fall through to the SPA's own routes).
+ */
 export function serverPageHref(path: string): string {
-  return serverPageUrl(apiBase, path)
+  const base = apiBase || (import.meta.env.DEV ? __AXOL_DEV_SERVE_URL__ : "")
+  return serverPageUrl(base, path)
 }
 
 // ---------------------------------------------------------------------------

--- a/web/app/src/routes/ControlPanel.tsx
+++ b/web/app/src/routes/ControlPanel.tsx
@@ -1595,7 +1595,7 @@ export default function ControlPanel() {
 
   return (
     <div className="min-h-screen">
-      <SiteNav current="control" />
+      <SiteNav current="control" pages={hostInfo?.pages} />
       <main className="safe-x mx-auto flex max-w-5xl flex-col gap-6 py-6 pb-[max(1.5rem,env(safe-area-inset-bottom))] sm:py-8">
         {update?.updateAvailable && (
           <UpdateBanner

--- a/web/app/test/server-pages.test.mjs
+++ b/web/app/test/server-pages.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import { isAbsolutePagePath, normalizeServerPages, serverPageUrl } from "../src/lib/server-pages.ts"
+
+test("only absolute, non-API paths count as backend pages", () => {
+  assert.equal(isAbsolutePagePath("/finetune"), true)
+  assert.equal(isAbsolutePagePath("/tools/x?tab=1"), true)
+  assert.equal(isAbsolutePagePath("finetune"), false)
+  assert.equal(isAbsolutePagePath("//evil.example/x"), false)
+  assert.equal(isAbsolutePagePath("/api/finetuning"), false)
+})
+
+test("the /api/info pages field is validated and de-duplicated", () => {
+  assert.deepEqual(normalizeServerPages(undefined), [])
+  assert.deepEqual(normalizeServerPages("nope"), [])
+  assert.deepEqual(
+    normalizeServerPages([
+      { label: " Finetuning ", path: "/finetune", description: " Train on Pi " },
+      { label: "Dup", path: "/finetune" },
+      { label: "", path: "/blank" },
+      { label: "Relative", path: "x" },
+      { label: "API", path: "/api/x" },
+      null,
+      { label: "Plain", path: "/plain", description: 3 },
+    ]),
+    [
+      { label: "Finetuning", path: "/finetune", description: "Train on Pi" },
+      { label: "Plain", path: "/plain" },
+    ]
+  )
+})
+
+test("page hrefs stay relative on the backend's own origin and absolute elsewhere", () => {
+  assert.equal(serverPageUrl("", "/finetune"), "/finetune")
+  assert.equal(
+    serverPageUrl("https://192.168.1.20:8001", "/finetune"),
+    "https://192.168.1.20:8001/finetune"
+  )
+  assert.equal(
+    serverPageUrl("https://station.local:8001/", "/finetune"),
+    "https://station.local:8001/finetune"
+  )
+})

--- a/web/app/test/server-pages.test.mjs
+++ b/web/app/test/server-pages.test.mjs
@@ -4,11 +4,11 @@ import test from "node:test"
 import { isAbsolutePagePath, normalizeServerPages, serverPageUrl } from "../src/lib/server-pages.ts"
 
 test("only absolute, non-API paths count as backend pages", () => {
-  assert.equal(isAbsolutePagePath("/finetune"), true)
+  assert.equal(isAbsolutePagePath("/datasets"), true)
   assert.equal(isAbsolutePagePath("/tools/x?tab=1"), true)
-  assert.equal(isAbsolutePagePath("finetune"), false)
+  assert.equal(isAbsolutePagePath("datasets"), false)
   assert.equal(isAbsolutePagePath("//evil.example/x"), false)
-  assert.equal(isAbsolutePagePath("/api/finetuning"), false)
+  assert.equal(isAbsolutePagePath("/api/datasets"), false)
 })
 
 test("the /api/info pages field is validated and de-duplicated", () => {
@@ -16,8 +16,8 @@ test("the /api/info pages field is validated and de-duplicated", () => {
   assert.deepEqual(normalizeServerPages("nope"), [])
   assert.deepEqual(
     normalizeServerPages([
-      { label: " Finetuning ", path: "/finetune", description: " Train on Pi " },
-      { label: "Dup", path: "/finetune" },
+      { label: " Datasets ", path: "/datasets", description: " Browse recorded datasets " },
+      { label: "Dup", path: "/datasets" },
       { label: "", path: "/blank" },
       { label: "Relative", path: "x" },
       { label: "API", path: "/api/x" },
@@ -25,20 +25,20 @@ test("the /api/info pages field is validated and de-duplicated", () => {
       { label: "Plain", path: "/plain", description: 3 },
     ]),
     [
-      { label: "Finetuning", path: "/finetune", description: "Train on Pi" },
+      { label: "Datasets", path: "/datasets", description: "Browse recorded datasets" },
       { label: "Plain", path: "/plain" },
     ]
   )
 })
 
 test("page hrefs stay relative on the backend's own origin and absolute elsewhere", () => {
-  assert.equal(serverPageUrl("", "/finetune"), "/finetune")
+  assert.equal(serverPageUrl("", "/datasets"), "/datasets")
   assert.equal(
-    serverPageUrl("https://192.168.1.20:8001", "/finetune"),
-    "https://192.168.1.20:8001/finetune"
+    serverPageUrl("https://192.168.1.20:8001", "/datasets"),
+    "https://192.168.1.20:8001/datasets"
   )
   assert.equal(
-    serverPageUrl("https://station.local:8001/", "/finetune"),
-    "https://station.local:8001/finetune"
+    serverPageUrl("https://station.local:8001/", "/datasets"),
+    "https://station.local:8001/datasets"
   )
 })

--- a/web/app/vite.config.ts
+++ b/web/app/vite.config.ts
@@ -64,6 +64,9 @@ export default defineConfig({
   define: {
     __AXOL_BUILD_COMMIT__: JSON.stringify(buildCommit()),
     __AXOL_BUILD_VERSION__: JSON.stringify(buildVersion()),
+    // Only /api is proxied in dev; a page the backend serves itself (see
+    // lib/server-pages.ts) has to be linked straight at the proxy target.
+    __AXOL_DEV_SERVE_URL__: JSON.stringify(SUPERVISOR),
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Why

`register()` covers commands, but a package built on `almond-axol` that serves a page of its own (extra `/api/...` routes plus the page) had to wrap `create_app` and reorder `app.router.routes` to get ahead of the SPA catch-all — and the panel had no way to link to that page: the hosted panel drives a station on another origin, so a relative link in the bundle cannot reach it.

## What

- `almond_axol/serve/extensions.py` (exported from `almond_axol.serve`):
  - `register_app_extension(fn)` — `fn(app)` runs inside `create_app` after the built-in routes and before `_mount_spa`, so added routes win over the catch-all like the built-ins.
  - `register_page(PanelPage(label, path, description=""))` — advertises a backend-served page; `PanelPage` validates the path (absolute, not `//host`, not under `/api/`).
  - Both are idempotent process-global registries like the command catalog.
- `/api/info` reports the registered pages as `pages: [{label, path, description?}]`.
- web: `lib/server-pages.ts` validates that field and builds the href; `ServerInfo.pages` is normalized in `fetchInfo`; `SiteNav` renders the pages ahead of Docs — relative when the panel is served by the backend, otherwise against the configured server base in a new tab so the panel stays connected. Under the Vite dev server (only `/api` is proxied) the link goes at the proxy target (`AXOL_SERVE_URL`). Only the control panel passes them; with no registered pages nothing changes.

## Verification

- `tests/test_serve_extensions.py`: extension routes beat the SPA catch-all, `/api/info` payload, `PanelPage` validation, registry idempotence; serve-related suites (`test_static_spa_safety`, `test_serve_*`, `test_tracker_setup_api`, `test_power_loss`) still pass.
- `web/app/test/server-pages.test.mjs`; `tsc -b`, eslint, prettier, `vite build` clean.
- Headless Chromium against the built bundle served by `create_app` with a registered page: nav shows the page relative same-origin (same tab), `http://<host>:8001/<path>` with `target=_blank rel=noreferrer` when a server host is configured, and the dev proxy target under `vite`; no JS errors.