### PR TITLE
Restore the pre-Rust Axol API; the realtime core is an implementation detail

### DIFF
--- a/almond_axol/cli/gravity_comp.py
+++ b/almond_axol/cli/gravity_comp.py
@@ -28,7 +28,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -37,9 +36,6 @@ from ..robot import Axol
 from ..teleop.recorder import TeleopRecorder
 from ..teleop.recorder import make as _recorder_make
 from .config import GravityCompCmdConfig, parse
-
-if TYPE_CHECKING:
-    from ..rt import RtAxol
 
 
 def _resolve_free_joints(names: list[str] | None) -> set[Joint] | None:
@@ -111,18 +107,14 @@ async def _run(cfg: GravityCompCmdConfig) -> None:
 
     # Rust owns CAN for every production hardware control loop. Python keeps
     # the gravity model and streams passthrough targets to the core.
-    from ..rt import RtAxol as _RtAxol
-
-    robot: RtAxol = _RtAxol(
-        Axol(
-            config=cfg.axol,
-            left_channel=cfg.left_channel,
-            right_channel=cfg.right_channel,
-        )
+    robot = Axol(
+        config=cfg.axol,
+        left_channel=cfg.left_channel,
+        right_channel=cfg.right_channel,
     )
 
     async with robot as axol:
-        # RtAxol.enable() leaves the joints in the required modes and verifies
+        # Axol.enable() leaves the joints in the required modes and verifies
         # the core's native feedback stream before returning.
 
         if rec is not None:
@@ -142,7 +134,7 @@ async def _run(cfg: GravityCompCmdConfig) -> None:
                 rec.set_engaged(False)
 
 
-def _record_measured(rec: TeleopRecorder, axol: RtAxol) -> None:
+def _record_measured(rec: TeleopRecorder, axol: Axol) -> None:
     """Append one measured-side row (arm joints only) to the recorder.
 
     Reads the cached positions/torques the impedance feedback frames refresh

--- a/almond_axol/cli/teleop.py
+++ b/almond_axol/cli/teleop.py
@@ -403,14 +403,10 @@ async def _run(cfg: TeleopCmdConfig) -> None:
     else:
         # The Rust realtime core is the sole hardware control backend. Python
         # owns VR/IK/model math and streams targets; Rust owns both CAN buses.
-        from ..rt import RtAxol
-
-        robot = RtAxol(
-            Axol(
-                config=cfg.axol,
-                left_channel=cfg.left_channel,
-                right_channel=cfg.right_channel,
-            ),
+        robot = Axol(
+            config=cfg.axol,
+            left_channel=cfg.left_channel,
+            right_channel=cfg.right_channel,
             max_vel=cfg.teleop.teleop_max_vel,
             max_accel=cfg.teleop.teleop_max_accel,
             record=cfg.teleop.record,

--- a/almond_axol/cli/tune/motion.py
+++ b/almond_axol/cli/tune/motion.py
@@ -45,7 +45,6 @@ import asyncio
 import logging
 import math
 import time
-from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -55,9 +54,6 @@ from ...robot.config import AxolConfig
 from ...robot.control import ContactWatchdog
 from ...tuning import save_run, tracking_metrics
 from ...tuning.motion import ReferenceMotion, list_motions, load_motion
-
-if TYPE_CHECKING:
-    from ...rt import RtAxol
 
 _PLAN_SPEED = 0.1 * np.pi  # rad/s — approach/return trajectory speed
 _PLAN_MIN_DURATION = 1.5  # s
@@ -531,9 +527,7 @@ async def _run(args: argparse.Namespace) -> None:
     traj_playback = [to_full(row) for row in sent]
 
     # Production playback always runs through the Rust core, matching teleop.
-    from ...rt import RtAxol as _RtAxol
-
-    robot: RtAxol = _RtAxol(Axol(config=config))
+    robot = Axol(config=config)
 
     async with robot as axol:
         contact: tuple[str, float] | None = None

--- a/almond_axol/cli/tune/repeatability.py
+++ b/almond_axol/cli/tune/repeatability.py
@@ -29,7 +29,6 @@ import argparse
 import asyncio
 import logging
 import time
-from typing import TYPE_CHECKING
 
 import numpy as np
 
@@ -39,9 +38,6 @@ from ...robot import Axol, closer_end_stop
 from ...robot.config import AxolConfig
 from ...teleop.config import VRTeleopConfig
 from ...teleop.trajectory import plan_collision_aware_trajectory
-
-if TYPE_CHECKING:
-    from ...rt import RtAxol
 
 _RATE_HZ = (
     250.0  # waypoint density — high for smooth playback (speed is set by --speed)
@@ -152,7 +148,7 @@ def _make_motion_command(
 
 
 def _snapshot_q(
-    axol: RtAxol, solver: KinematicsSolver, q_default: np.ndarray
+    axol: Axol, solver: KinematicsSolver, q_default: np.ndarray
 ) -> np.ndarray:
     """Read the *cached* arm positions into a full-N solver vector.
 
@@ -171,7 +167,7 @@ def _snapshot_q(
 
 
 async def _execute(
-    axol: RtAxol,
+    axol: Axol,
     solver: KinematicsSolver,
     trajectory: list[np.ndarray],
     rate_hz: float,
@@ -334,9 +330,7 @@ async def _run(args: argparse.Namespace) -> None:
         f"rate={args.rate:.0f} Hz. Press Ctrl-C to stop."
     )
 
-    from ...rt import RtAxol as _RtAxol
-
-    async with _RtAxol(Axol(config=axol_config, **axol_kwargs)) as axol:
+    async with Axol(config=axol_config, **axol_kwargs) as axol:
         # Always begin from the planned rest pose. If the operator parked the
         # arm anywhere else, sneak there with a one-off collision-aware plan
         # so the first cycle doesn't snap.

--- a/almond_axol/cli/waypoints.py
+++ b/almond_axol/cli/waypoints.py
@@ -42,7 +42,7 @@ import sys
 import threading
 import time
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import numpy as np
 
@@ -55,9 +55,6 @@ from ..utils.paths import almond_path
 from ..waypoints import Waypoint, WaypointSet
 from .config import LogLevel, normalize_bool_flags, parse
 from .gravity_comp import _resolve_free_joints
-
-if TYPE_CHECKING:
-    from ..rt import RtAxol
 
 _logger = logging.getLogger(__name__)
 
@@ -411,7 +408,7 @@ class _Session:
     def __init__(
         self,
         cfg: WaypointsCmdConfig,
-        robot: RobotBase | RtAxol,
+        robot: RobotBase,
         control: Control,
         stop_event: threading.Event,
     ) -> None:
@@ -934,18 +931,15 @@ async def _session(
     if cfg.sim:
         from ..robot.sim import Sim
 
-        robot: RobotBase | RtAxol = Sim()
+        robot: RobotBase = Sim()
     else:
         from ..robot import Axol
-        from ..rt import RtAxol
 
         # Rust is the sole hardware backend for both teaching and playback.
-        robot = RtAxol(
-            Axol(
-                config=cfg.axol,
-                left_channel=cfg.left_channel,
-                right_channel=cfg.right_channel,
-            )
+        robot = Axol(
+            config=cfg.axol,
+            left_channel=cfg.left_channel,
+            right_channel=cfg.right_channel,
         )
 
     async with robot:

--- a/almond_axol/diagnostics/can/send.py
+++ b/almond_axol/diagnostics/can/send.py
@@ -1,6 +1,6 @@
 """Cycle one joint through its limits while holding all others at their start position.
 
-The arms are driven through the Rust realtime core (``RtAxol``) — the same
+The arms are driven through the Rust realtime core (``Axol``) — the same
 control path as teleop — so what this exercises is the production controller
 and its CAN traffic, not a Python-side loop. Every motor of each selected arm
 must be on the bus (the core brings the whole arm up); only the chosen joint
@@ -42,10 +42,10 @@ from ...constants import (
     CAN_RIGHT,
     Joint,
 )
-from ...robot.axol import GRIPPER_TRAVEL, Axol, arm_limits
+from ...robot.axol import GRIPPER_TRAVEL, arm_limits
 from ...robot.config import AxolConfig
 from ...robot.mantis import Mantis
-from ...rt import RtAxol, RtMantis
+from ...rt import Axol, RtMantis
 
 _BAR_WIDTH = 24
 _TAU = 2 * math.pi
@@ -285,7 +285,7 @@ async def _run(
     cycle_count = 0
     send_error_count = 0
 
-    robot: RtAxol | RtMantis
+    robot: Axol | RtMantis
     if mantis:
         # Grippers-only core on the Mantis buses; ``enable`` (non-deferred)
         # brings the grippers up and arms it, as a take does.
@@ -297,14 +297,12 @@ async def _run(
             )
         )
     else:
-        # ``resolved()`` applies the default stiffness blend at the ``Axol``
+        # ``resolved()`` applies the default stiffness blend at the hardware
         # construction boundary, so the core runs the same gains teleop does.
-        robot = RtAxol(
-            Axol(
-                config=AxolConfig(),
-                left_channel=left_channel if run_left else None,
-                right_channel=right_channel if run_right else None,
-            )
+        robot = Axol(
+            config=AxolConfig(),
+            left_channel=left_channel if run_left else None,
+            right_channel=right_channel if run_right else None,
         )
     try:
         try:

--- a/almond_axol/diagnostics/can/send.py
+++ b/almond_axol/diagnostics/can/send.py
@@ -7,7 +7,7 @@ must be on the bus (the core brings the whole arm up); only the chosen joint
 moves.
 
 ``--target mantis`` drives the Mantis rig's handheld grippers instead
-(``RtMantis`` on ``can_mantis_l`` / ``can_mantis_r``): the core owns the
+(``Mantis`` on ``can_mantis_l`` / ``can_mantis_r``): the core owns the
 gripper buses exactly as it does during a take, and only ``--joint gripper``
 is meaningful there.
 
@@ -44,8 +44,7 @@ from ...constants import (
 )
 from ...robot.axol import GRIPPER_TRAVEL, arm_limits
 from ...robot.config import AxolConfig
-from ...robot.mantis import Mantis
-from ...rt import Axol, RtMantis
+from ...rt import Axol, Mantis
 
 _BAR_WIDTH = 24
 _TAU = 2 * math.pi
@@ -285,16 +284,14 @@ async def _run(
     cycle_count = 0
     send_error_count = 0
 
-    robot: Axol | RtMantis
+    robot: Axol | Mantis
     if mantis:
         # Grippers-only core on the Mantis buses; ``enable`` (non-deferred)
         # brings the grippers up and arms it, as a take does.
-        robot = RtMantis(
-            Mantis(
-                config=AxolConfig(),
-                left_channel=left_channel if run_left else None,
-                right_channel=right_channel if run_right else None,
-            )
+        robot = Mantis(
+            config=AxolConfig(),
+            left_channel=left_channel if run_left else None,
+            right_channel=right_channel if run_right else None,
         )
     else:
         # ``resolved()`` applies the default stiffness blend at the hardware

--- a/almond_axol/diagnostics/lift/cycle.py
+++ b/almond_axol/diagnostics/lift/cycle.py
@@ -42,7 +42,6 @@ import numpy as np
 
 from ...cli.lift import Interrupted, fmt_status, interrupt_event
 from ...constants import ARM_JOINTS, CAN_BASE, CAN_CHEST, CAN_LEFT, CAN_RIGHT, Joint
-from ...robot.axol import AxolHardware
 from ...robot.config import AxolConfig
 from ...robot.lift import Lift, LiftStatus, resolve_lift_channel
 from ...rt import Axol
@@ -601,7 +600,7 @@ def _rest_targets(
     return left_target, right_target
 
 
-async def _disable_arms_verified(robot: Axol, axol: AxolHardware) -> None:
+async def _disable_arms_verified(robot: Axol) -> None:
     """Disable every selected-arm motor and prove none still reports holding.
 
     ``Axol.disable`` is the deliberate stop: the core disables the motors on
@@ -613,7 +612,7 @@ async def _disable_arms_verified(robot: Axol, axol: AxolHardware) -> None:
     """
     missing = [
         f"{side} {joint.value}"
-        for side, arm in (("left", axol.left), ("right", axol.right))
+        for side, arm in (("left", robot.left), ("right", robot.right))
         if arm is not None
         for joint in ARM_JOINTS
         if joint not in arm.motors
@@ -624,7 +623,7 @@ async def _disable_arms_verified(robot: Axol, axol: AxolHardware) -> None:
         )
     motors = [
         (side, joint, motor)
-        for side, arm in (("left", axol.left), ("right", axol.right))
+        for side, arm in (("left", robot.left), ("right", robot.right))
         if arm is not None
         for joint, motor in arm.motors.items()
         if joint in ARM_JOINTS
@@ -646,7 +645,7 @@ async def _disable_arms_verified(robot: Axol, axol: AxolHardware) -> None:
             "the arms remain energized"
         )
 
-    await axol.connect()
+    await robot.connect()
     try:
         holding_results = await asyncio.gather(
             *(motor.is_holding() for _, _, motor in motors),
@@ -655,7 +654,7 @@ async def _disable_arms_verified(robot: Axol, axol: AxolHardware) -> None:
     finally:
         # A bus that will not close leaves ownership uncertain; that withholds
         # the PASS even when every motor reported disabled.
-        await _retry_cleanup(axol.disconnect, label="closing arm CAN buses")
+        await _retry_cleanup(robot.disconnect, label="closing arm CAN buses")
 
     problems = []
     for (side, joint, _), holding_result in zip(motors, holding_results, strict=True):
@@ -870,7 +869,6 @@ async def _run(args: argparse.Namespace) -> None:
     cycles = _resolve_cycles(args.cycles)
     lift_channel = resolve_lift_channel(args.lift_channel)
     lift: Lift | None = None
-    inner: AxolHardware | None = None
     axol: Axol | None = None
     arms_enabled = False
     arms_disabled = False
@@ -919,9 +917,6 @@ async def _run(args: argparse.Namespace) -> None:
                 left_channel=None if args.no_left else args.left_channel,
                 right_channel=None if args.no_right else args.right_channel,
             )
-            # The low-level object, for the post-disable verification reads
-            # once the core has released the buses.
-            inner = axol.hardware
             print("Enabling arms and holding their measured pose ...")
             # enable() can partially attach before surfacing a motor fault;
             # cleanup must treat the arm state as live from this point onward.
@@ -1094,7 +1089,7 @@ async def _run(args: argparse.Namespace) -> None:
             )
             await ensure_lift_upper_stopped()
             print("S1 rest verified; disabling arm motors ...")
-            await _disable_arms_verified(axol, inner)
+            await _disable_arms_verified(axol)
             arms_disabled = True
             completed = True
     except BaseException as exc:
@@ -1121,17 +1116,19 @@ async def _run(args: argparse.Namespace) -> None:
             # their last command (a failed/low lift must never cause the
             # process to torque off arms out of their clearance).
             try:
-                await _retry_cleanup(axol.detach, label="releasing the realtime core")
+                await _retry_cleanup(
+                    axol.disconnect, label="releasing the realtime core"
+                )
             except BaseException as exc:
                 cleanup_errors.append(exc)
                 print(f"WARNING: {exc}", file=sys.stderr)
-        if inner is not None:
-            # Every path above already closed the arm buses (detach, or the
-            # verified disable's proxy reopen/close); this proves it. A bus
-            # that cannot be closed leaves ownership uncertain and withholds
-            # the PASS.
+        if axol is not None:
+            # Every path above already closed the arm buses (the core release,
+            # or the verified disable's proxy reopen/close); this proves it. A
+            # bus that cannot be closed leaves ownership uncertain and
+            # withholds the PASS.
             try:
-                await _retry_cleanup(inner.disconnect, label="closing arm CAN buses")
+                await _retry_cleanup(axol.disconnect, label="closing arm CAN buses")
             except BaseException as exc:
                 cleanup_errors.append(exc)
                 print(f"WARNING: {exc}", file=sys.stderr)

--- a/almond_axol/diagnostics/lift/cycle.py
+++ b/almond_axol/diagnostics/lift/cycle.py
@@ -15,7 +15,7 @@ position save to finish before issuing the next move. The held arm joints
 remain monitored throughout lift motion, and Ctrl-C stops the lift. The other
 arm joints hold their measured starting positions throughout.
 
-The arms are driven through the Rust realtime core (``RtAxol``), the same
+The arms are driven through the Rust realtime core (``Axol``), the same
 control path as teleop: it owns the arm CAN buses, renders the S1 ramps at
 240 Hz, and keeps the held joints damped while the lift cycles.
 
@@ -42,10 +42,10 @@ import numpy as np
 
 from ...cli.lift import Interrupted, fmt_status, interrupt_event
 from ...constants import ARM_JOINTS, CAN_BASE, CAN_CHEST, CAN_LEFT, CAN_RIGHT, Joint
-from ...robot.axol import Axol
+from ...robot.axol import AxolHardware
 from ...robot.config import AxolConfig
 from ...robot.lift import Lift, LiftStatus, resolve_lift_channel
-from ...rt import RtAxol
+from ...rt import Axol
 
 _STATUS_PERIOD_MS = 200
 _STATUS_STALE_S = 1.0
@@ -523,7 +523,7 @@ def _validated_arm_pose(
 
 
 async def _read_valid_arm_positions(
-    axol: RtAxol,
+    axol: Axol,
     context: str,
 ) -> tuple[np.ndarray | None, np.ndarray | None]:
     left, right = await axol.get_positions()
@@ -543,7 +543,7 @@ async def _read_valid_arm_positions(
     )
 
 
-async def _verify_arms_holding(axol: RtAxol, context: str) -> None:
+async def _verify_arms_holding(axol: Axol, context: str) -> None:
     """Prove the realtime core still holds every selected arm joint.
 
     The core owns the CAN buses while the arms are up, so Python cannot ask
@@ -601,10 +601,10 @@ def _rest_targets(
     return left_target, right_target
 
 
-async def _disable_arms_verified(robot: RtAxol, axol: Axol) -> None:
+async def _disable_arms_verified(robot: Axol, axol: AxolHardware) -> None:
     """Disable every selected-arm motor and prove none still reports holding.
 
-    ``RtAxol.disable`` is the deliberate stop: the core disables the motors on
+    ``Axol.disable`` is the deliberate stop: the core disables the motors on
     disarm and Python repeats the shutdown once the bus is free. Its lifecycle
     intentionally suppresses individual motor errors (and, after a core fault
     or limp, deliberately leaves the motors energized). A diagnostic must be
@@ -675,7 +675,7 @@ async def _disable_arms_verified(robot: RtAxol, axol: Axol) -> None:
 
 
 async def _ramp_arms(
-    axol: RtAxol,
+    axol: Axol,
     start_left: np.ndarray | None,
     start_right: np.ndarray | None,
     target_left: np.ndarray | None,
@@ -749,7 +749,7 @@ async def _ramp_arms(
 
 
 async def _verify_arm_targets(
-    axol: RtAxol,
+    axol: Axol,
     target_left: np.ndarray | None,
     target_right: np.ndarray | None,
     context: str,
@@ -870,8 +870,8 @@ async def _run(args: argparse.Namespace) -> None:
     cycles = _resolve_cycles(args.cycles)
     lift_channel = resolve_lift_channel(args.lift_channel)
     lift: Lift | None = None
-    inner: Axol | None = None
-    axol: RtAxol | None = None
+    inner: AxolHardware | None = None
+    axol: Axol | None = None
     arms_enabled = False
     arms_disabled = False
     arms_at_clearance = False
@@ -912,14 +912,16 @@ async def _run(args: argparse.Namespace) -> None:
                 # gripper while exercising the independent lift mechanism.
                 has_gripper=False,
             )
-            inner = Axol(
+            # Production control path: the Rust core owns the arm buses and
+            # holds the clearance pose, damping live, while the lift cycles.
+            axol = Axol(
                 config=config,
                 left_channel=None if args.no_left else args.left_channel,
                 right_channel=None if args.no_right else args.right_channel,
             )
-            # Production control path: the Rust core owns the arm buses and
-            # holds the clearance pose, damping live, while the lift cycles.
-            axol = RtAxol(inner)
+            # The low-level object, for the post-disable verification reads
+            # once the core has released the buses.
+            inner = axol.hardware
             print("Enabling arms and holding their measured pose ...")
             # enable() can partially attach before surfacing a motor fault;
             # cleanup must treat the arm state as live from this point onward.

--- a/almond_axol/diagnostics/rom/disable.py
+++ b/almond_axol/diagnostics/rom/disable.py
@@ -33,7 +33,7 @@ from ...constants import (
     Joint,
 )
 from ...motor import ControlMode
-from ...robot.axol import GRIPPER_TRAVEL, Axol, AxolArm
+from ...robot.axol import GRIPPER_TRAVEL, AxolArm, AxolHardware
 
 # Marker prefix a --web-prompts step prints before blocking on stdin, matching
 # rom.enable; the dashboard turns it into a Continue button.
@@ -87,7 +87,7 @@ async def run(
     right_channel: str = CAN_RIGHT,
 ) -> None:
     """Open each gripper sequentially, then disable every motor."""
-    axol = Axol(
+    axol = AxolHardware(
         left_channel=None if no_left else left_channel,
         right_channel=None if no_right else right_channel,
     )

--- a/almond_axol/diagnostics/rom/enable.py
+++ b/almond_axol/diagnostics/rom/enable.py
@@ -10,7 +10,7 @@ the robot returns home but keeps holding the item with the motors left enabled
 — run ``almond_axol.diagnostics.rom.disable`` afterwards to open the grippers
 and retrieve the item.
 
-The arms are driven through the Rust realtime core (``RtAxol``), the same
+The arms are driven through the Rust realtime core (``Axol``), the same
 control path as teleop: the core owns the CAN buses, renders the streamed
 targets at 240 Hz, and runs the host damping against fresh feedback. A soak
 therefore exercises exactly the controller the robot ships with.
@@ -92,11 +92,11 @@ from ...robot.axol import (
     SHOULDER_1_LEFT_LIMITS,
     SHOULDER_2_LEFT_LIMITS,
     SHOULDER_2_RIGHT_LIMITS,
-    Axol,
+    AxolHardware,
 )
 from ...robot.config import ArmConfig, AxolConfig, FrictionParams
 from ...robot.mantis import Mantis
-from ...rt import RtAxol, RtMantis
+from ...rt import Axol, RtMantis
 from ..telemetry_log import TelemetryCsvLogger
 
 CONTROL_RATE_HZ = 100.0  # Hz
@@ -308,14 +308,14 @@ def home_pose() -> np.ndarray:
 
 
 async def _stream(
-    robot: RtAxol | RtMantis,
+    robot: Axol | RtMantis,
     left_q: np.ndarray,  # rad
     right_q: np.ndarray,  # rad
 ) -> None:
     """Ship one target pair to the core, refusing to keep "sweeping" limp arms.
 
     Once the core has gone limp (loss-of-trust fault: a silent motor)
-    ``RtAxol.motion_control`` streams gravity comp instead of tracking, so the
+    ``Axol.motion_control`` streams gravity comp instead of tracking, so the
     arms would hang weightless while this script kept announcing sweeps. Stop
     the run instead; the operator hand-guides the arms to rest.
     """
@@ -326,7 +326,7 @@ async def _stream(
 
 
 async def hold_pose(
-    robot: RtAxol | RtMantis,
+    robot: Axol | RtMantis,
     left_q: np.ndarray,  # rad
     right_q: np.ndarray,  # rad
     seconds: float,
@@ -347,7 +347,7 @@ async def hold_pose(
 
 
 async def _stream_hold_forever(
-    robot: RtAxol | RtMantis,
+    robot: Axol | RtMantis,
     left_q: np.ndarray,  # rad
     right_q: np.ndarray,  # rad
 ) -> None:
@@ -359,7 +359,7 @@ async def _stream_hold_forever(
 
 
 async def move_grippers(
-    robot: RtAxol | RtMantis,
+    robot: Axol | RtMantis,
     left_q: np.ndarray,  # rad
     right_q: np.ndarray,  # rad
     left_grip: float,  # normalized [0, 1] — 0 closed, 1 open
@@ -397,7 +397,7 @@ async def move_grippers(
 
 
 async def sweep_to_target(
-    robot: RtAxol | RtMantis,
+    robot: Axol | RtMantis,
     left_q: np.ndarray,  # rad
     right_q: np.ndarray,  # rad
     left_target: np.ndarray,  # rad
@@ -412,7 +412,7 @@ async def sweep_to_target(
 
 
 async def sweep_unchecked(
-    robot: RtAxol | RtMantis,
+    robot: Axol | RtMantis,
     left_q: np.ndarray,  # rad
     right_q: np.ndarray,  # rad
     left_target: np.ndarray,  # rad
@@ -451,7 +451,7 @@ def with_joint(
 
 
 async def sweep_joint_range(
-    robot: RtAxol | RtMantis,
+    robot: Axol | RtMantis,
     left_q: np.ndarray,  # rad
     right_q: np.ndarray,  # rad
     joint: Joint,
@@ -506,7 +506,7 @@ async def sweep_joint_range(
 
 
 async def run_rom_cycle(
-    robot: RtAxol | RtMantis,
+    robot: Axol | RtMantis,
     left_q: np.ndarray,  # rad
     right_q: np.ndarray,  # rad
     speed: float,  # rad/s
@@ -647,7 +647,7 @@ async def run_rom_cycle(
     return left_q, right_q
 
 
-async def return_home(robot: RtAxol | RtMantis) -> None:
+async def return_home(robot: Axol | RtMantis) -> None:
     """Ease the arms back to home from their current pose, keeping the grippers shut.
 
     Used to bring the robot to a safe home position while it stays clamped on
@@ -671,7 +671,7 @@ async def return_home(robot: RtAxol | RtMantis) -> None:
 async def _confirm(
     instruction: str,
     web_prompts: bool,
-    robot: RtAxol | RtMantis,
+    robot: Axol | RtMantis,
     left_q: np.ndarray,  # rad
     right_q: np.ndarray,  # rad
 ) -> None:
@@ -701,7 +701,7 @@ async def _confirm(
             pass
 
 
-async def _positions(robot: RtAxol | RtMantis) -> tuple[np.ndarray, np.ndarray]:
+async def _positions(robot: Axol | RtMantis) -> tuple[np.ndarray, np.ndarray]:
     """Measured positions as (left, right); an absent arm reports home."""
     left, right = await robot.get_positions()
     return (
@@ -752,8 +752,8 @@ async def run_axol(
         config.right.gripper.torque_limit = GRIPPER_TORQUE_LIMIT
     # Production control path: the Rust core owns the buses and runs the
     # 240 Hz loop; this script only streams targets (see the module docstring).
-    robot: RtAxol | RtMantis
-    axol: Axol | Mantis
+    robot: Axol | RtMantis
+    axol: AxolHardware | Mantis
     if target == "mantis":
         # Grippers-only core on the Mantis buses; the seven arm joints per
         # side are virtual (they latch the streamed targets), so the sweep
@@ -795,14 +795,14 @@ async def run_axol(
                 f"(stiffness {BENCH_STIFFNESS:g}), no gravity/friction/inertia/"
                 "host-damping feedforward."
             )
-        axol = Axol(
+        robot = Axol(
             config=config,
             left_channel=None if no_left else left_channel,
             right_channel=None if no_right else right_channel,
             left_joints=arm_joints["left"],
             right_joints=arm_joints["right"],
         )
-        robot = RtAxol(axol)
+        axol = robot.hardware
     await robot.enable()
     print("Motors enabled (realtime core armed).")
 
@@ -811,7 +811,7 @@ async def run_axol(
     if logger is not None:
         logger.start()
 
-    # Settle for 2 s at the measured pose (RtAxol.enable already primed the
+    # Settle for 2 s at the measured pose (Axol.enable already primed the
     # core with one gravity-compensated hold there).
     settle_left, settle_right = await _positions(robot)
     await hold_pose(robot, settle_left, settle_right, 2.0)

--- a/almond_axol/diagnostics/rom/enable.py
+++ b/almond_axol/diagnostics/rom/enable.py
@@ -92,10 +92,8 @@ from ...robot.axol import (
     SHOULDER_1_LEFT_LIMITS,
     SHOULDER_2_LEFT_LIMITS,
     SHOULDER_2_RIGHT_LIMITS,
-    AxolHardware,
 )
 from ...robot.config import ArmConfig, AxolConfig, FrictionParams
-from ...robot.mantis import MantisHardware
 from ...rt import Axol, Mantis
 from ..telemetry_log import TelemetryCsvLogger
 
@@ -753,7 +751,6 @@ async def run_axol(
     # Production control path: the Rust core owns the buses and runs the
     # 240 Hz loop; this script only streams targets (see the module docstring).
     robot: Axol | Mantis
-    axol: AxolHardware | MantisHardware
     if target == "mantis":
         # Grippers-only core on the Mantis buses; the seven arm joints per
         # side are virtual (they latch the streamed targets), so the sweep
@@ -763,7 +760,6 @@ async def run_axol(
             left_channel=None if no_left else left_channel,
             right_channel=None if no_right else right_channel,
         )
-        axol = robot.hardware
     else:
         # Bring up exactly the motors that are on each bus (see the module
         # docstring): every selected joint must answer the probe; an
@@ -802,12 +798,11 @@ async def run_axol(
             left_joints=arm_joints["left"],
             right_joints=arm_joints["right"],
         )
-        axol = robot.hardware
     await robot.enable()
     print("Motors enabled (realtime core armed).")
 
     # The logger samples the motor caches, which the core's telemetry fills.
-    logger = TelemetryCsvLogger(axol, "rom") if capture else None
+    logger = TelemetryCsvLogger(robot, "rom") if capture else None
     if logger is not None:
         logger.start()
 
@@ -957,7 +952,7 @@ async def run_axol(
             await robot.disable()
             print("Arms left limp (gravity comp) — hand-guide them to rest.")
         elif keep_enabled:
-            await robot.detach()
+            await robot.disconnect()
             print(
                 "\nMotors left enabled — robot is holding the item.\n"
                 "Run `uv run -m almond_axol.diagnostics.rom.disable` to open the "

--- a/almond_axol/diagnostics/rom/enable.py
+++ b/almond_axol/diagnostics/rom/enable.py
@@ -95,8 +95,8 @@ from ...robot.axol import (
     AxolHardware,
 )
 from ...robot.config import ArmConfig, AxolConfig, FrictionParams
-from ...robot.mantis import Mantis
-from ...rt import Axol, RtMantis
+from ...robot.mantis import MantisHardware
+from ...rt import Axol, Mantis
 from ..telemetry_log import TelemetryCsvLogger
 
 CONTROL_RATE_HZ = 100.0  # Hz
@@ -308,7 +308,7 @@ def home_pose() -> np.ndarray:
 
 
 async def _stream(
-    robot: Axol | RtMantis,
+    robot: Axol | Mantis,
     left_q: np.ndarray,  # rad
     right_q: np.ndarray,  # rad
 ) -> None:
@@ -326,7 +326,7 @@ async def _stream(
 
 
 async def hold_pose(
-    robot: Axol | RtMantis,
+    robot: Axol | Mantis,
     left_q: np.ndarray,  # rad
     right_q: np.ndarray,  # rad
     seconds: float,
@@ -347,7 +347,7 @@ async def hold_pose(
 
 
 async def _stream_hold_forever(
-    robot: Axol | RtMantis,
+    robot: Axol | Mantis,
     left_q: np.ndarray,  # rad
     right_q: np.ndarray,  # rad
 ) -> None:
@@ -359,7 +359,7 @@ async def _stream_hold_forever(
 
 
 async def move_grippers(
-    robot: Axol | RtMantis,
+    robot: Axol | Mantis,
     left_q: np.ndarray,  # rad
     right_q: np.ndarray,  # rad
     left_grip: float,  # normalized [0, 1] — 0 closed, 1 open
@@ -397,7 +397,7 @@ async def move_grippers(
 
 
 async def sweep_to_target(
-    robot: Axol | RtMantis,
+    robot: Axol | Mantis,
     left_q: np.ndarray,  # rad
     right_q: np.ndarray,  # rad
     left_target: np.ndarray,  # rad
@@ -412,7 +412,7 @@ async def sweep_to_target(
 
 
 async def sweep_unchecked(
-    robot: Axol | RtMantis,
+    robot: Axol | Mantis,
     left_q: np.ndarray,  # rad
     right_q: np.ndarray,  # rad
     left_target: np.ndarray,  # rad
@@ -451,7 +451,7 @@ def with_joint(
 
 
 async def sweep_joint_range(
-    robot: Axol | RtMantis,
+    robot: Axol | Mantis,
     left_q: np.ndarray,  # rad
     right_q: np.ndarray,  # rad
     joint: Joint,
@@ -506,7 +506,7 @@ async def sweep_joint_range(
 
 
 async def run_rom_cycle(
-    robot: Axol | RtMantis,
+    robot: Axol | Mantis,
     left_q: np.ndarray,  # rad
     right_q: np.ndarray,  # rad
     speed: float,  # rad/s
@@ -647,7 +647,7 @@ async def run_rom_cycle(
     return left_q, right_q
 
 
-async def return_home(robot: Axol | RtMantis) -> None:
+async def return_home(robot: Axol | Mantis) -> None:
     """Ease the arms back to home from their current pose, keeping the grippers shut.
 
     Used to bring the robot to a safe home position while it stays clamped on
@@ -671,7 +671,7 @@ async def return_home(robot: Axol | RtMantis) -> None:
 async def _confirm(
     instruction: str,
     web_prompts: bool,
-    robot: Axol | RtMantis,
+    robot: Axol | Mantis,
     left_q: np.ndarray,  # rad
     right_q: np.ndarray,  # rad
 ) -> None:
@@ -701,7 +701,7 @@ async def _confirm(
             pass
 
 
-async def _positions(robot: Axol | RtMantis) -> tuple[np.ndarray, np.ndarray]:
+async def _positions(robot: Axol | Mantis) -> tuple[np.ndarray, np.ndarray]:
     """Measured positions as (left, right); an absent arm reports home."""
     left, right = await robot.get_positions()
     return (
@@ -752,18 +752,18 @@ async def run_axol(
         config.right.gripper.torque_limit = GRIPPER_TORQUE_LIMIT
     # Production control path: the Rust core owns the buses and runs the
     # 240 Hz loop; this script only streams targets (see the module docstring).
-    robot: Axol | RtMantis
-    axol: AxolHardware | Mantis
+    robot: Axol | Mantis
+    axol: AxolHardware | MantisHardware
     if target == "mantis":
         # Grippers-only core on the Mantis buses; the seven arm joints per
         # side are virtual (they latch the streamed targets), so the sweep
         # helpers run unchanged and only the gripper physically moves.
-        axol = Mantis(
+        robot = Mantis(
             config=config,
             left_channel=None if no_left else left_channel,
             right_channel=None if no_right else right_channel,
         )
-        robot = RtMantis(axol)
+        axol = robot.hardware
     else:
         # Bring up exactly the motors that are on each bus (see the module
         # docstring): every selected joint must answer the probe; an

--- a/almond_axol/diagnostics/telemetry_log.py
+++ b/almond_axol/diagnostics/telemetry_log.py
@@ -17,7 +17,7 @@ SKU, partial bench arm) — so a ``--joints`` subset run still captures the
 joints it actually drives. Velocity is not cached by the motor layer, so it
 is not captured here.
 
-The Mantis rig (:class:`~almond_axol.robot.mantis.Mantis`) has one real motor
+The Mantis rig (:class:`~almond_axol.robot.mantis.MantisHardware`) has one real motor
 per side — the gripper — behind the same ``left`` / ``right`` surface; its
 arms carry no ``motors`` table, so they are sampled through their public
 ``positions`` / ``torques`` arrays (virtual arm joints echo their targets).
@@ -40,7 +40,7 @@ from ..utils.paths import almond_path
 from ..utils.state_files import secure_open_new_text
 
 if TYPE_CHECKING:
-    from ..robot.axol import Axol, AxolArm
+    from ..robot.axol import AxolArm, AxolHardware
 
 CAPTURE_DIR = almond_path("diagnostics", "captures")
 
@@ -52,7 +52,7 @@ class TelemetryCsvLogger:
 
     def __init__(
         self,
-        axol: Axol | Any,
+        axol: AxolHardware | Any,
         name: str,
         hz: float = _DEFAULT_HZ,
         out_dir: Path = CAPTURE_DIR,

--- a/almond_axol/lerobot/robot/config_mantis.py
+++ b/almond_axol/lerobot/robot/config_mantis.py
@@ -17,7 +17,7 @@ class MantisRobotConfig(AxolRobotConfig):
 
     Identical to :class:`AxolRobotConfig` — same camera slots, gains, and
     observation options, so recorded datasets keep the robot schema — but the
-    hardware behind it is :class:`~almond_axol.robot.mantis.Mantis`: one Damiao
+    hardware behind it is :class:`~almond_axol.robot.Mantis`: one Damiao
     gripper per CAN bus and virtual arm joints that echo the commanded IK
     targets. Cameras are the wrist slots only (``left_arm`` / ``right_arm``,
     mounted on the handheld grippers); there is no overhead camera.

--- a/almond_axol/lerobot/robot/robot_axol.py
+++ b/almond_axol/lerobot/robot/robot_axol.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
     from ...kinematics.config import KinematicsConfig
     from ...kinematics.fk import AxolForwardKinematics
     from ...kinematics.solver import KinematicsSolver
-    from ...rt import Axol, RtMantis
+    from ...rt import Axol, Mantis
 
 _logger = logging.getLogger(__name__)
 
@@ -142,7 +142,7 @@ class AxolRobot(Robot):
         self._left_trq_keys = [f"left_{j.value}.trq" for j in joints]
         self._right_trq_keys = [f"right_{j.value}.trq" for j in joints]
         self._ik_config = ik_config
-        self._axol: Axol | RtMantis | None = None
+        self._axol: Axol | Mantis | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
         self._loop_thread: threading.Thread | None = None
         self._connect_future: Future[None] | None = None
@@ -409,7 +409,7 @@ class AxolRobot(Robot):
 
         _logger.info("AxolRobot connected.")
 
-    def _build_hardware(self) -> Axol | RtMantis:
+    def _build_hardware(self) -> Axol | Mantis:
         """Construct the realtime-core-backed robot.
 
         LeRobot uses the same sole production backend as teleop: the Rust

--- a/almond_axol/lerobot/robot/robot_axol.py
+++ b/almond_axol/lerobot/robot/robot_axol.py
@@ -40,7 +40,6 @@ from lerobot.robots.robot import Robot
 from lerobot.utils.decorators import check_if_already_connected, check_if_not_connected
 
 from ...constants import Joint
-from ...robot.axol import Axol
 from ...robot.base import HardwareCleanupError
 from ...teleop.config import VRTeleopConfig
 from ...teleop.filter import TrapezoidalFilter
@@ -50,7 +49,7 @@ if TYPE_CHECKING:
     from ...kinematics.config import KinematicsConfig
     from ...kinematics.fk import AxolForwardKinematics
     from ...kinematics.solver import KinematicsSolver
-    from ...rt import RtAxol, RtMantis
+    from ...rt import Axol, RtMantis
 
 _logger = logging.getLogger(__name__)
 
@@ -143,7 +142,7 @@ class AxolRobot(Robot):
         self._left_trq_keys = [f"left_{j.value}.trq" for j in joints]
         self._right_trq_keys = [f"right_{j.value}.trq" for j in joints]
         self._ik_config = ik_config
-        self._axol: RtAxol | RtMantis | None = None
+        self._axol: Axol | RtMantis | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
         self._loop_thread: threading.Thread | None = None
         self._connect_future: Future[None] | None = None
@@ -175,7 +174,7 @@ class AxolRobot(Robot):
         )
         self._cartesian_last_send: float = 0.0
         # Optional flight-recorder prefix configured by collect-data before
-        # connect(). RtAxol owns the 240 Hz measured + motor-facing traces;
+        # connect(). Axol owns the 240 Hz measured + motor-facing traces;
         # keeping this runtime-only avoids exposing a diagnostics plumbing
         # detail as part of LeRobot's persistent robot configuration schema.
         self._control_trace: str | None = None
@@ -410,21 +409,19 @@ class AxolRobot(Robot):
 
         _logger.info("AxolRobot connected.")
 
-    def _build_hardware(self) -> RtAxol | RtMantis:
-        """Construct the realtime-core-backed driver.
+    def _build_hardware(self) -> Axol | RtMantis:
+        """Construct the realtime-core-backed robot.
 
         LeRobot uses the same sole production backend as teleop: the Rust
         core owns CAN at 240 Hz while Python streams policy/teleop targets.
         Overridden by the Mantis subclass (grippers-only core).
         """
-        from ...rt import RtAxol as _RtAxol
+        from ...rt import Axol as _Axol
 
-        return _RtAxol(
-            Axol(
-                self.config.axol_config,
-                left_channel=self.config.left_channel,
-                right_channel=self.config.right_channel,
-            ),
+        return _Axol(
+            self.config.axol_config,
+            left_channel=self.config.left_channel,
+            right_channel=self.config.right_channel,
             max_vel=VRTeleopConfig.teleop_max_vel,
             max_accel=VRTeleopConfig.teleop_max_accel,
             record=self._control_trace,
@@ -558,7 +555,7 @@ class AxolRobot(Robot):
     def limp(self) -> str | None:
         """Why the realtime core went limp, or ``None`` while it is healthy.
 
-        Mirrors :attr:`almond_axol.rt.RtAxol.limp`: once set, every arm joint
+        Mirrors :attr:`almond_axol.robot.Axol.limp`: once set, every arm joint
         is at kp = 0 with the streamed gravity feedforward for the rest of
         the session and :meth:`send_action` streams gravity comp instead of
         tracking. Recording flows check this before promising motion (a
@@ -1004,7 +1001,7 @@ class AxolRobot(Robot):
         :meth:`send_action`) and blocks until the cycle is sent. Telemetry must
         be active, so call this only while connected; drive it in a loop at the
         desired rate to keep the arms free to be hand-guided. See
-        :meth:`almond_axol.robot.axol.Axol.gravity_compensate` for the
+        :meth:`almond_axol.robot.axol.AxolHardware.gravity_compensate` for the
         ``kd``/``free_joints`` semantics.
         """
         assert self._axol is not None and self._loop is not None
@@ -1031,7 +1028,7 @@ class AxolRobot(Robot):
         Call after hand-guiding the arms (e.g. under
         :meth:`gravity_compensate`) and before resuming :meth:`send_action`, so
         the return-to-pose command is not rejected by the max-step safety
-        check. See :meth:`almond_axol.robot.axol.Axol.reset_command_state`.
+        check. See :meth:`almond_axol.robot.axol.AxolHardware.reset_command_state`.
 
         Mutates plain Python state on the arm wrappers, so it runs directly
         without the event loop.

--- a/almond_axol/lerobot/robot/robot_mantis.py
+++ b/almond_axol/lerobot/robot/robot_mantis.py
@@ -4,8 +4,8 @@ Same synchronous Robot surface as :class:`AxolRobot` — observations, actions,
 cameras, event loop — but the hardware is the Mantis rig: a pair of handheld
 Damiao grippers on their own CAN buses, with virtual arm joints latched from
 the commanded IK targets. Like the robot it is driven through the Rust
-realtime core (:class:`~almond_axol.rt.RtMantis` wrapping
-:class:`~almond_axol.robot.mantis.Mantis`): ``axol-rt`` owns the gripper
+realtime core (:class:`~almond_axol.robot.Mantis` wrapping
+:class:`~almond_axol.robot.mantis.MantisHardware`): ``axol-rt`` owns the gripper
 buses and streams the POSITION_FORCE commands for the duration of each take.
 ``collect-data`` drives it with the exact same control loop it uses for the
 robot, so Mantis datasets are schema-identical to robot-collected ones.
@@ -16,8 +16,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from ...robot.mantis import Mantis
-from ...rt import RtMantis
+from ...rt import Mantis
 from .config_mantis import MantisRobotConfig
 from .robot_axol import AxolRobot
 
@@ -58,33 +57,31 @@ class MantisRobot(AxolRobot):
         self._defer_gripper_enable = defer_gripper_enable
         super().__init__(config, ik_config=ik_config)
 
-    def _build_hardware(self) -> RtMantis:
-        return RtMantis(
-            Mantis(
-                self.config.axol_config,
-                left_channel=self.config.left_channel,
-                right_channel=self.config.right_channel,
-                defer_gripper_enable=self._defer_gripper_enable,
-            ),
+    def _build_hardware(self) -> Mantis:
+        return Mantis(
+            self.config.axol_config,
+            left_channel=self.config.left_channel,
+            right_channel=self.config.right_channel,
+            defer_gripper_enable=self._defer_gripper_enable,
             record=self._control_trace,
         )
 
     async def open_grippers_async(self) -> None:
         """Open both grippers fully, then release torque (pre-record prep).
 
-        See :meth:`~almond_axol.rt.RtMantis.open_grippers`: this also
+        See :meth:`~almond_axol.robot.Mantis.open_grippers`: this also
         performs the one-time hard-stop calibration, so the later
         :meth:`enable_grippers_async` at take start is immediate.
         """
-        assert isinstance(self._axol, RtMantis), "connect() first"
+        assert isinstance(self._axol, Mantis), "connect() first"
         await self._axol.open_grippers()
 
     async def enable_grippers_async(self) -> None:
         """Enable (calibrating on first use) both grippers and arm the core."""
-        assert isinstance(self._axol, RtMantis), "connect() first"
+        assert isinstance(self._axol, Mantis), "connect() first"
         await self._axol.enable_grippers()
 
     async def disable_grippers_async(self) -> None:
         """Disarm the core and disable both grippers, retaining calibration."""
-        assert isinstance(self._axol, RtMantis), "connect() first"
+        assert isinstance(self._axol, Mantis), "connect() first"
         await self._axol.disable_grippers()

--- a/almond_axol/motor/bus.py
+++ b/almond_axol/motor/bus.py
@@ -88,8 +88,8 @@ class CanBus:
     the core has disarmed.
 
     The proxy is **not a daemon**: it is a child process of *this* Python
-    process, spawned by :meth:`start` (``Axol.connect()`` / ``Axol.enable()``)
-    and reaped by :meth:`close` (``Axol.disconnect()`` / ``Axol.disable()``).
+    process, spawned by :meth:`start` (``AxolHardware.connect()`` / ``AxolHardware.enable()``)
+    and reaped by :meth:`close` (``AxolHardware.disconnect()`` / ``AxolHardware.disable()``).
     Its lifetime is the bus session, so ``axol-rt`` not appearing in ``ps``
     means this process has no open bus — not that a service needs starting.
     Startup spawns the process and waits for its ready handshake, so it is
@@ -267,14 +267,14 @@ class CanBus:
         """Explain why the bus cannot send right now, by lifecycle state."""
         if self._closed_reason is not None:
             return (
-                f"{self._closed_reason}; call Axol.connect() (CanBus.start()) "
+                f"{self._closed_reason}; call AxolHardware.connect() (CanBus.start()) "
                 "to reopen the bus"
             )
         if self._state == "unopened":
             return (
                 f"CAN bus {self._channel} has not been opened: the axol-rt "
                 "proxy is a child process of this Python process started by "
-                "Axol.connect() / Axol.enable() (CanBus.start()), not a "
+                "AxolHardware.connect() / AxolHardware.enable() (CanBus.start()), not a "
                 "daemon — await connect() before any motor I/O (per-arm "
                 "AxolArm.enable() does not open the bus itself)"
             )
@@ -282,13 +282,13 @@ class CanBus:
             return (
                 f"CAN bus {self._channel} is still starting: the axol-rt proxy "
                 "has been spawned but has not finished its ready handshake — "
-                "await the in-flight Axol.connect() / CanBus.start() before "
+                "await the in-flight AxolHardware.connect() / CanBus.start() before "
                 "issuing motor I/O (calling connect() again is idempotent and "
                 "waits for it)"
             )
         return (
-            f"CAN bus {self._channel} was closed (Axol.disconnect() / "
-            "Axol.disable() / CanBus.close()); call Axol.connect() to reopen it"
+            f"CAN bus {self._channel} was closed (AxolHardware.disconnect() / "
+            "AxolHardware.disable() / CanBus.close()); call AxolHardware.connect() to reopen it"
         )
 
     async def close(self) -> None:

--- a/almond_axol/motor/bus.py
+++ b/almond_axol/motor/bus.py
@@ -88,8 +88,8 @@ class CanBus:
     the core has disarmed.
 
     The proxy is **not a daemon**: it is a child process of *this* Python
-    process, spawned by :meth:`start` (``AxolHardware.connect()`` / ``AxolHardware.enable()``)
-    and reaped by :meth:`close` (``AxolHardware.disconnect()`` / ``AxolHardware.disable()``).
+    process, spawned by :meth:`start` (``Axol.connect()`` / ``Axol.enable()``)
+    and reaped by :meth:`close` (``Axol.disconnect()`` / ``Axol.disable()``).
     Its lifetime is the bus session, so ``axol-rt`` not appearing in ``ps``
     means this process has no open bus — not that a service needs starting.
     Startup spawns the process and waits for its ready handshake, so it is
@@ -267,14 +267,14 @@ class CanBus:
         """Explain why the bus cannot send right now, by lifecycle state."""
         if self._closed_reason is not None:
             return (
-                f"{self._closed_reason}; call AxolHardware.connect() (CanBus.start()) "
+                f"{self._closed_reason}; call Axol.connect() (CanBus.start()) "
                 "to reopen the bus"
             )
         if self._state == "unopened":
             return (
                 f"CAN bus {self._channel} has not been opened: the axol-rt "
                 "proxy is a child process of this Python process started by "
-                "AxolHardware.connect() / AxolHardware.enable() (CanBus.start()), not a "
+                "Axol.connect() / Axol.enable() (CanBus.start()), not a "
                 "daemon — await connect() before any motor I/O (per-arm "
                 "AxolArm.enable() does not open the bus itself)"
             )
@@ -282,13 +282,13 @@ class CanBus:
             return (
                 f"CAN bus {self._channel} is still starting: the axol-rt proxy "
                 "has been spawned but has not finished its ready handshake — "
-                "await the in-flight AxolHardware.connect() / CanBus.start() before "
+                "await the in-flight Axol.connect() / CanBus.start() before "
                 "issuing motor I/O (calling connect() again is idempotent and "
                 "waits for it)"
             )
         return (
-            f"CAN bus {self._channel} was closed (AxolHardware.disconnect() / "
-            "AxolHardware.disable() / CanBus.close()); call AxolHardware.connect() to reopen it"
+            f"CAN bus {self._channel} was closed (Axol.disconnect() / "
+            "Axol.disable() / CanBus.close()); call Axol.connect() to reopen it"
         )
 
     async def close(self) -> None:

--- a/almond_axol/robot/__init__.py
+++ b/almond_axol/robot/__init__.py
@@ -1,9 +1,13 @@
 """Public re-exports for almond_axol.robot."""
 
+# The production robot object lives with the realtime core it drives. Imported
+# last: ``almond_axol.rt`` imports this package's submodules, so every name it
+# needs must already be bound above.
+from ..rt.robot import Axol  # noqa: E402
 from .axol import (
     EITHER_STOP_JOINTS,
-    Axol,
     AxolArm,
+    AxolHardware,
     arm_limits,
     closer_end_stop,
     end_stop_offset_from_position,
@@ -24,6 +28,7 @@ __all__ = [
     "RobotBase",
     "Axol",
     "AxolArm",
+    "AxolHardware",
     "arm_limits",
     "closer_end_stop",
     "EITHER_STOP_JOINTS",

--- a/almond_axol/robot/__init__.py
+++ b/almond_axol/robot/__init__.py
@@ -1,14 +1,13 @@
 """Public re-exports for almond_axol.robot."""
 
-# The production robot objects live with the realtime core they drive.
-# Imported last: ``almond_axol.rt`` imports this package's submodules, so every
-# name it needs must already be bound above.
-from ..rt.mantis import Mantis  # noqa: E402
-from ..rt.robot import Axol  # noqa: E402
+# The robot objects live with the realtime core they drive. ``almond_axol.rt``
+# imports this package's *submodules* (never these re-exports), so the cycle
+# resolves whichever package is imported first.
+from ..rt.mantis import Mantis
+from ..rt.robot import Axol
 from .axol import (
     EITHER_STOP_JOINTS,
     AxolArm,
-    AxolHardware,
     arm_limits,
     closer_end_stop,
     end_stop_offset_from_position,
@@ -22,14 +21,13 @@ from .config import (
     PositionForceConfig,
 )
 from .jelly import Jelly, JellyConfig
-from .mantis import MantisGripperArm, MantisHardware
+from .mantis import MantisGripperArm
 from .sim import Sim
 
 __all__ = [
     "RobotBase",
     "Axol",
     "AxolArm",
-    "AxolHardware",
     "arm_limits",
     "closer_end_stop",
     "EITHER_STOP_JOINTS",
@@ -44,5 +42,4 @@ __all__ = [
     "Sim",
     "Mantis",
     "MantisGripperArm",
-    "MantisHardware",
 ]

--- a/almond_axol/robot/__init__.py
+++ b/almond_axol/robot/__init__.py
@@ -1,8 +1,9 @@
 """Public re-exports for almond_axol.robot."""
 
-# The production robot object lives with the realtime core it drives. Imported
-# last: ``almond_axol.rt`` imports this package's submodules, so every name it
-# needs must already be bound above.
+# The production robot objects live with the realtime core they drive.
+# Imported last: ``almond_axol.rt`` imports this package's submodules, so every
+# name it needs must already be bound above.
+from ..rt.mantis import Mantis  # noqa: E402
 from ..rt.robot import Axol  # noqa: E402
 from .axol import (
     EITHER_STOP_JOINTS,
@@ -21,7 +22,7 @@ from .config import (
     PositionForceConfig,
 )
 from .jelly import Jelly, JellyConfig
-from .mantis import Mantis, MantisGripperArm
+from .mantis import MantisGripperArm, MantisHardware
 from .sim import Sim
 
 __all__ = [
@@ -43,4 +44,5 @@ __all__ = [
     "Sim",
     "Mantis",
     "MantisGripperArm",
+    "MantisHardware",
 ]

--- a/almond_axol/robot/axol.py
+++ b/almond_axol/robot/axol.py
@@ -1,7 +1,13 @@
 """Hardware control classes for the Almond Axol dual-arm robot.
 
-Provides :class:`AxolArm` (single-arm CAN bus controller) and :class:`Axol`
-(dual-arm context manager that opens both buses and constructs all 16 motor drivers).
+Provides :class:`AxolArm` (single-arm CAN bus controller) and
+:class:`AxolHardware` (dual-arm context manager that opens both buses and
+constructs all 16 motor drivers).
+
+``AxolHardware`` sends CAN from Python on the caller's schedule. It is the
+right object for direct-register calibration and diagnostics on a quiet bus.
+Production motion goes through :class:`almond_axol.robot.Axol`, which wraps
+it and hands the buses to the Rust realtime core (``axol-rt``) while armed.
 """
 
 from __future__ import annotations
@@ -537,7 +543,7 @@ class AxolArm:
         Args:
             bus:          Shared CAN bus for this arm (one per physical interface).
             config:       Full dual-arm gains config; the correct side is selected via ``is_left``.
-            gravity_comp: Shared MuJoCo-based gravity compensator (one per Axol).
+            gravity_comp: Shared MuJoCo-based gravity compensator (one per AxolHardware).
             is_left:      ``True`` for the left arm, ``False`` for the right.
             joints:       The joints whose motors are on the bus; ``None``
                           (the default) is the full arm. The gripper is only
@@ -1076,9 +1082,9 @@ class AxolArm:
         On the gripperless SKU the gripper calibration and mode switch are
         skipped (there is no gripper motor).
 
-        This is the motor-level half of :meth:`Axol.enable`: it does **not**
+        This is the motor-level half of :meth:`AxolHardware.enable`: it does **not**
         open the CAN bus. Callers driving arms individually must have
-        awaited :meth:`Axol.connect` (or :meth:`Axol.enable`) first;
+        awaited :meth:`AxolHardware.connect` (or :meth:`AxolHardware.enable`) first;
         otherwise the first motor read fails with a ``CanOperationError``
         saying the bus is unopened or still starting.
 
@@ -1326,7 +1332,7 @@ class AxolArm:
         """Return each motor's enabled-and-holding state, fetched concurrently.
 
         Read-only — safe on a robot of unknown state (pairs with
-        :meth:`Axol.connect` for inspecting before acting). See
+        :meth:`AxolHardware.connect` for inspecting before acting). See
         :meth:`Motor.is_holding` for what "holding" means per motor family.
         Returns a list in Joint enum order. On the gripperless SKU the
         gripper entry is omitted (7 entries).
@@ -1864,14 +1870,14 @@ class AxolArm:
         return tau - gravity
 
 
-class Axol(RobotBase):
-    """Dual-arm Axol robot interface.
+class AxolHardware(RobotBase):
+    """Dual-arm Axol hardware interface, driven directly from Python.
 
     Opens one CAN bus per arm and constructs all 16 motor drivers on entry
     (14 on the gripperless SKU, ``config.has_gripper = False``).
     Use as an async context manager to ensure the buses are cleanly shut down.
 
-        async with Axol() as axol:
+        async with AxolHardware() as axol:
             await axol.enable()
             await axol.start_telemetry(500)  # 500 Hz
 
@@ -1888,7 +1894,7 @@ class Axol(RobotBase):
     touching motor state, for inspecting a robot of unknown state first
     (:meth:`get_holding`, :meth:`get_positions`, ...):
 
-        axol = Axol()
+        axol = AxolHardware()
         await axol.connect()      # open buses; inspect freely, nothing actuated
         await axol.enable()       # holding joints kept holding; cold joints brought up
         pos_l, pos_r = await axol.get_positions()
@@ -2066,7 +2072,7 @@ class Axol(RobotBase):
         just means no bus is open. Startup spawns the process and waits for
         its ready handshake, so it takes a moment: motor I/O issued from
         another task before this coroutine has returned fails with a
-        "CAN bus ... is still starting" error. Only the ``Axol``-level
+        "CAN bus ... is still starting" error. Only the ``AxolHardware``-level
         methods open buses; the per-arm :meth:`AxolArm.enable` /
         :meth:`AxolArm.disable` assume the bus is already open, so a
         controller that toggles arms individually must await ``connect()``

--- a/almond_axol/robot/axol.py
+++ b/almond_axol/robot/axol.py
@@ -4,10 +4,12 @@ Provides :class:`AxolArm` (single-arm CAN bus controller) and
 :class:`AxolHardware` (dual-arm context manager that opens both buses and
 constructs all 16 motor drivers).
 
-``AxolHardware`` sends CAN from Python on the caller's schedule. It is the
-right object for direct-register calibration and diagnostics on a quiet bus.
-Production motion goes through :class:`almond_axol.robot.Axol`, which wraps
-it and hands the buses to the Rust realtime core (``axol-rt``) while armed.
+``AxolHardware`` is internal to the package: it sends CAN from Python on the
+caller's schedule, which is what calibration and diagnostics tooling needs
+on a quiet bus. The public robot object is :class:`almond_axol.robot.Axol`
+(``almond_axol.rt.robot``): it presents this same surface, owns an
+``AxolHardware`` underneath, and hands the buses to the Rust realtime core
+(``axol-rt``) while enabled.
 """
 
 from __future__ import annotations
@@ -1872,6 +1874,11 @@ class AxolArm:
 
 class AxolHardware(RobotBase):
     """Dual-arm Axol hardware interface, driven directly from Python.
+
+    Internal — the public robot object is :class:`almond_axol.robot.Axol`,
+    which owns one of these and exposes the same methods. Use this class
+    directly only from package tooling that must send CAN from Python on a
+    quiet bus (calibration, register-level diagnostics).
 
     Opens one CAN bus per arm and constructs all 16 motor drivers on entry
     (14 on the gripperless SKU, ``config.has_gripper = False``).

--- a/almond_axol/robot/config.py
+++ b/almond_axol/robot/config.py
@@ -686,7 +686,7 @@ class AxolConfig:
                          is unchanged by the blend. The blend is baked
                          into the ``left`` / ``right`` gains by
                          :meth:`resolved`, which is called once at the
-                         robot-construction boundary (``Axol.__init__``).
+                         robot-construction boundary (``AxolHardware.__init__``).
                          The stiffness fields are left untouched on the
                          config itself, so a serialized :class:`AxolConfig`
                          round-trips cleanly (loading a dumped config and
@@ -714,7 +714,7 @@ class AxolConfig:
         gains, where the blend is the identity — so the result is
         **idempotent**: calling :meth:`resolved` again is a no-op. This is
         applied once at the single robot-construction boundary
-        (``Axol.__init__``) so every consumer sees consistent gains while
+        (``AxolHardware.__init__``) so every consumer sees consistent gains while
         the unresolved config stays safe to serialize and reload.
         """
         return replace(

--- a/almond_axol/robot/config.py
+++ b/almond_axol/robot/config.py
@@ -686,7 +686,7 @@ class AxolConfig:
                          is unchanged by the blend. The blend is baked
                          into the ``left`` / ``right`` gains by
                          :meth:`resolved`, which is called once at the
-                         robot-construction boundary (``AxolHardware.__init__``).
+                         robot-construction boundary (``Axol.__init__``).
                          The stiffness fields are left untouched on the
                          config itself, so a serialized :class:`AxolConfig`
                          round-trips cleanly (loading a dumped config and
@@ -714,7 +714,7 @@ class AxolConfig:
         gains, where the blend is the identity — so the result is
         **idempotent**: calling :meth:`resolved` again is a no-op. This is
         applied once at the single robot-construction boundary
-        (``AxolHardware.__init__``) so every consumer sees consistent gains while
+        (``Axol.__init__``) so every consumer sees consistent gains while
         the unresolved config stays safe to serialize and reload.
         """
         return replace(

--- a/almond_axol/robot/config.py
+++ b/almond_axol/robot/config.py
@@ -15,14 +15,13 @@ via :func:`dataclasses.replace`::
 
     from almond_axol.robot.config import AxolConfig, FrictionParams
     from almond_axol.robot import Axol
-    from almond_axol.rt import RtAxol
 
     config = AxolConfig()
     config.left.elbow.kp = 200
     config.left.elbow.mass = 0.6
     config.left.elbow.com = (-0.025, 0.0, -0.07)
     config.left.elbow.friction = FrictionParams(fc=0.4, k=10.0, fv=0.05, fo=0.0)
-    async with RtAxol(Axol(config=config)) as axol: ...
+    async with Axol(config=config) as axol: ...
 """
 
 from __future__ import annotations

--- a/almond_axol/robot/mantis.py
+++ b/almond_axol/robot/mantis.py
@@ -5,7 +5,7 @@ to the same Damiao gripper the robot uses — held by a human demonstrator. Each
 gripper sits alone on its own CAN bus (``can_mantis_l`` / ``can_mantis_r``)
 at the production gripper CAN ID (0x08).
 
-:class:`Mantis` mirrors the :class:`~almond_axol.robot.axol.Axol` control surface
+:class:`MantisHardware` mirrors the :class:`~almond_axol.robot.axol.AxolHardware` control surface
 (``enable`` / ``get_positions`` / ``motion_control`` / per-side ``positions`` /
 ``torques``) so the LeRobot wrapper and ``collect-data`` drive it unchanged.
 The seven arm joints per side are **virtual**: there is no arm, so
@@ -19,10 +19,11 @@ with the arm-state channel equal to the commanded IK solution.
 On hardware this class is the *maintenance* half of the driver: bus
 ownership between takes, gripper bring-up and calibration, torque-off
 verification. The per-tick POSITION_FORCE command stream runs through the
-Rust realtime core — :class:`almond_axol.rt.RtMantis` wraps a ``Mantis``,
-arms ``axol-rt`` on the two gripper buses for the duration of a take, and
-installs a command sink on each :class:`MantisGripperArm` so
-``motion_control`` hands its gripper tuple to the core instead of the wire.
+Rust realtime core — :class:`almond_axol.robot.Mantis` wraps a
+``MantisHardware``, arms ``axol-rt`` on the two gripper buses for the
+duration of a take, and installs a command sink on each
+:class:`MantisGripperArm` so ``motion_control`` hands its gripper tuple to
+the core instead of the wire.
 """
 
 from __future__ import annotations
@@ -72,7 +73,7 @@ class MantisGripperArm:
         self._bus = bus
         self._motor = Motor(bus, Joint.GRIPPER)
         self._gripper_config = gripper_config
-        # Realtime-core mode (:class:`almond_axol.rt.RtMantis`): while the
+        # Realtime-core mode (:class:`almond_axol.robot.Mantis`): while the
         # core is armed on this bus, ``_send_gripper_target`` hands the
         # gripper's POSITION_FORCE tuple (motor-frame target, speed limit,
         # torque limit) to this callable in the core's 8-slot command shape
@@ -327,8 +328,11 @@ class MantisGripperArm:
         await self._motor.set_position_force(*cmd)
 
 
-class Mantis(RobotBase):
-    """The Mantis rig's dual handheld grippers behind the ``Axol`` control surface.
+class MantisHardware(RobotBase):
+    """The Mantis rig's dual handheld grippers, driven directly from Python.
+
+    Mirrors the ``AxolHardware`` control surface. Production takes go through
+    :class:`almond_axol.robot.Mantis`, which wraps this object.
 
     Args:
         config:        Reused for the per-side gripper POSITION_FORCE tuning

--- a/almond_axol/robot/mantis.py
+++ b/almond_axol/robot/mantis.py
@@ -331,8 +331,9 @@ class MantisGripperArm:
 class MantisHardware(RobotBase):
     """The Mantis rig's dual handheld grippers, driven directly from Python.
 
-    Mirrors the ``AxolHardware`` control surface. Production takes go through
-    :class:`almond_axol.robot.Mantis`, which wraps this object.
+    Internal — the public rig object is :class:`almond_axol.robot.Mantis`,
+    which owns one of these and exposes the same methods. Mirrors the
+    ``AxolHardware`` control surface.
 
     Args:
         config:        Reused for the per-side gripper POSITION_FORCE tuning

--- a/almond_axol/rt/__init__.py
+++ b/almond_axol/rt/__init__.py
@@ -1,14 +1,16 @@
 """Production realtime core: the CAN control loop runs in Rust.
 
-Hardware control flows wrap :class:`~almond_axol.robot.axol.Axol` in
-:class:`RtAxol` (and the Mantis rig's :class:`~almond_axol.robot.mantis.Mantis`
-in :class:`RtMantis`). Python keeps VR, IK, and MuJoCo gravity, while
-per-joint targets are shipped over a Unix socket to ``axol-rt`` (see
-``rust/axol-rt``), which solely owns the buses and paces the 240 Hz control
-loop.
+:class:`almond_axol.robot.Axol` (defined here as :class:`Axol`) wraps the
+low-level :class:`~almond_axol.robot.axol.AxolHardware`, and the Mantis rig's
+:class:`~almond_axol.robot.mantis.Mantis` is wrapped by :class:`RtMantis`.
+Python keeps VR, IK, and MuJoCo gravity, while per-joint targets are shipped
+over a Unix socket to ``axol-rt`` (see ``rust/axol-rt``), which solely owns
+the buses and paces the 240 Hz control loop.
+
+``RtAxol`` is the deprecated previous spelling of ``Axol``.
 """
 
 from .mantis import RtMantis
-from .robot import RtAxol
+from .robot import Axol, RtAxol
 
-__all__ = ["RtAxol", "RtMantis"]
+__all__ = ["Axol", "RtAxol", "RtMantis"]

--- a/almond_axol/rt/__init__.py
+++ b/almond_axol/rt/__init__.py
@@ -1,12 +1,12 @@
 """Production realtime core: the CAN control loop runs in Rust.
 
-:class:`almond_axol.robot.Axol` (defined here as :class:`Axol`) wraps the
-low-level :class:`~almond_axol.robot.axol.AxolHardware`, and the Mantis rig's
-:class:`almond_axol.robot.Mantis` (:class:`Mantis` here) wraps
-:class:`~almond_axol.robot.mantis.MantisHardware`.
-Python keeps VR, IK, and MuJoCo gravity, while per-joint targets are shipped
-over a Unix socket to ``axol-rt`` (see ``rust/axol-rt``), which solely owns
-the buses and paces the 240 Hz control loop.
+:class:`almond_axol.robot.Axol` and :class:`almond_axol.robot.Mantis` are
+defined here. They present the classic robot API and own the low-level bus /
+motor / model objects (:mod:`almond_axol.robot.axol`,
+:mod:`almond_axol.robot.mantis`) as an implementation detail. Python keeps
+VR, IK, and MuJoCo gravity, while per-joint targets are shipped over a Unix
+socket to ``axol-rt`` (see ``rust/axol-rt``), which solely owns the buses and
+paces the 240 Hz control loop while the robot is enabled.
 """
 
 # ``almond_axol.robot`` re-exports ``Axol`` / ``Mantis`` from this package's

--- a/almond_axol/rt/__init__.py
+++ b/almond_axol/rt/__init__.py
@@ -7,8 +7,6 @@ low-level :class:`~almond_axol.robot.axol.AxolHardware`, and the Mantis rig's
 Python keeps VR, IK, and MuJoCo gravity, while per-joint targets are shipped
 over a Unix socket to ``axol-rt`` (see ``rust/axol-rt``), which solely owns
 the buses and paces the 240 Hz control loop.
-
-``RtAxol`` / ``RtMantis`` are the deprecated previous spellings.
 """
 
 # ``almond_axol.robot`` re-exports ``Axol`` / ``Mantis`` from this package's
@@ -17,7 +15,7 @@ the buses and paces the 240 Hz control loop.
 # ``robot/__init__`` importing ``rt.mantis`` while ``rt.mantis`` is itself
 # mid-import (through ``robot.base``) would otherwise fail.
 from .. import robot as _robot  # noqa: F401
-from .mantis import Mantis, RtMantis
-from .robot import Axol, RtAxol
+from .mantis import Mantis
+from .robot import Axol
 
-__all__ = ["Axol", "Mantis", "RtAxol", "RtMantis"]
+__all__ = ["Axol", "Mantis"]

--- a/almond_axol/rt/__init__.py
+++ b/almond_axol/rt/__init__.py
@@ -2,15 +2,22 @@
 
 :class:`almond_axol.robot.Axol` (defined here as :class:`Axol`) wraps the
 low-level :class:`~almond_axol.robot.axol.AxolHardware`, and the Mantis rig's
-:class:`~almond_axol.robot.mantis.Mantis` is wrapped by :class:`RtMantis`.
+:class:`almond_axol.robot.Mantis` (:class:`Mantis` here) wraps
+:class:`~almond_axol.robot.mantis.MantisHardware`.
 Python keeps VR, IK, and MuJoCo gravity, while per-joint targets are shipped
 over a Unix socket to ``axol-rt`` (see ``rust/axol-rt``), which solely owns
 the buses and paces the 240 Hz control loop.
 
-``RtAxol`` is the deprecated previous spelling of ``Axol``.
+``RtAxol`` / ``RtMantis`` are the deprecated previous spellings.
 """
 
-from .mantis import RtMantis
+# ``almond_axol.robot`` re-exports ``Axol`` / ``Mantis`` from this package's
+# submodules. Initialize it first so that, whichever package is imported
+# first, each submodule below is loaded exactly once and to completion —
+# ``robot/__init__`` importing ``rt.mantis`` while ``rt.mantis`` is itself
+# mid-import (through ``robot.base``) would otherwise fail.
+from .. import robot as _robot  # noqa: F401
+from .mantis import Mantis, RtMantis
 from .robot import Axol, RtAxol
 
-__all__ = ["Axol", "RtAxol", "RtMantis"]
+__all__ = ["Axol", "Mantis", "RtAxol", "RtMantis"]

--- a/almond_axol/rt/link.py
+++ b/almond_axol/rt/link.py
@@ -190,7 +190,7 @@ class RtLink:
                         # core is still serving, but every arm joint is at
                         # kp = 0 with the streamed gravity feedforward, and
                         # stays that way for the session. Sends remain open —
-                        # RtAxol turns motion_control into gravity comp so
+                        # Axol turns motion_control into gravity comp so
                         # the t_ff keeps tracking the hand-guided pose.
                         _logger.warning("axol-rt: %s", body)
                         if self._limp is None:

--- a/almond_axol/rt/mantis.py
+++ b/almond_axol/rt/mantis.py
@@ -1,7 +1,8 @@
 """Mantis grippers driven through the Rust realtime core.
 
 :class:`RtMantis` wraps :class:`~almond_axol.robot.mantis.Mantis` the way
-:class:`RtAxol` wraps ``Axol``: Python keeps the tracker/IK/collection
+:class:`~almond_axol.robot.Axol` wraps ``AxolHardware``: Python keeps the
+tracker/IK/collection
 logic and the gripper's *maintenance* flows, while every per-tick
 POSITION_FORCE command and every feedback frame goes through ``axol-rt``,
 which solely owns the two gripper buses and paces the loop with hard,
@@ -29,7 +30,7 @@ at its end:
 * :meth:`disable_grippers` — ``disarm`` (the core disables the motors),
   stop the core, reopen the proxies, and repeat the disable from Python so
   torque-off is *verified* — a Mantis gripper is always safe to release,
-  so unlike ``RtAxol`` a core fault never leaves it holding.
+  so unlike ``Axol`` a core fault never leaves it holding.
 * :meth:`disable` — session end: disarm if armed, then close the buses.
 
 Between takes the gripper caches are refreshed by the explicit reads in
@@ -68,7 +69,7 @@ _MAX_STEP_RAD = 10.0
 
 
 class RtMantis:
-    """The Mantis behind the ``RtAxol`` control surface, core-driven per take.
+    """The Mantis behind the ``Axol`` control surface, core-driven per take.
 
     Args:
         robot:       The classic driver; owns the buses, calibration state,
@@ -105,7 +106,7 @@ class RtMantis:
         self._paused_telemetry: tuple[float, bool] | None = None
         self._lifecycle_lock = asyncio.Lock()
         # Timestamped state history for capture-aligned observations, same
-        # shape and clock mapping as RtAxol.state_nearest.
+        # shape and clock mapping as Axol.state_nearest.
         self._state_history: deque[
             tuple[float, np.ndarray, np.ndarray, np.ndarray, np.ndarray]
         ] = deque(maxlen=512)
@@ -113,7 +114,7 @@ class RtMantis:
         self._state_sides: set[int] = set()
         self._state_side_ts: dict[int, float] = {}
 
-    # -- Surface shared with RtAxol -------------------------------------------
+    # -- Surface shared with Axol ---------------------------------------------
 
     @property
     def left(self) -> MantisGripperArm | None:
@@ -143,7 +144,7 @@ class RtMantis:
         """The armed core's latched ``limp: ...``, or ``None``.
 
         Only arm joints go limp; a gripper-only core never does. Exposed for
-        callers that poll :attr:`RtAxol.limp` generically.
+        callers that poll :attr:`~almond_axol.robot.Axol.limp` generically.
         """
         return self._link.limp if self._link is not None else None
 
@@ -533,7 +534,7 @@ class RtMantis:
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, float] | None:
         """Return the telemetry snapshot nearest a camera exposure timestamp.
 
-        Same contract as :meth:`RtAxol.state_nearest`; only populated while
+        Same contract as :meth:`~almond_axol.robot.Axol.state_nearest`; only populated while
         the core is armed.
         """
         deadline = time.perf_counter() + timeout

--- a/almond_axol/rt/mantis.py
+++ b/almond_axol/rt/mantis.py
@@ -46,7 +46,6 @@ import bisect
 import logging
 import threading
 import time
-import warnings
 from collections import deque
 from collections.abc import Callable
 from typing import Self
@@ -663,24 +662,3 @@ class Mantis(RobotBase):
 
     def reset_gravity_hold(self) -> None:
         """No gravity hold on a Mantis."""
-
-
-class RtMantis(Mantis):
-    """Deprecated spelling of :class:`Mantis`.
-
-    ``RtMantis(MantisHardware(...))`` was the previous way to opt into the
-    realtime core. :class:`almond_axol.robot.Mantis` now constructs the
-    hardware object itself; this shim keeps the old idiom working (with a
-    ``DeprecationWarning``) for one release.
-    """
-
-    def __init__(self, robot: MantisHardware | Mantis, **kwargs: object) -> None:
-        warnings.warn(
-            "RtMantis is deprecated: construct almond_axol.robot.Mantis(...) "
-            "directly (it wraps the realtime core by default)",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        if isinstance(robot, Mantis):
-            robot = robot.hardware
-        super().__init__(hardware=robot, **kwargs)  # type: ignore[arg-type]

--- a/almond_axol/rt/mantis.py
+++ b/almond_axol/rt/mantis.py
@@ -74,7 +74,9 @@ _MAX_STEP_RAD = 10.0
 class Mantis(RobotBase):
     """The Mantis rig behind the ``Axol`` control surface, core-driven per take.
 
-    Construct it exactly like the low-level hardware object::
+    Two gripper motors (one per SocketCAN bus) and no arm joints; the
+    ``motion_control`` surface accepts full 8-slot targets and only slot 7
+    (the gripper) reaches the hardware::
 
         async with Mantis() as mantis:
             await mantis.motion_control(left=q, right=q)
@@ -86,10 +88,10 @@ class Mantis(RobotBase):
         right_channel: SocketCAN interface of the right gripper, or ``None``.
         defer_gripper_enable: Leave the motors torque-off and the core
                      unstarted until :meth:`enable_grippers` (data collection).
-        hardware:    An already-constructed
-                     :class:`~almond_axol.robot.mantis.MantisHardware` to wrap
-                     instead of building one (the forwarded arguments must
-                     then be left at their defaults).
+
+    The keyword-only core options rarely need changing:
+
+    Args:
         loop_hz:     Core loop rate (the gripper's POSITION_FORCE command
                      and feedback cadence).
         watchdog_ms: Core watchdog — with no fresh target for this long it
@@ -100,33 +102,56 @@ class Mantis(RobotBase):
 
     def __init__(
         self,
-        config: AxolConfig | None = None,
+        config: AxolConfig = AxolConfig(),
         left_channel: str | None = CAN_MANTIS_LEFT,
         right_channel: str | None = CAN_MANTIS_RIGHT,
         *,
         defer_gripper_enable: bool = False,
-        hardware: MantisHardware | None = None,
         loop_hz: float = 240.0,
         watchdog_ms: float = 150.0,
         record: str | None = None,
     ) -> None:
-        if hardware is None:
-            hardware = MantisHardware(
-                config=AxolConfig() if config is None else config,
+        self._init_core(
+            MantisHardware(
+                config=config,
                 left_channel=left_channel,
                 right_channel=right_channel,
                 defer_gripper_enable=defer_gripper_enable,
-            )
-        elif (
-            config is not None
-            or left_channel != CAN_MANTIS_LEFT
-            or right_channel != CAN_MANTIS_RIGHT
-            or defer_gripper_enable
-        ):
-            raise ValueError(
-                "Mantis(hardware=...) takes the wrapped object as-is; do not also "
-                "pass config / channels / defer_gripper_enable"
-            )
+            ),
+            loop_hz=loop_hz,
+            watchdog_ms=watchdog_ms,
+            record=record,
+        )
+
+    @classmethod
+    def _wrap(
+        cls,
+        hardware: MantisHardware,
+        *,
+        loop_hz: float = 240.0,
+        watchdog_ms: float = 150.0,
+        record: str | None = None,
+    ) -> Self:
+        """Build the rig around an already-constructed low-level object.
+
+        Internal: lets tests substitute a hand-built
+        :class:`~almond_axol.robot.mantis.MantisHardware` (fake buses) for
+        the one :meth:`__init__` would construct.
+        """
+        self = cls.__new__(cls)
+        self._init_core(
+            hardware, loop_hz=loop_hz, watchdog_ms=watchdog_ms, record=record
+        )
+        return self
+
+    def _init_core(
+        self,
+        hardware: MantisHardware,
+        *,
+        loop_hz: float,
+        watchdog_ms: float,
+        record: str | None,
+    ) -> None:
         self._robot = hardware
         self._loop_hz = loop_hz
         self._watchdog_ms = watchdog_ms
@@ -161,16 +186,6 @@ class Mantis(RobotBase):
     @property
     def right(self) -> MantisGripperArm | None:
         return self._robot.right
-
-    @property
-    def hardware(self) -> MantisHardware:
-        """The wrapped low-level object (buses, calibration state, arms)."""
-        return self._robot
-
-    @property
-    def robot(self) -> MantisHardware:
-        """Alias of :attr:`hardware` (the original spelling)."""
-        return self._robot
 
     @property
     def armed(self) -> bool:
@@ -229,13 +244,6 @@ class Mantis(RobotBase):
         """Open the buses (deferred mode also verifies torque-off); no core."""
         async with self._lifecycle_lock:
             await self._robot.connect()
-
-    async def __aenter__(self) -> Self:
-        await self.enable()
-        return self
-
-    async def __aexit__(self, *_: object) -> None:
-        await self.disable()
 
     async def enable_grippers(self) -> None:
         """Bring both grippers up and hand their buses to the realtime core.
@@ -446,11 +454,12 @@ class Mantis(RobotBase):
                 raise
             await self._disarm_unlocked()
 
-    async def detach(self) -> None:
-        """Release the bus without changing torque — not meaningful here.
+    async def disconnect(self) -> None:
+        """Close the buses; on a Mantis this is :meth:`disable`.
 
-        A Mantis gripper is disabled at every take end; there is no holding
-        state worth preserving across processes, so this is :meth:`disable`.
+        ``Axol.disconnect()`` leaves the arms holding for a later process.
+        A Mantis gripper is disabled at every take end and has no holding
+        state worth preserving, so the grippers are torqued off here too.
         """
         await self.disable()
 

--- a/almond_axol/rt/mantis.py
+++ b/almond_axol/rt/mantis.py
@@ -1,6 +1,7 @@
 """Mantis grippers driven through the Rust realtime core.
 
-:class:`RtMantis` wraps :class:`~almond_axol.robot.mantis.Mantis` the way
+:class:`Mantis` (re-exported as :class:`almond_axol.robot.Mantis`) wraps
+:class:`~almond_axol.robot.mantis.MantisHardware` the way
 :class:`~almond_axol.robot.Axol` wraps ``AxolHardware``: Python keeps the
 tracker/IK/collection
 logic and the gripper's *maintenance* flows, while every per-tick
@@ -34,7 +35,7 @@ at its end:
 * :meth:`disable` — session end: disarm if armed, then close the buses.
 
 Between takes the gripper caches are refreshed by the explicit reads in
-:meth:`get_positions` (the classic ``Mantis`` path); while armed, the
+:meth:`get_positions` (the classic ``MantisHardware`` path); while armed, the
 core's ``F`` packets fill them at ``loop_hz`` and reads return the cache.
 """
 
@@ -45,16 +46,19 @@ import bisect
 import logging
 import threading
 import time
+import warnings
 from collections import deque
 from collections.abc import Callable
+from typing import Self
 
 import numpy as np
 
-from ..constants import ARM_JOINTS
+from ..constants import ARM_JOINTS, CAN_MANTIS_LEFT, CAN_MANTIS_RIGHT
 from ..motor import Joint
 from ..motor.motor import _JOINT_CONFIG
-from ..robot.base import mark_hardware_cleanup_uncertain
-from ..robot.mantis import Mantis, MantisGripperArm
+from ..robot.base import RobotBase, mark_hardware_cleanup_uncertain
+from ..robot.config import AxolConfig
+from ..robot.mantis import MantisGripperArm, MantisHardware
 from .link import FeedbackSlot, RtLink, config_header
 
 _logger = logging.getLogger(__name__)
@@ -68,12 +72,25 @@ _GRIPPER_SLOT = _N_ARM
 _MAX_STEP_RAD = 10.0
 
 
-class RtMantis:
-    """The Mantis behind the ``Axol`` control surface, core-driven per take.
+class Mantis(RobotBase):
+    """The Mantis rig behind the ``Axol`` control surface, core-driven per take.
+
+    Construct it exactly like the low-level hardware object::
+
+        async with Mantis() as mantis:
+            await mantis.motion_control(left=q, right=q)
 
     Args:
-        robot:       The classic driver; owns the buses, calibration state,
-                     and the per-side :class:`MantisGripperArm` objects.
+        config:        Per-side gripper POSITION_FORCE tuning
+                       (``ArmConfig.gripper``); everything else is ignored.
+        left_channel:  SocketCAN interface of the left gripper, or ``None``.
+        right_channel: SocketCAN interface of the right gripper, or ``None``.
+        defer_gripper_enable: Leave the motors torque-off and the core
+                     unstarted until :meth:`enable_grippers` (data collection).
+        hardware:    An already-constructed
+                     :class:`~almond_axol.robot.mantis.MantisHardware` to wrap
+                     instead of building one (the forwarded arguments must
+                     then be left at their defaults).
         loop_hz:     Core loop rate (the gripper's POSITION_FORCE command
                      and feedback cadence).
         watchdog_ms: Core watchdog — with no fresh target for this long it
@@ -84,12 +101,34 @@ class RtMantis:
 
     def __init__(
         self,
-        robot: Mantis,
+        config: AxolConfig | None = None,
+        left_channel: str | None = CAN_MANTIS_LEFT,
+        right_channel: str | None = CAN_MANTIS_RIGHT,
+        *,
+        defer_gripper_enable: bool = False,
+        hardware: MantisHardware | None = None,
         loop_hz: float = 240.0,
         watchdog_ms: float = 150.0,
         record: str | None = None,
     ) -> None:
-        self._robot = robot
+        if hardware is None:
+            hardware = MantisHardware(
+                config=AxolConfig() if config is None else config,
+                left_channel=left_channel,
+                right_channel=right_channel,
+                defer_gripper_enable=defer_gripper_enable,
+            )
+        elif (
+            config is not None
+            or left_channel != CAN_MANTIS_LEFT
+            or right_channel != CAN_MANTIS_RIGHT
+            or defer_gripper_enable
+        ):
+            raise ValueError(
+                "Mantis(hardware=...) takes the wrapped object as-is; do not also "
+                "pass config / channels / defer_gripper_enable"
+            )
+        self._robot = hardware
         self._loop_hz = loop_hz
         self._watchdog_ms = watchdog_ms
         self._link: RtLink | None = None
@@ -125,8 +164,13 @@ class RtMantis:
         return self._robot.right
 
     @property
-    def robot(self) -> Mantis:
-        """The wrapped classic driver (maintenance path)."""
+    def hardware(self) -> MantisHardware:
+        """The wrapped low-level object (buses, calibration state, arms)."""
+        return self._robot
+
+    @property
+    def robot(self) -> MantisHardware:
+        """Alias of :attr:`hardware` (the original spelling)."""
         return self._robot
 
     @property
@@ -173,7 +217,7 @@ class RtMantis:
     async def enable(self) -> None:
         """Open the buses; unless deferred, also arm the grippers now.
 
-        Mirrors :meth:`Mantis.enable`: ``defer_gripper_enable=True`` (data
+        Mirrors :meth:`MantisHardware.enable`: ``defer_gripper_enable=True`` (data
         collection) leaves the motors torque-off and the core unstarted
         until :meth:`enable_grippers`.
         """
@@ -187,7 +231,7 @@ class RtMantis:
         async with self._lifecycle_lock:
             await self._robot.connect()
 
-    async def __aenter__(self) -> RtMantis:
+    async def __aenter__(self) -> Self:
         await self.enable()
         return self
 
@@ -382,7 +426,7 @@ class RtMantis:
     async def open_grippers(self) -> None:
         """Open both grippers fully through the core, then release torque.
 
-        The pre-record move (see :meth:`Mantis.open_grippers`): arm, drive
+        The pre-record move (see :meth:`MantisHardware.open_grippers`): arm, drive
         the jaws to the calibrated open stop, confirm from feedback, disarm.
         A failure — or a cancellation mid-move (a Stop during the pre-record
         prep) — still torques both grippers off before it propagates.
@@ -619,3 +663,24 @@ class RtMantis:
 
     def reset_gravity_hold(self) -> None:
         """No gravity hold on a Mantis."""
+
+
+class RtMantis(Mantis):
+    """Deprecated spelling of :class:`Mantis`.
+
+    ``RtMantis(MantisHardware(...))`` was the previous way to opt into the
+    realtime core. :class:`almond_axol.robot.Mantis` now constructs the
+    hardware object itself; this shim keeps the old idiom working (with a
+    ``DeprecationWarning``) for one release.
+    """
+
+    def __init__(self, robot: MantisHardware | Mantis, **kwargs: object) -> None:
+        warnings.warn(
+            "RtMantis is deprecated: construct almond_axol.robot.Mantis(...) "
+            "directly (it wraps the realtime core by default)",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if isinstance(robot, Mantis):
+            robot = robot.hardware
+        super().__init__(hardware=robot, **kwargs)  # type: ignore[arg-type]

--- a/almond_axol/rt/robot.py
+++ b/almond_axol/rt/robot.py
@@ -63,7 +63,6 @@ import logging
 import math
 import threading
 import time
-import warnings
 from collections import deque
 from collections.abc import Iterable
 from typing import Self
@@ -897,24 +896,3 @@ class Axol(RobotBase):
             _logger.warning(
                 "rt: retaining raw control trace because the core is still running"
             )
-
-
-class RtAxol(Axol):
-    """Deprecated spelling of :class:`Axol`.
-
-    ``RtAxol(AxolHardware(...))`` was the previous way to opt into the realtime
-    core. :class:`almond_axol.robot.Axol` now constructs the hardware object
-    itself; this shim keeps the old idiom working (with a
-    ``DeprecationWarning``) for one release.
-    """
-
-    def __init__(self, robot: AxolHardware | Axol, **kwargs: object) -> None:
-        warnings.warn(
-            "RtAxol is deprecated: construct almond_axol.robot.Axol(...) "
-            "directly (it wraps the realtime core by default)",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        if isinstance(robot, Axol):
-            robot = robot.hardware
-        super().__init__(hardware=robot, **kwargs)  # type: ignore[arg-type]

--- a/almond_axol/rt/robot.py
+++ b/almond_axol/rt/robot.py
@@ -320,8 +320,30 @@ class Axol(RobotBase):
                 )
         return "\n".join(lines) + "\n"
 
-    async def enable(self) -> None:
-        """Full rt bring-up: prep (core resets) -> Python reads -> arm."""
+    async def enable(self, hold: bool = True) -> None:
+        """Bring every motor up.
+
+        Idempotent per motor: joints already holding from a previous session
+        are attached to with reads only (never reset), a holding gripper
+        keeps its grasp, and cold joints get the full bring-up including
+        gripper calibration.
+
+        With ``hold=True`` (the default) the realtime core then takes the
+        buses and the robot finishes actively holding its measured pose —
+        gravity feedforward and damping included — ready for
+        :meth:`motion_control`.
+
+        Pass ``hold=False`` to leave freshly brought-up joints enabled but
+        limp, with Python keeping the bus and no core started: for flows that
+        pick their own ``ControlMode`` and drive the motors' built-in
+        controllers (:meth:`set_control_mode`, :meth:`set_positions_velocity`,
+        :meth:`set_velocity`). :meth:`motion_control` is unavailable in that
+        state; :meth:`disable` is the classic torque-off.
+        """
+        if not hold:
+            self._require_quiet_bus("enable(hold=False)")
+            await self._robot.enable(hold=False)
+            return
         try:
             await self._enable()
         except BaseException:
@@ -352,6 +374,13 @@ class Axol(RobotBase):
         """Bring up the realtime core; :meth:`enable` owns rollback."""
         self._fb_packets = [0, 0]
         self._limp_announced = False
+        # Hand the interfaces to the core quiet: a robot that was
+        # ``connect()``-ed (or enabled with ``hold=False``) still has Python's
+        # maintenance proxies open and possibly a telemetry poll running. The
+        # core's prep must run with no other frames on the wire, and Python
+        # must not cache a pre-reset frame; torque is untouched by this.
+        if any(bus.is_open() for bus in self._buses()):
+            await self._robot.disconnect()
         await self._link.start()
         self._core_started = True
         await self._link.configure(self._config_text())
@@ -778,8 +807,8 @@ class Axol(RobotBase):
     def _require_enabled(self, what: str) -> None:
         if not self._armed:
             raise MotorError(
-                f"{what} requires an enabled robot: call enable() first (the "
-                "realtime core drives the motors)"
+                f"{what} requires the realtime core: call enable() (with the "
+                "default hold=True) first"
             )
 
     def torque_residuals(self) -> tuple[np.ndarray | None, np.ndarray | None]:

--- a/almond_axol/rt/robot.py
+++ b/almond_axol/rt/robot.py
@@ -1,11 +1,12 @@
-"""``Axol`` — the Axol robot driven through the Rust realtime core.
+"""``Axol`` — the Axol robot, with its control loop in the Rust realtime core.
 
 This is the production robot object (re-exported as
-:class:`almond_axol.robot.Axol`). It constructs the low-level
-:class:`~almond_axol.robot.axol.AxolHardware` and presents the same surface
-:class:`~almond_axol.teleop.VRTeleop` uses (``enable`` / ``disable`` /
-``get_positions`` / ``motion_control``), but the CAN buses are owned by the
-``axol-rt`` subprocess:
+:class:`almond_axol.robot.Axol`). Its public surface is the classic one —
+``connect`` / ``enable`` / ``disable`` / ``disconnect``, the ``get_*`` /
+``set_*`` register calls, telemetry, ``motion_control`` — and it owns the
+low-level :class:`~almond_axol.robot.axol.AxolHardware` (buses, motors,
+model math) as an implementation detail. What changed is behind the scenes:
+while enabled, the CAN buses are owned by the ``axol-rt`` subprocess:
 
 - ``enable()`` runs the split bring-up: the core resets the motors (prep),
   then Python resolves joint offsets and MyActuator decode ranges through a
@@ -64,13 +65,13 @@ import math
 import threading
 import time
 from collections import deque
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from typing import Self
 
 import numpy as np
 
 from ..constants import ARM_JOINTS, CAN_LEFT, CAN_RIGHT
-from ..motor import ControlMode, Joint, MotorError
+from ..motor import ControlMode, Joint, MotorError, MotorGains, MotorStatus
 from ..motor.bus import CanBus
 from ..motor.motor import _JOINT_CONFIG
 from ..robot.axol import AxolArm, AxolHardware
@@ -90,10 +91,11 @@ _LIMP_KD = 0.25
 
 
 class Axol(RobotBase):
-    """The dual-arm Axol robot, with the control loop in the Rust realtime core.
+    """Dual-arm Axol robot interface.
 
-    Construct it exactly like the low-level hardware object and use it as an
-    async context manager::
+    Opens one CAN bus per arm and constructs all 16 motor drivers on entry
+    (14 on the gripperless SKU, ``config.has_gripper = False``). Use as an
+    async context manager to ensure the buses are cleanly shut down::
 
         async with Axol() as axol:
             pos_l, pos_r = await axol.get_positions()
@@ -101,10 +103,11 @@ class Axol(RobotBase):
 
     ``enable()`` brings the motors up and hands both CAN buses to the
     ``axol-rt`` subprocess, which paces the 240 Hz loop; Python keeps the
-    model math and streams targets. :attr:`hardware` exposes the wrapped
-    :class:`~almond_axol.robot.axol.AxolHardware` for flows that also need
-    direct register access on a quiet bus (before ``enable()`` or after
-    ``disable()``).
+    model math and streams targets. While the core owns the bus, reads of
+    position / velocity / torque come from its per-tick telemetry (no CAN is
+    sent from Python) and the register-level calls (``get_temperatures``,
+    ``set_gains``, ``set_control_mode``, ...) are unavailable — use them on a
+    :meth:`connect`-ed robot before :meth:`enable`, or after :meth:`disable`.
     """
 
     # The core's tracker limits get headroom over the Python shaper's caps:
@@ -117,30 +120,37 @@ class Axol(RobotBase):
 
     def __init__(
         self,
-        config: AxolConfig | None = None,
+        config: AxolConfig = AxolConfig(),
         left_channel: str | None = CAN_LEFT,
         right_channel: str | None = CAN_RIGHT,
         left_joints: Iterable[Joint] | None = None,
         right_joints: Iterable[Joint] | None = None,
         *,
-        hardware: AxolHardware | None = None,
         loop_hz: float = 240.0,
         watchdog_ms: float = 150.0,
         max_vel: float = 2.0 * math.pi,
         max_accel: float = 7.0 * math.pi,
         record: str | None = None,
     ) -> None:
-        """Construct the robot for the realtime core.
+        """Construct the dual-arm interface.
 
-        The first five arguments are forwarded to
-        :class:`~almond_axol.robot.axol.AxolHardware`; see it for their
-        meaning. Nothing is opened or actuated until :meth:`enable`.
+        CAN buses and motors are created but not started; call ``enable()``
+        or use the class as an async context manager to bring up hardware.
 
         Args:
-            hardware: An already-constructed ``AxolHardware`` to wrap
-                instead of building one from the forwarded arguments (which
-                must then be left at their defaults).
-            loop_hz: Realtime core tick rate.
+            config:        Per-joint gains, friction parameters, and gripper config.
+            left_channel:  SocketCAN interface for the left arm, or ``None``
+                           to operate without it.
+            right_channel: SocketCAN interface for the right arm, or ``None``.
+            left_joints:   Joints physically present on the left arm (a
+                           partial bench arm); ``None`` means the full arm.
+            right_joints:  Same for the right arm.
+
+        The keyword-only arguments tune the realtime core and rarely need
+        changing:
+
+        Args:
+            loop_hz: Core tick rate.
             watchdog_ms: Core watchdog — how long it holds the last target
                 without a fresh one before treating the host as gone.
             max_vel: Teleop joint-velocity cap (rad/s) — the core's tracker
@@ -152,26 +162,66 @@ class Axol(RobotBase):
                 position/torque is captured from the core's feedback packets
                 at its native ``loop_hz`` instead of the Python target rate.
         """
-        if hardware is None:
-            hardware = AxolHardware(
-                config=AxolConfig() if config is None else config,
+        self._init_core(
+            AxolHardware(
+                config=config,
                 left_channel=left_channel,
                 right_channel=right_channel,
                 left_joints=left_joints,
                 right_joints=right_joints,
-            )
-        elif (
-            config is not None
-            or left_channel != CAN_LEFT
-            or right_channel != CAN_RIGHT
-            or left_joints is not None
-            or right_joints is not None
-        ):
-            raise ValueError(
-                "Axol(hardware=...) takes the wrapped object as-is; do not also "
-                "pass config / channels / joints"
-            )
+            ),
+            loop_hz=loop_hz,
+            watchdog_ms=watchdog_ms,
+            max_vel=max_vel,
+            max_accel=max_accel,
+            record=record,
+        )
+
+    @classmethod
+    def _wrap(
+        cls,
+        hardware: AxolHardware,
+        *,
+        loop_hz: float = 240.0,
+        watchdog_ms: float = 150.0,
+        max_vel: float = 2.0 * math.pi,
+        max_accel: float = 7.0 * math.pi,
+        record: str | None = None,
+    ) -> Self:
+        """Build the robot around an already-constructed low-level object.
+
+        Internal: lets tests and bench tooling substitute a hand-built
+        :class:`~almond_axol.robot.axol.AxolHardware` (fake buses, partial
+        arms) for the one :meth:`__init__` would construct.
+        """
+        self = cls.__new__(cls)
+        self._init_core(
+            hardware,
+            loop_hz=loop_hz,
+            watchdog_ms=watchdog_ms,
+            max_vel=max_vel,
+            max_accel=max_accel,
+            record=record,
+        )
+        return self
+
+    def _init_core(
+        self,
+        hardware: AxolHardware,
+        *,
+        loop_hz: float,
+        watchdog_ms: float,
+        max_vel: float,
+        max_accel: float,
+        record: str | None,
+    ) -> None:
         self._robot = hardware
+        # ``_core_started``: an ``axol-rt`` process exists for this session
+        # (from ``enable`` until teardown) — teardown must go through the
+        # core. ``_armed``: the core holds the buses (from its ``arm`` ack
+        # until ``disable`` / ``disconnect``) and Python must not send CAN.
+        self._core_started = False
+        self._armed = False
         self._loop_hz = loop_hz
         self._watchdog_ms = watchdog_ms
         self._max_vel = max_vel
@@ -209,24 +259,23 @@ class Axol(RobotBase):
         self._state_side_ts: dict[int, float] = {}
 
     @property
-    def hardware(self) -> AxolHardware:
-        """The wrapped low-level object (buses, motors, model math).
-
-        Its ``left`` / ``right`` arms and their ``motors`` are the same
-        objects this class reads and commands through. Direct register
-        access (``connect()``, ``is_holding()``, ...) is only valid while the
-        core does not own the bus — before :meth:`enable` or after
-        :meth:`disable`.
-        """
-        return self._robot
-
-    @property
     def left(self) -> AxolArm | None:
+        """The left :class:`~almond_axol.robot.axol.AxolArm`, or ``None``."""
         return self._robot.left
 
     @property
     def right(self) -> AxolArm | None:
+        """The right :class:`~almond_axol.robot.axol.AxolArm`, or ``None``."""
         return self._robot.right
+
+    def _require_quiet_bus(self, what: str) -> None:
+        """Refuse register-level CAN traffic while the core owns the bus."""
+        if self._armed:
+            raise MotorError(
+                f"{what} is unavailable while the robot is enabled: the realtime "
+                "core owns the CAN bus. Use it on a connect()-ed robot before "
+                "enable(), or after disable()."
+            )
 
     def _arms(self) -> list[tuple[int, AxolArm]]:
         out = []
@@ -304,6 +353,7 @@ class Axol(RobotBase):
         self._fb_packets = [0, 0]
         self._limp_announced = False
         await self._link.start()
+        self._core_started = True
         await self._link.configure(self._config_text())
         # The core's prep resets the MyActuator motors (multi-turn wrap state
         # changes) — it must complete before Python resolves offsets, and
@@ -343,6 +393,7 @@ class Axol(RobotBase):
         # before the realtime bus threads open their SocketCAN sockets.
         await asyncio.gather(*(bus.close() for bus in self._buses()))
         await self._link.arm()
+        self._armed = True
         await self._wait_for_caches()
         # Prime one full hold target at the measured pose: the core's own
         # bring-up hold has no gravity feedforward (t_ff = 0) and no damping
@@ -359,44 +410,50 @@ class Axol(RobotBase):
             self._loop_hz,
         )
 
-    async def __aenter__(self) -> Self:
-        """Enter the async context, arming the core via :meth:`enable`."""
-        await self.enable()
-        return self
+    async def connect(self) -> None:
+        """Open the CAN buses only — nothing is actuated.
 
-    async def __aexit__(self, *_: object) -> None:
-        """Exit the async context, tearing down via :meth:`disable`.
-
-        Unlike :meth:`RobotBase.__aexit__`, teardown errors are not wrapped
-        in ``HardwareCleanupError``: :meth:`disable` already decides, per
-        failure, whether the motors were left holding on purpose.
+        Every read API (``get_holding()``, ``get_positions()``, ...) becomes
+        usable for inspecting a robot of unknown state; :meth:`enable` opens
+        the buses itself, so this is optional. Not valid while enabled (the
+        core owns the bus).
         """
-        await self.disable()
+        self._require_quiet_bus("connect()")
+        await self._robot.connect()
 
     async def start_telemetry(self, hz: float, *, torque: bool = False) -> None:
-        """No-op: the core already streams full telemetry every tick.
+        """Begin background polling of every motor (classic, on a quiet bus).
 
-        Positions, velocities, and torques for every slot arrive in the
-        per-tick ``F`` packets regardless of ``hz`` / ``torque`` — a poll
-        loop would need the bus, which the core owns. Kept so flows written
-        against ``AxolHardware`` (gravity-comp, waypoints, tune.motion, the
-        LeRobot robot) run unchanged.
+        While enabled this is a no-op: positions, velocities, and torques
+        for every slot already arrive in the core's per-tick ``F`` packets
+        regardless of ``hz`` / ``torque``, and a poll loop would need the
+        bus, which the core owns.
         """
-        _logger.debug(
-            "rt: start_telemetry(%s) ignored — core streams at %.0f Hz",
-            hz,
-            self._loop_hz,
-        )
+        if self._armed:
+            _logger.debug(
+                "rt: start_telemetry(%s) ignored — core streams at %.0f Hz",
+                hz,
+                self._loop_hz,
+            )
+            return
+        await self._robot.start_telemetry(hz, torque=torque)
 
     async def stop_telemetry(self) -> None:
-        """No-op counterpart of :meth:`start_telemetry`."""
+        """Stop background polling (no-op while the core streams)."""
+        if self._armed:
+            return
+        await self._robot.stop_telemetry()
 
     async def wait_for_telemetry(self, timeout: float = 5.0) -> None:
-        """Block until the core's telemetry stream is flowing for every arm.
+        """Block until every motor has reported a position.
 
-        Same contract as :meth:`AxolHardware.wait_for_telemetry`; ``enable`` already
-        waited once, so after a successful bring-up this returns immediately.
+        While enabled this waits on the core's telemetry stream (``enable``
+        already waited once, so it returns immediately after a successful
+        bring-up); otherwise on the classic poll loop.
         """
+        if not self._armed:
+            await self._robot.wait_for_telemetry(timeout)
+            return
         deadline = time.monotonic() + timeout
         arms = self._arms()
 
@@ -679,8 +736,9 @@ class Axol(RobotBase):
         what it needs from Python is gravity evaluated at the *measured*
         (hand-guided) pose, not at a target the arm can no longer follow.
         Every control loop keeps its cadence, the arms stay weightless, and
-        the operator guides them to rest and stops the session.
+        the         operator guides them to rest and stops the session.
         """
+        self._require_enabled("motion_control()")
         limp = self._link.limp
         if limp is not None:
             if not self._limp_announced:
@@ -712,16 +770,23 @@ class Axol(RobotBase):
         Backs the guarded-return contact hold (limp arms, gravity held by
         feedforward). With the sinks installed, ``AxolArm.gravity_compensate``
         ships its tuples to the core instead of the bus — Python never
-        touches the wire. Same signature as
-        :meth:`AxolHardware.gravity_compensate`.
+        touches the wire.
         """
+        self._require_enabled("gravity_compensate()")
         await self._robot.gravity_compensate(kd, free_joints, gripper_targets)
+
+    def _require_enabled(self, what: str) -> None:
+        if not self._armed:
+            raise MotorError(
+                f"{what} requires an enabled robot: call enable() first (the "
+                "realtime core drives the motors)"
+            )
 
     def torque_residuals(self) -> tuple[np.ndarray | None, np.ndarray | None]:
         """Per-arm measured-minus-gravity torques from the telemetry caches.
 
         The core's telemetry refreshes measured torque every tick, so this
-        needs no CAN traffic — same contract as ``AxolHardware``.
+        needs no CAN traffic.
         """
         return self._robot.torque_residuals()
 
@@ -733,39 +798,167 @@ class Axol(RobotBase):
         """Re-snapshot the gravity-comp hold setpoint (pure Python state)."""
         self._robot.reset_gravity_hold()
 
+    # -- State reads ------------------------------------------------------------
+    #
+    # While enabled, position / velocity / torque come from the caches the
+    # core's per-tick telemetry fills (no CAN sent from Python). Everything
+    # else needs the bus and is only available on a quiet one.
+
+    def _cached_pair(
+        self, per_arm: Callable[[AxolArm], np.ndarray]
+    ) -> tuple[np.ndarray | None, np.ndarray | None]:
+        def one(arm: AxolArm | None) -> np.ndarray | None:
+            return per_arm(arm) if arm is not None else None
+
+        return one(self._robot.left), one(self._robot.right)
+
     async def get_positions(
         self,
     ) -> tuple[np.ndarray | None, np.ndarray | None]:
-        """Measured positions from the telemetry-filled caches (no CAN sent).
+        """Joint positions (rad; gripper ``[0, 1]``) for both arms.
 
-        Every joint — gripper included — refreshes from the core's per-tick
-        telemetry packets once armed (the gripper's POSITION_FORCE replies
-        land in the same slot stream).
+        While enabled, from the telemetry-filled caches — every joint,
+        gripper included, refreshes from the core's per-tick packets.
         """
+        if not self._armed:
+            return await self._robot.get_positions()
+        return self._cached_pair(lambda arm: arm.positions.copy())
 
-        def arm_positions(arm: AxolArm | None) -> np.ndarray | None:
-            return arm.positions.copy() if arm is not None else None
-
-        return (
-            arm_positions(self._robot.left),
-            arm_positions(self._robot.right),
+    async def get_velocities(
+        self,
+    ) -> tuple[np.ndarray | None, np.ndarray | None]:
+        """Joint velocities (rad/s) for both arms."""
+        if not self._armed:
+            return await self._robot.get_velocities()
+        return self._cached_pair(
+            lambda arm: np.array(
+                arm._pad_absent([m.velocity for m in arm.motors.values()]),
+                dtype=np.float32,
+            )
         )
 
-    async def detach(self) -> None:
-        """Release the bus with every motor left holding its last command.
+    async def get_torques(
+        self,
+    ) -> tuple[np.ndarray | None, np.ndarray | None]:
+        """Joint torques (Nm on Damiao, A on MyActuator) for both arms."""
+        if not self._armed:
+            return await self._robot.get_torques()
+        return self._cached_pair(lambda arm: arm.torques.copy())
 
-        For flows that hand a still-energized robot to a later process:
-        ``diag.rom-enable`` leaves the grippers clamped on the item for
-        ``diag.rom-disable`` to release, and ``diag.lift-cycle`` must never
-        torque off arms that are out of their clearance pose. No disarm is
+    async def get_temperatures(
+        self,
+    ) -> tuple[np.ndarray | None, np.ndarray | None]:
+        """Motor temperatures (°C). Quiet bus only."""
+        self._require_quiet_bus("get_temperatures()")
+        return await self._robot.get_temperatures()
+
+    async def get_voltages(self) -> tuple[np.ndarray | None, np.ndarray | None]:
+        """Bus voltages (V). Quiet bus only."""
+        self._require_quiet_bus("get_voltages()")
+        return await self._robot.get_voltages()
+
+    async def get_error_codes(
+        self,
+    ) -> tuple[list[MotorStatus] | None, list[MotorStatus] | None]:
+        """Per-motor status flags. Quiet bus only."""
+        self._require_quiet_bus("get_error_codes()")
+        return await self._robot.get_error_codes()
+
+    async def get_holding(self) -> tuple[list[bool] | None, list[bool] | None]:
+        """Enabled-and-holding per motor (usable right after :meth:`connect`).
+
+        Quiet bus only; while enabled every motor is holding by definition.
+        """
+        self._require_quiet_bus("get_holding()")
+        return await self._robot.get_holding()
+
+    async def get_gains(
+        self,
+    ) -> tuple[list[MotorGains] | None, list[MotorGains] | None]:
+        """Per-motor gains. Quiet bus only."""
+        self._require_quiet_bus("get_gains()")
+        return await self._robot.get_gains()
+
+    # -- State writes (quiet bus only) ------------------------------------------
+
+    async def clear_errors(self) -> None:
+        """Clear latched error flags on all motors."""
+        self._require_quiet_bus("clear_errors()")
+        await self._robot.clear_errors()
+
+    async def set_control_mode(self, mode: ControlMode) -> None:
+        """Set ``ControlMode`` on all motors (MyActuator motors reboot)."""
+        self._require_quiet_bus("set_control_mode()")
+        await self._robot.set_control_mode(mode)
+
+    async def set_gains(
+        self,
+        left: dict[Joint, MotorGains] | None = None,
+        right: dict[Joint, MotorGains] | None = None,
+    ) -> None:
+        """Write motor gains per joint (persisted to non-volatile memory)."""
+        self._require_quiet_bus("set_gains()")
+        await self._robot.set_gains(left or {}, right or {})
+
+    async def set_zero_position(
+        self,
+        left: list[Joint] | None = None,
+        right: list[Joint] | None = None,
+    ) -> None:
+        """Zero the given joints at their current position."""
+        self._require_quiet_bus("set_zero_position()")
+        await self._robot.set_zero_position(left, right)
+
+    async def set_acceleration(
+        self,
+        left: dict[Joint, float] | None = None,
+        right: dict[Joint, float] | None = None,
+    ) -> None:
+        """Set per-joint acceleration ramps (rad/s²)."""
+        self._require_quiet_bus("set_acceleration()")
+        await self._robot.set_acceleration(left or {}, right or {})
+
+    async def set_positions_velocity(
+        self,
+        left: np.ndarray | None = None,
+        right: np.ndarray | None = None,
+        max_speed: float = 0.0,
+    ) -> None:
+        """Position command with a speed limit per arm."""
+        self._require_quiet_bus("set_positions_velocity()")
+        await self._robot.set_positions_velocity(left, right, max_speed)
+
+    async def set_velocity(
+        self,
+        left: np.ndarray | None = None,
+        right: np.ndarray | None = None,
+    ) -> None:
+        """Velocity command per arm."""
+        self._require_quiet_bus("set_velocity()")
+        await self._robot.set_velocity(left, right)
+
+    # -- Teardown ---------------------------------------------------------------
+
+    async def disconnect(self) -> None:
+        """Close the CAN buses leaving motor torque exactly as it is.
+
+        While enabled: release the bus with every motor left holding its
+        last command, for flows that hand a still-energized robot to a later
+        process (``diag.rom-enable`` leaves the grippers clamped on the item
+        for ``diag.rom-disable`` to release; ``diag.lift-cycle`` must never
+        torque off arms that are out of their clearance pose). No disarm is
         sent — the core exits on the closed link and, as on every exit that
         is not an explicit ``D``, leaves each motor holding its last MIT
         command on firmware gains, gravity feedforward included. Host
         damping stops with the core, exactly as when a classic session
-        closed its buses without disabling. A later ``enable()`` (or the
-        maintenance-proxy attach ``rom.disable`` does) picks the robot up
-        from there.
+        closed its buses without disabling. A later ``enable()`` picks the
+        robot up from there.
+
+        After :meth:`connect` only: closes the maintenance proxies.
         """
+        if not self._armed:
+            await self._robot.disconnect()
+            return
         if self._rec is not None:
             self.set_recording_engaged(False)
         for _side, arm in self._arms():
@@ -775,12 +968,14 @@ class Axol(RobotBase):
             await self._link.close()
         except Exception:  # noqa: BLE001 - the motors hold either way
             _logger.exception("rt: core link teardown failed")
+        self._armed = False
+        self._core_started = False
         if self._rec is not None:
             try:
                 self._rec.dump()
             except Exception:  # noqa: BLE001 - continue trace finalization
                 _logger.exception("rt: could not dump the measurement trace")
-        _logger.info("rt: detached — motors left holding their last command")
+        _logger.info("rt: disconnected — motors left holding their last command")
 
     async def disable(self) -> None:
         """Disarm the core and tear the link down.
@@ -796,7 +991,13 @@ class Axol(RobotBase):
         this teardown: a disabled arm falls; a holding or limp arm waits for
         the operator. Matches the classic controller, where a session dying
         mid-command left the motors holding for the next ``enable()``.
+
+        Without a core for this session (after :meth:`connect` only) this is
+        the classic torque-off over the maintenance proxies.
         """
+        if not self._core_started:
+            await self._robot.disable()
+            return
         if self._rec is not None:
             self.set_recording_engaged(False)
         for _side, arm in self._arms():
@@ -835,6 +1036,8 @@ class Axol(RobotBase):
             await self._link.close()
         except Exception:  # noqa: BLE001 - continue with maintenance disable
             _logger.exception("rt: core link teardown failed")
+        self._armed = False
+        self._core_started = False
         # Reopen Rust maintenance proxies only after proving that the core's
         # bus-owning process has exited.
         buses = self._buses()

--- a/almond_axol/rt/robot.py
+++ b/almond_axol/rt/robot.py
@@ -1,8 +1,11 @@
-"""``RtAxol`` — the Axol robot driven through the Rust realtime core.
+"""``Axol`` — the Axol robot driven through the Rust realtime core.
 
-Presents the same surface :class:`~almond_axol.teleop.VRTeleop` uses
-(``enable`` / ``disable`` / ``get_positions`` / ``motion_control``), but the
-CAN buses are owned by the ``axol-rt`` subprocess:
+This is the production robot object (re-exported as
+:class:`almond_axol.robot.Axol`). It constructs the low-level
+:class:`~almond_axol.robot.axol.AxolHardware` and presents the same surface
+:class:`~almond_axol.teleop.VRTeleop` uses (``enable`` / ``disable`` /
+``get_positions`` / ``motion_control``), but the CAN buses are owned by the
+``axol-rt`` subprocess:
 
 - ``enable()`` runs the split bring-up: the core resets the motors (prep),
   then Python resolves joint offsets and MyActuator decode ranges through a
@@ -60,15 +63,20 @@ import logging
 import math
 import threading
 import time
+import warnings
 from collections import deque
+from collections.abc import Iterable
+from typing import Self
 
 import numpy as np
 
-from ..constants import ARM_JOINTS
+from ..constants import ARM_JOINTS, CAN_LEFT, CAN_RIGHT
 from ..motor import ControlMode, Joint, MotorError
 from ..motor.bus import CanBus
 from ..motor.motor import _JOINT_CONFIG
-from ..robot.axol import Axol, AxolArm
+from ..robot.axol import AxolArm, AxolHardware
+from ..robot.base import RobotBase
+from ..robot.config import AxolConfig
 from .link import FeedbackSlot, RtLink, config_header
 
 _logger = logging.getLogger(__name__)
@@ -82,8 +90,23 @@ _N_ARM = len(ARM_JOINTS)
 _LIMP_KD = 0.25
 
 
-class RtAxol:
-    """Axol with the control loop in the Rust realtime core."""
+class Axol(RobotBase):
+    """The dual-arm Axol robot, with the control loop in the Rust realtime core.
+
+    Construct it exactly like the low-level hardware object and use it as an
+    async context manager::
+
+        async with Axol() as axol:
+            pos_l, pos_r = await axol.get_positions()
+            await axol.motion_control(left=pos_l, right=pos_r)
+
+    ``enable()`` brings the motors up and hands both CAN buses to the
+    ``axol-rt`` subprocess, which paces the 240 Hz loop; Python keeps the
+    model math and streams targets. :attr:`hardware` exposes the wrapped
+    :class:`~almond_axol.robot.axol.AxolHardware` for flows that also need
+    direct register access on a quiet bus (before ``enable()`` or after
+    ``disable()``).
+    """
 
     # The core's tracker limits get headroom over the Python shaper's caps:
     # the in-core trapezoid exists to render a smooth 240 Hz trajectory and
@@ -95,16 +118,32 @@ class RtAxol:
 
     def __init__(
         self,
-        robot: Axol,
+        config: AxolConfig | None = None,
+        left_channel: str | None = CAN_LEFT,
+        right_channel: str | None = CAN_RIGHT,
+        left_joints: Iterable[Joint] | None = None,
+        right_joints: Iterable[Joint] | None = None,
+        *,
+        hardware: AxolHardware | None = None,
         loop_hz: float = 240.0,
         watchdog_ms: float = 150.0,
         max_vel: float = 2.0 * math.pi,
         max_accel: float = 7.0 * math.pi,
         record: str | None = None,
     ) -> None:
-        """Wrap ``robot`` for the realtime core.
+        """Construct the robot for the realtime core.
+
+        The first five arguments are forwarded to
+        :class:`~almond_axol.robot.axol.AxolHardware`; see it for their
+        meaning. Nothing is opened or actuated until :meth:`enable`.
 
         Args:
+            hardware: An already-constructed ``AxolHardware`` to wrap
+                instead of building one from the forwarded arguments (which
+                must then be left at their defaults).
+            loop_hz: Realtime core tick rate.
+            watchdog_ms: Core watchdog — how long it holds the last target
+                without a fresh one before treating the host as gone.
             max_vel: Teleop joint-velocity cap (rad/s) — the core's tracker
                 runs at ``_TRACKER_HEADROOM`` times this. Defaults match
                 ``VRTeleopConfig.teleop_max_vel``.
@@ -114,7 +153,26 @@ class RtAxol:
                 position/torque is captured from the core's feedback packets
                 at its native ``loop_hz`` instead of the Python target rate.
         """
-        self._robot = robot
+        if hardware is None:
+            hardware = AxolHardware(
+                config=AxolConfig() if config is None else config,
+                left_channel=left_channel,
+                right_channel=right_channel,
+                left_joints=left_joints,
+                right_joints=right_joints,
+            )
+        elif (
+            config is not None
+            or left_channel != CAN_LEFT
+            or right_channel != CAN_RIGHT
+            or left_joints is not None
+            or right_joints is not None
+        ):
+            raise ValueError(
+                "Axol(hardware=...) takes the wrapped object as-is; do not also "
+                "pass config / channels / joints"
+            )
+        self._robot = hardware
         self._loop_hz = loop_hz
         self._watchdog_ms = watchdog_ms
         self._max_vel = max_vel
@@ -150,6 +208,18 @@ class RtAxol:
         self._state_cond = threading.Condition()
         self._state_sides: set[int] = set()
         self._state_side_ts: dict[int, float] = {}
+
+    @property
+    def hardware(self) -> AxolHardware:
+        """The wrapped low-level object (buses, motors, model math).
+
+        Its ``left`` / ``right`` arms and their ``motors`` are the same
+        objects this class reads and commands through. Direct register
+        access (``connect()``, ``is_holding()``, ...) is only valid while the
+        core does not own the bus — before :meth:`enable` or after
+        :meth:`disable`.
+        """
+        return self._robot
 
     @property
     def left(self) -> AxolArm | None:
@@ -290,13 +360,18 @@ class RtAxol:
             self._loop_hz,
         )
 
-    async def __aenter__(self) -> RtAxol:
+    async def __aenter__(self) -> Self:
         """Enter the async context, arming the core via :meth:`enable`."""
         await self.enable()
         return self
 
     async def __aexit__(self, *_: object) -> None:
-        """Exit the async context, tearing down via :meth:`disable`."""
+        """Exit the async context, tearing down via :meth:`disable`.
+
+        Unlike :meth:`RobotBase.__aexit__`, teardown errors are not wrapped
+        in ``HardwareCleanupError``: :meth:`disable` already decides, per
+        failure, whether the motors were left holding on purpose.
+        """
         await self.disable()
 
     async def start_telemetry(self, hz: float, *, torque: bool = False) -> None:
@@ -304,9 +379,9 @@ class RtAxol:
 
         Positions, velocities, and torques for every slot arrive in the
         per-tick ``F`` packets regardless of ``hz`` / ``torque`` — a poll
-        loop would need the bus, which the core owns. Kept so classic
-        flows (gravity-comp, waypoints, tune.motion, the LeRobot robot)
-        run unchanged against ``RtAxol``.
+        loop would need the bus, which the core owns. Kept so flows written
+        against ``AxolHardware`` (gravity-comp, waypoints, tune.motion, the
+        LeRobot robot) run unchanged.
         """
         _logger.debug(
             "rt: start_telemetry(%s) ignored — core streams at %.0f Hz",
@@ -320,7 +395,7 @@ class RtAxol:
     async def wait_for_telemetry(self, timeout: float = 5.0) -> None:
         """Block until the core's telemetry stream is flowing for every arm.
 
-        Same contract as :meth:`Axol.wait_for_telemetry`; ``enable`` already
+        Same contract as :meth:`AxolHardware.wait_for_telemetry`; ``enable`` already
         waited once, so after a successful bring-up this returns immediately.
         """
         deadline = time.monotonic() + timeout
@@ -638,7 +713,8 @@ class RtAxol:
         Backs the guarded-return contact hold (limp arms, gravity held by
         feedforward). With the sinks installed, ``AxolArm.gravity_compensate``
         ships its tuples to the core instead of the bus — Python never
-        touches the wire. Same signature as :meth:`Axol.gravity_compensate`.
+        touches the wire. Same signature as
+        :meth:`AxolHardware.gravity_compensate`.
         """
         await self._robot.gravity_compensate(kd, free_joints, gripper_targets)
 
@@ -646,7 +722,7 @@ class RtAxol:
         """Per-arm measured-minus-gravity torques from the telemetry caches.
 
         The core's telemetry refreshes measured torque every tick, so this
-        needs no CAN traffic — same contract as ``Axol``.
+        needs no CAN traffic — same contract as ``AxolHardware``.
         """
         return self._robot.torque_residuals()
 
@@ -821,3 +897,24 @@ class RtAxol:
             _logger.warning(
                 "rt: retaining raw control trace because the core is still running"
             )
+
+
+class RtAxol(Axol):
+    """Deprecated spelling of :class:`Axol`.
+
+    ``RtAxol(AxolHardware(...))`` was the previous way to opt into the realtime
+    core. :class:`almond_axol.robot.Axol` now constructs the hardware object
+    itself; this shim keeps the old idiom working (with a
+    ``DeprecationWarning``) for one release.
+    """
+
+    def __init__(self, robot: AxolHardware | Axol, **kwargs: object) -> None:
+        warnings.warn(
+            "RtAxol is deprecated: construct almond_axol.robot.Axol(...) "
+            "directly (it wraps the realtime core by default)",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if isinstance(robot, Axol):
+            robot = robot.hardware
+        super().__init__(hardware=robot, **kwargs)  # type: ignore[arg-type]

--- a/almond_axol/teleop/mantis_grippers.py
+++ b/almond_axol/teleop/mantis_grippers.py
@@ -8,7 +8,7 @@ grippers until stopped. It deliberately starts no VR server and needs no
 tracker binding, cameras, headset, or tracker-to-TCP transform.
 
 The grippers are driven through the Rust realtime core
-(:class:`~almond_axol.rt.RtMantis`): this loop only reads the triggers and
+(:class:`~almond_axol.robot.Mantis`): this loop only reads the triggers and
 streams normalised targets at ``poll_interval``; ``axol-rt`` owns the gripper
 buses and paces the POSITION_FORCE commands. The trigger reader's own
 receive-only SocketCAN socket coexists with the core (the kernel duplicates
@@ -26,8 +26,7 @@ import numpy as np
 
 from ..constants import ARM_JOINTS
 from ..robot.base import HardwareCleanupError
-from ..robot.mantis import Mantis
-from ..rt import RtMantis
+from ..rt import Mantis
 from ..tracker.trigger import TriggerReader
 
 _logger = logging.getLogger(__name__)
@@ -39,9 +38,9 @@ _TRIGGER_WAIT_TIMEOUT_S = 5.0
 _RELEASED_GRIP_MIN = 0.8
 
 
-def _rt_mantis(**kwargs: Any) -> RtMantis:
+def _rt_mantis(**kwargs: Any) -> Mantis:
     """Default robot factory: the Mantis behind the realtime core."""
-    return RtMantis(Mantis(**kwargs))
+    return Mantis(**kwargs)
 
 
 def _read_fresh_grips(readers: dict[str, Any]) -> tuple[dict[str, float], list[str]]:

--- a/almond_axol/teleop/teleop.py
+++ b/almond_axol/teleop/teleop.py
@@ -157,8 +157,8 @@ class VRTeleop:
 
         if isinstance(robot, AxolHardware):
             raise TypeError(
-                "VRTeleop hardware requires almond_axol.robot.Axol (the realtime "
-                "core); direct Python control of AxolHardware has been removed"
+                "VRTeleop requires almond_axol.robot.Axol (or Sim); direct Python "
+                "control of the low-level AxolHardware object is not supported"
             )
         self._robot = robot
         self._jelly = jelly

--- a/almond_axol/teleop/teleop.py
+++ b/almond_axol/teleop/teleop.py
@@ -18,7 +18,7 @@ Typical usage::
 Or with custom components::
 
     async with VRTeleop(
-        RtAxol(Axol()),
+        Axol(),
         config=VRTeleopConfig(teleop_max_vel=2.0),
         vr_server_config=VRServerConfig(port=9000),
     ) as teleop:
@@ -47,13 +47,13 @@ from ..robot.base import (
     RobotBase,
     mark_hardware_cleanup_uncertain,
 )
-from ..robot.jelly import Jelly
 from ..robot.control import ContactWatchdog
+from ..robot.jelly import Jelly
+from ..teleop_activity import TeleopActivityMarker
 from ..utils.jetson_diag import TegraStatsDiag
 from ..utils.proc_diag import SystemDiag
 from ..vr.config import VRServerConfig
 from ..vr.server import VRServer
-from ..teleop_activity import TeleopActivityMarker
 from .config import VRTeleopConfig
 from .core import VRTeleopCore
 from .recorder import make as _recorder_make
@@ -153,12 +153,12 @@ class VRTeleop:
         # Direct Python control-loop teleop is no longer supported. Keep this guard at
         # the reusable API boundary so custom callers cannot silently bypass
         # the production Rust core; Sim remains a valid alternate target.
-        from ..robot.axol import Axol
+        from ..robot.axol import AxolHardware
 
-        if isinstance(robot, Axol):
+        if isinstance(robot, AxolHardware):
             raise TypeError(
-                "VRTeleop hardware requires RtAxol(Axol()); direct Python "
-                "control has been removed"
+                "VRTeleop hardware requires almond_axol.robot.Axol (the realtime "
+                "core); direct Python control of AxolHardware has been removed"
             )
         self._robot = robot
         self._jelly = jelly
@@ -214,7 +214,7 @@ class VRTeleop:
         # taps the measured side per control tick — cached joint positions
         # and torques (8 left + 8 right), refreshed by the impedance feedback
         # frames so reading them costs no CAN traffic.
-        # RtAxol receives feedback at the native 240 Hz wire rate and owns the
+        # Axol receives feedback at the native 240 Hz wire rate and owns the
         # same `_meas.npz` stage when recording is on. Sim keeps this
         # once-per-loop recorder.
         self._robot_recorder = (

--- a/docs/api/concepts.mdx
+++ b/docs/api/concepts.mdx
@@ -9,8 +9,8 @@ The Axol SDK is organized into focused modules:
 
 ```
 almond_axol/
-├── robot/        Axol (hardware) and Sim (visualizer) — start here
-├── rt/           RtAxol — realtime hardware control core (axol-rt, 240 Hz)
+├── robot/        Axol (the robot), AxolHardware (low-level) and Sim (visualizer) — start here
+├── rt/           Axol's realtime hardware control core (axol-rt, 240 Hz)
 ├── kinematics/   Bimanual IK solver (JAX + pyroki)
 ├── teleop/       VR headset → IK → robot control loop
 ├── vr/           WebSocket server that receives VR frames
@@ -28,7 +28,7 @@ The browser front-ends live outside the Python package, in `web/`: the [VR teleo
 End-to-end data flow for teleoperation:
 
 ```
-VR headset → VRServer (WSS) → VRTeleop → KinematicsSolver → RtAxol (axol-rt, 240 Hz) → motors
+VR headset → VRServer (WSS) → VRTeleop → KinematicsSolver → Axol (axol-rt, 240 Hz) → motors
 ```
 
 End-to-end data flow for LeRobot data collection:

--- a/docs/api/concepts.mdx
+++ b/docs/api/concepts.mdx
@@ -9,7 +9,7 @@ The Axol SDK is organized into focused modules:
 
 ```
 almond_axol/
-├── robot/        Axol (the robot), AxolHardware (low-level) and Sim (visualizer) — start here
+├── robot/        Axol (the robot) and Sim (visualizer) — start here
 ├── rt/           Axol's realtime hardware control core (axol-rt, 240 Hz)
 ├── kinematics/   Bimanual IK solver (JAX + pyroki)
 ├── teleop/       VR headset → IK → robot control loop

--- a/docs/api/robot.mdx
+++ b/docs/api/robot.mdx
@@ -49,14 +49,14 @@ asyncio.run(main())
 | Method | Description |
 |---|---|
 | `connect()` | Open the CAN buses only — nothing is actuated; all read APIs (`get_holding()`, `get_positions()`, ...) become usable for inspecting a robot of unknown state |
-| `enable()` | Bring every motor up. Idempotent per motor: joints already holding keep holding (reads only, gripper keeps its grasp); cold joints get the full bring-up incl. gripper calibration. Then hands the buses to the realtime core and finishes actively holding the measured pose (gravity feedforward and damping included) — see [Reconnecting to a live robot](#reconnecting-to-a-live-robot) |
+| `enable(hold=True)` | Bring every motor up. Idempotent per motor: joints already holding keep holding (reads only, gripper keeps its grasp); cold joints get the full bring-up incl. gripper calibration. With `hold=True` (default) the realtime core then takes the buses and the robot finishes actively holding its measured pose (gravity feedforward and damping included) — see [Reconnecting to a live robot](#reconnecting-to-a-live-robot). With `hold=False` freshly brought-up joints are left enabled but limp and Python keeps the bus (no core) — for flows that manage control modes themselves |
 | `disable()` | Disable all motors and close CAN buses. After a core `fault` or `limp` the motors are deliberately **left holding** (or limp) instead — see [Faults and limp](#faults-and-limp) |
 | `disconnect()` | Close CAN buses leaving motor torque exactly as it is — the robot keeps holding for a later process to reconnect |
 | `start_telemetry(hz, torque=False)` | Begin background polling loop on all motors. While enabled this is a no-op: the core already streams position, velocity, and torque for every motor each tick |
 | `wait_for_telemetry(timeout=5.0)` | Block until every motor has reported a position; call after `start_telemetry` before the first cached `positions` read |
 | `stop_telemetry()` | Stop background polling |
 | `clear_errors()` | Clear latched error flags on all motors |
-| `set_control_mode(mode)` | Set `ControlMode` on all motors. **MyActuator motors reboot to switch modes (torque off ~2 s)** — never call it while the arms hold a load (Damiao takes a live mode flip in stride — it is a plain register write) |
+| `set_control_mode(mode)` | Set `ControlMode` on all motors. **MyActuator motors reboot to switch modes (torque off ~2 s)** — never call it while the arms hold a load; use `enable(hold=False)` in flows that manage modes themselves (Damiao takes a live mode flip in stride — it is a plain register write) |
 
 <Note>
 **Who owns the bus.** Between `enable()` and `disable()` / `disconnect()` the realtime core owns the CAN buses. `get_positions()`, `get_velocities()`, `get_torques()`, `left.positions`, `left.torques`, and `torque_residuals()` keep working — they read the caches the core's telemetry fills, sending no CAN from Python. Register-level calls (`connect()`, `get_temperatures()`, `get_holding()`, `get_gains()`, `clear_errors()`, `set_control_mode()`, every `set_*` except `motion_control`) raise `MotorError` while enabled; use them on a `connect()`-ed robot before `enable()`, or after `disable()`. `motion_control()` and `gravity_compensate()` require an enabled robot.
@@ -69,7 +69,7 @@ If a controlling process dies (or disconnects) while the robot is torqued on, th
 - joints that are **already holding** are attached to with reads only (never reset — a reset reboots MyActuator motors and drops the arm for ~2 s), and a holding gripper keeps its grasp: its open-stop calibration is restored from the values persisted by the last full bring-up instead of re-running the sweep that forces the jaws open;
 - **cold** joints get the classic full bring-up;
 - a mixed robot (e.g. the previous session died mid-`enable`) simply gets the cold joints brought up while the holding ones are left alone;
-- `enable()` finishes by commanding the measured pose once (configured gains + gravity feedforward — the arm is already there, so nothing moves), so "enabled" always means *actively holding*.
+- with `hold=True` (the default) `enable()` finishes by commanding the measured pose once (configured gains + gravity feedforward — the arm is already there, so nothing moves), so "enabled" always means *actively holding*.
 
 ```python
 import asyncio
@@ -97,6 +97,7 @@ asyncio.run(main())
 Notes:
 
 - `connect()` is optional — `enable()` opens the buses itself. Call it when you want to inspect state (`get_holding()`, positions, temperatures) before acting. A process that must never actuate can `connect()`, check `get_holding()`, and only proceed when every joint is already holding.
+- Custom control modes: pass `enable(hold=False)` to leave freshly brought-up joints enabled but limp, then pick your mode with `set_control_mode()` (position/velocity/force) and drive with `set_positions_velocity()` / `set_velocity()`. The bus stays in Python and no core is started, so `motion_control()` is unavailable until a later `enable()`. The reconnect machinery targets the impedance workflow — a session that died in another control mode is asked to `disable()` and re-enable rather than being reattached.
 - To force a fresh bring-up of a live robot (re-run gripper calibration, reset motors), call `disable()` first, then `enable()`.
 - One corner intentionally raises `MotorError`: a gripper that is holding but has no valid persisted calibration — re-measuring would sweep the jaws open and drop whatever it grips. Empty the gripper, then `disable()` and `enable()`.
 - `enable()` also refuses (raising `MotorError`) if any arm joint's encoder reading is implausible for a zero at its calibration end stop — the zero was never set, or is stale, and bringing the robot up on garbage joint-frame values is unsafe. The gate runs **before anything is actuated** (`connect()` and the read APIs still work, for inspecting such a robot); run `axol motor.set-zero-pos --guided` to (re)zero. See [`motor.set-zero-pos`](/cli/motor-set-zero-pos).

--- a/docs/api/robot.mdx
+++ b/docs/api/robot.mdx
@@ -79,7 +79,7 @@ asyncio.run(main())
 Faults never drop the arms: a disabled arm falls, a holding or limp arm waits for the operator.
 
 <Note>
-`RtAxol(AxolHardware(...))` — the previous spelling — still works and emits a `DeprecationWarning`. Replace it with `Axol(...)`. The Mantis rig follows the same pattern: `almond_axol.robot.Mantis` is the core-backed rig, `MantisHardware` the low-level object, `RtMantis` the deprecated alias.
+The Mantis rig follows the same pattern: `almond_axol.robot.Mantis` is the core-backed rig, `MantisHardware` the low-level object.
 </Note>
 
 ## `AxolHardware`

--- a/docs/api/robot.mdx
+++ b/docs/api/robot.mdx
@@ -79,7 +79,7 @@ asyncio.run(main())
 Faults never drop the arms: a disabled arm falls, a holding or limp arm waits for the operator.
 
 <Note>
-`RtAxol(AxolHardware(...))` — the previous spelling — still works and emits a `DeprecationWarning`. Replace it with `Axol(...)`.
+`RtAxol(AxolHardware(...))` — the previous spelling — still works and emits a `DeprecationWarning`. Replace it with `Axol(...)`. The Mantis rig follows the same pattern: `almond_axol.robot.Mantis` is the core-backed rig, `MantisHardware` the low-level object, `RtMantis` the deprecated alias.
 </Note>
 
 ## `AxolHardware`

--- a/docs/api/robot.mdx
+++ b/docs/api/robot.mdx
@@ -26,10 +26,15 @@ Pass `left_channel=None` or `right_channel=None` to operate a single arm. Both a
 
 `left_joints` / `right_joints` restrict an arm to the motors actually on its bus, for a partial bench arm (e.g. `{Joint.WRIST_2, Joint.WRIST_3, Joint.GRIPPER}` for a wrist assembly). Absent joints are never constructed or enabled; every `(8,)` array keeps its Joint-enum shape, with absent joints reading `0.0` (the rest pose) and their commands ignored.
 
+<Note>
+The realtime core is the default for the CLI — `axol teleop`, `axol gravity-comp`, `axol waypoints`, and the control panel all construct `RtAxol` for you. When you drive the robot from your own Python, opting in is explicit: wrap the low-level object as `RtAxol(Axol())`. A bare `Axol` still works, but it sends CAN from Python on the caller's schedule — use it for calibration and diagnostics, not for motion.
+</Note>
+
 ```python
 import asyncio
 import numpy as np
 from almond_axol.robot import Axol
+from almond_axol.rt import RtAxol
 
 async def main():
     async with RtAxol(Axol()) as axol:

--- a/docs/api/robot.mdx
+++ b/docs/api/robot.mdx
@@ -3,41 +3,44 @@ title: "almond_axol.robot"
 description: "Hardware controllers for Axol and Jelly, simulation, configuration, and gravity compensation."
 ---
 
-Hardware controller for both arms. `Axol` is the low-level hardware/model object; production motion wraps it in `RtAxol`, which exclusively owns CAN while armed and runs the control loop at 240 Hz. Direct-register calibration and diagnostics use the low-level object outside that production loop. `Sim` is a drop-in replacement that renders the robot in a browser using viser (requires the `sim` extra).
+Hardware controller for both arms. `Axol` is the robot: it brings the motors up, hands both CAN buses to the Rust realtime core (`axol-rt`), which exclusively owns them while armed and runs the control loop at 240 Hz, and streams your `motion_control` targets to it. `AxolHardware` is the low-level hardware/model object underneath — direct-register calibration and diagnostics use it on a quiet bus, outside the production loop. `Sim` is a drop-in replacement for `Axol` that renders the robot in a browser using viser (requires the `sim` extra).
 
 ```python
-from almond_axol.robot import Axol, AxolConfig, Jelly, JellyConfig, Sim
-from almond_axol.rt import RtAxol
+from almond_axol.robot import Axol, AxolConfig, AxolHardware, Jelly, JellyConfig, Sim
 ```
 
 ## `Axol`
 
 ```python
 Axol(
-    config: AxolConfig = AxolConfig(),
+    config: AxolConfig | None = None,
     left_channel: str | None = "can_alm_axol_l",
     right_channel: str | None = "can_alm_axol_r",
     left_joints: Iterable[Joint] | None = None,
     right_joints: Iterable[Joint] | None = None,
+    *,
+    hardware: AxolHardware | None = None,
+    loop_hz: float = 240.0,
+    watchdog_ms: float = 150.0,
+    max_vel: float = 2π,
+    max_accel: float = 7π,
+    record: str | None = None,
 )
 ```
 
-Pass `left_channel=None` or `right_channel=None` to operate a single arm. Both arms are brought up concurrently on `__aenter__`.
+The first five arguments are forwarded to [`AxolHardware`](#axolhardware). Pass `left_channel=None` or `right_channel=None` to operate a single arm. `left_joints` / `right_joints` restrict an arm to the motors actually on its bus, for a partial bench arm (e.g. `{Joint.WRIST_2, Joint.WRIST_3, Joint.GRIPPER}` for a wrist assembly). Absent joints are never constructed or enabled; every `(8,)` array keeps its Joint-enum shape, with absent joints reading `0.0` (the rest pose) and their commands ignored.
 
-`left_joints` / `right_joints` restrict an arm to the motors actually on its bus, for a partial bench arm (e.g. `{Joint.WRIST_2, Joint.WRIST_3, Joint.GRIPPER}` for a wrist assembly). Absent joints are never constructed or enabled; every `(8,)` array keeps its Joint-enum shape, with absent joints reading `0.0` (the rest pose) and their commands ignored.
+`max_vel` / `max_accel` are the teleop joint caps the core's trajectory tracker is sized from (defaults match `VRTeleopConfig`); `record` is a flight-recorder prefix that captures measured position/torque from the core's feedback at `loop_hz`. `hardware=` wraps an `AxolHardware` you already built instead of constructing one.
 
-<Note>
-The realtime core is the default for the CLI — `axol teleop`, `axol gravity-comp`, `axol waypoints`, and the control panel all construct `RtAxol` for you. When you drive the robot from your own Python, opting in is explicit: wrap the low-level object as `RtAxol(Axol())`. A bare `Axol` still works, but it sends CAN from Python on the caller's schedule — use it for calibration and diagnostics, not for motion.
-</Note>
+This is the same object every CLI flow uses — `axol teleop`, `axol gravity-comp`, `axol waypoints`, the control panel — so code written against `Axol` exercises exactly the controller the robot ships with.
 
 ```python
 import asyncio
 import numpy as np
 from almond_axol.robot import Axol
-from almond_axol.rt import RtAxol
 
 async def main():
-    async with RtAxol(Axol()) as axol:
+    async with Axol() as axol:
         # non-blocking cached reads from the core's 240 Hz feedback
         print("left positions (rad):", axol.left.positions)
         print("left torques (Nm):", axol.left.torques)
@@ -49,6 +52,49 @@ async def main():
 
 asyncio.run(main())
 ```
+
+### Lifecycle
+
+| Method / attribute | Description |
+|---|---|
+| `enable()` | Full bring-up: the core resets the motors, Python resolves joint offsets and calibrates the grippers on the quiet bus, then the core takes the buses and arms. Finishes actively holding the measured pose (gravity feedforward and damping included). Joints already holding from a previous session are attached to, never reset |
+| `disable()` | Deliberate stop: the core disables the motors on disarm and Python repeats the disable once the bus is free. After a core `fault` or `limp`, the motors are deliberately **left holding** (or limp) instead — see [Faults and limp](#faults-and-limp) |
+| `detach()` | Release the core with every motor left holding its last command, for handing a still-energized robot to a later process |
+| `motion_control(left, right)` | Primary control: impedance (arm joints) + position-force (gripper). Python runs the model math (limits, gravity, pose-scheduled feedforward coefficients); the core renders the trajectory at 240 Hz |
+| `gravity_compensate(kd, free_joints, gripper_targets)` | One gravity-comp cycle streamed through the core — the arms go limp and hand-guidable, held up by feedforward |
+| `get_positions()` | `(left, right)` measured positions from the telemetry caches; no CAN traffic |
+| `left` / `right` | The `AxolArm` objects (`positions`, `torques`, `velocities` cached from the core's feedback) |
+| `hardware` | The wrapped [`AxolHardware`](#axolhardware) |
+| `start_telemetry(hz)` / `stop_telemetry()` / `wait_for_telemetry()` | Kept for flows written against `AxolHardware`; the core already streams telemetry every tick, so the first two are no-ops |
+| `state_nearest(perf_ts)` | Telemetry snapshot nearest a camera exposure timestamp, from a short 240 Hz history — used by data collection |
+| `torque_residuals()` / `reset_command_state()` / `reset_gravity_hold()` | Pure-Python state helpers behind guarded return and contact detection |
+
+### Faults and limp
+
+| Attribute | Meaning |
+|---|---|
+| `fault` | The core's latched `fault: ...` (dead bus, protocol error), or `None`. The core has stopped streaming and the motors hold their last command; `disable()` leaves them that way |
+| `limp` | Why the core went limp (`limp: ...` — a motor silent for a second, control timing lost), or `None`. Every arm joint is at kp = 0 with gravity feedforward for the rest of the session; `motion_control` streams gravity comp instead of tracking so the operator can hand-guide the arms to rest and stop |
+
+Faults never drop the arms: a disabled arm falls, a holding or limp arm waits for the operator.
+
+<Note>
+`RtAxol(AxolHardware(...))` — the previous spelling — still works and emits a `DeprecationWarning`. Replace it with `Axol(...)`.
+</Note>
+
+## `AxolHardware`
+
+```python
+AxolHardware(
+    config: AxolConfig = AxolConfig(),
+    left_channel: str | None = "can_alm_axol_l",
+    right_channel: str | None = "can_alm_axol_r",
+    left_joints: Iterable[Joint] | None = None,
+    right_joints: Iterable[Joint] | None = None,
+)
+```
+
+The low-level dual-arm object: one `CanBus` and one `AxolArm` (7 arm motors + gripper) per side, plus the gravity/friction/inertia model. It sends CAN from Python on the caller's schedule. Use it for calibration, register-level diagnostics, and inspecting a robot of unknown state — not for production motion; `Axol` wraps it for that, and the two must not touch the bus at the same time (`Axol.enable()` hands the buses to the core, `Axol.disable()` gets them back). Everything below is also reachable as `Axol(...).hardware` while the core is not armed.
 
 ### Lifecycle methods
 
@@ -73,12 +119,14 @@ If a controlling process dies (or disconnects) while the robot is torqued on, th
 - a mixed robot (e.g. the previous session died mid-`enable`) simply gets the cold joints brought up while the holding ones are left alone;
 - with `hold=True` (the default) `enable()` finishes by commanding the measured pose once (configured gains + gravity feedforward — the arm is already there, so nothing moves), so "enabled" always means *actively holding*.
 
+`Axol.enable()` runs the same convergence before arming the core, so a plain `async with Axol()` reconnects to a live robot too. The low-level flow, for a process that wants to inspect first:
+
 ```python
 import asyncio
-from almond_axol.robot import Axol
+from almond_axol.robot import AxolHardware
 
 async def main():
-    axol = Axol()
+    axol = AxolHardware()
     await axol.connect()                   # open buses; nothing actuated
     held_l, held_r = await axol.get_holding()   # optional: inspect first
     await axol.enable()                    # holding joints kept holding
@@ -177,14 +225,13 @@ Each arm joint is configured with a single `JointConfig` carrying its impedance 
 
 ```python
 from almond_axol.robot import Axol, AxolConfig, FrictionParams
-from almond_axol.rt import RtAxol
 
 config = AxolConfig()
 config.left.elbow.kp = 200
 config.left.elbow.mass = 0.6
 config.left.elbow.com = (-0.025, 0.0, -0.07)
 config.left.elbow.friction = FrictionParams(fc=0.4, k=10.0, fv=0.05, fo=0.0)
-async with RtAxol(Axol(config=config)) as axol: ...
+async with Axol(config=config) as axol: ...
 ```
 
 Or build a fully custom arm with `dataclasses.replace` (start from the `AxolConfig` defaults so you keep the per-side friction values that get injected at construction):
@@ -227,7 +274,7 @@ Gravity feedforward is computed centrally from the URDF — see [Gravity compens
 |---|---|---|
 | `has_gripper` | `True` | Whether this robot is the gripper-equipped SKU. Set `False` for the gripperless SKU: the gripper motors are never constructed, enabled, or calibrated; the gripper element of every `(8,)` joint array is ignored on write and reported as `0.0` on read (array shapes are unchanged). LeRobot datasets recorded on a gripperless robot carry 7 channels per arm instead of 8. |
 | `max_step_rad` | `0.5` | Maximum allowed change in any arm joint (rad) between consecutive `motion_control` calls. Commands that exceed this are dropped and a warning is logged. Set to `float("inf")` to disable. At 30 Hz, 0.5 rad/step ≈ 15 rad/s — roughly 2.5× the teleop velocity ceiling. |
-| `left_stiffness` | `1.0` | Compliance blend for the **left** arm. Either a scalar in `[0, 1]` (applied to every joint) or a 7-tuple of per-joint factors (order: `shoulder_1`, `shoulder_2`, `shoulder_3`, `elbow`, `wrist_1`, `wrist_2`, `wrist_3` — gripper excluded). The default `1.0` runs the hardware-tuned per-joint gains (e.g. `shoulder_1` `kp=350`) — the stiffest the hardware was measured to support, so lower values only *add compliance*, down to the hand-guidable `_SOFT_GAINS` at `0` (`shoulder_1` `kp=40`). `kp` / `kd` interpolate geometrically (log-space — matches perceived stiffness), with a damping-ratio-consistent soft endpoint so every slider position stays as well damped as the tuned gains; `j_eff` is unchanged by the blend; `kd_host` scales with `√(kp(s)/kp)`. The blend is baked into the `left` / `right` gains by `AxolConfig.resolved()`, called once at the robot-construction boundary (`Axol.__init__`); the stiffness fields themselves are left untouched so a serialized config round-trips cleanly. |
+| `left_stiffness` | `1.0` | Compliance blend for the **left** arm. Either a scalar in `[0, 1]` (applied to every joint) or a 7-tuple of per-joint factors (order: `shoulder_1`, `shoulder_2`, `shoulder_3`, `elbow`, `wrist_1`, `wrist_2`, `wrist_3` — gripper excluded). The default `1.0` runs the hardware-tuned per-joint gains (e.g. `shoulder_1` `kp=350`) — the stiffest the hardware was measured to support, so lower values only *add compliance*, down to the hand-guidable `_SOFT_GAINS` at `0` (`shoulder_1` `kp=40`). `kp` / `kd` interpolate geometrically (log-space — matches perceived stiffness), with a damping-ratio-consistent soft endpoint so every slider position stays as well damped as the tuned gains; `j_eff` is unchanged by the blend; `kd_host` scales with `√(kp(s)/kp)`. The blend is baked into the `left` / `right` gains by `AxolConfig.resolved()`, called once at the robot-construction boundary (`AxolHardware.__init__`); the stiffness fields themselves are left untouched so a serialized config round-trips cleanly. |
 | `right_stiffness` | `1.0` | Same, for the **right** arm. |
 
 ```python
@@ -250,12 +297,11 @@ If the arms sag or push back in gravity-comp mode, tune the relevant joint's `ma
 
 ```python
 from almond_axol.robot import AxolConfig, Axol
-from almond_axol.rt import RtAxol
 
 config = AxolConfig()
 config.left.elbow.mass = 0.6
 config.left.elbow.com = (-0.025, 0.0, -0.07)
-async with RtAxol(Axol(config=config)) as axol: ...
+async with Axol(config=config) as axol: ...
 ```
 
 See the [`gravity-comp`](/cli/gravity-comp) CLI command to hold the arms in gravity-compensation mode interactively.

--- a/docs/api/robot.mdx
+++ b/docs/api/robot.mdx
@@ -3,34 +3,25 @@ title: "almond_axol.robot"
 description: "Hardware controllers for Axol and Jelly, simulation, configuration, and gravity compensation."
 ---
 
-Hardware controller for both arms. `Axol` is the robot: it brings the motors up, hands both CAN buses to the Rust realtime core (`axol-rt`), which exclusively owns them while armed and runs the control loop at 240 Hz, and streams your `motion_control` targets to it. `AxolHardware` is the low-level hardware/model object underneath — direct-register calibration and diagnostics use it on a quiet bus, outside the production loop. `Sim` is a drop-in replacement for `Axol` that renders the robot in a browser using viser (requires the `sim` extra).
+Hardware controller for both arms. `Axol` opens one SocketCAN bus per arm on entry, enables all 16 motors, and calibrates the gripper open-stop. Once enabled, the 240 Hz control loop runs in the Rust realtime core (`axol-rt`), which owns the CAN buses for the session; Python keeps the model math and streams `motion_control` targets to it. `Sim` is a drop-in replacement that renders the robot in a browser using viser (requires the `sim` extra).
 
 ```python
-from almond_axol.robot import Axol, AxolConfig, AxolHardware, Jelly, JellyConfig, Sim
+from almond_axol.robot import Axol, AxolConfig, ArmConfig, JointConfig, FrictionParams, Jelly, JellyConfig, Sim
 ```
 
 ## `Axol`
 
 ```python
 Axol(
-    config: AxolConfig | None = None,
+    config: AxolConfig = AxolConfig(),
     left_channel: str | None = "can_alm_axol_l",
     right_channel: str | None = "can_alm_axol_r",
     left_joints: Iterable[Joint] | None = None,
     right_joints: Iterable[Joint] | None = None,
-    *,
-    hardware: AxolHardware | None = None,
-    loop_hz: float = 240.0,
-    watchdog_ms: float = 150.0,
-    max_vel: float = 2π,
-    max_accel: float = 7π,
-    record: str | None = None,
 )
 ```
 
-The first five arguments are forwarded to [`AxolHardware`](#axolhardware). Pass `left_channel=None` or `right_channel=None` to operate a single arm. `left_joints` / `right_joints` restrict an arm to the motors actually on its bus, for a partial bench arm (e.g. `{Joint.WRIST_2, Joint.WRIST_3, Joint.GRIPPER}` for a wrist assembly). Absent joints are never constructed or enabled; every `(8,)` array keeps its Joint-enum shape, with absent joints reading `0.0` (the rest pose) and their commands ignored.
-
-`max_vel` / `max_accel` are the teleop joint caps the core's trajectory tracker is sized from (defaults match `VRTeleopConfig`); `record` is a flight-recorder prefix that captures measured position/torque from the core's feedback at `loop_hz`. `hardware=` wraps an `AxolHardware` you already built instead of constructing one.
+Pass `left_channel=None` or `right_channel=None` to operate a single arm. Both arms are brought up concurrently on `__aenter__`. `left_joints` / `right_joints` restrict an arm to the motors actually on its bus, for a partial bench arm (e.g. `{Joint.WRIST_2, Joint.WRIST_3, Joint.GRIPPER}` for a wrist assembly); absent joints are never constructed or enabled, every `(8,)` array keeps its Joint-enum shape, and their elements read `0.0` with commands ignored.
 
 This is the same object every CLI flow uses — `axol teleop`, `axol gravity-comp`, `axol waypoints`, the control panel — so code written against `Axol` exercises exactly the controller the robot ships with.
 
@@ -41,7 +32,7 @@ from almond_axol.robot import Axol
 
 async def main():
     async with Axol() as axol:
-        # non-blocking cached reads from the core's 240 Hz feedback
+        # non-blocking cached reads (fed by the core's 240 Hz telemetry)
         print("left positions (rad):", axol.left.positions)
         print("left torques (Nm):", axol.left.torques)
 
@@ -53,62 +44,23 @@ async def main():
 asyncio.run(main())
 ```
 
-### Lifecycle
-
-| Method / attribute | Description |
-|---|---|
-| `enable()` | Full bring-up: the core resets the motors, Python resolves joint offsets and calibrates the grippers on the quiet bus, then the core takes the buses and arms. Finishes actively holding the measured pose (gravity feedforward and damping included). Joints already holding from a previous session are attached to, never reset |
-| `disable()` | Deliberate stop: the core disables the motors on disarm and Python repeats the disable once the bus is free. After a core `fault` or `limp`, the motors are deliberately **left holding** (or limp) instead — see [Faults and limp](#faults-and-limp) |
-| `detach()` | Release the core with every motor left holding its last command, for handing a still-energized robot to a later process |
-| `motion_control(left, right)` | Primary control: impedance (arm joints) + position-force (gripper). Python runs the model math (limits, gravity, pose-scheduled feedforward coefficients); the core renders the trajectory at 240 Hz |
-| `gravity_compensate(kd, free_joints, gripper_targets)` | One gravity-comp cycle streamed through the core — the arms go limp and hand-guidable, held up by feedforward |
-| `get_positions()` | `(left, right)` measured positions from the telemetry caches; no CAN traffic |
-| `left` / `right` | The `AxolArm` objects (`positions`, `torques`, `velocities` cached from the core's feedback) |
-| `hardware` | The wrapped [`AxolHardware`](#axolhardware) |
-| `start_telemetry(hz)` / `stop_telemetry()` / `wait_for_telemetry()` | Kept for flows written against `AxolHardware`; the core already streams telemetry every tick, so the first two are no-ops |
-| `state_nearest(perf_ts)` | Telemetry snapshot nearest a camera exposure timestamp, from a short 240 Hz history — used by data collection |
-| `torque_residuals()` / `reset_command_state()` / `reset_gravity_hold()` | Pure-Python state helpers behind guarded return and contact detection |
-
-### Faults and limp
-
-| Attribute | Meaning |
-|---|---|
-| `fault` | The core's latched `fault: ...` (dead bus, protocol error), or `None`. The core has stopped streaming and the motors hold their last command; `disable()` leaves them that way |
-| `limp` | Why the core went limp (`limp: ...` — a motor silent for a second, control timing lost), or `None`. Every arm joint is at kp = 0 with gravity feedforward for the rest of the session; `motion_control` streams gravity comp instead of tracking so the operator can hand-guide the arms to rest and stop |
-
-Faults never drop the arms: a disabled arm falls, a holding or limp arm waits for the operator.
-
-<Note>
-The Mantis rig follows the same pattern: `almond_axol.robot.Mantis` is the core-backed rig, `MantisHardware` the low-level object.
-</Note>
-
-## `AxolHardware`
-
-```python
-AxolHardware(
-    config: AxolConfig = AxolConfig(),
-    left_channel: str | None = "can_alm_axol_l",
-    right_channel: str | None = "can_alm_axol_r",
-    left_joints: Iterable[Joint] | None = None,
-    right_joints: Iterable[Joint] | None = None,
-)
-```
-
-The low-level dual-arm object: one `CanBus` and one `AxolArm` (7 arm motors + gripper) per side, plus the gravity/friction/inertia model. It sends CAN from Python on the caller's schedule. Use it for calibration, register-level diagnostics, and inspecting a robot of unknown state — not for production motion; `Axol` wraps it for that, and the two must not touch the bus at the same time (`Axol.enable()` hands the buses to the core, `Axol.disable()` gets them back). Everything below is also reachable as `Axol(...).hardware` while the core is not armed.
-
 ### Lifecycle methods
 
 | Method | Description |
 |---|---|
 | `connect()` | Open the CAN buses only — nothing is actuated; all read APIs (`get_holding()`, `get_positions()`, ...) become usable for inspecting a robot of unknown state |
-| `enable(hold=True)` | Bring every motor up. Idempotent per motor: joints already holding keep holding (reads only, gripper keeps its grasp); cold joints get the full bring-up incl. gripper calibration. With `hold=True` (default) the robot finishes actively holding its measured pose — see [Reconnecting to a live robot](#reconnecting-to-a-live-robot) |
-| `disable()` | Disable all motors and close CAN buses |
-| `disconnect()` | Close CAN buses leaving motor torque exactly as it is |
-| `start_telemetry(hz, torque=False)` | Begin background polling loop on all motors |
+| `enable()` | Bring every motor up. Idempotent per motor: joints already holding keep holding (reads only, gripper keeps its grasp); cold joints get the full bring-up incl. gripper calibration. Then hands the buses to the realtime core and finishes actively holding the measured pose (gravity feedforward and damping included) — see [Reconnecting to a live robot](#reconnecting-to-a-live-robot) |
+| `disable()` | Disable all motors and close CAN buses. After a core `fault` or `limp` the motors are deliberately **left holding** (or limp) instead — see [Faults and limp](#faults-and-limp) |
+| `disconnect()` | Close CAN buses leaving motor torque exactly as it is — the robot keeps holding for a later process to reconnect |
+| `start_telemetry(hz, torque=False)` | Begin background polling loop on all motors. While enabled this is a no-op: the core already streams position, velocity, and torque for every motor each tick |
 | `wait_for_telemetry(timeout=5.0)` | Block until every motor has reported a position; call after `start_telemetry` before the first cached `positions` read |
 | `stop_telemetry()` | Stop background polling |
 | `clear_errors()` | Clear latched error flags on all motors |
-| `set_control_mode(mode)` | Set `ControlMode` on all motors. **MyActuator motors reboot to switch modes (torque off ~2 s)** — never call it while the arms hold a load; use `enable(hold=False)` in flows that manage modes themselves (Damiao takes a live mode flip in stride — it is a plain register write) |
+| `set_control_mode(mode)` | Set `ControlMode` on all motors. **MyActuator motors reboot to switch modes (torque off ~2 s)** — never call it while the arms hold a load (Damiao takes a live mode flip in stride — it is a plain register write) |
+
+<Note>
+**Who owns the bus.** Between `enable()` and `disable()` / `disconnect()` the realtime core owns the CAN buses. `get_positions()`, `get_velocities()`, `get_torques()`, `left.positions`, `left.torques`, and `torque_residuals()` keep working — they read the caches the core's telemetry fills, sending no CAN from Python. Register-level calls (`connect()`, `get_temperatures()`, `get_holding()`, `get_gains()`, `clear_errors()`, `set_control_mode()`, every `set_*` except `motion_control`) raise `MotorError` while enabled; use them on a `connect()`-ed robot before `enable()`, or after `disable()`. `motion_control()` and `gravity_compensate()` require an enabled robot.
+</Note>
 
 ### Reconnecting to a live robot
 
@@ -117,29 +69,24 @@ If a controlling process dies (or disconnects) while the robot is torqued on, th
 - joints that are **already holding** are attached to with reads only (never reset — a reset reboots MyActuator motors and drops the arm for ~2 s), and a holding gripper keeps its grasp: its open-stop calibration is restored from the values persisted by the last full bring-up instead of re-running the sweep that forces the jaws open;
 - **cold** joints get the classic full bring-up;
 - a mixed robot (e.g. the previous session died mid-`enable`) simply gets the cold joints brought up while the holding ones are left alone;
-- with `hold=True` (the default) `enable()` finishes by commanding the measured pose once (configured gains + gravity feedforward — the arm is already there, so nothing moves), so "enabled" always means *actively holding*.
-
-`Axol.enable()` runs the same convergence before arming the core, so a plain `async with Axol()` reconnects to a live robot too. The low-level flow, for a process that wants to inspect first:
+- `enable()` finishes by commanding the measured pose once (configured gains + gravity feedforward — the arm is already there, so nothing moves), so "enabled" always means *actively holding*.
 
 ```python
 import asyncio
-from almond_axol.robot import AxolHardware
+from almond_axol.robot import Axol
 
 async def main():
-    axol = AxolHardware()
+    axol = Axol()
     await axol.connect()                   # open buses; nothing actuated
     held_l, held_r = await axol.get_holding()   # optional: inspect first
     await axol.enable()                    # holding joints kept holding
-
-    await axol.start_telemetry(500)
-    await axol.wait_for_telemetry()
 
     # Resume from the *measured* pose — after a reconnect the arms are
     # wherever the previous session left them, and the max_step_rad safety
     # check is seeded against that pose, so a stale or default target is
     # rejected instead of yanking the arms.
-    left = axol.left.positions
-    await axol.motion_control(left=left)
+    left, right = await axol.get_positions()
+    await axol.motion_control(left=left, right=right)
     # ... ramp toward your desired target from here ...
 
     await axol.disconnect()                # exit, leaving torque as-is
@@ -150,11 +97,19 @@ asyncio.run(main())
 Notes:
 
 - `connect()` is optional — `enable()` opens the buses itself. Call it when you want to inspect state (`get_holding()`, positions, temperatures) before acting. A process that must never actuate can `connect()`, check `get_holding()`, and only proceed when every joint is already holding.
-- Custom control modes: pass `enable(hold=False)` to leave freshly brought-up joints enabled but limp, then pick your mode with `set_control_mode()` (position/velocity/force). The reconnect machinery targets the impedance workflow — a session that died in another control mode is asked to `disable()` and re-enable rather than being reattached.
 - To force a fresh bring-up of a live robot (re-run gripper calibration, reset motors), call `disable()` first, then `enable()`.
 - One corner intentionally raises `MotorError`: a gripper that is holding but has no valid persisted calibration — re-measuring would sweep the jaws open and drop whatever it grips. Empty the gripper, then `disable()` and `enable()`.
 - `enable()` also refuses (raising `MotorError`) if any arm joint's encoder reading is implausible for a zero at its calibration end stop — the zero was never set, or is stale, and bringing the robot up on garbage joint-frame values is unsafe. The gate runs **before anything is actuated** (`connect()` and the read APIs still work, for inspecting such a robot); run `axol motor.set-zero-pos --guided` to (re)zero. See [`motor.set-zero-pos`](/cli/motor-set-zero-pos).
 - `disconnect()` closes the buses without touching torque, so the robot keeps holding and a later process can reconnect. Use `disable()` only when you actually want to torque off (with the arms in a safe pose).
+
+### Faults and limp
+
+| Attribute | Meaning |
+|---|---|
+| `fault` | The core's latched `fault: ...` (dead bus, protocol error), or `None`. The core has stopped streaming and the motors hold their last command; `disable()` leaves them that way |
+| `limp` | Why the core went limp (`limp: ...` — a motor silent for a second, control timing lost), or `None`. Every arm joint is at kp = 0 with gravity feedforward for the rest of the session; `motion_control` streams gravity comp instead of tracking so the operator can hand-guide the arms to rest and stop |
+
+Faults never drop the arms: a disabled arm falls, a holding or limp arm waits for the operator.
 
 ### State reads
 
@@ -175,7 +130,8 @@ Each returns `(left_array, right_array)` where the absent arm is `None`.
 
 | Method | Description |
 |---|---|
-| `motion_control(left, right)` | Impedance (arm) + position-force (gripper); primary control method |
+| `motion_control(left, right)` | Impedance (arm) + position-force (gripper); primary control method. Python runs the model math (limits, gravity, pose-scheduled feedforward coefficients); the core renders the trajectory at 240 Hz |
+| `gravity_compensate(kd, free_joints, gripper_targets)` | One gravity-comp cycle — the arms go limp and hand-guidable, held up by feedforward |
 | `set_positions_velocity(left, right, max_speed)` | Motor built-in position controller |
 | `set_velocity(left, right)` | Motor built-in speed controller |
 | `set_gains(left, right)` | Write PID gains; persisted to flash |
@@ -183,6 +139,10 @@ Each returns `(left_array, right_array)` where the absent arm is `None`.
 | `set_acceleration(left, right)` | Set per-joint acceleration ramp (rad/s²) |
 
 Individual arms are accessible via `axol.left` and `axol.right` (`AxolArm`), which expose the same methods operating on a single arm.
+
+<Note>
+The Mantis rig (`almond_axol.robot.Mantis`) has the same shape: `Mantis(config, left_channel, right_channel, *, defer_gripper_enable)`, the same lifecycle, and the gripper slot of each `motion_control` target reaching the hardware.
+</Note>
 
 ## `Jelly`
 
@@ -274,7 +234,7 @@ Gravity feedforward is computed centrally from the URDF — see [Gravity compens
 |---|---|---|
 | `has_gripper` | `True` | Whether this robot is the gripper-equipped SKU. Set `False` for the gripperless SKU: the gripper motors are never constructed, enabled, or calibrated; the gripper element of every `(8,)` joint array is ignored on write and reported as `0.0` on read (array shapes are unchanged). LeRobot datasets recorded on a gripperless robot carry 7 channels per arm instead of 8. |
 | `max_step_rad` | `0.5` | Maximum allowed change in any arm joint (rad) between consecutive `motion_control` calls. Commands that exceed this are dropped and a warning is logged. Set to `float("inf")` to disable. At 30 Hz, 0.5 rad/step ≈ 15 rad/s — roughly 2.5× the teleop velocity ceiling. |
-| `left_stiffness` | `1.0` | Compliance blend for the **left** arm. Either a scalar in `[0, 1]` (applied to every joint) or a 7-tuple of per-joint factors (order: `shoulder_1`, `shoulder_2`, `shoulder_3`, `elbow`, `wrist_1`, `wrist_2`, `wrist_3` — gripper excluded). The default `1.0` runs the hardware-tuned per-joint gains (e.g. `shoulder_1` `kp=350`) — the stiffest the hardware was measured to support, so lower values only *add compliance*, down to the hand-guidable `_SOFT_GAINS` at `0` (`shoulder_1` `kp=40`). `kp` / `kd` interpolate geometrically (log-space — matches perceived stiffness), with a damping-ratio-consistent soft endpoint so every slider position stays as well damped as the tuned gains; `j_eff` is unchanged by the blend; `kd_host` scales with `√(kp(s)/kp)`. The blend is baked into the `left` / `right` gains by `AxolConfig.resolved()`, called once at the robot-construction boundary (`AxolHardware.__init__`); the stiffness fields themselves are left untouched so a serialized config round-trips cleanly. |
+| `left_stiffness` | `1.0` | Compliance blend for the **left** arm. Either a scalar in `[0, 1]` (applied to every joint) or a 7-tuple of per-joint factors (order: `shoulder_1`, `shoulder_2`, `shoulder_3`, `elbow`, `wrist_1`, `wrist_2`, `wrist_3` — gripper excluded). The default `1.0` runs the hardware-tuned per-joint gains (e.g. `shoulder_1` `kp=350`) — the stiffest the hardware was measured to support, so lower values only *add compliance*, down to the hand-guidable `_SOFT_GAINS` at `0` (`shoulder_1` `kp=40`). `kp` / `kd` interpolate geometrically (log-space — matches perceived stiffness), with a damping-ratio-consistent soft endpoint so every slider position stays as well damped as the tuned gains; `j_eff` is unchanged by the blend; `kd_host` scales with `√(kp(s)/kp)`. The blend is baked into the `left` / `right` gains by `AxolConfig.resolved()`, called once at the robot-construction boundary (`Axol.__init__`); the stiffness fields themselves are left untouched so a serialized config round-trips cleanly. |
 | `right_stiffness` | `1.0` | Same, for the **right** arm. |
 
 ```python

--- a/docs/api/teleop.mdx
+++ b/docs/api/teleop.mdx
@@ -12,11 +12,10 @@ from almond_axol.teleop import VRTeleop, VRTeleopConfig
 ```python
 import asyncio
 from almond_axol.robot import Axol
-from almond_axol.rt import RtAxol
 from almond_axol.teleop import VRTeleop
 
 async def main():
-    async with VRTeleop(RtAxol(Axol())) as teleop:
+    async with VRTeleop(Axol()) as teleop:
         await teleop.run()  # blocking; Ctrl+C to exit
 
 asyncio.run(main())

--- a/rust/axol-rt/README.md
+++ b/rust/axol-rt/README.md
@@ -71,7 +71,7 @@ low-pass, the IK-output EMA, and the Python trapezoid with its engage
 velocity ramp and output guard — also stays: those filters condition the
 *target stream* and live with IK. A command sink hands
 per-joint 9-float tuples `(p_des, mode, kp, kd, t_ff, kd_host, damp_w0,
-damp_q, j_eff)` to `almond_axol.rt.RtAxol`, which ships them to this core
+damp_q, j_eff)` to `almond_axol.robot.Axol`, which ships them to this core
 (~120 Hz) instead of sending CAN from Python. `t_ff` is gravity only in
 tracked mode; `mode 0` (gravity comp) is a tracker-bypassing passthrough
 with `v_des = 0`.

--- a/rust/axol-rt/tools/rt_ramp_diag.py
+++ b/rust/axol-rt/tools/rt_ramp_diag.py
@@ -43,7 +43,6 @@ async def main(out: str) -> None:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(message)s")
 
     robot = Axol()
-    inner = robot.hardware
     await robot.enable()
     try:
         pos_l, pos_r = await robot.get_positions()
@@ -58,7 +57,7 @@ async def main(out: str) -> None:
         meas_log: list[np.ndarray] = []
         ts_log: list[np.ndarray] = []
 
-        left_arm = inner.left
+        left_arm = robot.left
         assert left_arm is not None
         names = ", ".join(
             f"joint[{j}] {math.degrees(a):+.0f}°" for j, a in EXCURSION.items()

--- a/rust/axol-rt/tools/rt_ramp_diag.py
+++ b/rust/axol-rt/tools/rt_ramp_diag.py
@@ -41,10 +41,9 @@ def min_jerk(alpha: float) -> float:
 
 async def main(out: str) -> None:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(message)s")
-    from almond_axol.rt import RtAxol
 
-    inner = Axol()
-    robot = RtAxol(inner)
+    robot = Axol()
+    inner = robot.hardware
     await robot.enable()
     try:
         pos_l, pos_r = await robot.get_positions()

--- a/rust/axol-rt/tools/rt_smoke.py
+++ b/rust/axol-rt/tools/rt_smoke.py
@@ -1,6 +1,6 @@
 """End-to-end smoke test for the hybrid rt path — no VR needed.
 
-Drives the robot through ``RtAxol``: the full ``motion_control`` math runs in
+Drives the robot through ``Axol``: the full ``motion_control`` math runs in
 Python at 120 Hz, the Rust core owns the bus at 240 Hz. The motion is a hold
 followed by a gentle wrist_3 sinusoid on both arms with a slow gripper
 open/close cycle riding along (empty-jaw safe: it sweeps at most 0.35 of
@@ -23,7 +23,6 @@ import time
 import numpy as np
 
 from almond_axol.robot import Axol
-from almond_axol.rt import RtAxol
 
 WRIST_3 = 6  # Joint enum index
 GRIPPER = 7
@@ -32,7 +31,7 @@ RATE_HZ = 120.0
 
 async def main(secs: float, amp_deg: float, freq_hz: float) -> None:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(message)s")
-    robot = RtAxol(Axol())
+    robot = Axol()
     await robot.enable()
     try:
         pos_l, pos_r = await robot.get_positions()

--- a/tests/test_axol_construction.py
+++ b/tests/test_axol_construction.py
@@ -1,0 +1,83 @@
+"""``almond_axol.robot.Axol`` is the realtime-core robot and builds its own hardware.
+
+``Axol(...)`` takes the same arguments as the low-level ``AxolHardware`` and
+constructs it internally; ``hardware=`` wraps an existing one; the old
+``RtAxol(AxolHardware(...))`` spelling keeps working behind a
+``DeprecationWarning``.
+"""
+
+from __future__ import annotations
+
+import unittest
+import warnings
+from unittest.mock import patch
+
+from almond_axol.constants import Joint
+from almond_axol.robot import Axol, AxolConfig, AxolHardware, RobotBase, Sim
+from almond_axol.robot import axol as axol_module
+from almond_axol.rt import Axol as RtModuleAxol
+from almond_axol.rt import RtAxol
+
+
+class AxolConstructionTest(unittest.TestCase):
+    def setUp(self) -> None:
+        # No CAN, no core binary: construction must not need either.
+        self.enterContext(patch.object(axol_module, "CanBus"))
+        self.enterContext(patch("almond_axol.rt.robot.RtLink"))
+
+    def test_axol_is_the_realtime_core_robot(self) -> None:
+        self.assertIs(Axol, RtModuleAxol)
+        self.assertTrue(issubclass(Axol, RobotBase))
+        self.assertTrue(issubclass(Sim, RobotBase))
+        self.assertFalse(issubclass(AxolHardware, Axol))
+
+    def test_forwards_hardware_arguments(self) -> None:
+        config = AxolConfig(has_gripper=False)
+        robot = Axol(
+            config,
+            left_channel="can0",
+            right_channel=None,
+            left_joints={Joint.WRIST_2, Joint.WRIST_3},
+            max_vel=1.0,
+        )
+        self.assertIsInstance(robot.hardware, AxolHardware)
+        self.assertIs(robot.left, robot.hardware.left)
+        self.assertIsNone(robot.right)
+        assert robot.left is not None
+        self.assertEqual(set(robot.left.motors), {Joint.WRIST_2, Joint.WRIST_3})
+        self.assertEqual(robot._max_vel, 1.0)
+
+    def test_default_config_when_omitted(self) -> None:
+        robot = Axol(left_channel="can0", right_channel=None)
+        assert robot.left is not None
+        self.assertIn(Joint.GRIPPER, robot.left.motors)
+
+    def test_hardware_keyword_wraps_an_existing_object(self) -> None:
+        hardware = AxolHardware(left_channel="can0", right_channel=None)
+        robot = Axol(hardware=hardware)
+        self.assertIs(robot.hardware, hardware)
+        with self.assertRaisesRegex(ValueError, "do not also pass"):
+            Axol(hardware=hardware, left_channel="can1")
+        with self.assertRaisesRegex(ValueError, "do not also pass"):
+            Axol(AxolConfig(), hardware=hardware)
+
+    def test_hardware_validation_still_applies(self) -> None:
+        with self.assertRaisesRegex(ValueError, "different CAN interfaces"):
+            Axol(left_channel="can0", right_channel="can0")
+
+    def test_rtaxol_is_a_deprecated_alias(self) -> None:
+        hardware = AxolHardware(left_channel="can0", right_channel=None)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            robot = RtAxol(hardware, max_vel=2.0)
+            # The old idiom written against the new ``Axol`` still resolves.
+            nested = RtAxol(Axol(hardware=hardware))
+        self.assertEqual([w.category for w in caught], [DeprecationWarning] * 2)
+        self.assertIsInstance(robot, Axol)
+        self.assertIs(robot.hardware, hardware)
+        self.assertEqual(robot._max_vel, 2.0)
+        self.assertIs(nested.hardware, hardware)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_axol_construction.py
+++ b/tests/test_axol_construction.py
@@ -1,42 +1,103 @@
-"""``almond_axol.robot.Axol`` / ``Mantis`` are the realtime-core robots.
+"""``almond_axol.robot.Axol`` / ``Mantis`` keep the classic API.
 
-``Axol(...)`` takes the same arguments as the low-level ``AxolHardware`` and
-constructs it internally; ``hardware=`` wraps an existing one. ``Mantis`` /
-``MantisHardware`` follow the same pattern.
+The realtime core is an implementation detail: ``Axol(...)`` takes the same
+arguments as before the Rust port, exposes the same lifecycle / read / write
+surface, and only differs behind the scenes (which calls go to the core's
+telemetry versus the bus, and when the bus is available at all).
 """
 
 from __future__ import annotations
 
+import inspect
 import unittest
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
+
+import numpy as np
 
 from almond_axol.constants import Joint
-from almond_axol.robot import (
-    Axol,
-    AxolConfig,
-    AxolHardware,
-    Mantis,
-    MantisHardware,
-    RobotBase,
-    Sim,
-)
+from almond_axol.motor import MotorError
+from almond_axol.robot import Axol, AxolConfig, Mantis, RobotBase, Sim
+from almond_axol.robot import __all__ as robot_exports
 from almond_axol.robot import axol as axol_module
 from almond_axol.robot import mantis as mantis_module
+from almond_axol.robot.axol import AxolHardware
+from almond_axol.robot.mantis import MantisHardware
 from almond_axol.rt import Axol as RtModuleAxol
 from almond_axol.rt import Mantis as RtModuleMantis
 
+# The public surface of ``almond_axol.robot.Axol`` before the realtime core
+# existed. Every name must still be there; the core must not leak new
+# required steps into user code.
+_CLASSIC_AXOL_API = {
+    "connect",
+    "enable",
+    "disable",
+    "disconnect",
+    "start_telemetry",
+    "stop_telemetry",
+    "wait_for_telemetry",
+    "clear_errors",
+    "set_control_mode",
+    "get_positions",
+    "get_velocities",
+    "get_torques",
+    "get_temperatures",
+    "get_voltages",
+    "get_error_codes",
+    "get_holding",
+    "get_gains",
+    "set_gains",
+    "set_zero_position",
+    "set_acceleration",
+    "set_positions_velocity",
+    "set_velocity",
+    "motion_control",
+    "gravity_compensate",
+    "reset_gravity_hold",
+    "reset_command_state",
+    "torque_residuals",
+    "left",
+    "right",
+}
 
-class AxolConstructionTest(unittest.TestCase):
+
+class AxolApiTest(unittest.TestCase):
     def setUp(self) -> None:
         # No CAN, no core binary: construction must not need either.
         self.enterContext(patch.object(axol_module, "CanBus"))
         self.enterContext(patch("almond_axol.rt.robot.RtLink"))
 
-    def test_axol_is_the_realtime_core_robot(self) -> None:
+    def test_axol_is_the_one_robot_class(self) -> None:
         self.assertIs(Axol, RtModuleAxol)
         self.assertTrue(issubclass(Axol, RobotBase))
         self.assertTrue(issubclass(Sim, RobotBase))
-        self.assertFalse(issubclass(AxolHardware, Axol))
+        # The low-level object is internal: not part of the package surface.
+        self.assertNotIn("AxolHardware", robot_exports)
+        self.assertNotIn("MantisHardware", robot_exports)
+
+    def test_classic_surface_is_intact(self) -> None:
+        missing = sorted(name for name in _CLASSIC_AXOL_API if not hasattr(Axol, name))
+        self.assertEqual(missing, [])
+        # No leftovers from the wrapper era.
+        for name in ("hardware", "detach"):
+            self.assertFalse(hasattr(Axol, name), name)
+
+    def test_classic_constructor_signature(self) -> None:
+        params = inspect.signature(Axol).parameters
+        positional = [
+            name
+            for name, p in params.items()
+            if p.kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+        ]
+        self.assertEqual(
+            positional,
+            ["config", "left_channel", "right_channel", "left_joints", "right_joints"],
+        )
+        # Core tuning is keyword-only and optional.
+        for name in ("loop_hz", "watchdog_ms", "max_vel", "max_accel", "record"):
+            self.assertIs(params[name].kind, inspect.Parameter.KEYWORD_ONLY)
+            self.assertIsNot(params[name].default, inspect.Parameter.empty)
+        self.assertNotIn("hardware", params)
 
     def test_forwards_hardware_arguments(self) -> None:
         config = AxolConfig(has_gripper=False)
@@ -47,8 +108,8 @@ class AxolConstructionTest(unittest.TestCase):
             left_joints={Joint.WRIST_2, Joint.WRIST_3},
             max_vel=1.0,
         )
-        self.assertIsInstance(robot.hardware, AxolHardware)
-        self.assertIs(robot.left, robot.hardware.left)
+        self.assertIsInstance(robot._robot, AxolHardware)
+        self.assertIs(robot.left, robot._robot.left)
         self.assertIsNone(robot.right)
         assert robot.left is not None
         self.assertEqual(set(robot.left.motors), {Joint.WRIST_2, Joint.WRIST_3})
@@ -59,28 +120,112 @@ class AxolConstructionTest(unittest.TestCase):
         assert robot.left is not None
         self.assertIn(Joint.GRIPPER, robot.left.motors)
 
-    def test_hardware_keyword_wraps_an_existing_object(self) -> None:
-        hardware = AxolHardware(left_channel="can0", right_channel=None)
-        robot = Axol(hardware=hardware)
-        self.assertIs(robot.hardware, hardware)
-        with self.assertRaisesRegex(ValueError, "do not also pass"):
-            Axol(hardware=hardware, left_channel="can1")
-        with self.assertRaisesRegex(ValueError, "do not also pass"):
-            Axol(AxolConfig(), hardware=hardware)
-
     def test_hardware_validation_still_applies(self) -> None:
         with self.assertRaisesRegex(ValueError, "different CAN interfaces"):
             Axol(left_channel="can0", right_channel="can0")
 
+    def test_wrap_builds_around_an_existing_object(self) -> None:
+        hardware = AxolHardware(left_channel="can0", right_channel=None)
+        robot = Axol._wrap(hardware, watchdog_ms=99.0)
+        self.assertIs(robot._robot, hardware)
+        self.assertEqual(robot._watchdog_ms, 99.0)
+        self.assertFalse(robot._armed)
 
-class MantisConstructionTest(unittest.TestCase):
+
+class AxolBusOwnershipTest(unittest.IsolatedAsyncioTestCase):
+    """Which calls reach the bus depends on who owns it."""
+
+    def setUp(self) -> None:
+        self.enterContext(patch.object(axol_module, "CanBus"))
+        self.enterContext(patch("almond_axol.rt.robot.RtLink"))
+        self.robot = Axol(left_channel="can0", right_channel=None)
+        self.hardware = self.robot._robot
+
+    async def test_quiet_bus_calls_go_to_the_hardware(self) -> None:
+        pair = (np.zeros(8, dtype=np.float32), None)
+        with (
+            patch.object(self.hardware, "connect", AsyncMock()) as connect,
+            patch.object(self.hardware, "get_positions", AsyncMock(return_value=pair)),
+            patch.object(
+                self.hardware, "get_holding", AsyncMock(return_value=([], None))
+            ),
+            patch.object(self.hardware, "start_telemetry", AsyncMock()) as telemetry,
+            patch.object(self.hardware, "disconnect", AsyncMock()) as disconnect,
+            patch.object(self.hardware, "disable", AsyncMock()) as disable,
+        ):
+            await self.robot.connect()
+            self.assertIs(await self.robot.get_positions(), pair)
+            self.assertEqual(await self.robot.get_holding(), ([], None))
+            await self.robot.start_telemetry(100)
+            await self.robot.disconnect()
+            await self.robot.disable()
+        connect.assert_awaited_once()
+        telemetry.assert_awaited_once_with(100, torque=False)
+        disconnect.assert_awaited_once()
+        # No core was started for this session: a classic torque-off.
+        disable.assert_awaited_once()
+
+    async def test_register_calls_are_refused_while_the_core_owns_the_bus(self) -> None:
+        self.robot._armed = True
+        for call in (
+            self.robot.connect(),
+            self.robot.get_holding(),
+            self.robot.get_temperatures(),
+            self.robot.set_control_mode(None),  # type: ignore[arg-type]
+            self.robot.set_gains(),
+        ):
+            with self.assertRaisesRegex(MotorError, "realtime core owns the CAN bus"):
+                await call
+
+    async def test_motion_requires_enable(self) -> None:
+        with self.assertRaisesRegex(MotorError, "call enable\\(\\) first"):
+            await self.robot.motion_control(left=np.zeros(8, dtype=np.float32))
+        with self.assertRaisesRegex(MotorError, "call enable\\(\\) first"):
+            await self.robot.gravity_compensate()
+
+    async def test_cached_reads_while_armed_send_no_can(self) -> None:
+        self.robot._armed = True
+        positions = np.arange(8, dtype=np.float32)
+        torques = np.full(8, 0.5, dtype=np.float32)
+        arm = self.hardware.left
+        assert arm is not None
+        with (
+            patch.object(type(arm), "positions", property(lambda _self: positions)),
+            patch.object(type(arm), "torques", property(lambda _self: torques)),
+            patch.object(self.hardware, "get_positions", AsyncMock()) as bus_read,
+        ):
+            pos_l, pos_r = await self.robot.get_positions()
+            trq_l, _ = await self.robot.get_torques()
+        bus_read.assert_not_awaited()
+        assert pos_l is not None and trq_l is not None
+        np.testing.assert_array_equal(pos_l, positions)
+        self.assertIsNot(pos_l, positions)
+        self.assertIsNone(pos_r)
+        np.testing.assert_array_equal(trq_l, torques)
+
+
+class MantisApiTest(unittest.TestCase):
     def setUp(self) -> None:
         self.enterContext(patch.object(mantis_module, "CanBus"))
 
-    def test_mantis_is_the_realtime_core_rig(self) -> None:
+    def test_mantis_is_the_one_rig_class(self) -> None:
         self.assertIs(Mantis, RtModuleMantis)
         self.assertTrue(issubclass(Mantis, RobotBase))
-        self.assertFalse(issubclass(MantisHardware, Mantis))
+        for name in ("hardware", "robot", "detach"):
+            self.assertFalse(hasattr(Mantis, name), name)
+
+    def test_classic_constructor_signature(self) -> None:
+        params = inspect.signature(Mantis).parameters
+        positional = [
+            name
+            for name, p in params.items()
+            if p.kind is inspect.Parameter.POSITIONAL_OR_KEYWORD
+        ]
+        self.assertEqual(positional, ["config", "left_channel", "right_channel"])
+        self.assertIs(
+            params["defer_gripper_enable"].kind, inspect.Parameter.KEYWORD_ONLY
+        )
+        self.assertNotIn("hardware", params)
 
     def test_forwards_hardware_arguments(self) -> None:
         rig = Mantis(
@@ -90,19 +235,16 @@ class MantisConstructionTest(unittest.TestCase):
             defer_gripper_enable=True,
             watchdog_ms=99.0,
         )
-        self.assertIsInstance(rig.hardware, MantisHardware)
-        self.assertIs(rig.robot, rig.hardware)
-        self.assertIs(rig.left, rig.hardware.left)
+        self.assertIsInstance(rig._robot, MantisHardware)
+        self.assertIs(rig.left, rig._robot.left)
         self.assertIsNone(rig.right)
-        self.assertTrue(rig.hardware._defer_gripper_enable)
+        self.assertTrue(rig._robot._defer_gripper_enable)
         self.assertEqual(rig._watchdog_ms, 99.0)
         self.assertFalse(rig.armed)
 
-    def test_hardware_keyword_wraps_an_existing_object(self) -> None:
+    def test_wrap_builds_around_an_existing_object(self) -> None:
         hardware = MantisHardware(left_channel="can_l", right_channel=None)
-        self.assertIs(Mantis(hardware=hardware).hardware, hardware)
-        with self.assertRaisesRegex(ValueError, "do not also pass"):
-            Mantis(hardware=hardware, defer_gripper_enable=True)
+        self.assertIs(Mantis._wrap(hardware)._robot, hardware)
         with self.assertRaisesRegex(ValueError, "different CAN interfaces"):
             Mantis(left_channel="can_l", right_channel="can_l")
 

--- a/tests/test_axol_construction.py
+++ b/tests/test_axol_construction.py
@@ -1,9 +1,10 @@
-"""``almond_axol.robot.Axol`` is the realtime-core robot and builds its own hardware.
+"""``almond_axol.robot.Axol`` / ``Mantis`` are the realtime-core robots.
 
 ``Axol(...)`` takes the same arguments as the low-level ``AxolHardware`` and
 constructs it internally; ``hardware=`` wraps an existing one; the old
 ``RtAxol(AxolHardware(...))`` spelling keeps working behind a
-``DeprecationWarning``.
+``DeprecationWarning``. ``Mantis`` / ``MantisHardware`` / ``RtMantis`` follow
+the same pattern.
 """
 
 from __future__ import annotations
@@ -13,10 +14,20 @@ import warnings
 from unittest.mock import patch
 
 from almond_axol.constants import Joint
-from almond_axol.robot import Axol, AxolConfig, AxolHardware, RobotBase, Sim
+from almond_axol.robot import (
+    Axol,
+    AxolConfig,
+    AxolHardware,
+    Mantis,
+    MantisHardware,
+    RobotBase,
+    Sim,
+)
 from almond_axol.robot import axol as axol_module
+from almond_axol.robot import mantis as mantis_module
 from almond_axol.rt import Axol as RtModuleAxol
-from almond_axol.rt import RtAxol
+from almond_axol.rt import Mantis as RtModuleMantis
+from almond_axol.rt import RtAxol, RtMantis
 
 
 class AxolConstructionTest(unittest.TestCase):
@@ -76,6 +87,51 @@ class AxolConstructionTest(unittest.TestCase):
         self.assertIsInstance(robot, Axol)
         self.assertIs(robot.hardware, hardware)
         self.assertEqual(robot._max_vel, 2.0)
+        self.assertIs(nested.hardware, hardware)
+
+
+class MantisConstructionTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.enterContext(patch.object(mantis_module, "CanBus"))
+
+    def test_mantis_is_the_realtime_core_rig(self) -> None:
+        self.assertIs(Mantis, RtModuleMantis)
+        self.assertTrue(issubclass(Mantis, RobotBase))
+        self.assertFalse(issubclass(MantisHardware, Mantis))
+
+    def test_forwards_hardware_arguments(self) -> None:
+        rig = Mantis(
+            AxolConfig(),
+            left_channel="can_l",
+            right_channel=None,
+            defer_gripper_enable=True,
+            watchdog_ms=99.0,
+        )
+        self.assertIsInstance(rig.hardware, MantisHardware)
+        self.assertIs(rig.robot, rig.hardware)
+        self.assertIs(rig.left, rig.hardware.left)
+        self.assertIsNone(rig.right)
+        self.assertTrue(rig.hardware._defer_gripper_enable)
+        self.assertEqual(rig._watchdog_ms, 99.0)
+        self.assertFalse(rig.armed)
+
+    def test_hardware_keyword_wraps_an_existing_object(self) -> None:
+        hardware = MantisHardware(left_channel="can_l", right_channel=None)
+        self.assertIs(Mantis(hardware=hardware).hardware, hardware)
+        with self.assertRaisesRegex(ValueError, "do not also pass"):
+            Mantis(hardware=hardware, defer_gripper_enable=True)
+        with self.assertRaisesRegex(ValueError, "different CAN interfaces"):
+            Mantis(left_channel="can_l", right_channel="can_l")
+
+    def test_rtmantis_is_a_deprecated_alias(self) -> None:
+        hardware = MantisHardware(left_channel="can_l", right_channel=None)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            rig = RtMantis(hardware, record=None)
+            nested = RtMantis(Mantis(hardware=hardware))
+        self.assertEqual([w.category for w in caught], [DeprecationWarning] * 2)
+        self.assertIsInstance(rig, Mantis)
+        self.assertIs(rig.hardware, hardware)
         self.assertIs(nested.hardware, hardware)
 
 

--- a/tests/test_axol_construction.py
+++ b/tests/test_axol_construction.py
@@ -98,6 +98,8 @@ class AxolApiTest(unittest.TestCase):
             self.assertIs(params[name].kind, inspect.Parameter.KEYWORD_ONLY)
             self.assertIsNot(params[name].default, inspect.Parameter.empty)
         self.assertNotIn("hardware", params)
+        enable = inspect.signature(Axol.enable).parameters
+        self.assertIs(enable["hold"].default, True)
 
     def test_forwards_hardware_arguments(self) -> None:
         config = AxolConfig(has_gripper=False)
@@ -165,6 +167,16 @@ class AxolBusOwnershipTest(unittest.IsolatedAsyncioTestCase):
         # No core was started for this session: a classic torque-off.
         disable.assert_awaited_once()
 
+    async def test_enable_without_hold_is_the_classic_bring_up(self) -> None:
+        # hold=False keeps the bus in Python for custom control modes: no core.
+        with patch.object(self.hardware, "enable", AsyncMock()) as enable:
+            await self.robot.enable(hold=False)
+        enable.assert_awaited_once_with(hold=False)
+        self.assertFalse(self.robot._core_started)
+        self.assertFalse(self.robot._armed)
+        with self.assertRaisesRegex(MotorError, "requires the realtime core"):
+            await self.robot.motion_control(left=np.zeros(8, dtype=np.float32))
+
     async def test_register_calls_are_refused_while_the_core_owns_the_bus(self) -> None:
         self.robot._armed = True
         for call in (
@@ -178,9 +190,9 @@ class AxolBusOwnershipTest(unittest.IsolatedAsyncioTestCase):
                 await call
 
     async def test_motion_requires_enable(self) -> None:
-        with self.assertRaisesRegex(MotorError, "call enable\\(\\) first"):
+        with self.assertRaisesRegex(MotorError, "requires the realtime core"):
             await self.robot.motion_control(left=np.zeros(8, dtype=np.float32))
-        with self.assertRaisesRegex(MotorError, "call enable\\(\\) first"):
+        with self.assertRaisesRegex(MotorError, "requires the realtime core"):
             await self.robot.gravity_compensate()
 
     async def test_cached_reads_while_armed_send_no_can(self) -> None:

--- a/tests/test_axol_construction.py
+++ b/tests/test_axol_construction.py
@@ -1,16 +1,13 @@
 """``almond_axol.robot.Axol`` / ``Mantis`` are the realtime-core robots.
 
 ``Axol(...)`` takes the same arguments as the low-level ``AxolHardware`` and
-constructs it internally; ``hardware=`` wraps an existing one; the old
-``RtAxol(AxolHardware(...))`` spelling keeps working behind a
-``DeprecationWarning``. ``Mantis`` / ``MantisHardware`` / ``RtMantis`` follow
-the same pattern.
+constructs it internally; ``hardware=`` wraps an existing one. ``Mantis`` /
+``MantisHardware`` follow the same pattern.
 """
 
 from __future__ import annotations
 
 import unittest
-import warnings
 from unittest.mock import patch
 
 from almond_axol.constants import Joint
@@ -27,7 +24,6 @@ from almond_axol.robot import axol as axol_module
 from almond_axol.robot import mantis as mantis_module
 from almond_axol.rt import Axol as RtModuleAxol
 from almond_axol.rt import Mantis as RtModuleMantis
-from almond_axol.rt import RtAxol, RtMantis
 
 
 class AxolConstructionTest(unittest.TestCase):
@@ -76,19 +72,6 @@ class AxolConstructionTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "different CAN interfaces"):
             Axol(left_channel="can0", right_channel="can0")
 
-    def test_rtaxol_is_a_deprecated_alias(self) -> None:
-        hardware = AxolHardware(left_channel="can0", right_channel=None)
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            robot = RtAxol(hardware, max_vel=2.0)
-            # The old idiom written against the new ``Axol`` still resolves.
-            nested = RtAxol(Axol(hardware=hardware))
-        self.assertEqual([w.category for w in caught], [DeprecationWarning] * 2)
-        self.assertIsInstance(robot, Axol)
-        self.assertIs(robot.hardware, hardware)
-        self.assertEqual(robot._max_vel, 2.0)
-        self.assertIs(nested.hardware, hardware)
-
 
 class MantisConstructionTest(unittest.TestCase):
     def setUp(self) -> None:
@@ -122,17 +105,6 @@ class MantisConstructionTest(unittest.TestCase):
             Mantis(hardware=hardware, defer_gripper_enable=True)
         with self.assertRaisesRegex(ValueError, "different CAN interfaces"):
             Mantis(left_channel="can_l", right_channel="can_l")
-
-    def test_rtmantis_is_a_deprecated_alias(self) -> None:
-        hardware = MantisHardware(left_channel="can_l", right_channel=None)
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            rig = RtMantis(hardware, record=None)
-            nested = RtMantis(Mantis(hardware=hardware))
-        self.assertEqual([w.category for w in caught], [DeprecationWarning] * 2)
-        self.assertIsInstance(rig, Mantis)
-        self.assertIs(rig.hardware, hardware)
-        self.assertIs(nested.hardware, hardware)
 
 
 if __name__ == "__main__":

--- a/tests/test_bus.py
+++ b/tests/test_bus.py
@@ -16,12 +16,11 @@ from unittest.mock import patch
 
 import can
 
-from almond_axol.motor import bus as bus_module
-from almond_axol.motor.bus import CanBus
-
 # CanBus.start() imports rt.link lazily; import it up front so the heavy
 # package import (which itself uses subprocess) happens before Popen is faked.
 import almond_axol.rt.link  # noqa: E402,F401
+from almond_axol.motor import bus as bus_module
+from almond_axol.motor.bus import CanBus
 
 
 def _frame(payload: bytes) -> bytes:
@@ -133,7 +132,7 @@ class CanBusStateTest(unittest.IsolatedAsyncioTestCase):
         message = str(ctx.exception)
         self.assertIn("has not been opened", message)
         self.assertIn("not a daemon", message)
-        self.assertIn("Axol.connect()", message)
+        self.assertIn("AxolHardware.connect()", message)
         self.assertIn("AxolArm.enable()", message)
 
     async def test_send_while_starting_says_still_starting(self) -> None:
@@ -167,7 +166,7 @@ class CanBusStateTest(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(can.CanOperationError) as ctx:
             await self.bus._send(0x123, b"\x01")
         self.assertIn("was closed", str(ctx.exception))
-        self.assertIn("Axol.connect()", str(ctx.exception))
+        self.assertIn("AxolHardware.connect()", str(ctx.exception))
 
     async def test_start_is_idempotent_while_open(self) -> None:
         await self.bus.start()

--- a/tests/test_bus.py
+++ b/tests/test_bus.py
@@ -132,7 +132,7 @@ class CanBusStateTest(unittest.IsolatedAsyncioTestCase):
         message = str(ctx.exception)
         self.assertIn("has not been opened", message)
         self.assertIn("not a daemon", message)
-        self.assertIn("AxolHardware.connect()", message)
+        self.assertIn("Axol.connect()", message)
         self.assertIn("AxolArm.enable()", message)
 
     async def test_send_while_starting_says_still_starting(self) -> None:
@@ -166,7 +166,7 @@ class CanBusStateTest(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(can.CanOperationError) as ctx:
             await self.bus._send(0x123, b"\x01")
         self.assertIn("was closed", str(ctx.exception))
-        self.assertIn("AxolHardware.connect()", str(ctx.exception))
+        self.assertIn("Axol.connect()", str(ctx.exception))
 
     async def test_start_is_idempotent_while_open(self) -> None:
         await self.bus.start()

--- a/tests/test_lift_cycle.py
+++ b/tests/test_lift_cycle.py
@@ -140,15 +140,17 @@ class FakeAxol:
 
 
 class FakeRtAxol:
-    """Stand-in for the realtime-core ``Axol`` the diagnostic drives.
+    """Stand-in for the ``Axol`` the diagnostic drives.
 
     Built the way the diagnostic builds the real one — from config and
-    channels — and exposing the low-level object as ``hardware``.
+    channels. ``disconnect()`` mirrors the real object: while the core is
+    armed it releases the core with the motors holding (recorded as
+    ``arms.detach``); otherwise it closes the maintenance buses.
     """
 
     def __init__(self, inner: FakeAxol) -> None:
         self.inner = inner
-        self.hardware = inner
+        self._armed = False
         self._events = inner._events
         self.left = inner.left
         self.right = inner.right
@@ -156,14 +158,26 @@ class FakeRtAxol:
         self.limp: str | None = None
 
     async def enable(self) -> None:
+        self._armed = True
         self._events.append("arms.enable")
+
+    async def disable(self) -> None:
+        self._armed = False
+        self._events.append("arms.disable")
 
     async def get_positions(self):  # noqa: ANN201
         self._events.append("arms.positions")
         return self.inner._positions
 
-    async def detach(self) -> None:
-        self._events.append("arms.detach")
+    async def connect(self) -> None:
+        await self.inner.connect()
+
+    async def disconnect(self) -> None:
+        if self._armed:
+            self._armed = False
+            self._events.append("arms.detach")
+            return
+        await self.inner.disconnect()
 
 
 class FakeOpeningLift:
@@ -548,24 +562,26 @@ class LiftCycleSequenceTest(unittest.IsolatedAsyncioTestCase):
         }
         holding_motor = SimpleNamespace(is_holding=AsyncMock(return_value=True))
         motors[Joint.ELBOW] = holding_motor
-        axol = SimpleNamespace(
+        robot = SimpleNamespace(
             left=SimpleNamespace(motors=motors),
             right=None,
             connect=AsyncMock(),
             disconnect=AsyncMock(),
+            disable=AsyncMock(),
+            fault=None,
+            limp=None,
         )
-        robot = SimpleNamespace(disable=AsyncMock(), fault=None, limp=None)
 
         with self.assertRaisesRegex(
             cycle.DiagnosticFailure, "left elbow still reports enabled"
         ):
-            await cycle._disable_arms_verified(robot, axol)
+            await cycle._disable_arms_verified(robot)
 
         # The core's disarm is the disable; verification reopens the proxies
         # afterwards and closes them again either way.
         robot.disable.assert_awaited_once_with()
-        axol.connect.assert_awaited_once_with()
-        axol.disconnect.assert_awaited_once_with()
+        robot.connect.assert_awaited_once_with()
+        robot.disconnect.assert_awaited_once_with()
         holding_motor.is_holding.assert_awaited_once_with()
 
     async def test_arm_shutdown_requires_every_arm_motor_to_be_present(self) -> None:
@@ -574,16 +590,18 @@ class LiftCycleSequenceTest(unittest.IsolatedAsyncioTestCase):
             for joint in cycle.ARM_JOINTS
             if joint is not Joint.ELBOW
         }
-        axol = SimpleNamespace(
+        robot = SimpleNamespace(
             left=SimpleNamespace(motors=motors),
             right=None,
             connect=AsyncMock(),
             disconnect=AsyncMock(),
+            disable=AsyncMock(),
+            fault=None,
+            limp=None,
         )
-        robot = SimpleNamespace(disable=AsyncMock(), fault=None, limp=None)
 
         with self.assertRaisesRegex(cycle.DiagnosticFailure, "missing: left elbow"):
-            await cycle._disable_arms_verified(robot, axol)
+            await cycle._disable_arms_verified(robot)
 
         robot.disable.assert_not_awaited()
 
@@ -592,15 +610,17 @@ class LiftCycleSequenceTest(unittest.IsolatedAsyncioTestCase):
             joint: SimpleNamespace(is_holding=AsyncMock(return_value=False))
             for joint in cycle.ARM_JOINTS
         }
-        axol = SimpleNamespace(
+        robot = SimpleNamespace(
             left=SimpleNamespace(motors=motors),
             right=None,
             connect=AsyncMock(),
             disconnect=AsyncMock(),
+            disable=AsyncMock(),
+            fault=None,
+            limp=None,
         )
-        robot = SimpleNamespace(disable=AsyncMock(), fault=None, limp=None)
 
-        await cycle._disable_arms_verified(robot, axol)
+        await cycle._disable_arms_verified(robot)
 
         robot.disable.assert_awaited_once_with()
         for motor in motors.values():
@@ -611,20 +631,18 @@ class LiftCycleSequenceTest(unittest.IsolatedAsyncioTestCase):
             joint: SimpleNamespace(is_holding=AsyncMock(return_value=False))
             for joint in cycle.ARM_JOINTS
         }
-        axol = SimpleNamespace(
+        robot = SimpleNamespace(
             left=SimpleNamespace(motors=motors),
             right=None,
             connect=AsyncMock(),
             disconnect=AsyncMock(),
-        )
-        robot = SimpleNamespace(
             disable=AsyncMock(side_effect=OSError("disable lost")),
             fault=None,
             limp=None,
         )
 
         with self.assertRaisesRegex(cycle.DiagnosticFailure, "disable lost"):
-            await cycle._disable_arms_verified(robot, axol)
+            await cycle._disable_arms_verified(robot)
 
     async def test_arm_shutdown_refuses_to_probe_a_faulted_core(self) -> None:
         # After a core fault the motors are deliberately left energized and the
@@ -633,18 +651,20 @@ class LiftCycleSequenceTest(unittest.IsolatedAsyncioTestCase):
             joint: SimpleNamespace(is_holding=AsyncMock(return_value=False))
             for joint in cycle.ARM_JOINTS
         }
-        axol = SimpleNamespace(
+        robot = SimpleNamespace(
             left=SimpleNamespace(motors=motors),
             right=None,
             connect=AsyncMock(),
             disconnect=AsyncMock(),
+            disable=AsyncMock(),
+            fault="fault: bus dead",
+            limp=None,
         )
-        robot = SimpleNamespace(disable=AsyncMock(), fault="fault: bus dead", limp=None)
 
         with self.assertRaisesRegex(cycle.DiagnosticFailure, "fault: bus dead"):
-            await cycle._disable_arms_verified(robot, axol)
+            await cycle._disable_arms_verified(robot)
 
-        axol.connect.assert_not_awaited()
+        robot.connect.assert_not_awaited()
         for motor in motors.values():
             motor.is_holding.assert_not_awaited()
 
@@ -752,8 +772,9 @@ class LiftCycleSequenceTest(unittest.IsolatedAsyncioTestCase):
         move = AsyncMock(side_effect=move_side_effect)
         wait_after = AsyncMock(return_value=_status(1000))
 
-        async def disable_arms(_robot, _axol) -> None:  # noqa: ANN001
-            events.append("arms.disable")
+        async def disable_arms(_robot) -> None:  # noqa: ANN001
+            # The verified disable goes through ``Axol.disable()``.
+            await _robot.disable()
 
         output = stdout if stdout is not None else io.StringIO()
         with (
@@ -970,9 +991,7 @@ class LiftCycleSequenceTest(unittest.IsolatedAsyncioTestCase):
             patch.object(
                 cycle,
                 "_disable_arms_verified",
-                AsyncMock(
-                    side_effect=lambda _robot, _axol: events.append("arms.disable")
-                ),
+                AsyncMock(side_effect=lambda _robot: events.append("arms.disable")),
             ),
             patch.object(cycle, "_verify_arm_targets", AsyncMock()),
             contextlib.redirect_stdout(io.StringIO()),

--- a/tests/test_lift_cycle.py
+++ b/tests/test_lift_cycle.py
@@ -140,10 +140,15 @@ class FakeAxol:
 
 
 class FakeRtAxol:
-    """Stand-in for the realtime-core wrapper the diagnostic drives."""
+    """Stand-in for the realtime-core ``Axol`` the diagnostic drives.
+
+    Built the way the diagnostic builds the real one — from config and
+    channels — and exposing the low-level object as ``hardware``.
+    """
 
     def __init__(self, inner: FakeAxol) -> None:
         self.inner = inner
+        self.hardware = inner
         self._events = inner._events
         self.left = inner.left
         self.right = inner.right
@@ -718,6 +723,15 @@ class LiftCycleSequenceTest(unittest.IsolatedAsyncioTestCase):
                 )
             return fake_axol
 
+        def make_robot(*, config, left_channel, right_channel):  # noqa: ANN001, ANN202
+            return FakeRtAxol(
+                make_axol(
+                    config=config,
+                    left_channel=left_channel,
+                    right_channel=right_channel,
+                )
+            )
+
         async def ramp(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
             events.append("arms.ramp")
             assert fake_axol is not None
@@ -744,8 +758,7 @@ class LiftCycleSequenceTest(unittest.IsolatedAsyncioTestCase):
         output = stdout if stdout is not None else io.StringIO()
         with (
             patch.object(cycle, "_open_lift", AsyncMock(return_value=lift)),
-            patch.object(cycle, "Axol", side_effect=make_axol),
-            patch.object(cycle, "RtAxol", side_effect=FakeRtAxol),
+            patch.object(cycle, "Axol", side_effect=make_robot),
             patch.object(cycle, "interrupt_event", _interrupt_context),
             patch.object(
                 cycle, "_wait_for_position_save", AsyncMock(return_value=initial)
@@ -852,6 +865,15 @@ class LiftCycleSequenceTest(unittest.IsolatedAsyncioTestCase):
                 events=events,
             )
 
+        def make_robot(*, config, left_channel, right_channel):  # noqa: ANN001, ANN202
+            return FakeRtAxol(
+                make_axol(
+                    config=config,
+                    left_channel=left_channel,
+                    right_channel=right_channel,
+                )
+            )
+
         ramp_calls = 0
 
         async def ramp(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
@@ -866,8 +888,7 @@ class LiftCycleSequenceTest(unittest.IsolatedAsyncioTestCase):
         stderr = io.StringIO()
         with (
             patch.object(cycle, "_open_lift", AsyncMock(return_value=lift)),
-            patch.object(cycle, "Axol", side_effect=make_axol),
-            patch.object(cycle, "RtAxol", side_effect=FakeRtAxol),
+            patch.object(cycle, "Axol", side_effect=make_robot),
             patch.object(cycle, "interrupt_event", _interrupt_context),
             patch.object(
                 cycle,
@@ -925,10 +946,18 @@ class LiftCycleSequenceTest(unittest.IsolatedAsyncioTestCase):
                 events=events,
             )
 
+        def make_robot(*, config, left_channel, right_channel):  # noqa: ANN001, ANN202
+            return FakeRtAxol(
+                make_axol(
+                    config=config,
+                    left_channel=left_channel,
+                    right_channel=right_channel,
+                )
+            )
+
         with (
             patch.object(cycle, "_open_lift", AsyncMock(return_value=lift)),
-            patch.object(cycle, "Axol", side_effect=make_axol),
-            patch.object(cycle, "RtAxol", side_effect=FakeRtAxol),
+            patch.object(cycle, "Axol", side_effect=make_robot),
             patch.object(cycle, "interrupt_event", _interrupt_context),
             patch.object(
                 cycle,
@@ -980,13 +1009,21 @@ class LiftCycleSequenceTest(unittest.IsolatedAsyncioTestCase):
                 events=events,
             )
 
+        def make_robot(*, config, left_channel, right_channel):  # noqa: ANN001, ANN202
+            return FakeRtAxol(
+                make_axol(
+                    config=config,
+                    left_channel=left_channel,
+                    right_channel=right_channel,
+                )
+            )
+
         ramp = AsyncMock(side_effect=lambda *args, **kwargs: events.append("arms.ramp"))
         stderr = io.StringIO()
         stdout = io.StringIO()
         with (
             patch.object(cycle, "_open_lift", AsyncMock(return_value=lift)),
-            patch.object(cycle, "Axol", side_effect=make_axol),
-            patch.object(cycle, "RtAxol", side_effect=FakeRtAxol),
+            patch.object(cycle, "Axol", side_effect=make_robot),
             patch.object(cycle, "interrupt_event", _interrupt_context),
             patch.object(
                 cycle,

--- a/tests/test_mantis_channels.py
+++ b/tests/test_mantis_channels.py
@@ -15,7 +15,7 @@ from almond_axol.cli.mantis_bridge import (
     managed_mantis_bridge,
 )
 from almond_axol.constants import CAN_LEFT, CAN_MANTIS_LEFT, CAN_MANTIS_RIGHT, CAN_RIGHT
-from almond_axol.robot.mantis import Mantis
+from almond_axol.robot.mantis import MantisHardware
 from almond_axol.serve.app import _mantis_channel_mismatch_message
 from almond_axol.serve.runner import (
     _bind_managed_mantis_trigger_channels,
@@ -36,7 +36,7 @@ class MantisChannelFlowTest(unittest.TestCase):
                 patch("almond_axol.robot.mantis.CanBus") as can_bus,
                 self.assertRaisesRegex(ValueError, "different CAN interfaces"),
             ):
-                Mantis(left_channel=left, right_channel=right)
+                MantisHardware(left_channel=left, right_channel=right)
 
             can_bus.assert_not_called()
 

--- a/tests/test_mantis_gripper_preopen.py
+++ b/tests/test_mantis_gripper_preopen.py
@@ -17,7 +17,7 @@ from unittest.mock import AsyncMock, Mock, patch
 from almond_axol.cli import collect_data
 from almond_axol.motor import ControlMode, MotorError
 from almond_axol.robot.axol import GRIPPER_TRAVEL
-from almond_axol.robot.mantis import Mantis, MantisGripperArm
+from almond_axol.robot.mantis import MantisGripperArm, MantisHardware
 
 
 class _FakeGripperMotor:
@@ -67,8 +67,8 @@ def _arm(motor: _FakeGripperMotor) -> MantisGripperArm:
         )
 
 
-def _mantis(left: MantisGripperArm, right: MantisGripperArm) -> Mantis:
-    robot = object.__new__(Mantis)
+def _mantis(left: MantisGripperArm, right: MantisGripperArm) -> MantisHardware:
+    robot = object.__new__(MantisHardware)
     robot.left = left
     robot.right = right
     robot._left_bus = SimpleNamespace(start=AsyncMock(), close=AsyncMock())

--- a/tests/test_motion_command_safety.py
+++ b/tests/test_motion_command_safety.py
@@ -16,7 +16,7 @@ from almond_axol.lerobot.teleop.teleop_vr import AxolVRTeleop
 from almond_axol.motor import ControlMode, Joint, MotorError
 from almond_axol.motor.damiao import _float_to_uint as damiao_float_to_uint
 from almond_axol.motor.myactuator import _float_to_uint as myactuator_float_to_uint
-from almond_axol.robot.axol import Axol, AxolArm
+from almond_axol.robot.axol import AxolArm, AxolHardware
 from almond_axol.robot.base import (
     HardwareCleanupError,
     RobotBase,
@@ -41,7 +41,7 @@ class MotionCommandSafetyTest(unittest.IsolatedAsyncioTestCase):
             patch("almond_axol.robot.axol.CanBus") as can_bus,
             self.assertRaisesRegex(ValueError, "different CAN interfaces"),
         ):
-            Axol(left_channel="can-shared", right_channel="can-shared")
+            AxolHardware(left_channel="can-shared", right_channel="can-shared")
 
         can_bus.assert_not_called()
 
@@ -62,7 +62,7 @@ class MotionCommandSafetyTest(unittest.IsolatedAsyncioTestCase):
             sibling_started.set()
             await release_sibling.wait()
 
-        robot = object.__new__(Axol)
+        robot = object.__new__(AxolHardware)
         robot.connect = AsyncMock()
         robot.left = SimpleNamespace(
             _prepare_enable_state=AsyncMock(return_value=([], [])),
@@ -117,7 +117,7 @@ class MotionCommandSafetyTest(unittest.IsolatedAsyncioTestCase):
             reset_command_state=Mock(),
             motors={Joint.GRIPPER: right_cold},
         )
-        robot = object.__new__(Axol)
+        robot = object.__new__(AxolHardware)
         robot.connect = AsyncMock()
         robot.left = left
         robot.right = right
@@ -170,7 +170,7 @@ class MotionCommandSafetyTest(unittest.IsolatedAsyncioTestCase):
             disable=AsyncMock(),
             motors={},
         )
-        robot = object.__new__(Axol)
+        robot = object.__new__(AxolHardware)
         robot.connect = AsyncMock()
         robot.left = left
         robot.right = right
@@ -226,7 +226,7 @@ class MotionCommandSafetyTest(unittest.IsolatedAsyncioTestCase):
             stop_telemetry=AsyncMock(side_effect=stop_right),
             disable=AsyncMock(),
         )
-        robot = object.__new__(Axol)
+        robot = object.__new__(AxolHardware)
         robot.left = left
         robot.right = right
         robot._left_bus = SimpleNamespace(close=AsyncMock(), stalled=False)
@@ -283,7 +283,7 @@ class MotionCommandSafetyTest(unittest.IsolatedAsyncioTestCase):
             disable=AsyncMock(),
             motors={},
         )
-        robot = object.__new__(Axol)
+        robot = object.__new__(AxolHardware)
         robot.connect = AsyncMock()
         robot.left = left
         robot.right = right
@@ -335,7 +335,7 @@ class MotionCommandSafetyTest(unittest.IsolatedAsyncioTestCase):
             disable=AsyncMock(),
             motors={Joint.GRIPPER: cold_motor},
         )
-        robot = object.__new__(Axol)
+        robot = object.__new__(AxolHardware)
         robot.connect = AsyncMock()
         robot.left = left
         robot.right = right
@@ -372,7 +372,7 @@ class MotionCommandSafetyTest(unittest.IsolatedAsyncioTestCase):
             disable=AsyncMock(side_effect=[disable_error, None]),
         )
         right = SimpleNamespace(stop_telemetry=AsyncMock(), disable=AsyncMock())
-        robot = object.__new__(Axol)
+        robot = object.__new__(AxolHardware)
         robot.left = left
         robot.right = right
         robot._left_bus = SimpleNamespace(close=AsyncMock(), stalled=False)
@@ -414,7 +414,7 @@ class MotionCommandSafetyTest(unittest.IsolatedAsyncioTestCase):
             sibling_started.set()
             await release_sibling.wait()
 
-        robot = object.__new__(Axol)
+        robot = object.__new__(AxolHardware)
         robot.left = SimpleNamespace(motion_control=fail_motion)
         robot.right = SimpleNamespace(motion_control=blocked_motion)
         target = np.zeros(len(Joint), dtype=np.float32)
@@ -466,7 +466,7 @@ class MotionCommandSafetyTest(unittest.IsolatedAsyncioTestCase):
             sibling_started.set()
             await release_sibling.wait()
 
-        robot = object.__new__(Axol)
+        robot = object.__new__(AxolHardware)
         robot._shutdown_pending = False
         robot.left = SimpleNamespace(stop_telemetry=fail_stop)
         robot.right = SimpleNamespace(stop_telemetry=blocked_stop)
@@ -724,7 +724,7 @@ class MotionCommandSafetyTest(unittest.IsolatedAsyncioTestCase):
         bad = good.copy()
         bad[3] = np.nan
 
-        for robot_type in (Axol, Mantis):
+        for robot_type in (AxolHardware, Mantis):
             with self.subTest(robot=robot_type.__name__):
                 robot = object.__new__(robot_type)
                 robot.left = _RecordingArm()
@@ -958,7 +958,7 @@ class MotionCommandSafetyTest(unittest.IsolatedAsyncioTestCase):
         # power cut, so disable() must not excuse it as unpowered.
         left_bus = SimpleNamespace(close=AsyncMock(), stalled=False)
         right_bus = SimpleNamespace(close=AsyncMock(), stalled=False)
-        robot = object.__new__(Axol)
+        robot = object.__new__(AxolHardware)
         robot.left = left
         robot.right = right
         robot._left_bus = left_bus
@@ -990,7 +990,7 @@ class MotionCommandSafetyTest(unittest.IsolatedAsyncioTestCase):
         right = SimpleNamespace(stop_telemetry=AsyncMock(), disable=AsyncMock())
         left_bus = SimpleNamespace(close=AsyncMock(side_effect=[close_error, None]))
         right_bus = SimpleNamespace(close=AsyncMock(), stalled=False)
-        robot = object.__new__(Axol)
+        robot = object.__new__(AxolHardware)
         robot.left = left
         robot.right = right
         robot._left_bus = left_bus

--- a/tests/test_motion_command_safety.py
+++ b/tests/test_motion_command_safety.py
@@ -23,7 +23,7 @@ from almond_axol.robot.base import (
     is_hardware_cleanup_uncertain,
 )
 from almond_axol.robot.jelly import Jelly, JellyConfig
-from almond_axol.robot.mantis import Mantis, MantisGripperArm
+from almond_axol.robot.mantis import MantisGripperArm, MantisHardware
 from almond_axol.teleop.teleop import VRTeleop
 
 
@@ -439,7 +439,7 @@ class MotionCommandSafetyTest(unittest.IsolatedAsyncioTestCase):
             sibling_started.set()
             await release_sibling.wait()
 
-        robot = object.__new__(Mantis)
+        robot = object.__new__(MantisHardware)
         robot.left = SimpleNamespace(motion_control=fail_motion)
         robot.right = SimpleNamespace(motion_control=blocked_motion)
         target = np.zeros(len(Joint), dtype=np.float32)
@@ -724,7 +724,7 @@ class MotionCommandSafetyTest(unittest.IsolatedAsyncioTestCase):
         bad = good.copy()
         bad[3] = np.nan
 
-        for robot_type in (AxolHardware, Mantis):
+        for robot_type in (AxolHardware, MantisHardware):
             with self.subTest(robot=robot_type.__name__):
                 robot = object.__new__(robot_type)
                 robot.left = _RecordingArm()
@@ -1068,7 +1068,7 @@ class MotionCommandSafetyTest(unittest.IsolatedAsyncioTestCase):
         right = SimpleNamespace(force_disable=AsyncMock(), disable=AsyncMock())
         left_bus = SimpleNamespace(close=AsyncMock(), stalled=False)
         right_bus = SimpleNamespace(close=AsyncMock(), stalled=False)
-        robot = object.__new__(Mantis)
+        robot = object.__new__(MantisHardware)
         robot.left = left
         robot.right = right
         robot._left_bus = left_bus
@@ -1113,7 +1113,7 @@ class MotionCommandSafetyTest(unittest.IsolatedAsyncioTestCase):
             enable=AsyncMock(),
             force_disable=AsyncMock(side_effect=cleanup_error),
         )
-        robot = object.__new__(Mantis)
+        robot = object.__new__(MantisHardware)
         robot.left = left
         robot.right = right
         robot._telemetry_settings = None
@@ -1140,7 +1140,7 @@ class MotionCommandSafetyTest(unittest.IsolatedAsyncioTestCase):
             force_disable=AsyncMock(side_effect=cleanup_error),
         )
         right = SimpleNamespace(enable=AsyncMock(), force_disable=AsyncMock())
-        robot = object.__new__(Mantis)
+        robot = object.__new__(MantisHardware)
         robot.left = left
         robot.right = right
         robot._telemetry_settings = (50.0, True)
@@ -1170,7 +1170,7 @@ class MotionCommandSafetyTest(unittest.IsolatedAsyncioTestCase):
         right = SimpleNamespace(force_disable=AsyncMock(), disable=AsyncMock())
         left_bus = SimpleNamespace(start=AsyncMock(), close=AsyncMock())
         right_bus = SimpleNamespace(start=AsyncMock(), close=AsyncMock())
-        robot = object.__new__(Mantis)
+        robot = object.__new__(MantisHardware)
         robot.left = left
         robot.right = right
         robot._left_bus = left_bus
@@ -1205,7 +1205,7 @@ class MotionCommandSafetyTest(unittest.IsolatedAsyncioTestCase):
             close=AsyncMock(side_effect=[close_error, None]),
         )
         right_bus = SimpleNamespace(close=AsyncMock(), stalled=False)
-        robot = object.__new__(Mantis)
+        robot = object.__new__(MantisHardware)
         robot.left = left
         robot.right = right
         robot._left_bus = left_bus

--- a/tests/test_power_loss.py
+++ b/tests/test_power_loss.py
@@ -23,7 +23,7 @@ from almond_axol.motor.bus import (
     set_channel_stalled,
     stalled_channels,
 )
-from almond_axol.robot.axol import Axol
+from almond_axol.robot.axol import AxolHardware
 from almond_axol.robot.base import HardwareCleanupError
 from almond_axol.rt.link import RtLink
 from almond_axol.serve import app as app_module
@@ -39,7 +39,6 @@ from almond_axol.serve.runner import STALL_STOP_ERROR, OperationRunner
 # The serve API doubles (settings store, session manager, updater) already exist
 # for the reservation tests; reuse them rather than growing a second set.
 from tests.test_serve_session_reservation import _Manager, _Settings, _Updater
-
 
 # What the Rust transports put on the wire when nothing ACKs for STALL_DETECT
 # (``proxy.rs`` for the maintenance proxy, ``serve.rs`` for the armed core).
@@ -99,7 +98,7 @@ class _FakeDriver:
         self.accepts_disable = accepts_disable
         self.bus_gone = bus_gone
         self.disable_calls = 0
-        # Firmware gain ceilings Axol.__init__ checks the config against.
+        # Firmware gain ceilings AxolHardware.__init__ checks the config against.
         self.kp_max = 500.0
         self.kd_max = 5.0
 
@@ -123,8 +122,8 @@ class _FakeDriver:
         return MotorStatus.OK
 
 
-def _axol_with_drivers(driver_for: Any) -> tuple[Axol, list[_FakeBus]]:
-    """Build an Axol whose motors are ``driver_for(channel)`` fakes."""
+def _axol_with_drivers(driver_for: Any) -> tuple[AxolHardware, list[_FakeBus]]:
+    """Build an AxolHardware whose motors are ``driver_for(channel)`` fakes."""
     buses: list[_FakeBus] = []
 
     def make_bus(channel: str) -> _FakeBus:
@@ -139,7 +138,7 @@ def _axol_with_drivers(driver_for: Any) -> tuple[Axol, list[_FakeBus]]:
             side_effect=lambda bus, *_args, **_kwargs: driver_for(bus.channel),
         ),
     ):
-        axol = Axol(left_channel="can-left", right_channel="can-right")
+        axol = AxolHardware(left_channel="can-left", right_channel="can-right")
     return axol, buses
 
 

--- a/tests/test_rollout_pose_lag.py
+++ b/tests/test_rollout_pose_lag.py
@@ -21,7 +21,7 @@ def _robot_with_cameras(
 ) -> AxolRobot:
     """Bare AxolRobot over fake cameras and a fake Rust-core telemetry history.
 
-    ``state_nearest`` mimics ``RtAxol.state_nearest``: the retained feedback
+    ``state_nearest`` mimics ``Axol.state_nearest``: the retained feedback
     sample closest to the requested exposure time, here ``state_offset_s``
     before it, so the expected pose lag is simply that offset.
     """

--- a/tests/test_rom_partial_arm.py
+++ b/tests/test_rom_partial_arm.py
@@ -290,7 +290,7 @@ class PartialArmTelemetryCaptureTest(unittest.IsolatedAsyncioTestCase):
 
 class PartialAxolTest(unittest.IsolatedAsyncioTestCase):
     def test_config_lists_only_present_motors(self) -> None:
-        rt = Axol(hardware=_partial_axol(set(WRIST_KIT)))
+        rt = Axol._wrap(_partial_axol(set(WRIST_KIT)))
         lines = rt._config_text().splitlines()
         # Slot-by-motor-id is protocol generation 2; a core that predates it
         # would slot these wrists at 0 and 1 and then reject every target,
@@ -304,7 +304,8 @@ class PartialAxolTest(unittest.IsolatedAsyncioTestCase):
         self.assertIn("gripper 0 can0 8", lines)
 
     async def test_feedback_feed_fills_present_slots_and_ignores_the_rest(self) -> None:
-        rt = Axol(hardware=_partial_axol(set(WRIST_KIT)))
+        rt = Axol._wrap(_partial_axol(set(WRIST_KIT)))
+        rt._armed = True  # the core's feed is what fills the caches
         arm = rt.left
         assert arm is not None
         feed = rt._make_feedback_feed()
@@ -391,7 +392,7 @@ class BenchConfigTest(unittest.IsolatedAsyncioTestCase):
         self.assertAlmostEqual(kd3, 0.9)
         self.assertEqual((t_ff3, kd_host3, j_eff3), (0.0, 0.0, 0.0))
         # The core's friction model rides the config; the bench config zeroes it.
-        rt = Axol(hardware=axol)
+        rt = Axol._wrap(axol)
         for line in rt._config_text().splitlines():
             if line.startswith("joint "):
                 self.assertEqual(line.split()[9:], ["0.0", "0.0", "0.0", "0.0"], line)

--- a/tests/test_rom_partial_arm.py
+++ b/tests/test_rom_partial_arm.py
@@ -4,7 +4,7 @@ A single-channel adapter with just a wrist assembly (wrist_2, wrist_3, gripper)
 on the bus must be able to run ``diag.rom-enable --joints wrist_2,wrist_3,gripper``.
 The pieces that make that work: the pre-flight presence probe and its
 decision rule, an ``AxolArm`` restricted to the motors actually present, and
-an ``RtAxol`` that configures/feeds only those motors (the core slots them by
+an ``Axol`` that configures/feeds only those motors (the core slots them by
 motor id).
 """
 
@@ -20,8 +20,8 @@ import numpy as np
 from almond_axol.constants import ARM_JOINTS, Joint
 from almond_axol.diagnostics.rom import enable as rom
 from almond_axol.motor import ControlMode, MotorError
-from almond_axol.robot.axol import Axol
-from almond_axol.rt import RtAxol
+from almond_axol.robot.axol import AxolHardware
+from almond_axol.rt import Axol
 from almond_axol.serve.robot_link import scoped_motor_faults
 
 WRIST_KIT = {Joint.WRIST_2, Joint.WRIST_3, Joint.GRIPPER}
@@ -117,7 +117,7 @@ class ProbeBusJointsTest(unittest.IsolatedAsyncioTestCase):
 
 
 # --------------------------------------------------------------------------- #
-# Partial AxolArm / RtAxol                                                    #
+# Partial AxolArm / Axol                                                      #
 # --------------------------------------------------------------------------- #
 
 
@@ -150,7 +150,7 @@ class _FakeDriver:
         self.position_force.append(args)
 
 
-def _partial_axol(joints: set[Joint], config: Any = None) -> Axol:
+def _partial_axol(joints: set[Joint], config: Any = None) -> AxolHardware:
     with (
         patch("almond_axol.robot.axol.CanBus", _FakeBus),
         patch(
@@ -159,7 +159,7 @@ def _partial_axol(joints: set[Joint], config: Any = None) -> Axol:
         ),
     ):
         kwargs = {} if config is None else {"config": config}
-        return Axol(
+        return AxolHardware(
             left_channel="can0", right_channel=None, left_joints=joints, **kwargs
         )
 
@@ -207,7 +207,7 @@ class PartialAxolArmTest(unittest.IsolatedAsyncioTestCase):
                 side_effect=lambda *_a, **_k: _FakeDriver(),
             ),
         ):
-            axol = Axol(
+            axol = AxolHardware(
                 AxolConfig(has_gripper=False),
                 left_channel="can0",
                 right_channel=None,
@@ -288,9 +288,9 @@ class PartialArmTelemetryCaptureTest(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(first[header.index("left:WRIST_3:pos")], "")
 
 
-class PartialRtAxolTest(unittest.IsolatedAsyncioTestCase):
+class PartialAxolTest(unittest.IsolatedAsyncioTestCase):
     def test_config_lists_only_present_motors(self) -> None:
-        rt = RtAxol(_partial_axol(set(WRIST_KIT)))
+        rt = Axol(hardware=_partial_axol(set(WRIST_KIT)))
         lines = rt._config_text().splitlines()
         # Slot-by-motor-id is protocol generation 2; a core that predates it
         # would slot these wrists at 0 and 1 and then reject every target,
@@ -304,7 +304,7 @@ class PartialRtAxolTest(unittest.IsolatedAsyncioTestCase):
         self.assertIn("gripper 0 can0 8", lines)
 
     async def test_feedback_feed_fills_present_slots_and_ignores_the_rest(self) -> None:
-        rt = RtAxol(_partial_axol(set(WRIST_KIT)))
+        rt = Axol(hardware=_partial_axol(set(WRIST_KIT)))
         arm = rt.left
         assert arm is not None
         feed = rt._make_feedback_feed()
@@ -391,7 +391,7 @@ class BenchConfigTest(unittest.IsolatedAsyncioTestCase):
         self.assertAlmostEqual(kd3, 0.9)
         self.assertEqual((t_ff3, kd_host3, j_eff3), (0.0, 0.0, 0.0))
         # The core's friction model rides the config; the bench config zeroes it.
-        rt = RtAxol(axol)
+        rt = Axol(hardware=axol)
         for line in rt._config_text().splitlines():
             if line.startswith("joint "):
                 self.assertEqual(line.split()[9:], ["0.0", "0.0", "0.0", "0.0"], line)

--- a/tests/test_rt_mantis.py
+++ b/tests/test_rt_mantis.py
@@ -185,7 +185,7 @@ class MantisTakeLifecycleTest(unittest.IsolatedAsyncioTestCase):
         patcher = patch("almond_axol.rt.mantis.RtLink", _FakeLink)
         patcher.start()
         self.addCleanup(patcher.stop)
-        self.rt = Mantis(hardware=self.mantis)
+        self.rt = Mantis._wrap(self.mantis)
 
     async def test_connect_opens_buses_and_verifies_torque_off_without_a_core(
         self,
@@ -354,7 +354,7 @@ class MantisTakeLifecycleTest(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(self.left._bus.open and self.right._bus.open)
 
     async def test_recording_gate_reaches_the_armed_core(self) -> None:
-        rt = Mantis(hardware=self.mantis, record="/tmp/axol-rt-mantis-test/trace")
+        rt = Mantis._wrap(self.mantis, record="/tmp/axol-rt-mantis-test/trace")
         await rt.connect()
         await rt.enable_grippers()
         (link,) = _FakeLink.instances
@@ -368,7 +368,7 @@ class MantisTakeLifecycleTest(unittest.IsolatedAsyncioTestCase):
 
     async def test_non_deferred_enable_arms_immediately(self) -> None:
         mantis = _mantis(self.left, self.right, defer=False)
-        rt = Mantis(hardware=mantis)
+        rt = Mantis._wrap(mantis)
 
         await rt.enable()
 
@@ -382,7 +382,7 @@ class MantisSurfaceTest(unittest.IsolatedAsyncioTestCase):
     async def test_axol_surface_stubs(self) -> None:
         left = _arm(_FakeGripperMotor(), "can_mantis_l", [])
         right = _arm(_FakeGripperMotor(), "can_mantis_r", [])
-        rt = Mantis(hardware=_mantis(left, right))
+        rt = Mantis._wrap(_mantis(left, right))
 
         self.assertIsNone(rt.fault)
         self.assertIsNone(rt.limp)
@@ -403,8 +403,8 @@ class MantisSurfaceTest(unittest.IsolatedAsyncioTestCase):
             robot = MantisRobot(config, defer_gripper_enable=True)
         hardware = robot._build_hardware()
         self.assertIsInstance(hardware, Mantis)
-        self.assertIsInstance(hardware.hardware, MantisHardware)
-        self.assertTrue(hardware.hardware._defer_gripper_enable)
+        self.assertIsInstance(hardware._robot, MantisHardware)
+        self.assertTrue(hardware._robot._defer_gripper_enable)
 
 
 if __name__ == "__main__":

--- a/tests/test_rt_mantis.py
+++ b/tests/test_rt_mantis.py
@@ -1,4 +1,4 @@
-"""``RtMantis``: the Mantis grippers driven through the Rust realtime core.
+"""``Mantis``: the Mantis grippers driven through the Rust realtime core.
 
 Per take the core is armed on the gripper buses (Python bring-up on the quiet
 bus, hand-over, arm, first target through the core) and disarmed at the end
@@ -18,9 +18,9 @@ import numpy as np
 
 from almond_axol.motor import ControlMode
 from almond_axol.robot.axol import GRIPPER_TRAVEL
-from almond_axol.robot.mantis import Mantis, MantisGripperArm
+from almond_axol.robot.mantis import MantisGripperArm, MantisHardware
 from almond_axol.rt.link import RtLinkError
-from almond_axol.rt.mantis import RtMantis
+from almond_axol.rt.mantis import Mantis
 
 
 class _FakeGripperMotor:
@@ -150,8 +150,8 @@ def _arm(motor: _FakeGripperMotor, channel: str, log: list[str]) -> MantisGrippe
 
 def _mantis(
     left: MantisGripperArm, right: MantisGripperArm, *, defer: bool = True
-) -> Mantis:
-    robot = object.__new__(Mantis)
+) -> MantisHardware:
+    robot = object.__new__(MantisHardware)
     robot.left = left
     robot.right = right
     robot._left_bus = left._bus
@@ -170,7 +170,7 @@ def _calibrated(arm: MantisGripperArm) -> None:
     arm._closed_pos = 1.0 + GRIPPER_TRAVEL
 
 
-class RtMantisTakeLifecycleTest(unittest.IsolatedAsyncioTestCase):
+class MantisTakeLifecycleTest(unittest.IsolatedAsyncioTestCase):
     def setUp(self) -> None:
         _FakeLink.instances = []
         _FakeLink.fail_on_arm = False
@@ -185,7 +185,7 @@ class RtMantisTakeLifecycleTest(unittest.IsolatedAsyncioTestCase):
         patcher = patch("almond_axol.rt.mantis.RtLink", _FakeLink)
         patcher.start()
         self.addCleanup(patcher.stop)
-        self.rt = RtMantis(self.mantis)
+        self.rt = Mantis(hardware=self.mantis)
 
     async def test_connect_opens_buses_and_verifies_torque_off_without_a_core(
         self,
@@ -354,7 +354,7 @@ class RtMantisTakeLifecycleTest(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(self.left._bus.open and self.right._bus.open)
 
     async def test_recording_gate_reaches_the_armed_core(self) -> None:
-        rt = RtMantis(self.mantis, record="/tmp/axol-rt-mantis-test/trace")
+        rt = Mantis(hardware=self.mantis, record="/tmp/axol-rt-mantis-test/trace")
         await rt.connect()
         await rt.enable_grippers()
         (link,) = _FakeLink.instances
@@ -368,7 +368,7 @@ class RtMantisTakeLifecycleTest(unittest.IsolatedAsyncioTestCase):
 
     async def test_non_deferred_enable_arms_immediately(self) -> None:
         mantis = _mantis(self.left, self.right, defer=False)
-        rt = RtMantis(mantis)
+        rt = Mantis(hardware=mantis)
 
         await rt.enable()
 
@@ -378,11 +378,11 @@ class RtMantisTakeLifecycleTest(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(rt.armed)
 
 
-class RtMantisSurfaceTest(unittest.IsolatedAsyncioTestCase):
+class MantisSurfaceTest(unittest.IsolatedAsyncioTestCase):
     async def test_axol_surface_stubs(self) -> None:
         left = _arm(_FakeGripperMotor(), "can_mantis_l", [])
         right = _arm(_FakeGripperMotor(), "can_mantis_r", [])
-        rt = RtMantis(_mantis(left, right))
+        rt = Mantis(hardware=_mantis(left, right))
 
         self.assertIsNone(rt.fault)
         self.assertIsNone(rt.limp)
@@ -394,7 +394,7 @@ class RtMantisSurfaceTest(unittest.IsolatedAsyncioTestCase):
             await rt.gravity_compensate()
         self.assertIsNone(rt.state_nearest(time.perf_counter(), timeout=0.0))
 
-    def test_robot_mantis_builds_an_rt_mantis(self) -> None:
+    def test_robot_mantis_builds_a_core_mantis(self) -> None:
         from almond_axol.lerobot.robot.config_mantis import MantisRobotConfig
         from almond_axol.lerobot.robot.robot_mantis import MantisRobot
 
@@ -402,9 +402,9 @@ class RtMantisSurfaceTest(unittest.IsolatedAsyncioTestCase):
         with patch.object(MantisRobot, "_build_cameras", return_value=({}, [])):
             robot = MantisRobot(config, defer_gripper_enable=True)
         hardware = robot._build_hardware()
-        self.assertIsInstance(hardware, RtMantis)
-        self.assertIsInstance(hardware.robot, Mantis)
-        self.assertTrue(hardware.robot._defer_gripper_enable)
+        self.assertIsInstance(hardware, Mantis)
+        self.assertIsInstance(hardware.hardware, MantisHardware)
+        self.assertTrue(hardware.hardware._defer_gripper_enable)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
A customer asked whether they should be using `RtAxol` given that the rt core is the default, and noticed the docs sample used `RtAxol` without importing it. The underlying problem was that the Rust port had changed the public API: the production robot was a wrapper class (`RtAxol(Axol(...))`) with a different surface from the pre-Rust `Axol`. This PR puts the API back the way it was before the port; the realtime core is an implementation detail.

## API

`almond_axol.robot.Axol` has the pre-Rust surface and constructor:

```python
Axol(config=AxolConfig(), left_channel="can_alm_axol_l", right_channel="can_alm_axol_r",
     left_joints=None, right_joints=None)
```

- `connect()` / `enable(hold=True)` / `disable()` / `disconnect()`, `start_telemetry` / `wait_for_telemetry` / `stop_telemetry`, `clear_errors`, `set_control_mode`, every `get_*` (positions, velocities, torques, temperatures, voltages, error_codes, holding, gains) and `set_*` (gains, zero_position, acceleration, positions_velocity, velocity), `motion_control`, `gravity_compensate`, `torque_residuals`, `reset_*`, `left` / `right`. `async with Axol()` uses `RobotBase`'s context manager again (`HardwareCleanupError` on failed teardown).
- Core tuning (`loop_hz`, `watchdog_ms`, `max_vel`, `max_accel`, `record`) is keyword-only and optional.
- `enable(hold=False)` is the classic limp bring-up with Python keeping the bus (no core started), for flows that set their own `ControlMode` and drive the built-in position/velocity controllers. Only `hold=True` involves the core.
- What differs is behind the scenes: while enabled, the core owns the CAN buses. Position / velocity / torque reads come from its telemetry caches (no CAN from Python); register-level calls raise `MotorError` until `disable()`, and work on a `connect()`-ed robot as before. `disconnect()` while enabled releases the core with the motors holding (what the wrapper called `detach()`); `disable()` without a core for the session is the classic torque-off.
- `fault` / `limp` remain as read-only attributes because they describe behaviour a caller must know about (the core never drops the arms after a fault).
- `RtAxol` / `RtMantis` are removed outright (never shipped in a release). The low-level classes are `AxolHardware` / `MantisHardware` in `almond_axol.robot.axol` / `.mantis`, used by package tooling only; they are no longer exported from `almond_axol.robot`.
- `almond_axol.robot.Mantis` gets the same treatment: pre-Rust constructor (`config, left_channel, right_channel, *, defer_gripper_enable`), no `hardware` / `robot` properties, `disconnect()` instead of `detach()`.
- `almond_axol.rt.__init__` initializes `almond_axol.robot` before its own submodules so the `robot` <-> `rt` re-export cycle resolves from whichever package is imported first (verified from every entry point).

## Callers

`axol teleop`, `gravity-comp`, `waypoints`, `tune.motion`, `tune.repeatability`, `diag.rom-enable`, `diag.lift-cycle`, `diag.can-send`, the LeRobot `AxolRobot` / `MantisRobot`, `axol teleop --mantis`, and the `rust/axol-rt/tools` scripts construct `Axol(...)` directly and use only its public surface. `diag.rom-disable` still uses `AxolHardware` (it deliberately never arms the core). The `enable()` / `disable()` bodies are untouched.

## Docs

`docs/api/robot.mdx` is the pre-Rust page again — one `Axol` section with the constructor, lifecycle table, reconnect flow, state reads, and state writes — plus a note on bus ownership while enabled and the `fault` / `limp` attributes. `teleop.mdx`, `concepts.mdx`, the Rust README, and module docstrings updated. The CanBus lifecycle errors and config docstrings name `Axol.connect()` / `Axol.__init__` again.

## Tests

- New `tests/test_axol_construction.py`: pins the classic method set and constructor signature for `Axol` and `Mantis`, that the low-level classes are not exported, that quiet-bus calls delegate to the hardware, that register calls are refused while the core owns the bus, and that cached reads while enabled send no CAN.
- Existing tests updated (`test_rom_partial_arm`, `test_lift_cycle`, `test_rt_mantis`, `test_bus`, `test_motion_command_safety`, `test_power_loss`, `test_mantis_channels`, `test_mantis_gripper_preopen`); fakes substitute a low-level object via the internal `Axol._wrap(hardware)`.
- Full suite: identical pass/fail set to `main` on this (macOS) machine; the remaining failures are pre-existing environment ones (no `axol-rt` binary, Linux-only affinity/rtprio/udev/state-file tests).

